### PR TITLE
chore: add Railway deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ RUN useradd --no-create-home --shell /bin/false appuser \
     && chown -R appuser:appuser /app
 USER appuser
 
-# Expose port
+# Expose port (Railway injects $PORT; default to 8000 for local/Docker Compose)
 EXPOSE 8000
 
 # Health check using curl (more reliable than python httpx import)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
-# Run application
-CMD ["uvicorn", "acn.api:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run application — use $PORT if set (Railway), otherwise default to 8000
+CMD ["sh", "-c", "uvicorn acn.api:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "uvicorn acn.api:app --host 0.0.0.0 --port $PORT",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Railway 部署支持

**Dockerfile**：CMD 改为 `uvicorn ... --port ${PORT:-8000}`，兼容 Railway 注入的 `$PORT` 和本地 Docker Compose 的固定 8000 端口。

**railway.json**：
- 指定使用 Dockerfile 构建
- 配置 `/health` 健康检查
- ON_FAILURE 重启策略，最多 3 次

## 部署步骤（Railway 侧）

1. Railway Dashboard → New Project → Deploy from GitHub Repo → 选 `ACNet-AI/ACN`
2. Add Plugin → Redis（Railway 自动注入 `REDIS_URL`）
3. Variables 中填入：
   - `DEV_MODE=false`
   - `ENABLE_DOCS=false`
   - `AUTH0_DOMAIN=`
   - `AUTH0_AUDIENCE=`
   - `INTERNAL_API_TOKEN=`（32位以上随机值）
   - `BACKEND_URL=`
   - `GATEWAY_BASE_URL=`（Railway 自动域名，部署后填入）
   - `CORS_ORIGINS=`
4. Deploy

Made with [Cursor](https://cursor.com)