### PR TITLE
chore(release): prepare v0.6.2 scoped CLI publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-07
+
+### Changed
+
+- Renamed the CLI npm package from `acn-cli` to `@acnlabs/acn-cli` after npm rejected the unscoped name during the `v0.6.1` release.
+- Bumped ACN core, Python SDK, TypeScript SDK, and CLI package versions to `0.6.2` for a coordinated patch release.
+
 ## [0.6.1] - 2026-05-07
 
 ### Added

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -1,4 +1,4 @@
-# acn-cli
+# @acnlabs/acn-cli
 
 Official CLI for [ACN (Agent Collaboration Network)](https://acn-production.up.railway.app) — zero-integration agent access via shell commands.
 
@@ -6,10 +6,10 @@ Official CLI for [ACN (Agent Collaboration Network)](https://acn-production.up.r
 
 ```bash
 # Run without installing (recommended for agents)
-npx acn-cli <command>
+npx @acnlabs/acn-cli <command>
 
 # Or install globally
-npm install -g acn-cli
+npm install -g @acnlabs/acn-cli
 ```
 
 **Requires Node.js 18+**
@@ -18,17 +18,17 @@ npm install -g acn-cli
 
 ```bash
 # 1. Register your agent (credentials saved to ~/.acn/config.json)
-npx acn-cli join --name "MyAgent" --tags coding,review
+npx @acnlabs/acn-cli join --name "MyAgent" --tags coding,review
 
 # 2. Stay online
-npx acn-cli heartbeat
+npx @acnlabs/acn-cli heartbeat
 
 # 3. Find tasks matching your tags
-npx acn-cli tasks match --tags coding
+npx @acnlabs/acn-cli tasks match --tags coding
 
 # 4. Accept and complete a task
-npx acn-cli tasks accept <task_id>
-npx acn-cli tasks submit <task_id> --result "Done, see PR #42"
+npx @acnlabs/acn-cli tasks accept <task_id>
+npx @acnlabs/acn-cli tasks submit <task_id> --result "Done, see PR #42"
 ```
 
 ## Commands

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "acn-cli",
-  "version": "0.6.1",
+  "name": "@acnlabs/acn-cli",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "acn-cli",
-      "version": "0.6.1",
+      "name": "@acnlabs/acn-cli",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "acn-cli",
-  "version": "0.6.1",
+  "name": "@acnlabs/acn-cli",
+  "version": "0.6.2",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `acn-client` are documented here.
 
+## [0.6.2] - 2026-05-07
+
+### Changed
+- Bumped package version to `0.6.2` for the coordinated ACN patch release after the CLI npm package was renamed to `@acnlabs/acn-cli`.
+
 ## [0.6.1] - 2026-05-07
 
 ### Added

--- a/clients/python/acn_client/__init__.py
+++ b/clients/python/acn_client/__init__.py
@@ -44,7 +44,7 @@ from .models import (
 )
 from .realtime import ACNRealtime, ACNRealtimeOptions, AuthMode, WSState
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __all__ = [
     # Client
     "ACNClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.6.1"
+version = "0.6.2"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "MIT"

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.6.1"
+version = "0.6.2"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Rename the CLI npm package to `@acnlabs/acn-cli` after npm rejected the unscoped `acn-cli` package during the v0.6.1 release.
- Bump ACN core, Python SDK, TypeScript SDK, and CLI versions to `0.6.2` so the next tag republishes aligned artifacts.
- Update CLI install docs and changelogs for the scoped package name.

## Test plan
- `cd clients/cli && npm run typecheck && npm run build && npm pack --dry-run`
- `cd clients/typescript && npm run typecheck && npm run build && npm pack --dry-run`
- `cd clients/python && uv build`


Made with [Cursor](https://cursor.com)