### PR TITLE
fix(payments): honor buyer-supplied network in create_payment_task

### DIFF
--- a/acn/protocols/ap2/core.py
+++ b/acn/protocols/ap2/core.py
@@ -604,6 +604,7 @@ class PaymentTaskManager:
         amount: str,
         currency: str = "USD",
         payment_method: SupportedPaymentMethod | None = None,
+        network: SupportedNetwork | None = None,
         task_type: str | None = None,
         metadata: dict | None = None,
     ) -> PaymentTask:
@@ -611,6 +612,8 @@ class PaymentTaskManager:
         Create a new payment task.
 
         Automatically resolves seller's wallet address from ACN Registry.
+        Honors the buyer-supplied ``network`` when provided; otherwise falls
+        back to the seller capability's first declared network.
         """
         # Get seller's payment capability
         capability = await self.discovery.get_agent_payment_capability(seller_agent)
@@ -639,11 +642,32 @@ class PaymentTaskManager:
             if supported_methods:
                 payment_method = supported_methods[0]
 
-        # Determine network and resolve the correct wallet address for that network
-        network = capability.supported_networks[0] if capability.supported_networks else None
-        if network and capability.wallet_addresses:
+        # Normalize seller's supported networks (tolerate mixed storage formats).
+        supported_networks: list[SupportedNetwork] = []
+        for net in capability.supported_networks or []:
+            if isinstance(net, SupportedNetwork):
+                supported_networks.append(net)
+                continue
+            try:
+                supported_networks.append(SupportedNetwork(str(net)))
+            except ValueError:
+                continue
+
+        # Honor caller-supplied network when seller declares it; otherwise
+        # fall back to the first declared network for backwards compatibility.
+        if network is not None:
+            if supported_networks and network not in supported_networks:
+                raise ValueError(
+                    f"Agent {seller_agent} does not accept network {network.value}"
+                )
+            selected_network = network
+        else:
+            selected_network = supported_networks[0] if supported_networks else None
+
+        # Resolve the correct wallet address for the chosen network.
+        if selected_network and capability.wallet_addresses:
             recipient_wallet = capability.wallet_addresses.get(
-                network.value, capability.wallet_address
+                selected_network.value, capability.wallet_address
             )
         else:
             recipient_wallet = capability.wallet_address
@@ -659,7 +683,7 @@ class PaymentTaskManager:
             currency=currency,
             payment_method=payment_method,
             recipient_wallet=recipient_wallet,
-            network=network,
+            network=selected_network,
         )
 
         # Save task

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -269,6 +269,7 @@ async def create_payment_task(
             amount=str(request.amount),
             currency=request.currency,
             payment_method=request.payment_method,
+            network=request.network,
             task_type="payment",
             metadata=task_metadata,
         )
@@ -279,6 +280,14 @@ async def create_payment_task(
         raise
     except HTTPException:
         raise
+    except ValueError as e:
+        # The seller does not accept this method/network, or the seller has
+        # no payment capability registered. These are caller-correctable.
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            status_code=400,
+            details={"reason": str(e)},
+        ) from e
     except Exception as e:
         logger.error("create_payment_task_failed", error=str(e), exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to create payment task") from e

--- a/tests/services/test_payment_task_manager_create.py
+++ b/tests/services/test_payment_task_manager_create.py
@@ -1,0 +1,136 @@
+"""Regression tests for PaymentTaskManager.create_payment_task.
+
+Buyer-supplied ``network`` must be honored end-to-end. Previously the
+manager hardcoded ``capability.supported_networks[0]`` and silently
+dropped the buyer's choice — a buyer asking for ``base`` would end up
+on whichever network the seller had listed first (typically
+``ethereum``), which is a correctness bug for multi-chain sellers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.protocols.ap2.core import (
+    PaymentCapability,
+    PaymentTaskManager,
+    SupportedNetwork,
+    SupportedPaymentMethod,
+)
+
+
+def _make_capability(
+    *,
+    networks: list[SupportedNetwork],
+    wallet_addresses: dict[str, str] | None = None,
+) -> PaymentCapability:
+    return PaymentCapability(
+        accepts_payment=True,
+        payment_methods=[SupportedPaymentMethod.USDC],
+        wallet_address="0xfallback",
+        wallet_addresses=wallet_addresses or {},
+        supported_networks=networks,
+    )
+
+
+def _make_mgr(capability: PaymentCapability) -> PaymentTaskManager:
+    discovery = AsyncMock()
+    discovery.get_agent_payment_capability = AsyncMock(return_value=capability)
+    fake_redis = AsyncMock()
+    return PaymentTaskManager(redis=fake_redis, discovery=discovery)
+
+
+@pytest.mark.asyncio
+async def test_create_uses_buyer_supplied_network() -> None:
+    capability = _make_capability(
+        networks=[SupportedNetwork.ETHEREUM, SupportedNetwork.BASE],
+        wallet_addresses={
+            SupportedNetwork.ETHEREUM.value: "0xeth",
+            SupportedNetwork.BASE.value: "0xbase",
+        },
+    )
+    mgr = _make_mgr(capability)
+
+    task = await mgr.create_payment_task(
+        buyer_agent="buyer-1",
+        seller_agent="seller-1",
+        task_description="ship it",
+        amount="1.00",
+        payment_method=SupportedPaymentMethod.USDC,
+        network=SupportedNetwork.BASE,
+    )
+
+    assert task.network == SupportedNetwork.BASE
+    assert task.recipient_wallet == "0xbase"
+
+
+@pytest.mark.asyncio
+async def test_create_falls_back_to_first_network_when_omitted() -> None:
+    """No regression: if the buyer omits ``network`` we keep the legacy
+    "first declared network wins" behavior so older clients keep working.
+    """
+    capability = _make_capability(
+        networks=[SupportedNetwork.ETHEREUM, SupportedNetwork.BASE],
+        wallet_addresses={
+            SupportedNetwork.ETHEREUM.value: "0xeth",
+            SupportedNetwork.BASE.value: "0xbase",
+        },
+    )
+    mgr = _make_mgr(capability)
+
+    task = await mgr.create_payment_task(
+        buyer_agent="buyer-1",
+        seller_agent="seller-1",
+        task_description="ship it",
+        amount="1.00",
+        payment_method=SupportedPaymentMethod.USDC,
+    )
+
+    assert task.network == SupportedNetwork.ETHEREUM
+    assert task.recipient_wallet == "0xeth"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_network_not_supported_by_seller() -> None:
+    capability = _make_capability(
+        networks=[SupportedNetwork.ETHEREUM],
+        wallet_addresses={SupportedNetwork.ETHEREUM.value: "0xeth"},
+    )
+    mgr = _make_mgr(capability)
+
+    with pytest.raises(ValueError, match="does not accept network"):
+        await mgr.create_payment_task(
+            buyer_agent="buyer-1",
+            seller_agent="seller-1",
+            task_description="ship it",
+            amount="1.00",
+            payment_method=SupportedPaymentMethod.USDC,
+            network=SupportedNetwork.SOLANA,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_falls_back_to_legacy_wallet_when_per_network_missing() -> None:
+    """If the seller declared the chosen network but never registered a
+    per-network address for it, we should still produce a task using the
+    legacy single ``wallet_address`` rather than blowing up.
+    """
+    capability = _make_capability(
+        networks=[SupportedNetwork.BASE],
+        wallet_addresses={},  # intentionally missing the BASE entry
+    )
+    mgr = _make_mgr(capability)
+
+    task = await mgr.create_payment_task(
+        buyer_agent="buyer-1",
+        seller_agent="seller-1",
+        task_description="ship it",
+        amount="1.00",
+        payment_method=SupportedPaymentMethod.USDC,
+        network=SupportedNetwork.BASE,
+    )
+
+    assert task.network == SupportedNetwork.BASE
+    assert task.recipient_wallet == "0xfallback"


### PR DESCRIPTION
## Summary

`POST /api/v1/payments/tasks` accepts a `network` field in the request body, but it was being silently dropped: `PaymentTaskManager.create_payment_task` hardcoded `capability.supported_networks[0]`, so a buyer asking for `base` would end up on whichever network the seller had listed first (typically `ethereum`).

This was caught during end-to-end smoke testing of the new CLI payment commands (`acn pay --network base`).

## Changes

- `acn/protocols/ap2/core.py` — `PaymentTaskManager.create_payment_task` now accepts `network: SupportedNetwork | None`, validates it against the seller's `capability.supported_networks`, and uses it to resolve the per-network wallet address. Falls back to the first declared network when the buyer omits it (preserves prior behavior for older clients).
- `acn/routes/payments.py` — Route handler now forwards `request.network` to the manager. Adds a `ValueError -> 400 INVALID_REQUEST` translation so a buyer asking for an unsupported network gets a clean client error instead of a 500.
- `tests/services/test_payment_task_manager_create.py` — New test module covering:
  - Buyer-supplied network is honored end-to-end (resolves to the right per-network wallet).
  - Network omission falls back to the first supported network.
  - Network not in seller's supported list raises `ValueError`.
  - Per-network address absent → fall back to the legacy `wallet_address`.

## Behavioral impact

- New explicit error path: requests asking for a `network` not in the seller's `supported_networks` will now return **400 INVALID_REQUEST** instead of being silently rerouted to a different network. This is a strict improvement — the previous behavior was incorrect.
- Older clients that don't send `network` are unchanged.

## Test plan

- [x] `pytest tests/services/test_payment_task_manager_create.py` — 4 new tests, all green
- [x] `pytest tests/services/test_payment_task_manager_retention.py tests/routes/test_payments_error_schema.py tests/routes/test_route_service_contracts.py` — 67 / 67 green, no regressions
- [x] `ruff check` + `mypy` clean
- [x] Reproduced the bug pre-fix during local CLI smoke test (`acn pay --network base` resolved to `ethereum`); same flow post-fix correctly resolves to `base`

Made with [Cursor](https://cursor.com)