### PR TITLE
feat(acn): adapt to A2A SDK 1.x

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -20,15 +20,15 @@ from pathlib import Path
 
 import redis.asyncio as aioredis
 import structlog  # type: ignore[import-untyped]
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     AgentCapabilities,
     AgentProvider,
     AgentSkill,
 )
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     AgentCard as A2AAgentCard,
 )
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     SecurityScheme as A2ASecurityScheme,
 )
 from fastapi import FastAPI, HTTPException, Request
@@ -1112,7 +1112,7 @@ async def get_acn_agent_card():
             default_output_modes=["text", "application/json"],
             security_schemes=security_schemes,
             security=security,
-            tags=[
+            skills=[
                 AgentSkill(
                     id="acn:discovery",
                     name="Agent Discovery",

--- a/acn/core/entities/agent.py
+++ b/acn/core/entities/agent.py
@@ -44,6 +44,9 @@ class Agent:
 
     # Endpoint is optional for pull-mode agents
     endpoint: str | None = None
+    # Explicit direct A2A JSON-RPC delivery URL. During the transition this
+    # mirrors endpoint; keeping the named field makes the semantics visible.
+    a2a_endpoint: str | None = None
 
     status: AgentStatus = AgentStatus.ONLINE
     description: str | None = None
@@ -73,6 +76,9 @@ class Agent:
 
     # A2A Agent Card (stored as raw dict; provided by registrant or auto-generated on demand)
     agent_card: dict | None = None
+    # Optional A2A Agent Card discovery URL. Persisted separately from the
+    # direct delivery URL so ACN does not have to guess endpoint semantics.
+    agent_card_url: str | None = None
 
     # Communication policy (gateway-level access control)
     # Default {"mode": "open"} backfilled in __post_init__ — keeps existing
@@ -114,6 +120,10 @@ class Agent:
         if not self.name:
             raise ValueError("name cannot be empty")
         # Note: owner and endpoint are now optional
+        if self.a2a_endpoint and not self.endpoint:
+            self.endpoint = self.a2a_endpoint
+        elif self.endpoint and not self.a2a_endpoint:
+            self.a2a_endpoint = self.endpoint
         if not self.subnet_ids:
             self.subnet_ids = ["public"]
         # Backward compat: if legacy wallet_address is set but wallet_addresses is empty,
@@ -266,6 +276,7 @@ class Agent:
             "name": self.name,
             "owner": self.owner,
             "endpoint": self.endpoint,
+            "a2a_endpoint": self.a2a_endpoint,
             "status": self.status.value,
             "description": self.description,
             "tags": self.tags,
@@ -286,6 +297,7 @@ class Agent:
             else None,
             # Agent Card
             "agent_card": self.agent_card,
+            "agent_card_url": self.agent_card_url,
             # Communication policy (Phase 1: open|closed)
             "communication_policy": self.communication_policy,
             # Payment

--- a/acn/infrastructure/messaging/__init__.py
+++ b/acn/infrastructure/messaging/__init__.py
@@ -53,7 +53,7 @@ Architecture:
     └─────────────────────────────────────────────────┘
 
 Usage:
-    from a2a.types import Message, TextPart, DataPart
+    from a2a.compat.v0_3.types import Message, TextPart, DataPart
     from acn.communication import (
         MessageRouter,
         BroadcastService,
@@ -100,7 +100,7 @@ Usage:
 """
 
 # Re-export official A2A types for convenience
-from a2a.types import DataPart, Message, Part, Role, TextPart
+from a2a.compat.v0_3.types import DataPart, Message, Part, Role, TextPart
 
 from .broadcast_service import BroadcastResult, BroadcastService, BroadcastStrategy
 from .manifest_dispatcher import ManifestDispatcher

--- a/acn/infrastructure/messaging/broadcast_service.py
+++ b/acn/infrastructure/messaging/broadcast_service.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 import redis.asyncio as redis
 
 # Official A2A SDK
-from a2a.types import Message  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import Message  # type: ignore[import-untyped]
 
 from ...core.exceptions import AgentNotFoundException, PolicyRejected
 from ...core.interfaces import IAgentRepository

--- a/acn/infrastructure/messaging/manifest_dispatcher.py
+++ b/acn/infrastructure/messaging/manifest_dispatcher.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from a2a.types import Message  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import Message  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from ...services.manifest_service import ManifestEntry, ManifestService

--- a/acn/infrastructure/messaging/message_router.py
+++ b/acn/infrastructure/messaging/message_router.py
@@ -13,6 +13,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -20,8 +21,12 @@ import httpx
 import redis.asyncio as redis
 
 # Official A2A SDK
-from a2a.client import A2AClient  # type: ignore[import-untyped]
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.client import Client, ClientConfig, ClientFactory  # type: ignore[import-untyped]
+from a2a.compat.v0_3.conversions import (  # type: ignore[import-untyped]
+    to_compat_stream_response,
+    to_core_send_message_request,
+)
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     DataPart,
     Message,
     MessageSendParams,
@@ -29,6 +34,11 @@ from a2a.types import (  # type: ignore[import-untyped]
     Role,
     SendMessageRequest,
     TextPart,
+)
+from a2a.types.a2a_pb2 import (  # type: ignore[import-untyped]
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
 )
 
 from ...config import get_settings
@@ -47,6 +57,15 @@ if TYPE_CHECKING:
     from .manifest_dispatcher import ManifestDispatcher
 
 logger = logging.getLogger(__name__)
+
+
+def _agent_delivery_endpoint(agent_info: Any) -> str:
+    """Return the direct A2A JSON-RPC delivery URL from new or legacy fields."""
+    a2a_endpoint = getattr(agent_info, "a2a_endpoint", None)
+    if isinstance(a2a_endpoint, str) and a2a_endpoint:
+        return a2a_endpoint
+    return agent_info.endpoint
+
 
 # Global message audit trail. Stored as a Redis stream (not one string
 # key per route_id) so memory is bounded by MAXLEN regardless of
@@ -153,7 +172,7 @@ class MessageRouter:
         self.allowlist_service = allowlist_service
 
         # Cache of A2A clients by endpoint (capped to prevent unbounded growth)
-        self._clients: dict[str, A2AClient] = {}
+        self._clients: dict[str, Client] = {}
         self._clients_max: int = 256
 
         # Message handlers for incoming messages
@@ -163,7 +182,7 @@ class MessageRouter:
             "Message Router initialized (using official A2A SDK)",
         )
 
-    async def _get_client(self, endpoint: str) -> A2AClient:
+    async def _get_client(self, endpoint: str) -> Client:
         """
         Get or create A2A client for endpoint
 
@@ -171,7 +190,7 @@ class MessageRouter:
             endpoint: Agent A2A endpoint URL
 
         Returns:
-            A2AClient instance
+            A2A client instance
         """
         # SSRF guard: resolve and verify the endpoint hostname BEFORE caching
         # the A2A client. Even though clients are cached per-endpoint URL,
@@ -194,8 +213,7 @@ class MessageRouter:
                 oldest = next(iter(self._clients))
                 try:
                     old_client = self._clients.pop(oldest)
-                    if hasattr(old_client, "httpx_client") and old_client.httpx_client:
-                        await old_client.httpx_client.aclose()
+                    await old_client.close()
                 except Exception:
                     pass
             # ``follow_redirects=False``: a 3xx pointing to a private
@@ -205,20 +223,58 @@ class MessageRouter:
                 limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
                 follow_redirects=False,
             )
-            self._clients[endpoint] = A2AClient(
+            client_config = ClientConfig(
                 httpx_client=httpx_client,
-                url=endpoint,
+                streaming=False,
+                supported_protocol_bindings=["JSONRPC"],
+            )
+            # Registered ACN endpoints are direct JSON-RPC targets, not
+            # discovery base URLs. Build a minimal legacy card locally so the
+            # a2a-sdk 1.x client uses its v0.3 compatibility transport without
+            # first fetching endpoint/.well-known/agent-card.json.
+            agent_card = AgentCard(
+                supported_interfaces=[
+                    AgentInterface(
+                        url=endpoint,
+                        protocol_binding="JSONRPC",
+                        protocol_version="0.3.0",
+                    )
+                ],
+                capabilities=AgentCapabilities(extended_agent_card=False),
+                default_input_modes=[],
+                default_output_modes=[],
+                description="",
+                skills=[],
+                version="",
+                name="",
+            )
+            self._clients[endpoint] = ClientFactory(client_config).create(
+                agent_card,
             )
             logger.debug(f"Created A2A client for {endpoint}")
 
         return self._clients[endpoint]
 
+    async def _send_message_with_client(
+        self,
+        client: Client,
+        request: SendMessageRequest,
+    ) -> Any:
+        """Send a compat request through either a 1.x client or legacy test stub."""
+        result = client.send_message(to_core_send_message_request(request))
+        if hasattr(result, "__aiter__"):
+            async for event in result:
+                return to_compat_stream_response(event, request_id=request.id)
+            return None
+        if isawaitable(result):
+            return await result
+        return result
+
     async def close(self) -> None:
         """Close all cached A2A clients and their underlying httpx connections"""
         for endpoint, client in self._clients.items():
             try:
-                if hasattr(client, "httpx_client") and client.httpx_client:
-                    await client.httpx_client.aclose()
+                await client.close()
             except Exception as e:
                 logger.warning("failed_to_close_a2a_client", endpoint=endpoint, error=str(e))
         self._clients.clear()
@@ -312,7 +368,7 @@ class MessageRouter:
                     message=message,
                 )
 
-        endpoint = agent_info.endpoint
+        endpoint = _agent_delivery_endpoint(agent_info)
         logger.debug(f"[{route_id}] Discovered endpoint: {endpoint}")
 
         # 2. Offline pre-check — skip the HTTP round-trip when the registry
@@ -383,7 +439,7 @@ class MessageRouter:
                 id=route_id,
                 params=MessageSendParams(message=message),
             )
-            response = await client.send_message(request)
+            response = await self._send_message_with_client(client, request)
 
             # 5. Log response
             logger.debug(f"[{route_id}] Received response: {type(response)}")
@@ -488,14 +544,25 @@ class MessageRouter:
         if not agent_info:
             raise ValueError(f"Agent not found: {to_agent}")
 
-        endpoint = agent_info.endpoint
+        endpoint = _agent_delivery_endpoint(agent_info)
         logger.info(f"Starting stream: {from_agent} -> {to_agent}")
 
         # Get A2A client and stream
         client = await self._get_client(endpoint)
 
-        async for event in client.send_message_streaming(message):
-            yield event
+        request = SendMessageRequest(
+            id=str(uuid4()),
+            params=MessageSendParams(message=message),
+        )
+        result = client.send_message(to_core_send_message_request(request))
+        if hasattr(result, "__aiter__"):
+            async for event in result:
+                yield to_compat_stream_response(event, request_id=request.id)
+            return
+        if isawaitable(result):
+            yield await result
+            return
+        yield result
 
     async def register_handler(
         self,

--- a/acn/infrastructure/messaging/subnet_manager.py
+++ b/acn/infrastructure/messaging/subnet_manager.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import redis.asyncio as redis
-from a2a.types import Message  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import Message  # type: ignore[import-untyped]
 from fastapi import WebSocket, WebSocketDisconnect
 
 from ...core.exceptions import PolicyRejected

--- a/acn/infrastructure/persistence/postgres/agent_repository.py
+++ b/acn/infrastructure/persistence/postgres/agent_repository.py
@@ -55,6 +55,7 @@ class PostgresAgentRepository(IAgentRepository):
             name=row.name,
             owner=row.owner,
             endpoint=row.endpoint,
+            a2a_endpoint=meta.get("a2a_endpoint") or row.endpoint,
             status=AgentStatus(row.status),
             # Prefer dedicated SQL column; fall back to JSONB for rows saved before this fix
             description=row.description or meta.get("description"),
@@ -71,6 +72,7 @@ class PostgresAgentRepository(IAgentRepository):
             referrer_id=row.referrer_id,
             owner_changed_at=row.owner_changed_at,
             agent_card=row.agent_card,
+            agent_card_url=meta.get("agent_card_url"),
             wallet_address=row.wallet_address,
             wallet_addresses=dict(row.wallet_addresses or {}),
             accepts_payment=row.accepts_payment,
@@ -89,6 +91,8 @@ class PostgresAgentRepository(IAgentRepository):
         extra_meta: dict = {
             "description": agent.description,
             "extra_metadata": agent.metadata,
+            "a2a_endpoint": agent.a2a_endpoint,
+            "agent_card_url": agent.agent_card_url,
             "erc8004_agent_id": agent.erc8004_agent_id,
             "erc8004_chain": agent.erc8004_chain,
             "erc8004_tx_hash": agent.erc8004_tx_hash,

--- a/acn/infrastructure/persistence/redis/a2a_task_store.py
+++ b/acn/infrastructure/persistence/redis/a2a_task_store.py
@@ -5,12 +5,16 @@ Provides persistent task storage using Redis, replacing InMemoryTaskStore.
 
 from __future__ import annotations
 
-import json
-
 import structlog  # type: ignore[import-untyped]
 from a2a.server.context import ServerCallContext  # type: ignore[import-untyped]
 from a2a.server.tasks import TaskStore  # type: ignore[import-untyped]
-from a2a.types import Task, TaskState  # type: ignore[import-untyped]
+from a2a.types.a2a_pb2 import (  # type: ignore[import-untyped]
+    ListTasksRequest,
+    ListTasksResponse,
+    Task,
+    TaskState,
+)
+from google.protobuf.json_format import MessageToJson, Parse
 from redis.asyncio import Redis
 
 logger = structlog.get_logger()
@@ -53,8 +57,11 @@ class RedisTaskStore(TaskStore):
             return None
 
         try:
-            task_data = json.loads(task_json)
-            return Task(**task_data)
+            if isinstance(task_json, bytes):
+                task_json = task_json.decode()
+            task = Task()
+            Parse(task_json, task)
+            return task
         except Exception as e:
             logger.error("task_load_failed", task_id=task_id, error=str(e))
             return None
@@ -69,8 +76,11 @@ class RedisTaskStore(TaskStore):
         task_key = f"{self.key_prefix}{task.id}"
 
         try:
-            # Serialize task
-            task_json = task.model_dump_json(by_alias=True, exclude_none=True)
+            # Serialize protobuf task with stable field names for readability.
+            task_json = MessageToJson(
+                task,
+                preserving_proto_field_name=True,
+            )
 
             # Save to Redis
             await self.redis.set(task_key, task_json)
@@ -85,7 +95,7 @@ class RedisTaskStore(TaskStore):
                 "task_saved",
                 task_id=task.id,
                 context_id=task.context_id,
-                status=task.status.state.value,
+                status=task.status.state,
             )
 
         except Exception as e:
@@ -112,6 +122,32 @@ class RedisTaskStore(TaskStore):
             await self._remove_from_indexes(task)
 
         logger.debug("task_deleted", task_id=task_id)
+
+    async def list(
+        self,
+        params: ListTasksRequest,
+        context: ServerCallContext | None = None,
+    ) -> ListTasksResponse:
+        """List tasks using the a2a-sdk 1.x TaskStore interface."""
+        task_ids = await self._get_task_ids(
+            params.context_id or None,
+            params.status or None,
+        )
+        tasks = []
+        for task_id in task_ids:
+            task = await self.get(task_id, context)
+            if task:
+                tasks.append(task)
+
+        total_size = len(tasks)
+        page_size = params.page_size or 100
+        paginated_tasks = tasks[:page_size]
+
+        return ListTasksResponse(
+            tasks=paginated_tasks,
+            total_size=total_size,
+            page_size=page_size,
+        )
 
     async def list_tasks(
         self,
@@ -159,7 +195,7 @@ class RedisTaskStore(TaskStore):
         """
         if context_id and status:
             # Intersection of context and status
-            index_key = f"{self.key_prefix}index:context:{context_id}:status:{status.value}"
+            index_key = f"{self.key_prefix}index:context:{context_id}:status:{status}"
             task_ids = await self.redis.smembers(index_key)
         elif context_id:
             # All tasks in context
@@ -167,7 +203,7 @@ class RedisTaskStore(TaskStore):
             task_ids = await self.redis.smembers(index_key)
         elif status:
             # All tasks with status
-            index_key = f"{self.key_prefix}index:status:{status.value}"
+            index_key = f"{self.key_prefix}index:status:{status}"
             task_ids = await self.redis.smembers(index_key)
         else:
             # All tasks - scan all task keys
@@ -197,13 +233,13 @@ class RedisTaskStore(TaskStore):
         await self.redis.expire(context_index, 30 * 24 * 3600)
 
         # Index by status
-        status_index = f"{self.key_prefix}index:status:{task.status.state.value}"
+        status_index = f"{self.key_prefix}index:status:{task.status.state}"
         await self.redis.sadd(status_index, task.id)
         await self.redis.expire(status_index, 30 * 24 * 3600)
 
         # Index by context + status
         context_status_index = (
-            f"{self.key_prefix}index:context:{task.context_id}:status:{task.status.state.value}"
+            f"{self.key_prefix}index:context:{task.context_id}:status:{task.status.state}"
         )
         await self.redis.sadd(context_status_index, task.id)
         await self.redis.expire(context_status_index, 30 * 24 * 3600)
@@ -219,12 +255,12 @@ class RedisTaskStore(TaskStore):
         await self.redis.srem(context_index, task.id)
 
         # Remove from status index
-        status_index = f"{self.key_prefix}index:status:{task.status.state.value}"
+        status_index = f"{self.key_prefix}index:status:{task.status.state}"
         await self.redis.srem(status_index, task.id)
 
         # Remove from context + status index
         context_status_index = (
-            f"{self.key_prefix}index:context:{task.context_id}:status:{task.status.state.value}"
+            f"{self.key_prefix}index:context:{task.context_id}:status:{task.status.state}"
         )
         await self.redis.srem(context_status_index, task.id)
 

--- a/acn/infrastructure/persistence/redis/a2a_task_store.py
+++ b/acn/infrastructure/persistence/redis/a2a_task_store.py
@@ -18,6 +18,7 @@ from google.protobuf.json_format import MessageToJson, Parse
 from redis.asyncio import Redis
 
 logger = structlog.get_logger()
+_List = list
 
 
 class RedisTaskStore(TaskStore):
@@ -155,7 +156,7 @@ class RedisTaskStore(TaskStore):
         status: TaskState | None = None,
         limit: int = 100,
         offset: int = 0,
-    ) -> list[Task]:
+    ) -> _List[Task]:
         """List tasks with optional filters
 
         Args:
@@ -183,7 +184,7 @@ class RedisTaskStore(TaskStore):
 
     async def _get_task_ids(
         self, context_id: str | None = None, status: TaskState | None = None
-    ) -> list[str]:
+    ) -> _List[str]:
         """Get task IDs based on filters
 
         Args:

--- a/acn/infrastructure/persistence/redis/agent_repository.py
+++ b/acn/infrastructure/persistence/redis/agent_repository.py
@@ -74,7 +74,9 @@ class RedisAgentRepository(IAgentRepository):
             "verification_code",
             "owner",
             "endpoint",
+            "a2a_endpoint",
             "referrer_id",
+            "agent_card_url",
             "social_card_url",
         }
         clean_dict = {}
@@ -341,6 +343,7 @@ class RedisAgentRepository(IAgentRepository):
             "owner": agent_dict.get("owner"),
             # endpoint is now optional
             "endpoint": agent_dict.get("endpoint"),
+            "a2a_endpoint": agent_dict.get("a2a_endpoint") or agent_dict.get("endpoint"),
             "status": AgentStatus(agent_dict["status"]),
             "description": agent_dict.get("description"),
             # Read: support both new "tags" and legacy "skills" key
@@ -379,6 +382,7 @@ class RedisAgentRepository(IAgentRepository):
             "agent_card": (
                 json.loads(agent_dict["agent_card"]) if agent_dict.get("agent_card") else None
             ),
+            "agent_card_url": agent_dict.get("agent_card_url") or None,
             # Communication policy — older rows predate this field, so fall
             # back to None and let Agent.__post_init__ default it to open.
             "communication_policy": (

--- a/acn/infrastructure/persistence/redis/registry.py
+++ b/acn/infrastructure/persistence/redis/registry.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import redis.asyncio as redis
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     AgentCapabilities,
     AgentCard,
     AgentSkill,

--- a/acn/models.py
+++ b/acn/models.py
@@ -7,8 +7,8 @@ Pydantic models for ACN service
 from datetime import UTC, datetime
 from enum import StrEnum
 
-from a2a.types import AgentCard as A2AAgentCard  # type: ignore[import-untyped]
-from a2a.types import AgentSkill as A2AAgentSkill  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import AgentCard as A2AAgentCard  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import AgentSkill as A2AAgentSkill  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Re-export SDK types as canonical Agent Card / Skill for ACN
@@ -29,7 +29,18 @@ class AgentInfo(BaseModel):
     owner: str = Field(..., description="Agent owner (system/user-{id}/provider-{id})")
     name: str = Field(..., description="Agent name")
     description: str | None = Field(None, description="Agent description")
-    endpoint: str = Field(..., description="Agent A2A endpoint URL")
+    endpoint: str = Field(..., description="Agent A2A JSON-RPC endpoint URL")
+    a2a_endpoint: str | None = Field(
+        None,
+        description=(
+            "Explicit A2A JSON-RPC delivery URL. Mirrors endpoint during the "
+            "field-name transition."
+        ),
+    )
+    agent_card_url: str | None = Field(
+        None,
+        description="A2A Agent Card discovery URL, if provided by the registrant.",
+    )
     tags: list[str] = Field(default_factory=list, description="Agent capability tags (e.g. ['coding', 'search'])")
     status: AgentStatus = Field(default=AgentStatus.ONLINE, description="Agent status")
     # 支持多子网归属
@@ -137,7 +148,24 @@ class AgentRegisterRequest(BaseModel):
         description="Agent owner (system/user-{id}/provider-{id})",
     )
     name: str = Field(..., min_length=1, max_length=128, description="Agent name")
-    endpoint: str = Field(..., max_length=512, description="Agent A2A endpoint URL")
+    endpoint: str | None = Field(
+        None,
+        max_length=512,
+        description="[Deprecated] Direct A2A JSON-RPC endpoint URL. Use a2a_endpoint.",
+    )
+    a2a_endpoint: str | None = Field(
+        None,
+        max_length=512,
+        description="Direct A2A JSON-RPC endpoint URL used for message delivery.",
+    )
+    agent_card_url: str | None = Field(
+        None,
+        max_length=512,
+        description=(
+            "A2A Agent Card discovery URL. If a2a_endpoint is omitted, ACN "
+            "fetches this card and extracts the JSON-RPC endpoint."
+        ),
+    )
     tags: list[str] = Field(default_factory=list, max_length=50, description="Agent capability tags")
     agent_card: dict | None = Field(
         None,
@@ -203,11 +231,13 @@ class AgentRegisterRequest(BaseModel):
 
         return validate_policy_dict(v)
 
-    @field_validator("endpoint")
+    @field_validator("endpoint", "a2a_endpoint", "agent_card_url")
     @classmethod
-    def endpoint_must_be_url(cls, v: str) -> str:
+    def endpoint_must_be_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
         if not (v.startswith("http://") or v.startswith("https://")):
-            raise ValueError("endpoint must start with http:// or https://")
+            raise ValueError("URL must start with http:// or https://")
         # SSRF guard: forbid IP-literal endpoints in private/reserved ranges
         # at registration time. Hostname → DNS rebinding is checked at
         # request-dispatch time in _proxy_to_agent / MessageRouter.
@@ -219,6 +249,16 @@ class AgentRegisterRequest(BaseModel):
         except SSRFViolation as e:
             raise ValueError(str(e)) from e
         return v
+
+    @model_validator(mode="after")
+    def require_delivery_or_discovery_url(self):
+        if not (self.a2a_endpoint or self.endpoint or self.agent_card_url):
+            raise ValueError("a2a_endpoint, endpoint, or agent_card_url is required")
+        return self
+
+    def get_direct_a2a_endpoint(self) -> str | None:
+        """Return the explicit direct delivery URL, if provided."""
+        return self.a2a_endpoint or self.endpoint
 
     @field_validator("tags", mode="before")
     @classmethod

--- a/acn/protocols/a2a/auth_middleware.py
+++ b/acn/protocols/a2a/auth_middleware.py
@@ -51,14 +51,14 @@ Implementation choice: ASGI middleware vs FastAPI dependency
 ============================================================
 
 A FastAPI dependency would be the path of least resistance, but the
-A2A FastAPI app is built by ``A2AFastAPIApplication`` from the
-``a2a-sdk`` library — its routes are not declared with our Depends
-annotations and we can't easily inject. ASGI middleware sits at the
-HTTP layer, before the SDK's routing, and works regardless of how
-the SDK structures its endpoints. The price is that we have to
-replay the request body manually after reading it (Starlette / ASGI
-``receive`` is single-shot by default); the helper below caches the
-body and synthesises a fresh ``receive`` for the downstream call.
+A2A endpoints are assembled from ``a2a-sdk`` Starlette routes — their
+handlers are not declared with our Depends annotations and we can't
+easily inject. ASGI middleware sits at the HTTP layer, before the
+SDK's routing, and works regardless of how the SDK structures its
+endpoints. The price is that we have to replay the request body
+manually after reading it (Starlette / ASGI ``receive`` is single-shot
+by default); the helper below caches the body and synthesises a fresh
+``receive`` for the downstream call.
 
 Why JSON-RPC error response with HTTP 400 (PR #2 v3)
 =====================================================

--- a/acn/protocols/a2a/server.py
+++ b/acn/protocols/a2a/server.py
@@ -14,16 +14,13 @@ import uuid
 from typing import Any
 
 import structlog  # type: ignore[import-untyped]
-from a2a.server.agent_execution import (  # type: ignore[import-untyped]
-    AgentExecutor,
-    RequestContext,
+from a2a.compat.v0_3.conversions import (  # type: ignore[import-untyped]
+    to_compat_message,
+    to_core_agent_card,
+    to_core_task_artifact_update_event,
+    to_core_task_status_update_event,
 )
-from a2a.server.apps import A2AFastAPIApplication  # type: ignore[import-untyped]
-from a2a.server.events import EventQueue  # type: ignore[import-untyped]
-from a2a.server.request_handlers import (  # type: ignore[import-untyped]
-    DefaultRequestHandler,
-)
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     AgentCapabilities,
     AgentCard,
     AgentProvider,
@@ -37,6 +34,18 @@ from a2a.types import (  # type: ignore[import-untyped]
     TaskStatus,
     TaskStatusUpdateEvent,
     TextPart,
+)
+from a2a.server.agent_execution import (  # type: ignore[import-untyped]
+    AgentExecutor,
+    RequestContext,
+)
+from a2a.server.events import EventQueue  # type: ignore[import-untyped]
+from a2a.server.request_handlers import (  # type: ignore[import-untyped]
+    DefaultRequestHandler,
+)
+from a2a.server.routes import (  # type: ignore[import-untyped]
+    create_agent_card_routes,
+    create_jsonrpc_routes,
 )
 from fastapi import FastAPI
 from redis.asyncio import Redis
@@ -84,6 +93,26 @@ logger = structlog.get_logger()
 #   entry — they use ``/communication/internal/send`` (token-gated).
 #   Demoting ``system:`` here therefore breaks no real flow.
 _A2A_SAFE_FROM_AGENT_FALLBACK = "unknown"
+
+
+async def _enqueue_status_event(
+    event_queue: EventQueue,
+    event: TaskStatusUpdateEvent,
+) -> None:
+    if isinstance(event_queue, EventQueue):
+        await event_queue.enqueue_event(to_core_task_status_update_event(event))
+        return
+    await event_queue.enqueue_event(event)
+
+
+async def _enqueue_artifact_event(
+    event_queue: EventQueue,
+    event: TaskArtifactUpdateEvent,
+) -> None:
+    if isinstance(event_queue, EventQueue):
+        await event_queue.enqueue_event(to_core_task_artifact_update_event(event))
+        return
+    await event_queue.enqueue_event(event)
 
 
 def _safe_a2a_from_agent(context: RequestContext) -> str:
@@ -177,8 +206,8 @@ class ACNAgentExecutor(AgentExecutor):
         """
         try:
             # Get message from context
-            message = context.message
-            if not message:
+            core_message = context.message
+            if not core_message:
                 await self._send_status(
                     event_queue,
                     context,
@@ -187,6 +216,7 @@ class ACNAgentExecutor(AgentExecutor):
                     final=True,
                 )
                 return
+            message = to_compat_message(core_message)
 
             # Determine action
             action = self._extract_action(message, context)
@@ -357,7 +387,7 @@ class ACNAgentExecutor(AgentExecutor):
             status=status,
             final=True,
         )
-        await event_queue.enqueue_event(event)
+        await _enqueue_status_event(event_queue, event)
 
     async def _send_status(
         self,
@@ -394,7 +424,7 @@ class ACNAgentExecutor(AgentExecutor):
             status=status,
             final=final,
         )
-        await event_queue.enqueue_event(event)
+        await _enqueue_status_event(event_queue, event)
 
     async def _send_artifact(
         self,
@@ -417,7 +447,7 @@ class ACNAgentExecutor(AgentExecutor):
             artifact=artifact,
             last_chunk=last_chunk,
         )
-        await event_queue.enqueue_event(event)
+        await _enqueue_artifact_event(event_queue, event)
 
     def _extract_action(self, message: Message, context: RequestContext) -> str:
         """Extract ACN action from message
@@ -809,14 +839,9 @@ def create_a2a_app(
     # Use Redis-based task store for persistence
     task_store = RedisTaskStore(redis, key_prefix="a2a:tasks:")
 
-    # Create request handler
-    request_handler = DefaultRequestHandler(
-        agent_executor=executor,
-        task_store=task_store,
-    )
-
-    # Create ACN Agent Card (A2A Protocol v0.3.0 compliant)
-    agent_card = AgentCard(
+    # Create ACN Agent Card in the v0.3 compatibility model, then convert
+    # it to the protobuf shape expected by a2a-sdk 1.x server routes.
+    compat_agent_card = AgentCard(
         protocol_version=settings.a2a_protocol_version,
         name="ACN Infrastructure Agent",
         version=settings.service_version,
@@ -837,7 +862,7 @@ def create_a2a_app(
         ),
         default_input_modes=["text", "application/json"],
         default_output_modes=["text", "application/json"],
-        tags=[
+        skills=[
             AgentSkill(
                 id="acn:broadcast",
                 name="Multi-Agent Broadcasting",
@@ -872,18 +897,29 @@ def create_a2a_app(
             ),
         ],
     )
+    agent_card = to_core_agent_card(compat_agent_card)
 
-    # Create A2A FastAPI application
-    a2a_app_builder = A2AFastAPIApplication(
+    # Create request handler
+    request_handler = DefaultRequestHandler(
         agent_card=agent_card,
-        http_handler=request_handler,
+        agent_executor=executor,
+        task_store=task_store,
     )
 
-    # Build the FastAPI app
-    a2a_app = a2a_app_builder.build(
-        agent_card_url="/.well-known/agent-card.json",
-        rpc_url="/jsonrpc",
-    )
+    # Build the FastAPI app using the a2a-sdk 1.x Starlette routes.
+    a2a_app = FastAPI()
+    for route in [
+        *create_agent_card_routes(
+            agent_card=agent_card,
+            card_url="/.well-known/agent-card.json",
+        ),
+        *create_jsonrpc_routes(
+            request_handler=request_handler,
+            rpc_url="/jsonrpc",
+            enable_v0_3_compat=True,
+        ),
+    ]:
+        a2a_app.router.routes.append(route)
 
     logger.info(
         "a2a_app_created",

--- a/acn/routes/communication.py
+++ b/acn/routes/communication.py
@@ -6,7 +6,7 @@ Clean Architecture implementation: Route → MessageService → MessageRouter
 import uuid
 
 import structlog  # type: ignore[import-untyped]
-from a2a.types import Message, TextPart  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import Message, TextPart  # type: ignore[import-untyped]
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -275,6 +275,14 @@ def _extract_jsonrpc_endpoint_from_agent_card(agent_card: dict) -> str | None:
     return url if isinstance(url, str) and url else None
 
 
+def _validate_resolved_a2a_endpoint(endpoint: str) -> None:
+    """Apply registration-time endpoint validation to URLs parsed from cards."""
+    try:
+        validate_endpoint_url(endpoint, allow_loopback=settings.dev_mode)
+    except SSRFViolation as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
 async def _resolve_registration_endpoint(
     *,
     direct_endpoint: str | None,
@@ -283,11 +291,13 @@ async def _resolve_registration_endpoint(
 ) -> tuple[str, dict | None]:
     """Resolve the direct A2A endpoint while preserving the discovery card."""
     if direct_endpoint:
+        _validate_resolved_a2a_endpoint(direct_endpoint)
         return direct_endpoint, agent_card
 
     if agent_card:
         direct_endpoint = _extract_jsonrpc_endpoint_from_agent_card(agent_card)
         if direct_endpoint:
+            _validate_resolved_a2a_endpoint(direct_endpoint)
             return direct_endpoint, agent_card
 
     if not agent_card_url:
@@ -314,10 +324,7 @@ async def _resolve_registration_endpoint(
             status_code=400,
             detail="A2A Agent Card does not include a JSON-RPC delivery URL",
         )
-    try:
-        validate_endpoint_url(direct_endpoint, allow_loopback=settings.dev_mode)
-    except SSRFViolation as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    _validate_resolved_a2a_endpoint(direct_endpoint)
 
     return direct_endpoint, fetched_card
 
@@ -470,8 +477,12 @@ def _agent_entity_to_info(agent, *, strip_sensitive: bool = False) -> AgentInfo:
     if strip_sensitive:
         base_url = settings.gateway_base_url or f"http://localhost:{settings.port}"
         exposed_endpoint = f"{base_url}/api/v1/agents/{agent.agent_id}"
+        exposed_agent_card_url = f"{exposed_endpoint}/.well-known/agent-card.json"
+        exposed_agent_card = None
     else:
         exposed_endpoint = agent.endpoint or ""
+        exposed_agent_card_url = getattr(agent, "agent_card_url", None)
+        exposed_agent_card = agent.agent_card
 
     return AgentInfo(
         agent_id=agent.agent_id,
@@ -480,11 +491,11 @@ def _agent_entity_to_info(agent, *, strip_sensitive: bool = False) -> AgentInfo:
         description=agent.description,
         endpoint=exposed_endpoint,
         a2a_endpoint=exposed_endpoint,
-        agent_card_url=agent.agent_card_url,
+        agent_card_url=exposed_agent_card_url,
         tags=agent.tags,
         status=agent.status.value,
         subnet_ids=agent.subnet_ids,
-        agent_card=agent.agent_card,
+        agent_card=exposed_agent_card,
         metadata=metadata,
         registered_at=agent.registered_at,
         last_heartbeat=agent.last_heartbeat,

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -14,7 +14,11 @@ from typing import Literal
 
 import httpx
 import structlog  # type: ignore[import-untyped]
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+)
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -26,7 +30,7 @@ from fastapi import (
     Response,
 )
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..auth.middleware import require_permission, verify_token
 from ..config import Settings, get_settings
@@ -100,7 +104,24 @@ class AgentJoinRequest(BaseModel):
     name: str = Field(..., min_length=2, max_length=100, description="Agent name")
     description: str = Field(..., min_length=10, max_length=500, description="What this agent does (required)")
     tags: list[str] = Field(default_factory=list, max_length=20, description="Capability tags (e.g. ['coding', 'search']). Optional but recommended for discoverability.")
-    endpoint: str = Field(..., max_length=500, description="Agent A2A endpoint URL (must be http/https)")
+    endpoint: str | None = Field(
+        None,
+        max_length=500,
+        description="[Deprecated] Direct A2A JSON-RPC endpoint URL. Use a2a_endpoint.",
+    )
+    a2a_endpoint: str | None = Field(
+        None,
+        max_length=500,
+        description="Direct A2A JSON-RPC endpoint URL used for message delivery.",
+    )
+    agent_card_url: str | None = Field(
+        None,
+        max_length=500,
+        description=(
+            "A2A Agent Card discovery URL. If a2a_endpoint is omitted, ACN "
+            "fetches this card and extracts the JSON-RPC endpoint."
+        ),
+    )
     referrer_id: str | None = Field(None, max_length=128, description="Referrer agent ID")
     # `agent_card` is a structured A2A Agent Card; total payload size is
     # bounded by BodySizeLimitMiddleware (security audit H6) — we don't
@@ -125,9 +146,11 @@ class AgentJoinRequest(BaseModel):
             raise ValueError("Name must contain at least one letter.")
         return v
 
-    @field_validator("endpoint")
+    @field_validator("endpoint", "a2a_endpoint", "agent_card_url")
     @classmethod
-    def validate_endpoint(cls, v: str) -> str:
+    def validate_endpoint(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
         v = v.strip()
         if not re.match(r"^https?://", v, re.IGNORECASE):
             raise ValueError("Endpoint must be an http:// or https:// URL.")
@@ -139,6 +162,16 @@ class AgentJoinRequest(BaseModel):
         except SSRFViolation as e:
             raise ValueError(str(e)) from e
         return v
+
+    @model_validator(mode="after")
+    def require_delivery_or_discovery_url(self):
+        if not (self.a2a_endpoint or self.endpoint or self.agent_card_url):
+            raise ValueError("a2a_endpoint, endpoint, or agent_card_url is required")
+        return self
+
+    def get_direct_a2a_endpoint(self) -> str | None:
+        """Return the explicit direct delivery URL, if provided."""
+        return self.a2a_endpoint or self.endpoint
     # Payment capability (optional — can be set later via POST /payments/{id}/payment-capability)
     wallet_addresses: dict[str, str] = Field(
         default_factory=dict,
@@ -219,6 +252,74 @@ class AgentJoinResponse(BaseModel):
     tasks_endpoint: str = Field(..., description="Endpoint to fetch tasks")
     heartbeat_endpoint: str = Field(..., description="Heartbeat endpoint")
     agent_card_url: str = Field(..., description="URL to retrieve the stored Agent Card")
+
+
+def _extract_jsonrpc_endpoint_from_agent_card(agent_card: dict) -> str | None:
+    """Return the direct JSON-RPC URL from v1 interfaces or legacy v0.3 url."""
+    interfaces = (
+        agent_card.get("supportedInterfaces")
+        or agent_card.get("supported_interfaces")
+        or []
+    )
+    for interface in interfaces:
+        protocol_binding = (
+            interface.get("protocolBinding")
+            or interface.get("protocol_binding")
+            or ""
+        )
+        if protocol_binding.upper() == "JSONRPC" and interface.get("url"):
+            return interface["url"]
+
+    # Legacy v0.3 cards expose the direct delivery URL as `url`.
+    url = agent_card.get("url")
+    return url if isinstance(url, str) and url else None
+
+
+async def _resolve_registration_endpoint(
+    *,
+    direct_endpoint: str | None,
+    agent_card_url: str | None,
+    agent_card: dict | None,
+) -> tuple[str, dict | None]:
+    """Resolve the direct A2A endpoint while preserving the discovery card."""
+    if direct_endpoint:
+        return direct_endpoint, agent_card
+
+    if agent_card:
+        direct_endpoint = _extract_jsonrpc_endpoint_from_agent_card(agent_card)
+        if direct_endpoint:
+            return direct_endpoint, agent_card
+
+    if not agent_card_url:
+        raise HTTPException(
+            status_code=422,
+            detail="a2a_endpoint, endpoint, or agent_card_url is required",
+        )
+
+    try:
+        await safe_resolve_target(agent_card_url, allow_loopback=settings.dev_mode)
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+            response = await client.get(agent_card_url)
+            response.raise_for_status()
+            fetched_card = response.json()
+    except (httpx.HTTPError, ValueError, SSRFViolation) as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unable to fetch A2A Agent Card: {e}",
+        ) from e
+
+    direct_endpoint = _extract_jsonrpc_endpoint_from_agent_card(fetched_card)
+    if not direct_endpoint:
+        raise HTTPException(
+            status_code=400,
+            detail="A2A Agent Card does not include a JSON-RPC delivery URL",
+        )
+    try:
+        validate_endpoint_url(direct_endpoint, allow_loopback=settings.dev_mode)
+    except SSRFViolation as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return direct_endpoint, fetched_card
 
 
 class AgentClaimRequest(BaseModel):
@@ -315,15 +416,22 @@ async def dev_register_agent(
             )
 
     try:
+        endpoint, agent_card = await _resolve_registration_endpoint(
+            direct_endpoint=request.get_direct_a2a_endpoint(),
+            agent_card_url=request.agent_card_url,
+            agent_card=request.agent_card,
+        )
         # Use AgentService (Clean Architecture)
         agent = await agent_service.register_agent(
             owner=request.owner,
             name=request.name,
-            endpoint=request.endpoint,
+            endpoint=endpoint,
+            a2a_endpoint=endpoint,
             tags=request.tags,
             subnet_ids=subnet_ids,
-            agent_card=request.agent_card,
+            agent_card=agent_card,
             communication_policy=request.communication_policy,
+            agent_card_url=request.agent_card_url,
             social_card_url=request.social_card_url,
         )
 
@@ -371,6 +479,8 @@ def _agent_entity_to_info(agent, *, strip_sensitive: bool = False) -> AgentInfo:
         name=agent.name,
         description=agent.description,
         endpoint=exposed_endpoint,
+        a2a_endpoint=exposed_endpoint,
+        agent_card_url=agent.agent_card_url,
         tags=agent.tags,
         status=agent.status.value,
         subnet_ids=agent.subnet_ids,
@@ -421,17 +531,24 @@ async def register_agent(
             )
 
     try:
+        endpoint, agent_card = await _resolve_registration_endpoint(
+            direct_endpoint=request.get_direct_a2a_endpoint(),
+            agent_card_url=request.agent_card_url,
+            agent_card=request.agent_card,
+        )
         # Use AgentService (Clean Architecture)
         agent = await agent_service.register_agent(
             owner=request.owner,
             name=request.name,
-            endpoint=request.endpoint,
+            endpoint=endpoint,
+            a2a_endpoint=endpoint,
             tags=request.tags,
             subnet_ids=subnet_ids,
             description=getattr(request, "description", None),
             metadata=getattr(request, "metadata", {}),
-            agent_card=request.agent_card,
+            agent_card=agent_card,
             communication_policy=request.communication_policy,
+            agent_card_url=request.agent_card_url,
             social_card_url=request.social_card_url,
         )
 
@@ -791,18 +908,26 @@ async def _join_agent_impl(
         if body.wallet_address and "ethereum" not in wallet_addresses:
             wallet_addresses["ethereum"] = body.wallet_address
 
+        endpoint, agent_card = await _resolve_registration_endpoint(
+            direct_endpoint=body.get_direct_a2a_endpoint(),
+            agent_card_url=body.agent_card_url,
+            agent_card=body.agent_card,
+        )
+
         agent, api_key = await agent_service.join_agent(
             name=body.name,
             description=body.description,
             tags=body.tags,
-            endpoint=body.endpoint,
+            endpoint=endpoint,
+            a2a_endpoint=endpoint,
             referrer_id=referrer_id,
-            agent_card=body.agent_card,
+            agent_card=agent_card,
             wallet_addresses=wallet_addresses,
             accepts_payment=body.accepts_payment,
             payment_methods=body.payment_methods,
             token_pricing=body.token_pricing,
             communication_policy=body.communication_policy,
+            agent_card_url=body.agent_card_url,
             social_card_url=getattr(body, "social_card_url", None),
         )
 

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -75,6 +75,7 @@ class AgentService:
         owner: str,
         name: str,
         endpoint: str,
+        a2a_endpoint: str | None = None,
         tags: list[str] | None = None,
         subnet_ids: list[str] | None = None,
         description: str | None = None,
@@ -84,6 +85,7 @@ class AgentService:
         accepts_payment: bool = False,
         payment_methods: list[str] | None = None,
         communication_policy: dict | None = None,
+        agent_card_url: str | None = None,
         social_card_url: str | None = None,
     ) -> Agent:
         """
@@ -95,7 +97,8 @@ class AgentService:
         Args:
             owner: Agent owner identifier
             name: Agent name
-            endpoint: Agent A2A endpoint URL
+            endpoint: Direct Agent A2A JSON-RPC endpoint URL
+            a2a_endpoint: Explicit direct Agent A2A JSON-RPC endpoint URL
             tags: List of capability tag IDs
             subnet_ids: Subnets to join
             description: Agent description
@@ -114,11 +117,14 @@ class AgentService:
             # Update existing agent
             logger.info("update_existing_agent", agent_id=existing_agent.agent_id)
             existing_agent.name = name
+            existing_agent.a2a_endpoint = a2a_endpoint or endpoint
             existing_agent.description = description
             existing_agent.tags = tags or []
             existing_agent.metadata = metadata or {}
             if agent_card is not None:
                 existing_agent.agent_card = agent_card
+            if agent_card_url is not None:
+                existing_agent.agent_card_url = agent_card_url
 
             # Update subnets if provided
             if subnet_ids:
@@ -165,6 +171,7 @@ class AgentService:
             owner=owner,
             name=name,
             endpoint=endpoint,
+            a2a_endpoint=a2a_endpoint or endpoint,
             description=description,
             tags=tags or [],
             subnet_ids=subnet_ids or ["public"],
@@ -174,6 +181,7 @@ class AgentService:
             accepts_payment=accepts_payment,
             payment_methods=payment_methods or [],
             communication_policy=communication_policy,
+            agent_card_url=agent_card_url,
             social_card_url=social_card_url,
         )
 
@@ -470,6 +478,7 @@ class AgentService:
         description: str,
         tags: list[str],
         endpoint: str,
+        a2a_endpoint: str | None = None,
         referrer_id: str | None = None,
         metadata: dict | None = None,
         agent_card: dict | None = None,
@@ -478,6 +487,7 @@ class AgentService:
         payment_methods: list[str] | None = None,
         token_pricing: dict | None = None,
         communication_policy: dict | None = None,
+        agent_card_url: str | None = None,
         social_card_url: str | None = None,
     ) -> tuple[Agent, str]:
         """
@@ -494,7 +504,8 @@ class AgentService:
             name: Agent name
             description: Agent description
             tags: List of capability tag IDs
-            endpoint: A2A endpoint URL (optional for pull mode)
+            endpoint: Direct A2A JSON-RPC endpoint URL
+            a2a_endpoint: Explicit direct A2A JSON-RPC endpoint URL
             referrer_id: ID of agent who referred this one
             metadata: Additional metadata
             agent_card: A2A Agent Card (v0.3.0) to store at registration time
@@ -515,6 +526,7 @@ class AgentService:
             name=name,
             owner=None,  # No owner initially
             endpoint=endpoint,
+            a2a_endpoint=a2a_endpoint or endpoint,
             description=description,
             tags=tags or [],
             subnet_ids=["public"],
@@ -529,6 +541,7 @@ class AgentService:
             payment_methods=payment_methods or [],
             token_pricing=token_pricing,
             communication_policy=communication_policy,
+            agent_card_url=agent_card_url,
             social_card_url=social_card_url,
         )
 

--- a/acn/services/message_service.py
+++ b/acn/services/message_service.py
@@ -7,7 +7,7 @@ Wraps MessageRouter with additional business rules and validation.
 from typing import Any
 
 import structlog  # type: ignore[import-untyped]
-from a2a.types import Message  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import Message  # type: ignore[import-untyped]
 
 from ..core.exceptions import AgentNotFoundException
 from ..core.interfaces import IAgentRepository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "python-multipart>=0.0.9",
     # A2A Protocol - Official SDK
     # https://github.com/a2aproject/A2A
-    "a2a-sdk[http-server]>=0.3.24,<0.3.25,<1.0.0",
+    "a2a-sdk[http-server]>=1.0.2,<2.0.0",
     # AP2 Protocol - Agent Payments Protocol (Google)
     # https://github.com/google-agentic-commerce/AP2
     "ap2 @ git+https://github.com/google-agentic-commerce/AP2.git@61f5de49f47d0517182d664bd05b7df1ff1f4e40",

--- a/tests/infrastructure/test_broadcast_service_policy.py
+++ b/tests/infrastructure/test_broadcast_service_policy.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from a2a.types import Message, Role, TextPart
+from a2a.compat.v0_3.types import Message, Role, TextPart
 
 from acn.core.exceptions import PolicyRejected
 from acn.infrastructure.messaging.broadcast_service import (
@@ -236,7 +236,7 @@ class TestNonDictResultRegression:
     @pytest.mark.asyncio
     async def test_send_message_response_counts_as_success(self):
         """The realistic happy-path: real a2a SDK return type."""
-        from a2a.types import SendMessageResponse
+        from a2a.compat.v0_3.types import SendMessageResponse
 
         # Construct a SendMessageResponse the same way the SDK does
         # for a successful message delivery. The exact body shape
@@ -276,7 +276,7 @@ class TestNonDictResultRegression:
     async def test_send_message_response_alongside_rejected(self):
         """Mixed: real SendMessageResponse for one target, policy
         rejection for another. Counters must bucket each correctly."""
-        from a2a.types import SendMessageResponse
+        from a2a.compat.v0_3.types import SendMessageResponse
 
         real_response = SendMessageResponse(
             root={

--- a/tests/infrastructure/test_broadcast_service_unified_entry.py
+++ b/tests/infrastructure/test_broadcast_service_unified_entry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from a2a.types import Message, Role, TextPart
+from a2a.compat.v0_3.types import Message, Role, TextPart
 
 from acn.core.exceptions import AgentNotFoundException
 from acn.infrastructure.messaging.broadcast_service import (

--- a/tests/infrastructure/test_manifest_dispatcher.py
+++ b/tests/infrastructure/test_manifest_dispatcher.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from a2a.types import (  # type: ignore[import-untyped]
+from a2a.compat.v0_3.types import (  # type: ignore[import-untyped]
     DataPart,
     Message,
     Part,

--- a/tests/infrastructure/test_message_router_a2a_client.py
+++ b/tests/infrastructure/test_message_router_a2a_client.py
@@ -1,0 +1,72 @@
+"""Tests for MessageRouter's a2a-sdk 1.x client bridge."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from acn.infrastructure.messaging import message_router as router_module
+from acn.infrastructure.messaging.message_router import MessageRouter, create_text_message
+
+
+@pytest.mark.asyncio
+async def test_router_uses_registered_endpoint_as_direct_legacy_jsonrpc_target(monkeypatch):
+    """Registered endpoints are direct A2A JSON-RPC URLs, not card discovery roots."""
+    requests: list[httpx.Request] = []
+    real_async_client = httpx.AsyncClient
+
+    async def _safe_resolve_target(_endpoint: str, *, allow_loopback: bool = False) -> None:
+        return None
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = json.loads(request.content)
+        assert payload["method"] == "message/send"
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {
+                    "kind": "message",
+                    "messageId": "reply-1",
+                    "role": "agent",
+                    "parts": [{"kind": "text", "text": "ok"}],
+                },
+            },
+        )
+
+    def _async_client_factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(_handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(router_module, "safe_resolve_target", _safe_resolve_target)
+    monkeypatch.setattr(router_module.httpx, "AsyncClient", _async_client_factory)
+
+    agent_info = MagicMock()
+    agent_info.endpoint = "https://agent.example.com/a2a"
+    agent_info.status = "online"
+    agent_info.communication_policy = {"mode": "open"}
+
+    registry = MagicMock()
+    registry.get_agent = AsyncMock(return_value=agent_info)
+
+    router = MessageRouter(
+        registry=registry,
+        redis_client=AsyncMock(),
+    )
+
+    try:
+        response = await router.route(
+            from_agent="agent-a",
+            to_agent="agent-b",
+            message=create_text_message("hello"),
+        )
+    finally:
+        await router.close()
+
+    assert response.result.message_id == "reply-1"
+    assert [str(request.url) for request in requests] == ["https://agent.example.com/a2a"]

--- a/tests/protocols/test_a2a_handle_routing_policy.py
+++ b/tests/protocols/test_a2a_handle_routing_policy.py
@@ -31,7 +31,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from a2a.types import (
+from a2a.compat.v0_3.types import (
     DataPart,
     Message,
     Role,

--- a/tests/protocols/test_a2a_startup_smoke.py
+++ b/tests/protocols/test_a2a_startup_smoke.py
@@ -1,0 +1,44 @@
+"""Startup smoke tests for the A2A integration.
+
+These intentionally exercise import and route construction rather than
+handler behavior. Railway failures from dependency drift happen before
+the app can serve requests, so this file pins those startup-time edges.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from acn.protocols.a2a.server import create_a2a_app
+
+
+def test_acn_api_imports_with_a2a_sdk_1_x():
+    """Importing the main API must not depend on removed a2a-sdk 0.3 symbols."""
+    module = importlib.import_module("acn.api")
+
+    assert hasattr(module, "app")
+
+
+def test_create_a2a_app_mounts_agent_card_and_jsonrpc_routes():
+    app = create_a2a_app(
+        registry=MagicMock(),
+        router=MagicMock(),
+        broadcast=MagicMock(),
+        subnet_manager=MagicMock(),
+        redis=MagicMock(),
+        metrics=None,
+    )
+
+    route_paths = {getattr(route, "path", "") for route in app.routes}
+    assert "/.well-known/agent-card.json" in route_paths
+    assert "/jsonrpc" in route_paths
+
+    response = TestClient(app).get("/.well-known/agent-card.json")
+
+    assert response.status_code == 200
+    card = response.json()
+    assert card["name"] == "ACN Infrastructure Agent"
+    assert card["skills"]

--- a/tests/routes/test_a2a_endpoint_schema.py
+++ b/tests/routes/test_a2a_endpoint_schema.py
@@ -1,10 +1,15 @@
 """Regression tests for A2A discovery vs direct delivery URL semantics."""
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from acn.models import AgentRegisterRequest
-from acn.routes.registry import AgentJoinRequest, _extract_jsonrpc_endpoint_from_agent_card
+from acn.routes.registry import (
+    AgentJoinRequest,
+    _extract_jsonrpc_endpoint_from_agent_card,
+    _resolve_registration_endpoint,
+)
 
 
 def test_register_request_accepts_explicit_a2a_endpoint_without_legacy_endpoint():
@@ -58,3 +63,15 @@ def test_extract_jsonrpc_endpoint_falls_back_to_legacy_card_url():
         _extract_jsonrpc_endpoint_from_agent_card({"url": "https://agent.example.com/a2a"})
         == "https://agent.example.com/a2a"
     )
+
+
+@pytest.mark.asyncio
+async def test_resolved_agent_card_endpoint_is_registration_validated():
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_registration_endpoint(
+            direct_endpoint=None,
+            agent_card_url=None,
+            agent_card={"url": "ftp://agent.example.com/a2a"},
+        )
+
+    assert exc_info.value.status_code == 400

--- a/tests/routes/test_a2a_endpoint_schema.py
+++ b/tests/routes/test_a2a_endpoint_schema.py
@@ -1,0 +1,60 @@
+"""Regression tests for A2A discovery vs direct delivery URL semantics."""
+
+import pytest
+from pydantic import ValidationError
+
+from acn.models import AgentRegisterRequest
+from acn.routes.registry import AgentJoinRequest, _extract_jsonrpc_endpoint_from_agent_card
+
+
+def test_register_request_accepts_explicit_a2a_endpoint_without_legacy_endpoint():
+    request = AgentRegisterRequest(
+        owner="user-1",
+        name="Agent",
+        a2a_endpoint="https://agent.example.com/a2a",
+    )
+
+    assert request.endpoint is None
+    assert request.get_direct_a2a_endpoint() == "https://agent.example.com/a2a"
+
+
+def test_join_request_accepts_agent_card_url_as_discovery_only_input():
+    request = AgentJoinRequest(
+        name="Discovery Agent",
+        description="An agent that publishes an Agent Card",
+        agent_card_url="https://agent.example.com/.well-known/agent-card.json",
+    )
+
+    assert request.get_direct_a2a_endpoint() is None
+    assert request.agent_card_url == "https://agent.example.com/.well-known/agent-card.json"
+
+
+def test_register_request_still_requires_delivery_or_discovery_url():
+    with pytest.raises(ValidationError):
+        AgentRegisterRequest(owner="user-1", name="Agent")
+
+
+def test_extract_jsonrpc_endpoint_prefers_supported_interfaces():
+    card = {
+        "name": "Agent",
+        "url": "https://legacy.example.com/a2a",
+        "supportedInterfaces": [
+            {
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "0.3.0",
+                "url": "https://agent.example.com/a2a/jsonrpc",
+            }
+        ],
+    }
+
+    assert (
+        _extract_jsonrpc_endpoint_from_agent_card(card)
+        == "https://agent.example.com/a2a/jsonrpc"
+    )
+
+
+def test_extract_jsonrpc_endpoint_falls_back_to_legacy_card_url():
+    assert (
+        _extract_jsonrpc_endpoint_from_agent_card({"url": "https://agent.example.com/a2a"})
+        == "https://agent.example.com/a2a"
+    )

--- a/tests/routes/test_agent_card_url_sanitize.py
+++ b/tests/routes/test_agent_card_url_sanitize.py
@@ -45,8 +45,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from acn.api import app
+from acn.core.entities.agent import Agent
 from acn.core.exceptions import AgentNotFoundException
 from acn.routes.dependencies import get_agent_service, limiter
+from acn.routes.registry import _agent_entity_to_info
 
 
 @pytest.fixture(autouse=True)
@@ -111,6 +113,33 @@ def _proxy_url(agent_id: str) -> str:
 
     base_url = settings.gateway_base_url or f"http://localhost:{settings.port}"
     return f"{base_url}/api/v1/agents/{agent_id}"
+
+
+def test_public_agent_info_rewrites_card_url_and_omits_raw_card():
+    agent = Agent(
+        agent_id="agent-target",
+        name="Target",
+        owner="user-1",
+        endpoint="https://real-backend.example.com:9443/a2a",
+        agent_card_url="https://real-backend.example.com/.well-known/agent-card.json",
+        agent_card={
+            "name": "Target",
+            "url": "https://real-backend.example.com:9443/a2a",
+            "supportedInterfaces": [
+                {
+                    "protocolBinding": "JSONRPC",
+                    "url": "https://real-backend.example.com:9443/a2a",
+                }
+            ],
+        },
+    )
+
+    info = _agent_entity_to_info(agent, strip_sensitive=True)
+
+    assert info.endpoint == _proxy_url("agent-target")
+    assert info.a2a_endpoint == _proxy_url("agent-target")
+    assert info.agent_card_url == f"{_proxy_url('agent-target')}/.well-known/agent-card.json"
+    assert info.agent_card is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/services/test_message_service_system_sender.py
+++ b/tests/services/test_message_service_system_sender.py
@@ -13,7 +13,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from a2a.types import Message, TextPart
+from a2a.compat.v0_3.types import Message, TextPart
 
 from acn.services.message_service import MessageService
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,23 +8,26 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.24"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "culsans", marker = "python_full_version < '3.13'" },
     { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
     { name = "httpx" },
     { name = "httpx-sse" },
+    { name = "json-rpc" },
+    { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/76/cefa956fb2d3911cb91552a1da8ce2dbb339f1759cb475e2982f0ae2332b/a2a_sdk-0.3.24.tar.gz", hash = "sha256:3581e6e8a854cd725808f5732f90b7978e661b6d4e227a4755a8f063a3c1599d", size = 255550 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/f3/1c312eae0298542eef1a096be378a3ad2d20b171ea0ac6be26b81f542720/a2a_sdk-1.0.2.tar.gz", hash = "sha256:e4ee4dd509894c32c9a6df728319875fa4f049e70ae82476fa447353e3a4b648", size = 375193 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/6e/cae5f0caea527b39c0abd7204d9416768764573c76649ca03cc345a372be/a2a_sdk-0.3.24-py3-none-any.whl", hash = "sha256:7b248767096bb55311f57deebf6b767349388d94c1b376c60cb8f6b715e053f6", size = 145752 },
+    { url = "https://files.pythonhosted.org/packages/c9/03/58c92a44e7b94a42614880df2365f074969e47067c4c736e31e855aca2fd/a2a_sdk-1.0.2-py3-none-any.whl", hash = "sha256:4dbc083b6808ee28207ac6daad263360f87612c37b2d06f5521efb530318141c", size = 234302 },
 ]
 
 [package.optional-dependencies]
 http-server = [
-    { name = "fastapi" },
     { name = "sse-starlette" },
     { name = "starlette" },
 ]
@@ -68,7 +71,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.24,<0.3.25,<1.0.0" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=1.0.2,<2.0.0" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "ap2", git = "https://github.com/google-agentic-commerce/AP2.git?rev=61f5de49f47d0517182d664bd05b7df1ff1f4e40" },
     { name = "asyncpg", specifier = ">=0.29" },
@@ -206,6 +209,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/5f/24155e30ba7f8c96918af1350eb0663e2430aad9e001c0489d89cd708ab1/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa", size = 1769801 },
     { url = "https://files.pythonhosted.org/packages/eb/f8/7314031ff5c10e6ece114da79b338ec17eeff3a079e53151f7e9f43c4723/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767", size = 466523 },
     { url = "https://files.pythonhosted.org/packages/b4/63/278a98c715ae467624eafe375542d8ba9b4383a016df8fdefe0ae28382a7/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344", size = 499694 },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/13/50b91a3ea6b030d280d2654be97c48b6ed81753a50286ee43c646ba36d3c/aiologic-0.16.0.tar.gz", hash = "sha256:c267ccbd3ff417ec93e78d28d4d577ccca115d5797cdbd16785a551d9658858f", size = 225952 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/27/206615942005471499f6fbc36621582e24d0686f33c74b2d018fcfd4fe67/aiologic-0.16.0-py3-none-any.whl", hash = "sha256:e00ce5f68c5607c864d26aec99c0a33a83bdf8237aa7312ffbb96805af67d8b6", size = 135193 },
 ]
 
 [[package]]
@@ -855,6 +872,19 @@ wheels = [
 ]
 
 [[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811 },
+]
+
+[[package]]
 name = "cytoolz"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1474,6 +1504,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450 },
 ]
 
 [[package]]
@@ -2640,6 +2679,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade ACN to `a2a-sdk` 1.x and bridge SDK boundary changes with the v0.3 compatibility models used internally.
- Replace removed A2A server/client APIs with the 1.x route/client factory APIs while preserving existing direct JSON-RPC endpoint delivery.
- Split registration semantics for `a2a_endpoint` vs `agent_card_url`, keep legacy `endpoint` compatible, and add smoke/regression coverage.

## Test plan
- `uv run ruff check acn/models.py acn/routes/registry.py acn/core/entities/agent.py acn/services/agent_service.py acn/infrastructure/persistence/redis/agent_repository.py acn/infrastructure/persistence/postgres/agent_repository.py acn/infrastructure/messaging/message_router.py tests/routes/test_a2a_endpoint_schema.py`
- `uv run pytest tests/routes/test_a2a_endpoint_schema.py tests/infrastructure/test_message_router_a2a_client.py tests/services/test_agent_service.py`
- `uv run pytest`