### PR TITLE
chore: unbreak main CI (ruff order + stale auth-audit tests)

### DIFF
--- a/clients/python/acn_client/__init__.py
+++ b/clients/python/acn_client/__init__.py
@@ -11,6 +11,7 @@ Example:
 
 from .client import ACNClient, ACNError
 from .models import (
+    KNOWN_PAYMENT_TASK_STATUSES,
     AgentInfo,
     AgentJoinRequest,
     AgentJoinResponse,
@@ -21,7 +22,6 @@ from .models import (
     BroadcastRequest,
     BroadcastStrategy,
     CommunicationProfile,
-    KNOWN_PAYMENT_TASK_STATUSES,
     ManifestContentResponse,
     ManifestEntry,
     ManifestSendRequest,

--- a/tests/routes/test_auth_failure_audit_h_audit.py
+++ b/tests/routes/test_auth_failure_audit_h_audit.py
@@ -434,9 +434,12 @@ class TestJwtAndPermissionBranches:
     Each path has its own ``record_auth_failure`` call and we want a
     failing test if any branch silently regresses to no-op.
 
-    We hit ``DELETE /api/v1/subnets/{id}`` because it is gated by
+    We hit ``DELETE /api/v1/agents/{id}`` because it is gated by
     ``require_permission("acn:write")`` — the simplest reachable handler
-    that exercises the full middleware stack.
+    that exercises the full middleware stack. (We previously used
+    ``DELETE /api/v1/subnets/{id}`` for the same purpose; that endpoint
+    was migrated to ``AgentApiKeyDep`` when subnet self-service shipped
+    for agents, so it no longer exercises the JWT middleware path.)
     """
 
     def _settings_with_auth0(self):
@@ -468,7 +471,7 @@ class TestJwtAndPermissionBranches:
             return_value=self._settings_with_auth0(),
         ), patch("acn.auth.middleware.record_auth_failure") as record:
             with TestClient(app) as client:
-                r = client.delete("/api/v1/subnets/some-id")
+                r = client.delete("/api/v1/agents/some-id")
             assert r.status_code == 401
             # ``record_auth_failure`` may be called once (verify_token) or
             # not at all if the route never reaches the dependency — pin the
@@ -517,7 +520,7 @@ class TestJwtAndPermissionBranches:
         ) as record:
             with TestClient(app) as client:
                 r = client.delete(
-                    "/api/v1/subnets/some-id",
+                    "/api/v1/agents/some-id",
                     headers={"Authorization": f"Bearer {bogus}"},
                 )
             assert r.status_code == 401
@@ -552,7 +555,7 @@ class TestJwtAndPermissionBranches:
         ) as record:
             with TestClient(app) as client:
                 r = client.delete(
-                    "/api/v1/subnets/some-id",
+                    "/api/v1/agents/some-id",
                     headers={"Authorization": "Bearer not-checked"},
                 )
             assert r.status_code == 403
@@ -568,7 +571,7 @@ class TestJwtAndPermissionBranches:
             assert kwargs.get("actor_id") == "auth0|user-42"
             # The middleware variant doesn't have access to a proxy-aware IP,
             # but it must still pass *some* path/method context.
-            assert kwargs.get("path") == "/api/v1/subnets/some-id"
+            assert kwargs.get("path") == "/api/v1/agents/some-id"
             assert kwargs.get("method") == "DELETE"
             assert kwargs.get("extra", {}).get("permission") == "acn:write"
 


### PR DESCRIPTION
## Summary

Unblock main CI. Two unrelated regressions had piled up on main:

1. **ruff I001 import order** in \`acn_client/__init__.py\` — the 0.7.x SDK release commits left \`KNOWN_PAYMENT_TASK_STATUSES\` interleaved with PascalCase imports; \`ruff check\` rejects it.
2. **Stale H-audit middleware tests** — three tests in \`tests/routes/test_auth_failure_audit_h_audit.py\` used \`DELETE /api/v1/subnets/{id}\` as a "simple JWT-gated endpoint", but that route was migrated from \`require_permission("acn:write")\` to \`AgentApiKeyDep\` when subnet self-service shipped. The tests now hit the API-key path and never exercise the JWT middleware they intended to verify, so they fail with 422/401 mismatches.

\`gh run list --branch main\` shows main has been red since #25594320968 (May 9, 06:37 UTC) on this exact pair of issues; every PR opened since inherits the failure.

## Changes

- \`clients/python/acn_client/__init__.py\` — \`ruff check --fix\`. One line moved.
- \`tests/routes/test_auth_failure_audit_h_audit.py\` — three tests repointed to \`DELETE /api/v1/agents/{id}\`, which is the only \`acn:write\`-protected route with no required body. Docstring updated so the next migration knows why this endpoint was chosen.

## Test plan

- [x] \`ruff check .\` — clean
- [x] \`pytest tests/routes/test_auth_failure_audit_h_audit.py\` — 14 / 14 green (was 11/14, 3 failing)
- [x] \`python -c "import acn_client; print(acn_client.__version__)"\` — \`0.7.1\`

## Coordination

- PRs #27 and #28 are blocked on this hotfix landing first; once merged, both will rebase / merge main and turn green.