### PR TITLE
chore(core): bump service_version to 0.7.1

### DIFF
--- a/acn/config.py
+++ b/acn/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
 
     # Service
     service_name: str = "ACN"
-    service_version: str = "0.6.3"
+    service_version: str = "0.7.1"
     host: str = "0.0.0.0"
     port: int = 8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.6.3"
+version = "0.7.1"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}


### PR DESCRIPTION
## Summary

- Bumps `acn/config.py::Settings.service_version` and `pyproject.toml::version` from `0.6.3` to `0.7.1`.
- Brings the ACN core's self-reported version in line with the 0.7.1 SDK/CLI release wave (#27, #28, #30, plus the Python/TS SDKs and Docker image already published on tag `v0.7.1`).
- No behavior change. The single source of truth for the runtime number is `settings.service_version`, consumed by `/health`, `/`, and the a2a-card endpoints — every other report site flows through that field.

## Why

After tagging `v0.7.1` and triggering the next Railway deploy, the only way to confirm the rollout from outside the dashboard is to hit `https://acn-production.up.railway.app/health`. Today that endpoint still returns `0.6.3`, even though the deployed code may already include the network-passthrough fix (#27) and the `payment_methods` symmetry fix (#28). Bumping the version makes the redeploy verifiable without a separate canary.

## Test plan

- [x] `ruff check acn/config.py pyproject.toml` — passes.
- [ ] After merge + Railway redeploy: `curl https://acn-production.up.railway.app/health` returns `{"status":"ok","version":"0.7.1"}`.
- [ ] Smoke `curl https://acn-production.up.railway.app/` (root info endpoint) — version field also reflects `0.7.1`.

## Out of scope

- Railway auto-deploy wiring. The dashboard still controls when this gets shipped; this PR only makes the result observable.

Made with [Cursor](https://cursor.com)