### PR TITLE
fix(saga): cast event_id to uuid in update_step_status text() SQL (hotfix #2 — follow-up to #33)

### DIFF
--- a/acn/infrastructure/persistence/postgres/settlement_outbox_repository.py
+++ b/acn/infrastructure/persistence/postgres/settlement_outbox_repository.py
@@ -33,6 +33,7 @@ from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy import bindparam, func, select, text, update
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -290,6 +291,24 @@ class PostgresSettlementOutboxRepository(ISettlementOutboxRepository):
             and unambiguous. Cross-checked by
             ``test_update_step_status_persists_step_value`` against
             a real PG instance to keep this from regressing.
+
+        Why ``type_=PGUUID(as_uuid=False)`` on ``:event_id``:
+            The ``event_id`` column is declared as PG ``uuid`` (see
+            ``SettlementOutboxModel``). Every OTHER write path in
+            this repository goes through ORM constructs
+            (``update(SettlementOutboxModel).where(...)``) where
+            SQLAlchemy reads the column type from the mapper and
+            generates the correct PG cast automatically. This method
+            uses raw ``text()`` because it needs ``jsonb_set`` (no
+            ergonomic ORM construct), which bypasses the mapper.
+            Without an explicit ``type_`` on the bindparam,
+            SQLAlchemy defaults the Python ``str`` to VARCHAR, so
+            the rendered SQL becomes ``WHERE event_id = $4::VARCHAR``
+            and PG raises ``UndefinedFunctionError: operator does
+            not exist: uuid = character varying``. Setting
+            ``type_=PGUUID(as_uuid=False)`` tells SQLAlchemy "this
+            string is a uuid, render it as ``$4::uuid``" — matching
+            the column type and producing a valid equality.
         """
         async with self._session_factory() as sess:
             await sess.execute(
@@ -308,7 +327,11 @@ class PostgresSettlementOutboxRepository(ISettlementOutboxRepository):
                 ).bindparams(
                     bindparam("path", value=[step]),
                     bindparam("status", value=status),
-                    bindparam("event_id", value=event_id),
+                    bindparam(
+                        "event_id",
+                        value=event_id,
+                        type_=PGUUID(as_uuid=False),
+                    ),
                     bindparam("updated_at", value=datetime.now(UTC)),
                 )
             )

--- a/tests/integration/test_settlement_outbox_pg.py
+++ b/tests/integration/test_settlement_outbox_pg.py
@@ -296,19 +296,46 @@ async def test_update_step_status_persists_step_value(
     _engine, factory = engine_and_factory
     repo = PostgresSettlementOutboxRepository(session_factory=factory)
 
-    # Start from the default step_status the producer writes.
-    await repo.enqueue(_event("evt-step"))
+    # The production schema declares ``event_id`` as PG ``uuid``, so
+    # the test must use a syntactically valid UUID — passing a
+    # placeholder like ``"evt-step"`` would fail at INSERT time with
+    # ``invalid input syntax for type uuid``. We derive a stable UUID
+    # from a seed so the test is deterministic across runs.
+    from uuid import NAMESPACE_OID, uuid5
+
+    event_id = str(uuid5(NAMESPACE_OID, "evt-step"))
+    event = SettlementEvent(
+        event_id=event_id,
+        task_id=f"task-{event_id}",
+        trigger="review_pass",
+        payload={
+            "task_id": f"task-{event_id}",
+            "creator_id": "user-creator",
+            "assignee_id": "agent-worker",
+            "reward": "100",
+            "reward_currency": "ap_points",
+            "use_escrow": True,
+            "is_multi": False,
+            "metadata": {},
+        },
+        step_status={
+            "escrow_release": "pending",
+            "reward_distribute": "pending",
+            "reputation_write": "pending",
+        },
+    )
+    await repo.enqueue(event)
 
     # Patch one step — this is the path that was broken in prod.
     await repo.update_step_status(
-        event_id="evt-step",
+        event_id=event_id,
         step="reputation_write",
         status="ok",
     )
 
     # Patch a second step to verify multi-key JSONB merge survives.
     await repo.update_step_status(
-        event_id="evt-step",
+        event_id=event_id,
         step="escrow_release",
         status="skipped",
     )
@@ -318,7 +345,7 @@ async def test_update_step_status_persists_step_value(
         row = (
             await session.execute(
                 SettlementOutboxModel.__table__.select().where(
-                    SettlementOutboxModel.event_id == "evt-step"
+                    SettlementOutboxModel.event_id == event_id
                 )
             )
         ).first()


### PR DESCRIPTION
## Summary

Follow-up production hotfix to **#33**.

After #33 merged + Railway redeployed + worker re-armed, the smoke task's stuck outbox row re-attempted settlement. The ``text()`` parser was happy this time (#33's fix worked), but PostgreSQL itself rejected the SQL:

```
asyncpg.exceptions.UndefinedFunctionError:
operator does not exist: uuid = character varying
HINT: No operator matches the given name and argument types.
[SQL: ... WHERE event_id = $4::VARCHAR]
```

## Root Cause

`event_id` column is declared `uuid` in `SettlementOutboxModel`:

```python
event_id: Mapped[str] = mapped_column(UUID(as_uuid=False), nullable=False, unique=True)
```

Every other write path uses ORM constructs (`update(SettlementOutboxModel).where(SettlementOutboxModel.event_id == event_id)`) — SQLAlchemy reads column type from the mapper and renders `$N::uuid`. **Only `update_step_status` uses raw `text()`** (because it needs `jsonb_set`, which has no ergonomic ORM construct). Raw `text()` bypasses the mapper, so without an explicit `type_` on the bindparam, SQLAlchemy defaults the Python `str` to VARCHAR.

## Fix

```diff
-from sqlalchemy import bindparam, func, select, text, update
+from sqlalchemy import bindparam, func, select, text, update
+from sqlalchemy.dialects.postgresql import UUID as PGUUID

...

-                    bindparam("event_id", value=event_id),
+                    bindparam(
+                        "event_id",
+                        value=event_id,
+                        type_=PGUUID(as_uuid=False),
+                    ),
```

Rendered SQL now reads `WHERE event_id = $4::uuid`. Equality succeeds.

## Why Both Bugs Landed in #32

Neither the SQLAlchemy parser collision (#33) nor the UUID-vs-VARCHAR mismatch (this PR) shows up against the in-memory `FakeSettlementOutboxRepository` — plain dict, string key, no SQL parser, no PG type system. CI's Python unit tests use the fake repo exclusively. The real-PG integration tests at `tests/integration/test_settlement_outbox_pg.py` are gated on `ACN_INTEGRATION_PG_URL`, which **CI does not set**, so they all skip.

This is a real test coverage gap. **Out of scope for this hotfix** (it's an infrastructure change: provision a disposable PG in GH Actions). Tracked separately. The two `text()`-specific bugs are now covered by `test_update_step_status_persists_step_value` so they can't regress even by the existing skipped path once CI is fixed.

## Test Fixture Adjustment

The new integration test now derives a deterministic UUID via `uuid5(NAMESPACE_OID, "evt-step")` instead of passing the placeholder `"evt-step"` — required because the real PG schema enforces UUID syntax at INSERT time. The existing tests in the file still use placeholder strings like `"evt-A"`; they remain unchanged here (a) to keep this PR focused and (b) because they're skipped in CI anyway. A separate cleanup PR will normalise them when we wire CI to set `ACN_INTEGRATION_PG_URL`.

## Self-Healing After Deploy

Same as #33's plan. The stuck production row (state=retrying, attempts=9 after #33's worker run, currently capped because `SETTLEMENT_WORKER_ENABLED=false`) will:

1. Re-claim once worker is re-armed.
2. Skip `escrow_release` and `reward_distribute` (step_status=skipped).
3. Re-run `reputation_write` (idempotent — `UNIQUE(agent_id, task_id, kind)` rejects the duplicate insert, swallowed as ok).
4. `update_step_status("reputation_write", "done")` — this PR's fix makes the SQL valid against PG.
5. `mark_done(event_id)` — same UUID column lives in this query but it goes through ORM, was already working.
6. Reconciler delta returns to 0.

## Business Impact: Zero

Same as #33. Legacy double-write path released payment and recorded completion synchronously.

## Test plan

- [x] `ruff check` passes
- [ ] CI passes
- [ ] Merge → Railway redeploy → re-enable worker → verify self-heal → verify reconciler delta back to 0


Made with [Cursor](https://cursor.com)