### PR TITLE
Prepare v0.6.1 client release surface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,41 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ===========================================
+  # Publish CLI to npm
+  # ===========================================
+  publish-cli:
+    name: Publish CLI
+    runs-on: ubuntu-latest
+    needs: [test]
+    environment: release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: |
+          cd clients/cli
+          npm ci
+
+      - name: Build
+        run: |
+          cd clients/cli
+          npm run build
+
+      - name: Publish to npm
+        run: |
+          cd clients/cli
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ===========================================
   # Docker Image
   # ===========================================
   docker:
@@ -144,7 +179,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [publish-python, publish-npm, docker]
+    needs: [publish-python, publish-npm, publish-cli, docker]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-07
+
+### Added
+
+- **Release workflow now publishes `acn-cli` to npm** alongside the Python SDK, TypeScript SDK, Docker image, and GitHub Release.
+- **CLI three-layer communication surface**:
+  - `acn message notify` for Notify-only sends with optional `attention_fee`, TTL, and self-hosted `content_url`.
+  - `acn notify` for manifest queue receive-side operations (`list`, `pull`, `ack`, `delete`).
+  - `acn inbox mode` and `acn inbox allowlist` for reception policy and trusted senders.
+  - `acn session` for real-time session invitations and lifecycle operations.
+
+### Changed
+
+- Bumped ACN core, Python SDK, TypeScript SDK, and CLI package versions to `0.6.1` for a coordinated patch release.
+- Updated Python, TypeScript, and CLI client docs to reflect the three-layer communication model.
+
+### Fixed
+
+- `_payload_to_a2a_message` now preserves proper A2A envelopes and clean `{ "text": "..." }` payloads instead of wrapping every request body with `str(payload)`.
+- `acn notify pull` now follows `next_cursor` by default so ACN-hosted content larger than 16 KB is not silently truncated.
+- `acn notify list` exposes the backend's `message_type` filter.
+- `acn message notify --type` now includes the full backend-supported set, including `session_invite`.
+
 ## [0.5.0] - 2026-03-10
 
 ### Breaking Changes

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-cli",
-  "version": "0.1.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-cli",
-      "version": "0.1.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-cli",
-  "version": "0.1.0",
+  "version": "0.6.1",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `acn-client` are documented here.
 
+## [0.6.1] - 2026-05-07
+
+### Added
+- Manifest/Notify-layer client methods are documented in the README:
+  `manifest_send`, `list_manifest`, `fetch_manifest_content`,
+  `ack_manifest`, `delete_manifest`, and `get_communication_profile`.
+- Session-layer client methods are documented in the README:
+  `invite_session`, `accept_session`, `reject_session`, `close_session`,
+  and `list_pending_sessions`.
+
+### Changed
+- Bumped package version to `0.6.1` for the coordinated ACN patch release.
+- README now describes the three-layer communication surface and uses
+  `broadcast_by_tag` instead of the deprecated `broadcast_by_skill`.
+
 ## [0.4.0] - 2026-03-02
 
 ### Added

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -109,10 +109,26 @@ ACNClient(
 
 | Method | Description |
 |--------|-------------|
-| `send_message(request)` | Send message to agent |
+| `send_message(request)` | Send an async message; gateway routes by recipient policy |
+| `manifest_send(request)` | Send Notify-only metadata with optional `attention_fee` / `content_url` |
 | `broadcast(request)` | Broadcast to multiple agents |
-| `broadcast_by_skill(...)` | Broadcast by skill |
-| `get_message_history(agent_id, consume=False, ...)` | Get offline inbox (pending messages); set `consume=True` to clear after read |
+| `broadcast_by_tag(from_agent, tags, message, ...)` | Broadcast to agents matching all tags |
+| `get_message_history(agent_id, consume=False, ...)` | Get offline direct-delivery inbox; set `consume=True` to clear after read |
+| `list_manifest(agent_id, ...)` | List Notify-layer manifest queue entries; supports `message_type` filter |
+| `fetch_manifest_content(mid, cursor=None)` | Pull manifest content; pass `next_cursor` to page ACN-hosted payloads |
+| `ack_manifest(agent_id, mid)` | Ack a paid notification and release `attention_fee` |
+| `delete_manifest(agent_id, mid)` | Reject/delete a notification and refund any locked `attention_fee` |
+| `get_communication_profile(agent_id)` | Read a target agent's public communication mode |
+
+#### Session Methods
+
+| Method | Description |
+|--------|-------------|
+| `invite_session(target_agent_id, ...)` | Invite an agent to a real-time session |
+| `accept_session(session_id)` | Accept a pending session invitation |
+| `reject_session(session_id)` | Reject a pending session invitation |
+| `close_session(session_id)` | Close a session |
+| `list_pending_sessions()` | List invitations addressed to the authenticated agent |
 
 #### Payment Methods
 

--- a/clients/python/acn_client/__init__.py
+++ b/clients/python/acn_client/__init__.py
@@ -44,7 +44,7 @@ from .models import (
 )
 from .realtime import ACNRealtime, ACNRealtimeOptions, AuthMode, WSState
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = [
     # Client
     "ACNClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "MIT"

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,15 +1,15 @@
-# @acn/client
+# acn-client
 
 Official TypeScript/JavaScript client for [ACN (Agent Collaboration Network)](https://github.com/acnlabs/ACN).
 
 ## Installation
 
 ```bash
-npm install @acn/client
+npm install acn-client
 # or
-yarn add @acn/client
+yarn add acn-client
 # or
-pnpm add @acn/client
+pnpm add acn-client
 ```
 
 ## Quick Start
@@ -17,7 +17,7 @@ pnpm add @acn/client
 ### HTTP Client
 
 ```typescript
-import { ACNClient } from '@acn/client';
+import { ACNClient } from 'acn-client';
 
 const client = new ACNClient('http://localhost:9000');
 
@@ -37,7 +37,7 @@ console.log('Skills:', skills);
 ### Real-time WebSocket
 
 ```typescript
-import { ACNRealtime } from '@acn/client';
+import { ACNRealtime } from 'acn-client';
 
 const realtime = new ACNRealtime('ws://localhost:9000');
 
@@ -66,7 +66,7 @@ realtime.disconnect();
 ### Simple Subscription Helper
 
 ```typescript
-import { subscribeToACN } from '@acn/client';
+import { subscribeToACN } from 'acn-client';
 
 const unsubscribe = subscribeToACN('ws://localhost:9000', 'agents', (msg) => {
   console.log('Agent event:', msg);
@@ -121,10 +121,26 @@ Options:
 
 | Method | Description |
 |--------|-------------|
-| `sendMessage(request)` | Send message to agent |
+| `sendMessage(request)` | Send an async message; gateway routes by recipient policy |
+| `manifestSend(request)` | Send Notify-only metadata with optional `attention_fee` / `content_url` |
 | `broadcast(request)` | Broadcast to multiple agents |
-| `broadcastBySkill(request)` | Broadcast by skill |
-| `getMessageHistory(agentId, options?)` | Get offline inbox (pending messages); pass `{ consume: true }` to clear after read |
+| `broadcastByTag(request)` | Broadcast to agents matching all tags |
+| `getMessageHistory(agentId, options?)` | Get offline direct-delivery inbox; pass `{ consume: true }` to clear after read |
+| `listManifest(agentId, options?)` | List Notify-layer manifest queue entries; supports `messageType` filter |
+| `fetchManifestContent(mid, cursor?)` | Pull manifest content; pass `next_cursor` to page ACN-hosted payloads |
+| `ackManifest(agentId, mid)` | Ack a paid notification and release `attention_fee` |
+| `deleteManifest(agentId, mid)` | Reject/delete a notification and refund any locked `attention_fee` |
+| `getCommunicationProfile(agentId)` | Read a target agent's public communication mode |
+
+#### Session Methods
+
+| Method | Description |
+|--------|-------------|
+| `inviteSession(targetAgentId, request?)` | Invite an agent to a real-time session |
+| `acceptSession(sessionId)` | Accept a pending session invitation |
+| `rejectSession(sessionId)` | Reject a pending session invitation |
+| `closeSession(sessionId)` | Close a session |
+| `listPendingSessions()` | List invitations addressed to the authenticated agent |
 
 #### Payment Methods
 

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@acn/client",
-  "version": "0.2.0",
+  "name": "acn-client",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@acn/client",
-      "version": "0.2.0",
+      "name": "acn-client",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -65,4 +65,3 @@
     "node": ">=18.0.0"
   }
 }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.6.0"
+version = "0.6.1"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary

Prepares a coordinated `v0.6.1` patch release after #21 by aligning published package versions, release automation, and client-facing docs.

- Bump ACN core, Python SDK, TypeScript SDK, and CLI package metadata to `0.6.1`.
- Add `publish-cli` to the release workflow so `acn-cli` is published to npm alongside Python SDK, TypeScript SDK, Docker, and GitHub Release.
- Update Python and TypeScript README communication method tables for the three-layer model: `message`/manifest, `notify` receive queue, offline inbox, and sessions.
- Update root and Python SDK changelogs for the release.
- Sync TypeScript package-lock package name/version with `package.json` (`acn-client@0.6.1`).

## Why

#21 changed both the runtime communication behaviour and the CLI surface. The existing `v0.6.0` release predates that merge, and the release workflow did not publish the CLI package at all, so `npx acn-cli` users would not receive the new `message` / `notify` / `inbox` / `session` commands.

## Test plan

- [x] `clients/cli`: `npm ci && npm run build`
- [x] `clients/typescript`: `npm ci && npm run build`
- [x] `clients/python`: `uv lock --check`, `ruff check`, `pytest`, and `uv build`
- [x] Searched for stale `0.6.0`, `@acn/client`, and deprecated `broadcastBySkill(request)` / `broadcast_by_skill(...)` README references


Made with [Cursor](https://cursor.com)