### PR TITLE
ci(saga): run real-PG integration tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,25 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      # Real Postgres for tests under ``tests/integration/`` that
+      # exercise raw ``text()`` SQL (PR #33 / #34 were both silent
+      # bugs that in-memory fakes could not catch). Gated behind
+      # ``ACN_INTEGRATION_PG_URL``; without that env var the tests
+      # ``pytest.skip`` and a laptop ``pytest`` still passes.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: acn
+          POSTGRES_PASSWORD: acn
+          POSTGRES_DB: acn_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U acn -d acn_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -54,6 +73,11 @@ jobs:
         env:
           REDIS_URL: redis://localhost:6379
           ENABLE_DOCS: "true"
+          # Enables ``tests/integration/test_settlement_outbox_pg.py``.
+          # Without this, the integration tests in that file skip
+          # silently — exactly the gap that let PR #33 (text() parser
+          # collision) and PR #34 (uuid type mismatch) ship to prod.
+          ACN_INTEGRATION_PG_URL: postgresql+asyncpg://acn:acn@localhost:5432/acn_test
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/tests/integration/test_settlement_outbox_pg.py
+++ b/tests/integration/test_settlement_outbox_pg.py
@@ -25,6 +25,7 @@ import asyncio
 import os
 from datetime import UTC, datetime
 from typing import Any
+from uuid import NAMESPACE_OID, uuid5
 
 import pytest
 from sqlalchemy.ext.asyncio import (
@@ -82,13 +83,34 @@ async def engine_and_factory() -> tuple[Any, Any]:
     await engine.dispose()
 
 
-def _event(event_id: str, task_id: str | None = None) -> SettlementEvent:
+def _uuid_for(label: str) -> str:
+    """Derive a stable UUID string from a human-readable label.
+
+    ``SettlementOutboxModel.event_id`` is a real PG ``uuid`` column, so
+    short tags like ``"evt-A"`` blow up at INSERT time with
+    ``invalid input syntax for type uuid``. UUID5 is deterministic
+    (same label → same UUID across runs), so assertions can still
+    pivot on the label without leaking randomness into the test
+    output.
+    """
+    return str(uuid5(NAMESPACE_OID, label))
+
+
+def _event(label: str, task_id: str | None = None) -> SettlementEvent:
+    """Build a settlement event keyed by ``label``.
+
+    ``label`` is a human-friendly tag (e.g. ``"evt-A"``); the
+    underlying ``event_id`` is the deterministic UUID derived via
+    :func:`_uuid_for`. Tests use ``_uuid_for(label)`` directly when
+    they need to assert on the persisted ``event_id``.
+    """
+    event_id = _uuid_for(label)
     return SettlementEvent(
         event_id=event_id,
-        task_id=task_id or f"task-{event_id}",
+        task_id=task_id or f"task-{label}",
         trigger="review_pass",
         payload={
-            "task_id": task_id or f"task-{event_id}",
+            "task_id": task_id or f"task-{label}",
             "creator_id": "user-creator",
             "assignee_id": "agent-worker",
             "reward": "100",
@@ -183,7 +205,7 @@ async def test_skip_locked_prevents_double_claim_across_replicas(
     a_can_commit.set()
     a_event = await a_task
 
-    assert {a_event, b_event} == {"evt-A", "evt-B"}, (
+    assert {a_event, b_event} == {_uuid_for("evt-A"), _uuid_for("evt-B")}, (
         f"SKIP LOCKED contract violated: A={a_event}, B={b_event}"
     )
 
@@ -224,7 +246,7 @@ async def test_uow_rollback_drops_enqueued_outbox_row(
     async with factory() as session:
         result = await session.execute(
             SettlementOutboxModel.__table__.select().where(
-                SettlementOutboxModel.event_id == "evt-rollback"
+                SettlementOutboxModel.event_id == _uuid_for("evt-rollback")
             )
         )
         rows = result.all()
@@ -251,13 +273,14 @@ async def test_enqueue_claim_done_round_trip(
     _engine, factory = engine_and_factory
     repo = PostgresSettlementOutboxRepository(session_factory=factory)
 
+    rt_id = _uuid_for("evt-rt")
     await repo.enqueue(_event("evt-rt"))
 
     batch = await repo.claim_batch(limit=10, now=datetime.now(UTC))
     assert len(batch) == 1
-    assert batch[0].event_id == "evt-rt"
+    assert batch[0].event_id == rt_id
 
-    await repo.mark_done("evt-rt")
+    await repo.mark_done(rt_id)
     counts = await repo.count_by_state()
     assert counts["done"] == 1
     assert counts["pending"] == 0
@@ -296,34 +319,10 @@ async def test_update_step_status_persists_step_value(
     _engine, factory = engine_and_factory
     repo = PostgresSettlementOutboxRepository(session_factory=factory)
 
-    # The production schema declares ``event_id`` as PG ``uuid``, so
-    # the test must use a syntactically valid UUID — passing a
-    # placeholder like ``"evt-step"`` would fail at INSERT time with
-    # ``invalid input syntax for type uuid``. We derive a stable UUID
-    # from a seed so the test is deterministic across runs.
-    from uuid import NAMESPACE_OID, uuid5
-
-    event_id = str(uuid5(NAMESPACE_OID, "evt-step"))
-    event = SettlementEvent(
-        event_id=event_id,
-        task_id=f"task-{event_id}",
-        trigger="review_pass",
-        payload={
-            "task_id": f"task-{event_id}",
-            "creator_id": "user-creator",
-            "assignee_id": "agent-worker",
-            "reward": "100",
-            "reward_currency": "ap_points",
-            "use_escrow": True,
-            "is_multi": False,
-            "metadata": {},
-        },
-        step_status={
-            "escrow_release": "pending",
-            "reward_distribute": "pending",
-            "reputation_write": "pending",
-        },
-    )
+    # ``event_id`` is a real PG ``uuid`` column — ``_uuid_for`` derives
+    # a deterministic UUID from a label so the test is reproducible.
+    event = _event("evt-step")
+    event_id = event.event_id
     await repo.enqueue(event)
 
     # Patch one step — this is the path that was broken in prod.

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.6.3"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## 背景

PR #33 (text() 解析器碰撞) 和 PR #34 (PG uuid vs varchar 类型不匹配) 都是 raw `text()` SQL 在 in-memory fake 下默不作声、真 PG 一上线就炸的 silent bug。根因不是写法,是 CI 从来没真跑过 PG。

`tests/integration/test_settlement_outbox_pg.py` 早就写好了真 PG 用例,通过 `ACN_INTEGRATION_PG_URL` env var 自动 skip — 但 CI 从来没设过这个 env,等于装饰品。

## 改动

- `.github/workflows/ci.yml`: 给 `python` job 加 `postgres:16-alpine` service container,把 `ACN_INTEGRATION_PG_URL=postgresql+asyncpg://acn:acn@localhost:5432/acn_test` 注入到 pytest step。
- `tests/integration/test_settlement_outbox_pg.py`: 修一个 latent bug —— `_event()` 用 `"evt-A"` 这种短 tag 当 `event_id`,但 schema 里是 PG `uuid` 列,真 PG 一插入就 `invalid input syntax for type uuid`。把 helper 改成 UUID5 派生(label → 稳定 UUID),断言仍按 label 走方便排查。

跑出来 4/4 通过:
```
test_skip_locked_prevents_double_claim_across_replicas PASSED
test_uow_rollback_drops_enqueued_outbox_row             PASSED
test_enqueue_claim_done_round_trip                      PASSED
test_update_step_status_persists_step_value             PASSED
```

`uv.lock`: `uv sync` 顺手把 `acn` 版本号对齐到 pyproject 已经声明的 0.7.1,无功能影响。

## 兼容性

- 本地无 `ACN_INTEGRATION_PG_URL` 时,4 个测试仍然 skip — 不需要 docker 也能 `pytest`。
- CI 通过 service container 拉 postgres:16-alpine,起新 PG 实例,每次 run 都是干净环境。
- 测试 fixture 自带 `DROP/CREATE settlement_outbox` 表,不依赖 alembic 迁移。

## 验证

- ✅ 本地真 PG 跑 4/4 PASS
- ✅ 本地无 env 跑 4/4 SKIP
- ✅ 完整 suite (1350 tests) PASS
- ✅ ruff PASS
- ⏳ GitHub Actions 真跑(等 CI)

## 风险

- 给 CI 加 PG service 会增加约 5-10s 启动开销(健康检查)。可接受。
- 如果 postgres:16 镜像 pull 失败,CI 会卡 health check,健康检查最多重试 10 次 × 10s = 100s 后失败 — 不会无限挂。


Made with [Cursor](https://cursor.com)