### PR TITLE
chore: use redis aclose() to silence deprecation warning

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -704,7 +704,9 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error("audit_stop_failed", error=str(e))
     await router_instance.close()
-    await registry_instance.redis.close()
+    # redis-py 5.0.1+ deprecated Redis.close() in favor of aclose() for the
+    # async client (https://github.com/redis/redis-py/pull/2745).
+    await registry_instance.redis.aclose()
     if _pg_engine is not None:
         await _pg_engine.dispose()
     logger.info("acn_stopped")

--- a/acn/infrastructure/messaging/websocket_manager.py
+++ b/acn/infrastructure/messaging/websocket_manager.py
@@ -155,7 +155,8 @@ class WebSocketManager:
                 pass
 
         if self._pubsub:
-            await self._pubsub.close()
+            # redis-py 5.0.1+ deprecated PubSub.close() in favor of aclose().
+            await self._pubsub.aclose()
 
         # Close all connections
         for conn in list(self._connections.values()):


### PR DESCRIPTION
## Summary

Switch the two `Redis.close()` / `PubSub.close()` call sites in our shutdown paths to `aclose()`.

`redis-py` 5.0.1 deprecated the sync-named `close()` on the async client and on `PubSub` in favor of `aclose()` (see [redis/redis-py#2745](https://github.com/redis/redis-py/pull/2745)). We're already on a redis-py version that emits this warning every time the FastAPI lifespan tears down — visible in `pytest` output during PR #15 self-review:

```
acn/api.py:707: DeprecationWarning: Call to deprecated close.
  (Use aclose() instead) -- Deprecated since version 5.0.1.
    await registry_instance.redis.close()
```

## Changes

- `acn/api.py:706` — lifespan teardown: `registry_instance.redis.close()` → `aclose()`
- `acn/infrastructure/messaging/websocket_manager.py:158` — `WebSocketManager.stop()`: `self._pubsub.close()` → `aclose()`

Both are async methods with identical semantics to the deprecated `close()` — drop-in.

## Out of scope (not Redis)

- `MessageRouter.close()` (`acn/infrastructure/messaging/message_router.py:216`) — our own method that already uses httpx `aclose()` internally; just shares the name.
- `WebSocket.close()` calls in `routes/websocket.py`, `websocket_manager.py:476`, `subnet_manager.py:640` — Starlette WebSocket close, different API.

## Test plan

- [x] `pytest -k "shutdown or websocket_manager or lifespan"` — 12/12 passed; no Redis deprecation warning remaining
- [ ] Full test suite via CI
- [ ] Smoke: start server, hit `/healthz`, send `SIGTERM`, confirm shutdown logs are clean
