### PR TITLE
chore(release): prep CLI 0.7.0 + TS SDK 0.7.1 + CLI changelog

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to `@acnlabs/acn-cli` are documented here.
+
+## [0.7.0] - 2026-05-10
+
+### Added
+- `acn pay` — create a payment task from the configured agent to a
+  named seller agent, with `--amount`, `--currency`, `--method`,
+  `--network`, `--description`, and `--metadata` flags. The
+  `from_agent` field is derived from the local CLI config so callers
+  cannot accidentally spoof a different sender.
+- `acn wallet tasks` — list payment tasks where the configured agent
+  is buyer or seller, with optional `--limit`. Output formatted as a
+  human-readable table.
+- `acn wallet stats` — show payment statistics for the configured
+  agent (counts and totals split by buyer vs seller role, plus
+  per-status breakdown).
+- `acn wallet estimate` — estimate the cost of calling another
+  agent's service before invoking it, taking
+  `--input-tokens` / `--output-tokens` for token-priced agents.
+
+### Changed
+- The `acn-client` SDK dependency series now tracks the v0.7.x line.
+  The CLI handles the v0.7.0 breaking changes (lowercase
+  `PaymentMethod` / `PaymentNetwork` enum values, renamed
+  `PaymentTask` fields) so end-users do not need to.
+- Aligned with `acn-client` v0.7.1, which fixes the `PaymentStats`
+  shape returned by `acn wallet stats`.
+
+## [0.6.3] - 2026-05-09
+
+### Changed
+- Coordinated patch release matching the `acn-client` SDK.
+
+## [0.6.2] - 2026-05-07
+
+### Changed
+- Initial publication under the `@acnlabs/acn-cli` package name.

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to `acn-client` (TypeScript) are documented here.
+
+## [0.7.1] - 2026-05-10
+
+### Changed (BREAKING)
+- `PaymentStats` field set now mirrors the server's
+  `PaymentTaskManager.get_payment_stats` response — the previous
+  `total_received / total_sent / transaction_count / avg_amount`
+  fields were never emitted by the server, so reads silently returned
+  all-zero stats.
+  - New shape: `total_tasks`, `as_buyer` (`PaymentRoleStats`),
+    `as_seller` (`PaymentRoleStats`), `by_status: Record<string, number>`,
+    `completed_transactions`.
+  - New helper interface `PaymentRoleStats` (`count`, `total_amount` as
+    decimal string) is exported from the package root.
+
+## [0.7.0] - 2026-05-09
+
+### Added
+- `createPaymentTask(...)` — create a payment task; the authenticated
+  agent must equal `from_agent`.
+- `estimateCost(...)` — POST `/payments/billing/estimate` to estimate
+  the cost of calling an agent before invoking its service.
+- `setTokenPricing(...)` / `getTokenPricing(...)` — manage OpenAI-style
+  per-million-token pricing in USD.
+- `KNOWN_PAYMENT_TASK_STATUSES` constant listing the payment task
+  status values the ACN server currently emits, plus a derived
+  `PaymentTaskStatus` union type.
+
+### Changed (BREAKING)
+- `PaymentMethod` and `PaymentNetwork` are now lowercase string-literal
+  unions (e.g. `"usdc"`, `"base"`), aligning with the ACN server.
+  Direct string-literal comparisons against the old uppercase values
+  must be updated.
+- `PaymentMethod` and `PaymentNetwork` gained `debit_card`, `paypal`,
+  `apple_pay`, `google_pay`, `btc`, and `bitcoin` to match the server.
+- `PaymentCapability` field set now mirrors the server contract: added
+  `wallet_addresses`, `token_pricing`, `api_endpoint`, `webhook_url`;
+  removed unused `min_amount`, `max_amount`, `currency`.
+- `PaymentTask` field set now mirrors the server `ap2.core.PaymentTask`:
+  `task_id`, `buyer_agent`, `seller_agent`, `task_description`,
+  `amount` (decimal string), `payment_method`, dispute / timestamp
+  fields (was `id`, `payer_agent_id`, `payee_agent_id`).
+- `PaymentTaskStatus` is no longer a hardcoded enum; it is a derived
+  union over `KNOWN_PAYMENT_TASK_STATUSES` so additions on the server
+  are forward-compatible without an SDK release.
+- `setPaymentCapability` / `getPaymentCapability` now hit
+  `/api/v1/payments/{id}/payment-capability` (was `/agents/...`,
+  which always 404'd against the current server).
+- `discoverPaymentAgents` no longer accepts `min_amount` / `max_amount`
+  (the server never read them).
+- `deleteSubnet` no longer accepts `force` (the server never read it).
+
+### Compatibility
+- `getPaymentCapability` normalizes the server's `payment_methods`
+  response into `supported_methods` so application code can read either
+  field. With ACN backend ≥ commit `ccc0a1d` (May 10 2026) the server
+  itself emits both names; this normalization remains in place as
+  back-compat for older ACN deployments.
+
+## [0.6.3] - 2026-05-07
+
+### Changed
+- Bumped to `0.6.3` for coordinated ACN patch release.


### PR DESCRIPTION
## Summary

Pre-flight cleanup for the coordinated 0.7.x release wave — strictly metadata, no behavior change.

## Changes

- \`@acnlabs/acn-cli\` bumped from \`0.6.3\` → \`0.7.0\`. Minor bump per SemVer for the new \`acn pay\` / \`acn wallet tasks\` / \`acn wallet stats\` / \`acn wallet estimate\` commands. Picks up acn-client 0.7.x breaking changes transparently for end users (the breaking part stayed inside SDK types, the CLI surface only added new commands).
- \`clients/typescript/CHANGELOG.md\` — new file. The Python SDK already had a CHANGELOG; the TS SDK was missing one through the 0.7.0 → 0.7.1 jump. Documents both versions, including the \`getPaymentCapability\` \`payment_methods → supported_methods\` normalization (now back-compat for older backends per #28).
- \`clients/cli/CHANGELOG.md\` — new file. Documents the 0.7.0 additions and the SDK alignment.

## Sanity check

- \`npm run build\` in both \`clients/cli\` and \`clients/typescript\` — clean
- Lockfile updated by \`npm install\` in \`clients/cli\` (only the package's own version line changed; no dependency drift)

## Release coordination

Once this lands, the coordinated publish list is:

| Package | Version | Notes |
|---|---|---|
| PyPI \`acn-client\` | \`0.7.1\` | already bumped on main |
| npm \`acn-client\` | \`0.7.1\` | already bumped on main |
| npm \`@acnlabs/acn-cli\` | \`0.7.0\` | this PR |
| ClawHub \`acn\` skill | \`0.6.5\` | already bumped on main |

Made with [Cursor](https://cursor.com)