### PR TITLE
fix(acn): use Postgres ARRAY for containment queries

### DIFF
--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -12,7 +12,6 @@ Design decisions:
 from datetime import UTC, datetime
 
 from sqlalchemy import (
-    ARRAY,
     Boolean,
     DateTime,
     Float,
@@ -23,7 +22,7 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 

--- a/tests/infrastructure/test_postgres_agent_array_queries.py
+++ b/tests/infrastructure/test_postgres_agent_array_queries.py
@@ -1,0 +1,32 @@
+"""Regression tests for PostgreSQL ARRAY containment queries.
+
+Railway runs against SQLAlchemy 2.0.49, where the base ``sqlalchemy.ARRAY``
+type does not implement ``.contains()``. The ORM model must use
+``sqlalchemy.dialects.postgresql.ARRAY`` so agent search paths can compile
+``skills @> ARRAY[...]`` instead of raising at runtime.
+"""
+
+from sqlalchemy import String, cast, select
+from sqlalchemy.dialects.postgresql import ARRAY, dialect
+
+from acn.infrastructure.persistence.postgres.models import AgentModel
+
+
+def test_agent_tags_contains_compiles_with_postgres_array_operator():
+    stmt = select(AgentModel).where(
+        AgentModel.tags.contains(cast(["coding"], ARRAY(String)))
+    )
+
+    compiled = str(stmt.compile(dialect=dialect()))
+
+    assert "skills @> CAST(" in compiled
+
+
+def test_agent_subnet_ids_contains_compiles_with_postgres_array_operator():
+    stmt = select(AgentModel).where(
+        AgentModel.subnet_ids.contains(cast(["public"], ARRAY(String)))
+    )
+
+    compiled = str(stmt.compile(dialect=dialect()))
+
+    assert "subnet_ids @> CAST(" in compiled


### PR DESCRIPTION
## Summary
- Switch ORM ARRAY columns from the base SQLAlchemy ARRAY type to PostgreSQL dialect ARRAY.
- Add regression coverage that compiles `tags.contains(...)` and `subnet_ids.contains(...)` to PostgreSQL `@>` containment.
- Fixes Railway runtime 500s from `/api/v1/agents` search paths under SQLAlchemy 2.0.49.

## Test plan
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy acn`
- `uv run --extra dev pytest tests/infrastructure/test_postgres_agent_array_queries.py tests/infrastructure/test_postgres_agent_mark_offline_stale.py`


Made with [Cursor](https://cursor.com)