### PR TITLE
refactor(currency): drop AP_POINTS backward compat, Credits is the sole platform currency

### DIFF
--- a/acn/protocols/ap2/core.py
+++ b/acn/protocols/ap2/core.py
@@ -65,22 +65,14 @@ CREDITS_PER_USD = 100.0  # 1 USD = 100 Credits (AgentPlanet backend convention)
 # Credits are the tradeable, escrow-capable currency on the backend
 # (wallet.balance, 1 USD = 100 Credits). All Labs task rewards and
 # escrow lock/release operations use Credits.
+#
+# NOTE: backend ap_points (wallet.ap_points) is a separate, non-transferable
+# field for platform behaviour rewards (register/referral). It does NOT
+# participate in escrow and is not a valid task reward_currency.
 CREDITS = "credits"
 
-# Legacy currency identifier kept for backward compatibility.
-# Existing tasks stored with reward_currency="ap_points" must still
-# settle correctly — all settlement gates include AP_POINTS alongside
-# CREDITS. New tasks should use CREDITS.
-#
-# NOTE: backend ap_points (wallet.ap_points) is a *separate* field —
-# platform behaviour rewards (register/referral) that are non-transferable
-# and do NOT participate in escrow. The string "ap_points" as a
-# reward_currency in ACN tasks was a historical mislabelling.
-AP_POINTS = "ap_points"
-
-# Convenience set for settlement gate checks — covers both the new
-# canonical value and legacy values that appear in existing DB rows.
-PLATFORM_CURRENCIES: frozenset[str] = frozenset({CREDITS, AP_POINTS, "points"})
+# Settlement gate: only Credits is a valid task reward currency.
+PLATFORM_CURRENCIES: frozenset[str] = frozenset({CREDITS})
 
 
 class SupportedPaymentMethod(StrEnum):

--- a/acn/services/escrow_client.py
+++ b/acn/services/escrow_client.py
@@ -18,7 +18,7 @@ from acn.core.interfaces.escrow_provider import (
     IEscrowProvider,
     ReleaseResult,
 )
-from acn.protocols.ap2.core import AP_POINTS
+from acn.protocols.ap2.core import CREDITS
 
 logger = structlog.get_logger()
 
@@ -43,7 +43,7 @@ class AgentPlanetEscrowProvider(IEscrowProvider):
 
     @property
     def supported_currencies(self) -> list[str]:
-        return [AP_POINTS]
+        return [CREDITS]
 
     def _get_headers(self) -> dict:
         headers = {"Content-Type": "application/json"}

--- a/tests/services/test_settlement_event_builder.py
+++ b/tests/services/test_settlement_event_builder.py
@@ -28,7 +28,7 @@ def _build_task(
     creator_id: str = "user-creator",
     assignee_id: str | None = "agent-worker",
     reward: str = "100",
-    reward_currency: str = "ap_points",
+    reward_currency: str = "credits",
     use_escrow: bool = True,
     max_participants: int | None = 1,
     metadata: dict | None = None,
@@ -69,7 +69,7 @@ def _service() -> TaskService:
 
 
 def test_main_path_escrow_and_reward_both_pending() -> None:
-    """The mainline production case: use_escrow=True + ap_points +
+    """The mainline production case: use_escrow=True + credits +
     positive reward + assignee present. All three steps pending.
     """
     event = _service()._build_review_pass_event(
@@ -120,8 +120,8 @@ def test_zero_reward_escrow_task_skips_both_payment_steps() -> None:
     assert event.step_status["reputation_write"] == "pending"
 
 
-def test_non_ap_points_currency_skips_reward_and_escrow() -> None:
-    """Non-ap_points reward: ACN v0.1 escrow only supports ap_points
+def test_non_credits_currency_skips_reward_and_escrow() -> None:
+    """Non-Credits reward: ACN escrow only supports Credits
     (see ``AgentPlanetEscrowProvider``), so reward_distribute is
     skipped and — per B-2 — escrow_release is too. This avoids
     enqueuing events for currencies the worker can't actually

--- a/tests/services/test_settlement_saga.py
+++ b/tests/services/test_settlement_saga.py
@@ -65,7 +65,7 @@ def _event(
     step_status: dict[str, str] | None = None,
 ) -> SettlementEvent:
     """Producer-shaped event: use_escrow=True, single-participant,
-    100 ap_points reward, assignee + creator both present. This is
+    100 credits reward, assignee + creator both present. This is
     the mainline production saga input.
     """
     return SettlementEvent(

--- a/tests/services/test_task_service_settlement.py
+++ b/tests/services/test_task_service_settlement.py
@@ -39,7 +39,7 @@ from acn.services.task_service import TaskService
 def _submitted_task(**overrides: Any) -> Task:
     """A reward-bearing single-participant task awaiting completion.
 
-    Reward + assignee + ap_points currency are deliberately set so the
+    Reward + assignee + credits currency are deliberately set so the
     legacy ``_distribute_reward`` branch *would* fire if it ran — that
     lets the saga-on test prove suppression rather than vacuously
     pass.


### PR DESCRIPTION
## 背景

PR #37 加了 `PLATFORM_CURRENCIES = {credits, ap_points, points}` 是为了向后兼容生产库里已有的 `reward_currency="ap_points"` 任务。经确认这些都是测试任务，不需要兼容。

## 改动

- `PLATFORM_CURRENCIES` 只保留 `frozenset({CREDITS})` — Credits 是唯一有效的任务奖励货币
- 删除 `AP_POINTS` 常量（以及 legacy 注释）
- `escrow_client.supported_currencies` 返回 `[CREDITS]` 而不是旧的 `[AP_POINTS]`
- 测试 fixture、docstring、函数名统一更新为 `"credits"`

## 测试
- ✅ 439 tests PASS
- ✅ ruff PASS
- ⏳ CI


Made with [Cursor](https://cursor.com)