### PR TITLE
fix(saga): drop ::text cast in update_step_status SQL to avoid SQLAlchemy parser collision (production hotfix)

### DIFF
--- a/acn/infrastructure/persistence/postgres/settlement_outbox_repository.py
+++ b/acn/infrastructure/persistence/postgres/settlement_outbox_repository.py
@@ -276,6 +276,20 @@ class PostgresSettlementOutboxRepository(ISettlementOutboxRepository):
         ``updated_at`` is passed from the Python side (not ``now()``)
         for consistency with the other write paths: tests that
         ``freeze_time`` can pin all timestamps in one place.
+
+        Why no ``::text`` cast on ``:status``:
+            An earlier version wrote ``to_jsonb(:status::text)``.
+            SQLAlchemy's ``text()`` parser refused to recognise
+            ``:status`` as a bound parameter in that form (the ``::``
+            PostgreSQL cast suffix collided with the ``:param``
+            placeholder rule), raising
+            ``ArgumentError: This text() construct doesn't define a
+            bound parameter named 'status'`` at runtime. The
+            ``bindparam("status", value=str)`` already binds the
+            value as text, so ``to_jsonb(:status)`` is both correct
+            and unambiguous. Cross-checked by
+            ``test_update_step_status_persists_step_value`` against
+            a real PG instance to keep this from regressing.
         """
         async with self._session_factory() as sess:
             await sess.execute(
@@ -285,7 +299,7 @@ class PostgresSettlementOutboxRepository(ISettlementOutboxRepository):
                     SET step_status = jsonb_set(
                             COALESCE(step_status, '{}'::jsonb),
                             :path,
-                            to_jsonb(:status::text),
+                            to_jsonb(:status),
                             true
                         ),
                         updated_at = :updated_at

--- a/tests/integration/test_settlement_outbox_pg.py
+++ b/tests/integration/test_settlement_outbox_pg.py
@@ -262,3 +262,71 @@ async def test_enqueue_claim_done_round_trip(
     assert counts["done"] == 1
     assert counts["pending"] == 0
     assert counts["paying"] == 0
+
+
+# =============================================================================
+# 8. update_step_status — JSONB merge round-trip on real PG
+# =============================================================================
+#
+# This guards against a real production regression:
+# the original ``update_step_status`` SQL wrote ``to_jsonb(:status::text)``
+# but SQLAlchemy's ``text()`` parser refused to recognise ``:status``
+# as a bound parameter because the ``::`` PostgreSQL cast suffix
+# collided with the ``:param`` placeholder rule, raising
+# ``ArgumentError: This text() construct doesn't define a bound
+# parameter named 'status'`` at runtime — but ONLY against a real PG;
+# every fake-repo test in the suite happily passed.
+#
+# Production symptom: worker's business steps all succeeded
+# (``reputation_write`` wrote the row, ``escrow_release`` /
+# ``reward_distribute`` correctly skipped) but ``step_status`` was
+# never persisted, so the saga state machine looped at ``retrying``
+# until ``max_attempts``. Fix: drop the redundant ``::text`` cast
+# (``bindparam`` already binds Python ``str`` to PG ``text``).
+#
+# This test runs the actual SQL and asserts the JSONB merge
+# materialised — guarantees we never regress to the broken form
+# without a real-PG test catching it.
+
+
+@pytest.mark.asyncio
+async def test_update_step_status_persists_step_value(
+    engine_and_factory: tuple[Any, Any],
+) -> None:
+    _engine, factory = engine_and_factory
+    repo = PostgresSettlementOutboxRepository(session_factory=factory)
+
+    # Start from the default step_status the producer writes.
+    await repo.enqueue(_event("evt-step"))
+
+    # Patch one step — this is the path that was broken in prod.
+    await repo.update_step_status(
+        event_id="evt-step",
+        step="reputation_write",
+        status="ok",
+    )
+
+    # Patch a second step to verify multi-key JSONB merge survives.
+    await repo.update_step_status(
+        event_id="evt-step",
+        step="escrow_release",
+        status="skipped",
+    )
+
+    # Read back via raw SQL to bypass any ORM-side caching.
+    async with factory() as session:
+        row = (
+            await session.execute(
+                SettlementOutboxModel.__table__.select().where(
+                    SettlementOutboxModel.event_id == "evt-step"
+                )
+            )
+        ).first()
+        assert row is not None
+        assert row.step_status == {
+            "escrow_release": "skipped",
+            "reward_distribute": "pending",
+            "reputation_write": "ok",
+        }, (
+            f"update_step_status JSONB merge broken: got {row.step_status!r}"
+        )


### PR DESCRIPTION
## Summary

Production hotfix for PR #32.

The first real `review_pass` saga we ran end-to-end on production exposed that `update_step_status` silently failed every worker attempt with:

```
ArgumentError: This text() construct doesn't define a bound parameter named 'status'
```

The business steps (`reputation_write` ok, `escrow_release` / `reward_distribute` skipped) all ran correctly — `reputation_events` had 1 row, the UNIQUE(agent_id, task_id, kind) constraint rejected duplicates on retry. **But** the JSONB patch that persists each step's status never landed, so the saga loop kept retrying.

## Root Cause

`to_jsonb(:status::text)`. SQLAlchemy's `text()` parser sees the `::` PostgreSQL cast suffix immediately after the `:status` placeholder and refuses to register `status` as a bound parameter — a known interaction between SQLAlchemy's `:param` syntax and PostgreSQL's `::` cast operator.

## Fix

Drop the redundant cast — `bindparam("status", value=str)` already binds the value as PG `text`:

```diff
-                            to_jsonb(:status::text),
+                            to_jsonb(:status),
```

One-character behavioural change. Plus a multi-line docstring explaining the trap so the next maintainer doesn't reintroduce it.

## Test Coverage Gap (now closed)

Every `update_step_status` test in the suite used `FakeSettlementOutboxRepository` (in-memory dict). The existing PG integration tests covered `enqueue / claim_batch / mark_done / SKIP LOCKED / UoW rollback` but never exercised the actual `update_step_status` SQL.

Added `test_update_step_status_persists_step_value` to `tests/integration/test_settlement_outbox_pg.py`:
- Real PG fixture (gated on `ACN_INTEGRATION_PG_URL`).
- Calls `update_step_status` twice with different step + status values.
- Reads back the row and asserts the JSONB merge materialised.
- Would have caught the bug at PR review time.

## Self-Healing After Deploy

Production currently has 1 stuck row (state=retrying, attempts=5). After this merges + Railway redeploys + worker is re-enabled, the worker will:

1. `claim_batch` re-picks the row (next_attempt_at has passed).
2. `escrow_release` step_status=skipped → continue, only record metric.
3. `reward_distribute` step_status=skipped → continue, only record metric.
4. `reputation_write` step_status=pending → re-run business handler. UNIQUE constraint rejects duplicate insert; service layer swallows as idempotent ok.
5. `update_step_status("reputation_write", "done")` — **this is the line that was broken; fixed SQL succeeds**.
6. `mark_done(event_id)` → outbox state = `done`.
7. Reconciler next run: `saga_done_count=1` vs `feedback_count=1` → `delta=0`.

No manual SQL surgery needed.

## Business Impact: Zero

The legacy double-write path (which Todo 7 will eventually retire) released payment and recorded completion synchronously inside `complete_task`. The worker was always the secondary settlement path during this transition. The bug never affected user-visible behaviour.

## Test plan

- [x] `ruff check` passes on the two modified files
- [ ] CI runs unit tests on the PR
- [ ] Merge → Railway auto-redeploys ACN (~2 min)
- [ ] Re-enable worker: `SETTLEMENT_WORKER_ENABLED=true`
- [ ] Verify stuck row self-heals to state=done
- [ ] Verify `acn_settlement_attempts_total{result="success"}` counter increments
- [ ] Verify reconciler delta remains 0


Made with [Cursor](https://cursor.com)