### PR TITLE
fix: restore OAuth subnet block and deprecated field marker lost in merge

### DIFF
--- a/acn/models.py
+++ b/acn/models.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 
 from a2a.types import AgentCard as A2AAgentCard  # type: ignore[import-untyped]
 from a2a.types import AgentSkill as A2AAgentSkill  # type: ignore[import-untyped]
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Re-export SDK types as canonical Agent Card / Skill for ACN
 AgentCard = A2AAgentCard
@@ -212,7 +212,9 @@ class SubnetCreateRequest(BaseModel):
     1. No security_schemes = Public subnet (anyone can join)
     2. Bearer token = Simple token auth
     3. API Key = Key-based auth
-    4. OpenID Connect = Enterprise OAuth/SSO
+
+    Note: openIdConnect / oauth2 types are not yet supported and will be rejected.
+    See https://github.com/acnlabs/ACN/issues/9 for implementation plan.
 
     Examples:
         # Public subnet (no auth)
@@ -227,15 +229,12 @@ class SubnetCreateRequest(BaseModel):
             }
         }
 
-        # Enterprise OAuth
+        # API Key auth
         {
-            "subnet_id": "enterprise",
-            "name": "Enterprise",
+            "subnet_id": "team-b",
+            "name": "Team B",
             "security_schemes": {
-                "oauth": {
-                    "type": "openIdConnect",
-                    "openIdConnectUrl": "https://auth.company.com/.well-known/openid"
-                }
+                "key": {"type": "apiKey", "in": "header", "name": "X-Subnet-Key"}
             }
         }
     """
@@ -250,6 +249,23 @@ class SubnetCreateRequest(BaseModel):
         None, max_length=10, description="Required security schemes. None = use first available"
     )
     metadata: dict = Field(default_factory=dict, description="Additional metadata")
+
+    @model_validator(mode="after")
+    def reject_unsupported_security_types(self) -> "SubnetCreateRequest":
+        if not self.security_schemes:
+            return self
+        unsupported = [
+            name
+            for name, scheme in self.security_schemes.items()
+            if scheme.get("type") in ("openIdConnect", "oauth2")
+        ]
+        if unsupported:
+            raise ValueError(
+                f"Security scheme type(s) not yet supported: "
+                f"{', '.join(unsupported)}. "
+                f"Supported types: http (bearer), apiKey."
+            )
+        return self
 
 
 class SubnetCreateResponse(BaseModel):

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -53,7 +53,7 @@ class TaskCreateRequest(BaseModel):
     required_skills: list[str] = Field(default_factory=list)
     reward_amount: str = Field(default="0", description="Reward amount")
     reward_currency: str = Field(default="points", description="Currency: USD, USDC, points")
-    is_repeatable: bool = Field(default=False, description="DEPRECATED: use is_multi_participant")
+    is_repeatable: bool = Field(default=False, description="DEPRECATED: use is_multi_participant", deprecated=True)
     is_multi_participant: bool = Field(default=False, description="Multiple agents can work in parallel")
     allow_repeat_by_same: bool = Field(default=False, description="Same agent can rejoin after completing")
     max_completions: int | None = Field(None, description="Max completions (open/multi mode)")


### PR DESCRIPTION
## 问题

PR #11 合并时使用 `--theirs` 解决冲突，导致 PR #10 对 `models.py` 的两处安全改动被覆盖：

1. `SubnetCreateRequest.reject_unsupported_security_types` — 阻止创建 `openIdConnect`/`oauth2` 类型子网的 `@model_validator` 消失，恢复为旧版可创建 OAuth 子网（虽然 `subnet_manager` 层仍会拒绝访问，但 API 层的防护消失了）
2. `CreateTaskRequest.is_repeatable` — `deprecated=True` 标记丢失

## 修复

- 重新添加 `model_validator` 和 `model_validator` import
- 重新添加 `deprecated=True`
- 更新 `SubnetCreateRequest` docstring（移除 OAuth 示例）

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest` — 82 passed

Made with [Cursor](https://cursor.com)