### PR TITLE
feat(clients): add follow, policy, and allowlist APIs to all three clients

### DIFF
--- a/clients/cli/src/commands/follow.ts
+++ b/clients/cli/src/commands/follow.ts
@@ -145,5 +145,22 @@ export function followCommand(): Command {
       }
     });
 
+  cmd
+    .command('check <target_id>')
+    .description('Check whether you are following a specific agent')
+    .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
+    .action(async (targetId: string, opts: { agentId?: string }) => {
+      const agentId = opts.agentId ?? requireAgentId();
+      try {
+        const res = await acnGet<FollowActionResponse>(
+          `/agents/${agentId}/follows/${targetId}`
+        );
+        const label = res.following ? 'Following' : 'Not following';
+        output(res, `${label} ${targetId}`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
   return cmd;
 }

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -1466,14 +1466,14 @@ class ACNClient:
             offset: Pagination offset.
 
         Returns:
-            List of ``{ target_id, reason?, added_at }`` dicts.
+            List of ``{ target_id, reason?, created_at }`` dicts.
         """
         data = await self._request(
             "GET",
             f"/api/v1/agents/{agent_id}/allowlist",
             params={"limit": limit, "offset": offset},
         )
-        entries: list[dict[str, Any]] = data.get("allowlist", [])
+        entries: list[dict[str, Any]] = data.get("entries", [])
         return entries
 
     # -------------------------------------------------------------------------

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -1267,6 +1267,215 @@ class ACNClient:
             raise ACNError(response.status_code, msg)
         return TaskInfo.model_validate(response.json())
 
+    # ============================================
+    # Social Graph (Follow)
+    # ============================================
+
+    async def follow(self, agent_id: str, target_id: str) -> dict[str, Any]:
+        """Follow another agent.
+
+        Idempotent — re-following an already-followed agent returns 200
+        with ``changed=False``.
+
+        Args:
+            agent_id: The follower (must match the authenticated agent's ID).
+            target_id: The agent to follow.
+
+        Returns:
+            ``{ follower_id, followee_id, following, changed }``
+        """
+        return await self._request(
+            "POST", f"/api/v1/agents/{agent_id}/follows/{target_id}"
+        )
+
+    async def unfollow(self, agent_id: str, target_id: str) -> dict[str, Any]:
+        """Unfollow an agent.
+
+        Idempotent — unfollowing someone you don't follow returns 200
+        with ``changed=False``.
+
+        Args:
+            agent_id: The follower (must match the authenticated agent's ID).
+            target_id: The agent to unfollow.
+
+        Returns:
+            ``{ follower_id, followee_id, following, changed }``
+        """
+        return await self._request(
+            "DELETE", f"/api/v1/agents/{agent_id}/follows/{target_id}"
+        )
+
+    async def check_follow(self, agent_id: str, target_id: str) -> dict[str, Any]:
+        """Check whether ``agent_id`` is following ``target_id`` (public).
+
+        Returns:
+            ``{ follower_id, followee_id, following }``
+        """
+        return await self._request(
+            "GET", f"/api/v1/agents/{agent_id}/follows/{target_id}"
+        )
+
+    async def list_follows(
+        self,
+        agent_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AgentInfo]:
+        """List agents that ``agent_id`` follows (public).
+
+        Args:
+            agent_id: Agent whose following list to fetch.
+            limit: Max entries per page (server cap 500).
+            offset: Pagination offset.
+        """
+        data = await self._request(
+            "GET",
+            f"/api/v1/agents/{agent_id}/follows",
+            params={"limit": limit, "offset": offset},
+        )
+        return [AgentInfo.model_validate(a) for a in data.get("agents", [])]
+
+    async def list_followers(
+        self,
+        agent_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AgentInfo]:
+        """List agents that follow ``agent_id`` (public).
+
+        Args:
+            agent_id: Agent whose followers to fetch.
+            limit: Max entries per page (server cap 500).
+            offset: Pagination offset.
+        """
+        data = await self._request(
+            "GET",
+            f"/api/v1/agents/{agent_id}/followers",
+            params={"limit": limit, "offset": offset},
+        )
+        return [AgentInfo.model_validate(a) for a in data.get("agents", [])]
+
+    # ============================================
+    # Communication Policy
+    # ============================================
+
+    async def get_policy(self, agent_id: str) -> dict[str, Any]:
+        """Get the current communication policy for the authenticated agent.
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+
+        Returns:
+            ``{ agent_id, communication_policy: { mode, reject_reason? } }``
+        """
+        return await self._request("GET", f"/api/v1/agents/{agent_id}/policy")
+
+    async def update_policy(
+        self,
+        agent_id: str,
+        mode: str,
+        *,
+        reject_reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Update the agent's inbound communication policy.
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+            mode: ``'open'`` | ``'closed'`` | ``'manifest'`` | ``'allowlist'``
+            reject_reason: Optional message shown to rejected senders
+                (only meaningful when ``mode='closed'``).
+
+        Returns:
+            ``{ agent_id, communication_policy: { mode, reject_reason? } }``
+        """
+        policy: dict[str, Any] = {"mode": mode}
+        if reject_reason is not None:
+            policy["reject_reason"] = reject_reason
+        return await self._request(
+            "PATCH",
+            f"/api/v1/agents/{agent_id}/policy",
+            json={"communication_policy": policy},
+        )
+
+    # ============================================
+    # Allowlist
+    # ============================================
+
+    async def add_to_allowlist(
+        self,
+        agent_id: str,
+        target_id: str,
+        *,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Add an agent to the allowlist (owner only).
+
+        Only effective when ``communication_policy.mode = 'allowlist'``.
+        Idempotent — re-adding returns ``changed=False``.
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+            target_id: Agent to trust.
+            reason: Optional free-form note (≤ 200 chars).
+
+        Returns:
+            ``{ agent_id, target_id, allowlisted, changed }``
+        """
+        body: dict[str, Any] = {}
+        if reason is not None:
+            body["reason"] = reason
+        return await self._request(
+            "POST",
+            f"/api/v1/agents/{agent_id}/allowlist/{target_id}",
+            json=body or None,
+        )
+
+    async def remove_from_allowlist(
+        self, agent_id: str, target_id: str
+    ) -> dict[str, Any]:
+        """Remove an agent from the allowlist (owner only).
+
+        Idempotent — removing a non-member returns ``changed=False``.
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+            target_id: Agent to remove.
+
+        Returns:
+            ``{ agent_id, target_id, allowlisted, changed }``
+        """
+        return await self._request(
+            "DELETE",
+            f"/api/v1/agents/{agent_id}/allowlist/{target_id}",
+        )
+
+    async def list_allowlist(
+        self,
+        agent_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List the agent's allowlist (owner only).
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+            limit: Max entries per page (server cap 500).
+            offset: Pagination offset.
+
+        Returns:
+            List of ``{ target_id, reason?, added_at }`` dicts.
+        """
+        data = await self._request(
+            "GET",
+            f"/api/v1/agents/{agent_id}/allowlist",
+            params={"limit": limit, "offset": offset},
+        )
+        entries: list[dict[str, Any]] = data.get("allowlist", [])
+        return entries
+
     # -------------------------------------------------------------------------
     # ERC-8004 On-Chain Identity
     # -------------------------------------------------------------------------

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -15,13 +15,19 @@ import type {
   AgentSearchResponse,
   AgentAnalytics,
   AgentActivity,
+  AllowlistActionResponse,
+  AllowlistListResponse,
   AuditEvent,
   AuditQueryOptions,
   BroadcastBySkillRequest,
   BroadcastByTagRequest,
   BroadcastRequest,
+  CommunicationPolicyMode,
+  CommunicationPolicyResponse,
   CommunicationProfile,
   DashboardData,
+  FollowActionResponse,
+  FollowCheckResponse,
   ManifestContentResponse,
   ManifestListResponse,
   ManifestMessageType,
@@ -117,8 +123,42 @@ export class ACNClient {
       });
 
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ message: response.statusText }));
-        throw new ACNError(response.status, error.detail || error.message || 'Request failed');
+        let body: Record<string, unknown> = {};
+        try {
+          const parsed = await response.json();
+          if (parsed && typeof parsed === 'object') body = parsed as Record<string, unknown>;
+        } catch { /* non-JSON body */ }
+
+        // Derive human-readable message
+        let message: string;
+        const rawDetail = body.detail;
+        if (typeof rawDetail === 'string') {
+          message = rawDetail;
+        } else if (Array.isArray(rawDetail) && rawDetail.length > 0) {
+          // FastAPI 422 validation list
+          message = rawDetail
+            .slice(0, 5)
+            .map((item: unknown) => {
+              if (item && typeof item === 'object') {
+                const i = item as Record<string, unknown>;
+                const loc = Array.isArray(i.loc) ? (i.loc as unknown[]).slice(1).join('.') : '';
+                const msg = String(i.msg ?? i.type ?? item);
+                return loc ? `${loc}: ${msg}` : msg;
+              }
+              return String(item);
+            })
+            .join('; ');
+        } else {
+          message = String(body.message ?? response.statusText ?? `HTTP ${response.status}`);
+        }
+
+        const errorCode = typeof body.error === 'string' ? body.error : undefined;
+        const requestId =
+          typeof body.request_id === 'string'
+            ? body.request_id
+            : (response.headers.get('X-Request-ID') ?? undefined);
+
+        throw new ACNError(response.status, message, { errorCode, requestId });
       }
 
       if (response.status === 204) {
@@ -793,18 +833,162 @@ export class ACNClient {
   async getAuditStats(options?: { start_time?: string; end_time?: string }): Promise<Record<string, unknown>> {
     return this.get('/api/v1/audit/stats', options);
   }
+
+  // ============================================
+  // Social Graph (Follow)
+  // ============================================
+
+  /**
+   * Follow another agent.
+   *
+   * Idempotent — re-following returns `changed: false`.
+   * @param agentId   The follower (must match the authenticated agent).
+   * @param targetId  The agent to follow.
+   */
+  async follow(agentId: string, targetId: string): Promise<FollowActionResponse> {
+    return this.post(`/api/v1/agents/${agentId}/follows/${targetId}`);
+  }
+
+  /**
+   * Unfollow an agent.
+   *
+   * Idempotent — unfollowing a non-followed agent returns `changed: false`.
+   * @param agentId   The follower (must match the authenticated agent).
+   * @param targetId  The agent to unfollow.
+   */
+  async unfollow(agentId: string, targetId: string): Promise<FollowActionResponse> {
+    return this.delete(`/api/v1/agents/${agentId}/follows/${targetId}`);
+  }
+
+  /**
+   * Check whether `agentId` is following `targetId` (public endpoint).
+   */
+  async checkFollow(agentId: string, targetId: string): Promise<FollowCheckResponse> {
+    return this.get(`/api/v1/agents/${agentId}/follows/${targetId}`);
+  }
+
+  /**
+   * List agents that `agentId` follows (public endpoint).
+   */
+  async listFollows(
+    agentId: string,
+    options?: { limit?: number; offset?: number }
+  ): Promise<AgentSearchResponse> {
+    return this.get(`/api/v1/agents/${agentId}/follows`, options);
+  }
+
+  /**
+   * List agents that follow `agentId` (public endpoint).
+   */
+  async listFollowers(
+    agentId: string,
+    options?: { limit?: number; offset?: number }
+  ): Promise<AgentSearchResponse> {
+    return this.get(`/api/v1/agents/${agentId}/followers`, options);
+  }
+
+  // ============================================
+  // Communication Policy
+  // ============================================
+
+  /**
+   * Get the authenticated agent's current communication policy (owner only).
+   */
+  async getPolicy(agentId: string): Promise<CommunicationPolicyResponse> {
+    return this.get(`/api/v1/agents/${agentId}/policy`);
+  }
+
+  /**
+   * Update the agent's inbound communication policy (owner only).
+   *
+   * @param agentId       Must match the authenticated agent.
+   * @param mode          `open` | `closed` | `manifest` | `allowlist`
+   * @param rejectReason  Optional message shown to rejected senders (closed mode).
+   */
+  async updatePolicy(
+    agentId: string,
+    mode: CommunicationPolicyMode,
+    rejectReason?: string
+  ): Promise<CommunicationPolicyResponse> {
+    const policy: Record<string, unknown> = { mode };
+    if (rejectReason !== undefined) policy.reject_reason = rejectReason;
+    return this.request('PATCH', `/api/v1/agents/${agentId}/policy`, {
+      body: { communication_policy: policy },
+    });
+  }
+
+  // ============================================
+  // Allowlist
+  // ============================================
+
+  /**
+   * Add an agent to the allowlist (owner only).
+   *
+   * Only effective when `communication_policy.mode = 'allowlist'`.
+   * Idempotent — re-adding returns `changed: false`.
+   *
+   * @param agentId   Must match the authenticated agent.
+   * @param targetId  Agent to trust.
+   * @param reason    Optional free-form note (≤ 200 chars).
+   */
+  async addToAllowlist(
+    agentId: string,
+    targetId: string,
+    reason?: string
+  ): Promise<AllowlistActionResponse> {
+    return this.post(
+      `/api/v1/agents/${agentId}/allowlist/${targetId}`,
+      reason !== undefined ? { reason } : undefined
+    );
+  }
+
+  /**
+   * Remove an agent from the allowlist (owner only).
+   *
+   * Idempotent — removing a non-member returns `changed: false`.
+   */
+  async removeFromAllowlist(agentId: string, targetId: string): Promise<AllowlistActionResponse> {
+    return this.delete(`/api/v1/agents/${agentId}/allowlist/${targetId}`);
+  }
+
+  /**
+   * List the authenticated agent's allowlist (owner only).
+   */
+  async listAllowlist(
+    agentId: string,
+    options?: { limit?: number; offset?: number }
+  ): Promise<AllowlistListResponse> {
+    return this.get(`/api/v1/agents/${agentId}/allowlist`, options);
+  }
 }
 
 /**
  * ACN API Error
+ *
+ * Three body shapes are normalised here:
+ * - 4xx with string detail   → `{ detail: "..." }`
+ * - 422 validation (FastAPI) → `{ detail: [{loc, msg, type}, ...] }`
+ * - 5xx sanitised (H4)       → `{ error: "...", message: "...", request_id: "..." }`
+ *
+ * `errorCode` and `requestId` mirror the Python SDK's ACNError so
+ * callers can branch on the error code and quote request_id in support
+ * tickets without extra parsing.
  */
 export class ACNError extends Error {
+  /** ACN internal error code (present on sanitised 5xx responses) */
+  errorCode?: string;
+  /** Request ID minted by ACN for 5xx responses (useful for support) */
+  requestId?: string;
+
   constructor(
     public status: number,
-    message: string
+    message: string,
+    options?: { errorCode?: string; requestId?: string }
   ) {
     super(message);
     this.name = 'ACNError';
+    this.errorCode = options?.errorCode;
+    this.requestId = options?.requestId;
   }
 }
 

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -91,6 +91,19 @@ export type {
   WSMessage,
   WSEventType,
   WSConnectionOptions,
+
+  // Follow / Social Graph Types
+  FollowActionResponse,
+  FollowCheckResponse,
+
+  // Communication Policy Types
+  CommunicationPolicyMode,
+  CommunicationPolicyResponse,
+
+  // Allowlist Types
+  AllowlistActionResponse,
+  AllowlistEntry,
+  AllowlistListResponse,
 } from './types';
 
 

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -645,7 +645,8 @@ export interface CommunicationPolicyResponse {
 
 /** Result of an allowlist add/remove action */
 export interface AllowlistActionResponse {
-  agent_id: string;
+  /** The allowlist owner's agent ID */
+  owner_id: string;
   target_id: string;
   /** Post-state: true after add, false after remove */
   allowlisted: boolean;
@@ -653,17 +654,19 @@ export interface AllowlistActionResponse {
   changed: boolean;
 }
 
-/** Single allowlist entry */
+/** Single allowlist entry (as returned by GET listing) */
 export interface AllowlistEntry {
   target_id: string;
   reason?: string;
-  added_at: string;
+  /** ISO-8601 UTC timestamp of when the entry was added */
+  created_at: string;
 }
 
 /** GET /allowlist response */
 export interface AllowlistListResponse {
-  agent_id: string;
-  allowlist: AllowlistEntry[];
+  /** The allowlist owner's agent ID */
+  owner_id: string;
+  entries: AllowlistEntry[];
   total: number;
 }
 

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -604,6 +604,69 @@ export interface ApiResponse<T> {
   message?: string;
 }
 
+// ============================================
+// Follow / Social Graph Types
+// ============================================
+
+/** Result of a follow or unfollow action */
+export interface FollowActionResponse {
+  follower_id: string;
+  followee_id: string;
+  /** Post-state: true after follow, false after unfollow */
+  following: boolean;
+  /** Whether this call actually mutated state (false on idempotent repeat) */
+  changed: boolean;
+}
+
+/** Result of a follow-status check */
+export interface FollowCheckResponse {
+  follower_id: string;
+  followee_id: string;
+  following: boolean;
+}
+
+// ============================================
+// Communication Policy Types
+// ============================================
+
+export type CommunicationPolicyMode = 'open' | 'closed' | 'manifest' | 'allowlist';
+
+export interface CommunicationPolicyResponse {
+  agent_id: string;
+  communication_policy: {
+    mode: CommunicationPolicyMode;
+    reject_reason?: string;
+  };
+}
+
+// ============================================
+// Allowlist Types
+// ============================================
+
+/** Result of an allowlist add/remove action */
+export interface AllowlistActionResponse {
+  agent_id: string;
+  target_id: string;
+  /** Post-state: true after add, false after remove */
+  allowlisted: boolean;
+  /** Whether this call actually mutated state */
+  changed: boolean;
+}
+
+/** Single allowlist entry */
+export interface AllowlistEntry {
+  target_id: string;
+  reason?: string;
+  added_at: string;
+}
+
+/** GET /allowlist response */
+export interface AllowlistListResponse {
+  agent_id: string;
+  allowlist: AllowlistEntry[];
+  total: number;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- **Python SDK**: 新增 `follow`/`unfollow`/`check_follow`/`list_follows`/`list_followers`、`get_policy`/`update_policy`、`add_to_allowlist`/`remove_from_allowlist`/`list_allowlist` 共 11 个方法
- **TypeScript SDK**: 相同 11 个方法 + 配套类型（`FollowActionResponse`、`FollowCheckResponse`、`CommunicationPolicyResponse`、`AllowlistActionResponse`、`AllowlistListResponse`）
- **TypeScript SDK**: `ACNError` 补齐 `errorCode` 和 `requestId`，请求方法新增结构化 422 错误解析（与 Python SDK 对齐）
- **CLI**: 新增 `acn follow check <target_id>`

## Test plan
- `cd clients/typescript && npm run typecheck && npm run build`
- `cd clients/cli && npm run typecheck && npm run build`
- `cd clients/python && uv run ruff check acn_client/`

Made with [Cursor](https://cursor.com)