### PR TITLE
feat(payments): add confirm payment endpoint, SDK method, and CLI subcommand

### DIFF
--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -293,6 +293,70 @@ async def create_payment_task(
         raise HTTPException(status_code=500, detail="Failed to create payment task") from e
 
 
+class ConfirmPaymentRequest(BaseModel):
+    tx_hash: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="On-chain transaction hash (or any external payment reference)",
+    )
+
+
+@router.post("/tasks/{task_id}/confirm")
+async def confirm_payment_task(
+    task_id: str,
+    body: ConfirmPaymentRequest,
+    agent_info: AgentApiKeyDep,
+    payment_tasks: PaymentTasksDep = None,
+):
+    """Confirm that an external payment has been made (requires Agent API Key).
+
+    The authenticated agent must be the buyer of the payment task.
+    Transitions the task to ``payment_confirmed`` and stores the
+    ``tx_hash`` so the seller can verify on-chain or in the external
+    payment system.
+
+    Typical flow::
+
+        1. Buyer calls ``POST /payments/tasks`` → gets ``task_id`` + seller wallet address
+        2. Buyer executes the actual payment (on-chain transfer, Stripe, etc.)
+        3. Buyer calls ``POST /payments/tasks/{task_id}/confirm`` with the ``tx_hash``
+        4. Seller receives ``payment_task.payment_confirmed`` webhook → releases goods/service
+    """
+    task = await payment_tasks.get_task(task_id)
+    if not task:
+        raise ACNHTTPError(
+            ErrorCode.PAYMENT_TASK_NOT_FOUND,
+            status_code=404,
+            details={"task_id": task_id},
+        )
+
+    if agent_info["agent_id"] != task.buyer_agent:
+        raise ACNHTTPError(
+            ErrorCode.FROM_AGENT_MISMATCH,
+            status_code=403,
+            details={
+                "authenticated_as": agent_info["agent_id"],
+                "from_agent": task.buyer_agent,
+            },
+        )
+
+    try:
+        updated = await payment_tasks.update_task_status(
+            task_id=task_id,
+            status=PaymentTaskStatus.PAYMENT_CONFIRMED,
+            tx_hash=body.tx_hash,
+        )
+        return {
+            "task_id": updated.task_id,
+            "status": updated.status.value,
+            "tx_hash": updated.tx_hash,
+        }
+    except Exception as e:
+        logger.error("confirm_payment_task_failed", task_id=task_id, error=str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to confirm payment task") from e
+
+
 @router.get("/tasks/{task_id}")
 async def get_payment_task(task_id: str, _: InternalTokenDep, payment_tasks: PaymentTasksDep = None):
     """Get payment task status (internal only)"""

--- a/clients/cli/src/commands/pay.ts
+++ b/clients/cli/src/commands/pay.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { acnPost } from '../api.js';
+import { acnGet, acnPost } from '../api.js';
 import { loadConfig } from '../config.js';
 import { output, handleError } from '../output.js';
 
@@ -22,9 +22,11 @@ function requireAgentId(): string {
 }
 
 export function payCommand(): Command {
-  const cmd = new Command('pay').description('Create a payment task to another agent');
+  const cmd = new Command('pay').description('Manage payment tasks between agents');
 
-  cmd
+  // ── sub-command: create ──────────────────────────────────────────────
+  const createCmd = new Command('create').description('Create a payment task to another agent');
+  createCmd
     .requiredOption('--to <agent>', 'Recipient agent ID')
     .requiredOption('--amount <n>', 'Payment amount (positive number)')
     .requiredOption('--currency <c>', 'Currency code, e.g. USD, USDC')
@@ -89,6 +91,57 @@ export function payCommand(): Command {
         }
       }
     );
+
+  // ── sub-command: confirm ─────────────────────────────────────────────
+  const confirmCmd = new Command('confirm').description(
+    'Confirm an external payment has been made (buyer only)'
+  );
+  confirmCmd
+    .requiredOption('--task-id <id>', 'Payment task ID to confirm')
+    .requiredOption(
+      '--tx-hash <hash>',
+      'On-chain transaction hash or external payment reference (e.g. Stripe charge ID)'
+    )
+    .action(async (opts: { taskId: string; txHash: string }) => {
+      try {
+        const res = await acnPost<{ task_id: string; status: string; tx_hash: string }>(
+          `/payments/tasks/${opts.taskId}/confirm`,
+          { tx_hash: opts.txHash }
+        );
+        output(
+          res,
+          `Payment confirmed: ${res.task_id}\n` +
+            `  status : ${res.status}\n` +
+            `  tx_hash: ${res.tx_hash}`
+        );
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  // ── sub-command: status ──────────────────────────────────────────────
+  const statusCmd = new Command('status').description(
+    'Show payment tasks for the authenticated agent'
+  );
+  statusCmd
+    .option('--status <s>', 'Filter by status (e.g. created, payment_confirmed)')
+    .option('--limit <n>', 'Max results (default 50)', '50')
+    .action(async (opts: { status?: string; limit: string }) => {
+      const agentId = requireAgentId();
+      try {
+        const res = await acnGet<{ agent_id: string; tasks: unknown[] }>(
+          `/payments/tasks/agent/${agentId}`,
+          { status: opts.status, limit: Number(opts.limit) }
+        );
+        output(res, `${res.tasks.length} payment task(s) for ${res.agent_id}`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  cmd.addCommand(createCmd);
+  cmd.addCommand(confirmCmd);
+  cmd.addCommand(statusCmd);
 
   return cmd;
 }

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -939,6 +939,28 @@ class ACNClient:
             },
         )
 
+    async def confirm_payment(self, task_id: str, tx_hash: str) -> dict[str, Any]:
+        """Confirm that an external payment has been made (requires Agent API Key).
+
+        Call this after you have executed the actual payment (on-chain transfer,
+        Stripe charge, etc.). ACN stores the ``tx_hash``, transitions the task
+        to ``payment_confirmed``, and sends a ``payment_task.payment_confirmed``
+        webhook to the seller so they can release their goods or service.
+
+        Args:
+            task_id: The payment task ID returned by ``create_payment_task``.
+            tx_hash: On-chain transaction hash or any external payment reference
+                     (e.g. Stripe charge ID, PayPal transaction ID).
+
+        Returns:
+            ``{"task_id": ..., "status": "payment_confirmed", "tx_hash": ...}``
+        """
+        return await self._request(
+            "POST",
+            f"/api/v1/payments/tasks/{task_id}/confirm",
+            json={"tx_hash": tx_hash},
+        )
+
     async def get_payment_task(self, task_id: str) -> PaymentTask:
         """Get a payment task by ID.
 


### PR DESCRIPTION
## 背景

AP2 外部支付链路一直差"最后一公里"：

1. Buyer 调 `acn pay create` → 拿到 `task_id` 和 seller 钱包地址
2. Buyer 在链上/法币渠道完成实际支付
3. **之前没有第 3 步** → seller 永远收不到通知，task 卡在 `created`

## 新增

### 后端 `POST /api/v1/payments/tasks/{task_id}/confirm`
- 需要 Agent API Key，且调用方必须是该 task 的 buyer
- Body: `{ "tx_hash": "..." }`
- 把 task 状态推进到 `payment_confirmed`，存储 tx_hash
- 触发 `payment_task.payment_confirmed` webhook 通知 seller

### Python SDK
```python
result = await client.confirm_payment(
    task_id="task-xxx",
    tx_hash="0xabc..."   # 或 Stripe charge ID 等任意外部支付凭证
)
# {"task_id": "...", "status": "payment_confirmed", "tx_hash": "..."}
```

### CLI
```bash
# 完整流程
acn pay create --to agent-B --amount 10 --currency USDC --method usdc --network base
# → task_id: abc123, 打款到 0x...

# 打完款后回填
acn pay confirm --task-id abc123 --tx-hash 0xdeadbeef...

# 查看自己的支付任务
acn pay status
acn pay status --status payment_confirmed --limit 10
```

`acn pay` 原来只是一个单命令，顺手重构成三个子命令：`create` / `confirm` / `status`。

## 测试
- ✅ 后端 4 项 consistency test PASS
- ✅ CLI TypeScript build PASS
- ✅ ruff PASS
- ⏳ GitHub Actions（等 CI）

Made with [Cursor](https://cursor.com)