### PR TITLE
fix(acn): pin A2A SDK to DataPart-compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "python-multipart>=0.0.9",
     # A2A Protocol - Official SDK
     # https://github.com/a2aproject/A2A
-    "a2a-sdk[http-server]>=0.2.0",
+    "a2a-sdk[http-server]>=0.3.24,<0.3.25",
     # AP2 Protocol - Agent Payments Protocol (Google)
     # https://github.com/google-agentic-commerce/AP2
     "ap2 @ git+https://github.com/google-agentic-commerce/AP2.git@61f5de49f47d0517182d664bd05b7df1ff1f4e40",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "python-multipart>=0.0.9",
     # A2A Protocol - Official SDK
     # https://github.com/a2aproject/A2A
-    "a2a-sdk[http-server]>=0.3.24,<0.3.25",
+    "a2a-sdk[http-server]>=0.3.24,<0.3.25,<1.0.0",
     # AP2 Protocol - Agent Payments Protocol (Google)
     # https://github.com/google-agentic-commerce/AP2
     "ap2 @ git+https://github.com/google-agentic-commerce/AP2.git@61f5de49f47d0517182d664bd05b7df1ff1f4e40",

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.2.0" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.24,<0.3.25" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "ap2", git = "https://github.com/google-agentic-commerce/AP2.git?rev=61f5de49f47d0517182d664bd05b7df1ff1f4e40" },
     { name = "asyncpg", specifier = ">=0.29" },

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.24,<0.3.25" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.24,<0.3.25,<1.0.0" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "ap2", git = "https://github.com/google-agentic-commerce/AP2.git?rev=61f5de49f47d0517182d664bd05b7df1ff1f4e40" },
     { name = "asyncpg", specifier = ">=0.29" },


### PR DESCRIPTION
## Summary
- Pin `a2a-sdk[http-server]` to the locked `0.3.24` series used by local/CI validation.
- Prevent Railway Docker rebuilds from resolving to newer A2A SDK releases where `DataPart` is no longer exported from `a2a.types`.
- Fixes Railway healthcheck failures caused by `ImportError: cannot import name 'DataPart' from 'a2a.types'` during `uvicorn acn.api:app` startup.

## Test plan
- `uv lock`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy acn`
- `uv run --extra dev pytest tests/protocols/test_a2a_handle_routing_policy.py tests/infrastructure/test_manifest_dispatcher.py`
- `DEV_MODE=false INTERNAL_API_TOKEN=abcdefghijklmnopqrstuvwxyz123456 CORS_ORIGINS='[\"https://acnlabs.dev\"]' AUTH0_DOMAIN=example.auth0.com AUTH0_AUDIENCE=https://acn.acnlabs.dev uv run --extra dev python -c 'from a2a.types import DataPart; import acn.api'`


Made with [Cursor](https://cursor.com)