### PR TITLE
fix(acn): E2E smoke findings — 4 P0 bugs + acn-client 0.11.x release

### DIFF
--- a/acn/infrastructure/persistence/redis/subnet_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_repository.py
@@ -48,6 +48,10 @@ class RedisSubnetRepository(ISubnetRepository):
             subnet_dict["harness_secret"] = ""
         if subnet_dict.get("description") is None:
             subnet_dict["description"] = ""
+        # redis-py refuses raw bool values for HSET — round-trip via the
+        # "True"/"False" string form that `_dict_to_subnet` already parses
+        # (see `is_private` parser).
+        subnet_dict["is_private"] = str(bool(subnet_dict.get("is_private", False)))
 
         # Save to Redis hash
         await self.redis.hset(subnet_key, mapping=subnet_dict)  # type: ignore[arg-type]

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -66,8 +66,22 @@ def require_task_write_auth():
     ) -> dict:
         s = settings
 
-        # Dev mode: accept anything
+        # Dev mode: accept anything — but if the bearer is an actual agent
+        # API key, still resolve it to the agent's identity. Otherwise
+        # downstream ACLs that key on agent UUID (subnet membership, task
+        # ownership, ...) will trivially fail with "Bearer acn_…" being
+        # treated as the agent id.
         if s.dev_mode:
+            if credentials and credentials.credentials.startswith("acn_"):
+                agent = await agent_service.get_agent_by_api_key(credentials.credentials)
+                if agent:
+                    request.state.rate_limit_key = f"agent:{agent.agent_id}"
+                    return {
+                        "sub": agent.agent_id,
+                        "type": "agent",
+                        "agent_name": agent.name,
+                        "permissions": ["acn:read", "acn:write", "acn:admin"],
+                    }
             sub = credentials.credentials if credentials else "dev@clients"
             request.state.rate_limit_key = f"dev:{sub}"
             return {"sub": sub, "type": "dev", "permissions": ["acn:read", "acn:write", "acn:admin"]}

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -70,6 +70,13 @@ class SubnetService:
             security_config=security_config or {},
             metadata=metadata or {},
         )
+        # The owner is implicitly a member: every ACL that keys off
+        # `subnet.member_agent_ids` (private GET /tasks/{id}, accept_task,
+        # is_subnet_member, ...) otherwise 403s the owner from acting on the
+        # subnet they just created. Mirror this in the entity at construction
+        # time so harness bootstrap (create_subnet → register_harness →
+        # create_task) works without a follow-up join_subnet hack.
+        subnet.add_member(owner)
 
         logger.info("create_subnet", subnet_id=subnet_id, name=name, owner=owner)
         await self.repository.save(subnet)

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -458,6 +458,13 @@ class TaskService:
             )
 
         logger.info("task_accepted", task_id=task_id, agent_id=agent_id)
+
+        # Symmetry with the multi-participant path (_join_task line 630): emit
+        # TASK_ACCEPTED webhook so Org Harnesses (e.g. paperclip-acn-plugin)
+        # can mirror state. Without this, single-participant tasks silently
+        # skip the accept notification and downstream harnesses are stuck
+        # showing "open".
+        await self._notify_webhook(WebhookEventType.TASK_ACCEPTED, task)
         return task, None
 
     async def invite_agent(

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `acn-client` (TypeScript) are documented here.
 
+## [0.11.1] - 2026-05-14
+
+### Fixed
+- **Subnet membership paths**: `joinSubnet`, `leaveSubnet`, and
+  `getAgentSubnets` now send requests to the ACN backend's actual path —
+  `/api/v1/subnets/{agent_id}/subnets/{subnet_id}` and
+  `/api/v1/subnets/{agent_id}/subnets`. Earlier builds (≤ 0.11.0) called
+  `/api/v1/agents/{agent_id}/…`, which 404'd against any live ACN server.
+  No caller-code changes required — the SDK method signatures are
+  unchanged.
+
 ## [0.11.0] - 2026-05-14
 
 This release adds first-class support for ACN's **Org-Harness Task Pool**

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to `acn-client` (TypeScript) are documented here.
 
+## [0.11.0] - 2026-05-14
+
+This release adds first-class support for ACN's **Org-Harness Task Pool**
+(create / accept / submit / review / cancel tasks, subnet harness webhook
+registration). It also fixes a critical authentication bug that prevented
+every authenticated route from working in earlier 0.10.x builds.
+
+### Fixed
+- **Auth header**: requests now send `Authorization: Bearer <apiKey>` instead
+  of the unsupported `X-API-Key`. The ACN server has only ever accepted
+  Bearer, so every authenticated route from earlier 0.10.x silently 401'd.
+  No caller-code changes required; if you had a reverse proxy stripping the
+  `Authorization` header to work around the old behaviour, remove that rule.
+- `reviewTask(approved, notes)` now sends the third argument as the `notes`
+  field expected by `TaskReviewRequest`. Earlier 0.10.x sent it as
+  `feedback`, which the server silently dropped — review notes never
+  reached the audit trail. No caller-code changes required; the SDK
+  signature's third parameter was renamed `feedback` → `notes` for clarity.
+
+### Changed (BREAKING)
+- `TaskStatus` union now mirrors the server enum exactly:
+  - **Removed**: `'in_review'` (never emitted by the server)
+  - **Added**: `'submitted'`, `'rejected'`
+  - Final values: `'open' | 'in_progress' | 'submitted' | 'completed' | 'rejected' | 'cancelled'`
+  - **Action required**: code that compared `task.status === 'in_review'`
+    must now compare against `'submitted'`.
+- `Task.reward` is a decimal string (e.g. `"10.00"`) matching the server's
+  `TaskResponse.reward`. The convenience numeric alias `reward_amount` is
+  available as an optional read-only field.
+- `TaskCreateRequest` now reflects the server contract:
+  - **Required**: `title`, `description` (10–10 000 chars), `reward` (string),
+    `deadline_hours` (1–2 160).
+  - **Removed**: `reward_amount: number` (was incorrect — server requires
+    string `reward`).
+  - **Added (optional)**: `max_participants`, `task_type`, `required_tags`,
+    `auto_approve`, `use_escrow`, `reward_currency`.
+
+### Added
+- Task Pool methods:
+  - `createTask(req)` — POST `/api/v1/tasks`
+  - `getTask(taskId)` — GET `/api/v1/tasks/{id}`
+  - `listTasks(opts?)` — GET `/api/v1/tasks` with `status / creator_id /
+    assignee_id / limit / offset` filters
+  - `acceptTask(taskId, message?)` — POST `/api/v1/tasks/{id}/accept`,
+    returns `TaskAcceptResponse` (`{ task, participation_id }`)
+  - `submitTask(taskId, submission, opts?)` — POST `/api/v1/tasks/{id}/submit`
+    with optional `artifacts` and `participationId`
+  - `reviewTask(taskId, approved, notes?)` — POST `/api/v1/tasks/{id}/review`
+  - `cancelTask(taskId)` — POST `/api/v1/tasks/{id}/cancel`
+  - `getTaskParticipations(taskId)` — GET `/api/v1/tasks/{id}/participations`
+- `registerSubnetHarness(subnetId, harnessUrl, harnessSecret?)` — PATCH
+  `/api/v1/subnets/{id}/harness` to register (or clear, via `null`) a
+  webhook URL with optional HMAC secret. Used by the Paperclip ACN plugin
+  and any other Org-Harness consumer.
+- Exported types: `Task`, `TaskStatus`, `TaskAcceptResponse`,
+  `TaskCreateRequest`, `TaskListOptions`, `TaskListResponse`,
+  `Participation`, `ParticipationListResponse`, `SubnetHarnessRequest`.
+
+### Notes
+- CHANGELOG entries for `0.8.0`, `0.9.0`, and `0.10.0` were never published.
+  This release consolidates everything that has landed on the 0.10 line.
+
 ## [0.7.1] - 2026-05-10
 
 ### Changed (BREAKING)

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/clients/typescript/scripts/smoke.ts
+++ b/clients/typescript/scripts/smoke.ts
@@ -1,0 +1,135 @@
+/**
+ * Smoke test for v0.11.0 SDK against a running ACN backend.
+ *
+ * Covers every contract that the 6-round audit touched:
+ *  1. Auth header (Authorization: Bearer) — must succeed on a protected route
+ *  2. Agent self-registration (/agents/join)
+ *  3. Subnet create
+ *  4. registerSubnetHarness (PATCH /subnets/:id/harness with secret)
+ *  5. createTask  — `reward: string`, `deadline_hours: number`, required fields
+ *  6. getTask     — response shape matches Task interface
+ *  7. listTasks   — `status: "open" | "in_progress" | "submitted"` filter
+ *  8. acceptTask  — returns { task, participation_id }
+ *  9. submitTask  — sends `submission` (not `submissionContent`)
+ * 10. reviewTask  — sends `notes` (not `feedback`)
+ * 11. TaskStatus  — assert backend emits one of the documented values
+ *
+ * Usage:
+ *   ACN_URL=http://127.0.0.1:9000 npx tsx scripts/smoke.ts
+ */
+
+import { ACNClient } from "../src/index.js";
+
+const ACN_URL = process.env.ACN_URL ?? "http://127.0.0.1:9000";
+// ACN backend rejects names ending with 8+ digits (auto-generated guard),
+// so use a short alphanumeric suffix instead of Date.now().
+const STAMP = Math.random().toString(36).slice(2, 8);
+
+function log(stage: string, detail?: unknown) {
+  if (detail !== undefined) {
+    console.log(`\n[${stage}]`, typeof detail === "string" ? detail : JSON.stringify(detail, null, 2));
+  } else {
+    console.log(`\n[${stage}]`);
+  }
+}
+
+async function main() {
+  // ── 1. Register a fresh creator agent (gets its own acn_xxx api key) ────
+  log("register creator agent");
+  const anon = new ACNClient({ baseUrl: ACN_URL });
+  const creator = await anon.joinACN({
+    name: `smoke-creator-${STAMP}`,
+    description: "v0.11.0 SDK smoke test creator (auto-generated, safe to delete)",
+    a2a_endpoint: "http://127.0.0.1:0/jsonrpc",
+    tags: ["smoke", "creator"],
+  });
+  log("creator.agent_id", creator.agent_id);
+
+  const creatorClient = new ACNClient({ baseUrl: ACN_URL, apiKey: creator.api_key });
+
+  // ── 2. Register a solver agent in a second subnet identity ──────────────
+  log("register solver agent");
+  const solver = await anon.joinACN({
+    name: `smoke-solver-${STAMP}`,
+    description: "v0.11.0 SDK smoke test solver (auto-generated, safe to delete)",
+    a2a_endpoint: "http://127.0.0.1:0/jsonrpc",
+    tags: ["smoke", "solver"],
+  });
+  log("solver.agent_id", solver.agent_id);
+  const solverClient = new ACNClient({ baseUrl: ACN_URL, apiKey: solver.api_key });
+
+  // ── 3. Create a subnet (creator owns it) ─────────────────────────────────
+  log("create subnet");
+  const subnet = await creatorClient.createSubnet({
+    name: `smoke-${STAMP}`,
+    description: "v0.11.0 SDK smoke test subnet",
+  });
+  log("subnet.subnet_id", subnet.subnet_id);
+
+  // ── 4. Register a harness webhook (with secret) — proves PATCH /harness ─
+  log("registerSubnetHarness");
+  await creatorClient.registerSubnetHarness(
+    subnet.subnet_id,
+    "http://127.0.0.1:0/webhook",
+    "smoke-secret-32-bytes-of-entropy-yes",
+  );
+
+  // ── 5. createTask using new schema (reward: string, deadline_hours) ─────
+  log("createTask");
+  const created = await creatorClient.createTask({
+    title: `smoke task ${STAMP}`,
+    description: "v0.11.0 SDK smoke task — verifies createTask field set.",
+    reward: "0",
+    deadline_hours: 24,
+    reward_currency: "credits",
+    max_participants: 1,
+  });
+  log("created.task_id", created.task_id);
+  log("created.status (should be 'open')", created.status);
+  log("created.reward type", typeof created.reward);
+  if (created.status !== "open") throw new Error(`expected status 'open', got '${created.status}'`);
+  if (typeof created.reward !== "string") throw new Error(`expected reward string, got ${typeof created.reward}`);
+
+  // ── 6. getTask ──────────────────────────────────────────────────────────
+  log("getTask");
+  const fetched = await creatorClient.getTask(created.task_id);
+  if (fetched.task_id !== created.task_id) throw new Error("getTask mismatch");
+
+  // ── 7. listTasks with new TaskStatus filter ─────────────────────────────
+  log("listTasks status=open");
+  const open = await creatorClient.listTasks({ status: "open", limit: 50 });
+  if (!open.tasks.some((t) => t.task_id === created.task_id)) {
+    throw new Error("freshly created task not present in listTasks(open)");
+  }
+
+  // ── 8. acceptTask (solver) — returns TaskAcceptResponse ─────────────────
+  log("acceptTask (solver)");
+  const accept = await solverClient.acceptTask(created.task_id, "I'll take this");
+  log("accept.participation_id", accept.participation_id ?? "<null/single-participant>");
+  log("accept.task.status (should be in_progress)", accept.task.status);
+  if (accept.task.status !== "in_progress") throw new Error(`expected in_progress after accept, got ${accept.task.status}`);
+
+  // ── 9. submitTask — body field name must be `submission` ────────────────
+  log("submitTask (solver)");
+  const submitted = await solverClient.submitTask(
+    created.task_id,
+    "Smoke submission content (≥5 chars).",
+    { participationId: accept.participation_id ?? undefined },
+  );
+  log("submitted.status (should be 'submitted')", submitted.status);
+  if (submitted.status !== "submitted") throw new Error(`expected 'submitted', got ${submitted.status}`);
+
+  // ── 10. reviewTask — body field name must be `notes` ───────────────────
+  log("reviewTask approve (creator)");
+  const reviewed = await creatorClient.reviewTask(created.task_id, true, "LGTM via smoke");
+  log("reviewed.status (should be 'completed')", reviewed.status);
+  if (reviewed.status !== "completed") throw new Error(`expected 'completed', got ${reviewed.status}`);
+
+  // ── 11. Final sanity ────────────────────────────────────────────────────
+  log("DONE — all 11 contract checks passed");
+}
+
+main().catch((err) => {
+  console.error("\n❌ SMOKE FAILED:", err);
+  process.exit(1);
+});

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -244,6 +244,22 @@ export class ACNClient {
     return this.post('/api/v1/agents/join', request);
   }
 
+  /**
+   * Resolve the authenticated agent (i.e. the one whose API key the client
+   * carries). Returns the full agent record. Useful for harnesses that
+   * need to know their own `agent_id` to skip echo-loops on webhook
+   * deliveries — when an ACN task.created event arrives whose `creator_id`
+   * matches the harness's own agent_id, the harness can recognise the task
+   * as one it issued itself and avoid re-mirroring it.
+   */
+  async getMyAgent(): Promise<{
+    agent_id: string;
+    name: string;
+    [key: string]: unknown;
+  }> {
+    return this.get('/api/v1/agents/me');
+  }
+
   /** Get agent by ID */
   async getAgent(agentId: string): Promise<AgentInfo> {
     return this.get(`/api/v1/agents/${agentId}`);

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -322,19 +322,37 @@ export class ACNClient {
     return this.get(`/api/v1/subnets/${subnetId}/agents`);
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  //  Subnet membership (agent-side)
+  //
+  //  The ACN backend hangs these three endpoints off the `subnets` router
+  //  rather than the `agents` router — i.e. the live paths are
+  //
+  //      POST   /api/v1/subnets/{agent_id}/subnets/{subnet_id}
+  //      DELETE /api/v1/subnets/{agent_id}/subnets/{subnet_id}
+  //      GET    /api/v1/subnets/{agent_id}/subnets
+  //
+  //  This is asymmetric with the surrounding "agent-side" routes (heartbeat,
+  //  claim, transfer, ...) which are all rooted at `/api/v1/agents/{id}/…`.
+  //  We mirror the backend's actual contract verbatim here so the SDK works
+  //  out of the box; once the backend ships canonical
+  //  `/api/v1/agents/{id}/subnets/…` aliases we can flip these without a
+  //  caller-visible signature change.
+  // ──────────────────────────────────────────────────────────────────────
+
   /** Join agent to subnet */
   async joinSubnet(agentId: string, subnetId: string): Promise<{ success: boolean }> {
-    return this.post(`/api/v1/agents/${agentId}/subnets/${subnetId}`);
+    return this.post(`/api/v1/subnets/${agentId}/subnets/${subnetId}`);
   }
 
   /** Remove agent from subnet */
   async leaveSubnet(agentId: string, subnetId: string): Promise<{ success: boolean }> {
-    return this.delete(`/api/v1/agents/${agentId}/subnets/${subnetId}`);
+    return this.delete(`/api/v1/subnets/${agentId}/subnets/${subnetId}`);
   }
 
   /** Get agent's subnets */
   async getAgentSubnets(agentId: string): Promise<{ subnets: string[] }> {
-    return this.get(`/api/v1/agents/${agentId}/subnets`);
+    return this.get(`/api/v1/subnets/${agentId}/subnets`);
   }
 
   // ============================================

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -438,12 +438,16 @@ export interface PaymentCapability {
 // Task Types (Saga / Org-Harness Task Pool)
 // ============================================
 
-/** Task status values for ACN task pool. */
+/**
+ * Task status values for ACN task pool — mirrors backend `TaskStatus` enum
+ * (`acn.core.entities.task.TaskStatus`).
+ */
 export type TaskStatus =
   | 'open'
   | 'in_progress'
-  | 'in_review'
+  | 'submitted'
   | 'completed'
+  | 'rejected'
   | 'cancelled';
 
 /** ACN task (org-harness task pool). Aligns with server `TaskResponse`. */

--- a/tests/infrastructure/test_subnet_repository_redis_save.py
+++ b/tests/infrastructure/test_subnet_repository_redis_save.py
@@ -1,0 +1,131 @@
+"""Redis subnet repository save / round-trip regression tests.
+
+These pin down two storage contracts that future refactors of
+``RedisSubnetRepository`` cannot silently break:
+
+  1. ``save()`` must never pass a Python ``bool`` to ``redis.hset(mapping=...)``.
+     redis-py rejects raw bools with
+     ``DataError: Invalid input of type: 'bool'``, which previously caused
+     ``POST /api/v1/subnets`` to 500 in Redis-fallback mode.
+  2. The string form must round-trip through ``_dict_to_subnet`` so that
+     ``is_private`` is preserved across a save/load cycle.
+
+Mirrors the AsyncMock style used in ``test_follow_repository``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.infrastructure.persistence.redis.subnet_repository import (
+    RedisSubnetRepository,
+)
+
+
+def _make_redis_mock() -> AsyncMock:
+    """Build a redis-py async client mock that:
+    - records calls to ``hset``;
+    - exposes an awaitable ``pipeline()`` async context manager that
+      itself records ``sadd`` / ``execute`` calls.
+    """
+    redis = AsyncMock()
+
+    class _PipeProxy:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, tuple, dict]] = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def sadd(self, *args, **kwargs):
+            self.calls.append(("sadd", args, kwargs))
+
+        async def execute(self):
+            self.calls.append(("execute", (), {}))
+            return []
+
+    pipe = _PipeProxy()
+    # pipeline() is synchronous on redis.asyncio (returns the context manager)
+    redis.pipeline = MagicMock(return_value=pipe)
+    redis._pipe = pipe  # expose for assertions
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_save_serialises_is_private_as_string_not_bool() -> None:
+    """Regression: bool ``is_private`` must be stringified before HSET.
+
+    Previously the field was passed through as Python ``True``/``False``,
+    which redis-py refuses (``DataError: Invalid input of type 'bool'``),
+    crashing every subnet create on Redis-fallback deployments.
+    """
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    subnet = Subnet(
+        subnet_id="subnet-test-1",
+        name="test",
+        owner="agent-owner",
+        is_private=True,
+    )
+
+    await repo.save(subnet)
+
+    redis.hset.assert_awaited_once()
+    _, kwargs = redis.hset.await_args
+    mapping = kwargs["mapping"]
+    # No bare bools in the HSET payload.
+    assert not any(isinstance(v, bool) for v in mapping.values()), (
+        f"bool leaked into Redis HSET payload: {mapping!r}"
+    )
+    # Round-trip format expected by `_dict_to_subnet`.
+    assert mapping["is_private"] == "True"
+
+
+@pytest.mark.asyncio
+async def test_save_round_trip_preserves_is_private() -> None:
+    """``save`` + ``_dict_to_subnet`` must preserve ``is_private`` value."""
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+
+    for value in (True, False):
+        subnet = Subnet(
+            subnet_id=f"subnet-rt-{value}",
+            name="rt",
+            owner="agent-owner",
+            is_private=value,
+        )
+        await repo.save(subnet)
+        _, kwargs = redis.hset.await_args
+        loaded = repo._dict_to_subnet(kwargs["mapping"])
+        assert loaded.is_private is value
+
+
+@pytest.mark.asyncio
+async def test_save_normalises_none_fields_to_empty_string() -> None:
+    """Existing contract: ``None`` for nullable str fields must serialise as ''.
+
+    Locks in current behaviour so the bool-fix patch does not regress the
+    surrounding ``if ... is None`` normalisation block.
+    """
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    subnet = Subnet(
+        subnet_id="subnet-none",
+        name="nones",
+        owner="agent-owner",
+        description=None,
+        harness_url=None,
+        harness_secret=None,
+    )
+
+    await repo.save(subnet)
+
+    _, kwargs = redis.hset.await_args
+    mapping = kwargs["mapping"]
+    assert mapping["description"] == ""
+    assert mapping["harness_url"] == ""
+    assert mapping["harness_secret"] == ""

--- a/tests/services/test_subnet_service.py
+++ b/tests/services/test_subnet_service.py
@@ -1,0 +1,75 @@
+"""Unit Tests for SubnetService
+
+Regression tests for the subnet lifecycle business logic.
+"""
+
+import pytest
+
+from acn.services import SubnetService
+
+
+class TestSubnetServiceCreate:
+    """create_subnet adds the owner as a member by construction.
+
+    Regression target: before this fix, ``Subnet`` was persisted with an
+    empty ``member_agent_ids`` set, so every ACL keyed off member-list
+    membership (e.g. private GET ``/api/v1/tasks/{id}``, ``accept_task``'s
+    ``is_subnet_member`` check) rejected the owner from acting on the
+    subnet they themselves had just created. This silently broke the
+    canonical Org-Harness bootstrap flow (create_subnet → register_harness
+    → create_task) and was only visible E2E.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_subnet_seeds_owner_as_member(self, mock_subnet_repository):
+        """The owner is implicitly a member at create time."""
+        # No existing subnet so the create proceeds.
+        mock_subnet_repository.exists.return_value = False
+
+        service = SubnetService(mock_subnet_repository)
+        subnet = await service.create_subnet(
+            subnet_id="subnet-test",
+            name="Test Subnet",
+            owner="agent-owner-123",
+        )
+
+        assert "agent-owner-123" in subnet.member_agent_ids, (
+            "owner must be a member of their own subnet at creation time; "
+            "otherwise every member-list ACL (private GET task, accept_task, "
+            "is_subnet_member) trivially 403s the owner."
+        )
+        mock_subnet_repository.save.assert_called_once()
+        # save() received the SAME subnet instance with the member set; this
+        # rules out a regression where the entity is mutated only AFTER save.
+        saved_subnet = mock_subnet_repository.save.call_args.args[0]
+        assert "agent-owner-123" in saved_subnet.member_agent_ids
+
+    @pytest.mark.asyncio
+    async def test_create_subnet_preserves_only_owner_at_member_set(
+        self, mock_subnet_repository
+    ):
+        """No additional members are accidentally added."""
+        mock_subnet_repository.exists.return_value = False
+
+        service = SubnetService(mock_subnet_repository)
+        subnet = await service.create_subnet(
+            subnet_id="subnet-test",
+            name="Test Subnet",
+            owner="agent-owner-123",
+        )
+
+        assert subnet.member_agent_ids == {"agent-owner-123"}
+
+    @pytest.mark.asyncio
+    async def test_create_subnet_rejects_duplicate_id(self, mock_subnet_repository):
+        """Pre-existing subnet causes ValueError; owner not silently overwritten."""
+        mock_subnet_repository.exists.return_value = True
+
+        service = SubnetService(mock_subnet_repository)
+        with pytest.raises(ValueError, match="already exists"):
+            await service.create_subnet(
+                subnet_id="subnet-test",
+                name="Test Subnet",
+                owner="agent-owner-123",
+            )
+        mock_subnet_repository.save.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## 背景

把 ACN 当作 identity / settlement layer 嵌进 Paperclip 时，通过 [paperclip-acn-plugin](https://github.com/acnlabs/paperclip-acn-plugin)（独立 repo）做完整端到端冒烟（ACN→PC mirror、PC→ACN createTask、accept→submit→review 全生命周期）。过程中拽出 4 个 ACN 后端 P0 bug + 1 个 SDK 路径 P1 bug，每一个都独立挡住一段业务流；现有单元测试覆盖不到只有 E2E 才能拼出来。本 PR 把它们一并修了，并顺势把 `acn-client` TypeScript SDK 从 0.10.x 推到 0.11.1（含 Task Pool 全套契约 + Bearer auth 修复）。

完整审计轨迹同步到 [`.cursor/plans/acn_上线前安全审计_*.plan.md`](.cursor/plans) §8.8。

## ACN 后端 bug 修复（4 项，均带回归测）

| # | 严重 | 描述 | Commit |
|---|---|---|---|
| 1 | P0 | **`RedisSubnetRepository.save()` 崩在 bool `is_private`** — redis-py 拒绝 raw bool HSET，导致 Redis-fallback 模式下任何 `subnet_service.add_member` / `save_subnet` 500。round-trip via \`\"True\"/\"False\"\` 字符串形式（`_dict_to_subnet` 已能解析）。回归测 3 用例 | `3b49652` |
| 2 | P0 | **`dev_mode` 把 raw API key 当 agent_id** — `require_task_write_auth` 在 dev_mode 返回 `sub = raw bearer`，所有下游 ACL（subnet member、task creator、…）拿 \`\"Bearer acn_…\"\` 跟 agent UUID 比，永远 fail。原 smoke 不走 subnet 才遮住。修：dev_mode 下若 bearer 以 `acn_` 开头，仍解析其真实 agent_id；非 `acn_` token 走原 dev short-circuit。`acn/auth/middleware.py` 三处同样模式留作下轮 | `3b49652` |
| 3 | P0 | **单参与者 `accept_task` 漏发 `TASK_ACCEPTED` webhook** — 多参与者路径走 `_join_task` 有发，单参与者分支直接 `return task, None` 跳过 `_notify_webhook`。Org Harness 订阅方永远收不到 accept 事件，mirror issue 卡在 open | `3b49652` |
| 4 | P0 | **`create_subnet` 不把 owner 加入 `member_agent_ids`** — owner 通过 `subnet.owner` 隐式持有，但所有 ACL（private GET `/tasks/{id}` / `accept_task` 的 `is_subnet_member`）都查显式成员集，owner 在自己 subnet 里被 403。修：构造期 `subnet.add_member(owner)`。回归测 3 用例 | `eece53f` |

## acn-client TypeScript SDK release（0.10.x → 0.11.1）

| 版本 | 主要变更 | Commit |
|---|---|---|
| **0.11.0** | **Auth header `X-API-Key` → `Bearer`**（修一直没工作的 0.10.x 认证）；Task Pool 8 个方法（create/get/list/accept/submit/review/cancel/participations）；`registerSubnetHarness`；`getMyAgent`（webhook echo-loop 防护用）；`TaskStatus` 对齐 backend enum；`Task.reward: string`；E2E smoke `scripts/smoke.ts` 覆盖 11/11 契约 | `26862ff` |
| **0.11.1** | `joinSubnet` / `leaveSubnet` / `getAgentSubnets` 路径修正：之前打到 `/api/v1/agents/{id}/…` 全部 404，对齐 backend 事实路径 `/api/v1/subnets/{id}/…`（详见下文 follow-up #1） | `079e049` |

### Breaking changes（需要 callers 改）

- `TaskStatus` union：去掉 `'in_review'`，新增 `'submitted'` / `'rejected'`
- `Task.reward`: `number` → `string`（如 `\"10.00\"`，对齐 server `TaskResponse.reward`）
- `TaskCreateRequest` 新字段 `deadline_hours: number`（必填，1-2160）；移除 `reward_amount: number`

### 非 breaking 行为变化（订阅方注意）

- 任何订阅 ACN webhook 的 Org Harness，会**突然开始**收到原本漏发的单参与者 `task.accepted` 事件 — 行为对齐，但订阅方需要做好幂等
- `create_subnet` 之后 owner 不用再额外 `join_subnet`（旧的 workaround 可以删了）

## Commits（按 base→head 顺序）

```
3b49652  fix(acn): three E2E-blocking bugs caught by paperclip-acn-plugin smoke
26862ff  feat(typescript-sdk): release acn-client 0.11.0
eece53f  fix(subnet_service): seed owner into member set at create time
079e049  fix(typescript-sdk): release acn-client 0.11.1 — correct subnet membership paths
8f64d12  chore(deps): sync uv.lock to acn 0.10.0
```

## 测试

- ✅ 新增 6 个 ACN 回归测：`tests/infrastructure/test_subnet_repository_redis_save.py`（3）+ `tests/services/test_subnet_service.py`（3），本地全过
- ✅ 相关 subnet 测试套件 28 个全过（含 routes/test_subnets_harness、routes/test_subnets_error_schema）
- ✅ SDK build 通过；`scripts/smoke.ts` 11/11 契约对真 ACN backend 通过
- ⏳ GitHub Actions（等 CI）

## Follow-up（不在本 PR 范围）

1. **`acn/routes/subnets.py` router prefix 错位** — agent-side join/leave/get_agent_subnets 端点挂在 \`/api/v1/subnets/{agent_id}/subnets/…\`（应在 \`/api/v1/agents/{agent_id}/subnets/…\`）。SDK 已随后端事实路径对齐；backend mirror canonical alias 留作下一轮重构。P2。
2. **`acn/auth/middleware.py` 三处同 dev_mode bug** — `require_task_write_auth` 已修，但 middleware 里另外三个同样模式的 helper 待同步。下轮一并扫。

## 关联

- 同批 plugin 仓首份 commit：`acnlabs/paperclip-acn-plugin@0433ab8`（standalone，43 个单测覆盖 + 3 个 E2E 脚本）
- 审计轨迹：`.cursor/plans/acn_上线前安全审计_*.plan.md` §8.8

Made with [Cursor](https://cursor.com)