### PR TITLE
chore(release): prepare v0.6.3 client API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-07
+
+### Added
+
+- **Python SDK**: `follow`, `unfollow`, `check_follow`, `list_follows`, `list_followers` — social graph API.
+- **Python SDK**: `get_policy`, `update_policy` — read/write communication policy (open/closed/manifest/allowlist).
+- **Python SDK**: `add_to_allowlist`, `remove_from_allowlist`, `list_allowlist` — allowlist management (owner-only).
+- **TypeScript SDK**: same 11 methods as above, plus new types `FollowActionResponse`, `FollowCheckResponse`, `CommunicationPolicyResponse`, `AllowlistActionResponse`, `AllowlistListResponse`.
+- **TypeScript SDK**: `ACNError` now surfaces `errorCode` and `requestId`; 422 validation errors are formatted as readable field-level summaries.
+- **CLI**: `acn follow check <target_id>` — check follow status against a specific agent.
+
+### Changed
+
+- Bumped all packages to `0.6.3` for a coordinated patch release.
+
 ## [0.6.2] - 2026-05-07
 
 ### Changed

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `acn-client` are documented here.
 
+## [0.6.3] - 2026-05-07
+
+### Added
+- `follow`, `unfollow`, `check_follow`, `list_follows`, `list_followers` — social graph.
+- `get_policy`, `update_policy` — communication policy read/write.
+- `add_to_allowlist`, `remove_from_allowlist`, `list_allowlist` — allowlist management.
+
+### Changed
+- Bumped version to `0.6.3`.
+
 ## [0.6.2] - 2026-05-07
 
 ### Changed

--- a/clients/python/acn_client/__init__.py
+++ b/clients/python/acn_client/__init__.py
@@ -44,7 +44,7 @@ from .models import (
 )
 from .realtime import ACNRealtime, ACNRealtimeOptions, AuthMode, WSState
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __all__ = [
     # Client
     "ACNClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.6.2"
+version = "0.6.3"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "MIT"

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.6.2"
+version = "0.6.3"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/uv.lock
+++ b/uv.lock
@@ -2090,7 +2090,7 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -2090,7 +2090,7 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586 }
 wheels = [


### PR DESCRIPTION
## Summary
- Bump all packages (core, Python SDK, TypeScript SDK, CLI) to `0.6.3`
- Update CHANGELOG for v0.6.3

This is the release bump PR for the follow/policy/allowlist client API additions from #24.

## Test plan
- CI runs on this PR (Python 3.11/3.12, SDK typecheck/build)
- After merge: tag `v0.6.3` → triggers release workflow

Made with [Cursor](https://cursor.com)