### PR TITLE
feat(routes): canonical /api/v1/agents/{id}/subnets/... membership API

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -85,6 +85,7 @@ from .protocols.ap2 import (
     create_webhook_config_from_settings,
 )
 from .routes import (
+    agent_subnets,
     allowlist,
     analytics,
     communication,
@@ -1189,6 +1190,15 @@ app.include_router(follows.router)
 # ``/{agent_id}/{rest_path:path}`` does not greedily forward
 # allowlist requests to the agent's real endpoint.
 app.include_router(allowlist.router)
+# Canonical agent-side subnet membership routes
+# (`POST/DELETE /api/v1/agents/{id}/subnets/{subnet_id}`,
+#  `GET /api/v1/agents/{id}/subnets`).
+# MUST be registered before `registry.router` for the same reason
+# `follows` and `allowlist` are: registry mounts a catch-all
+# `/{agent_id}/{rest_path:path}` for A2A proxy forwarding, which would
+# otherwise greedily swallow these requests and demand the proxy's
+# `X-ACN-Authorization` header.
+app.include_router(agent_subnets.router)
 app.include_router(registry.router)
 app.include_router(onchain.router)
 app.include_router(communication.router)

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -1,0 +1,203 @@
+"""Shared business logic for agent-side subnet membership operations.
+
+Both `routes/subnets.py` (legacy `/api/v1/subnets/{agent_id}/subnets/…`
+paths) and `routes/agent_subnets.py` (canonical `/api/v1/agents/{agent_id}/
+subnets/…` paths) call into these helpers so the two route surfaces stay
+behaviourally identical, byte-for-byte. The only thing each route owns is
+its own URL + OpenAPI metadata (e.g. `deprecated=True` on the legacy
+path); every ACL, side-effect, and response payload lives here.
+
+Keeping logic out of route modules also lets the new canonical handlers
+live in their own thin file rather than bloating `routes/registry.py`
+(already 2300+ lines).
+"""
+
+from __future__ import annotations
+
+import structlog  # type: ignore[import-untyped]
+from fastapi import HTTPException
+
+from ..core.errors import ACNHTTPError, ErrorCode
+from ..core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from ..protocols.ap2 import WebhookEventType
+from ..protocols.ap2.webhook import WebhookService
+from ..services import AgentService, SubnetService
+
+logger = structlog.get_logger()
+
+
+def _require_self(agent_info: dict, path_agent_id: str) -> None:
+    """Reject if the API key's agent_id doesn't match the path `agent_id`.
+
+    Agents may only manage their own subnet membership.
+    """
+    if agent_info["agent_id"] != path_agent_id:
+        raise ACNHTTPError(
+            ErrorCode.API_KEY_AGENT_MISMATCH,
+            403,
+            details={
+                "path_agent": path_agent_id,
+                "key_agent": agent_info["agent_id"],
+            },
+        )
+
+
+async def do_join_subnet(
+    *,
+    agent_id: str,
+    subnet_id: str,
+    agent_info: dict,
+    subnet_service: SubnetService,
+    agent_service: AgentService,
+    webhook_service: WebhookService | None,
+) -> dict:
+    """Join `agent_id` into `subnet_id`. Idempotent at the service layer.
+
+    Side effects:
+    - `agent.subnet_ids` gains `subnet_id`
+    - `subnet.member_agent_ids` gains `agent_id`
+    - `agent.joined_subnet` Org Harness webhook is fired best-effort
+    """
+    _require_self(agent_info, agent_id)
+
+    # Verify subnet exists (and capture entity for harness-webhook delivery).
+    try:
+        subnet = await subnet_service.get_subnet(subnet_id)
+    except SubnetNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            404,
+            details={"subnet_id": subnet_id},
+        ) from e
+
+    try:
+        await agent_service.join_subnet(agent_id, subnet_id)
+        await subnet_service.add_member(subnet_id, agent_id)
+
+        logger.info("agent_joined_subnet", agent_id=agent_id, subnet_id=subnet_id)
+
+        if subnet.harness_url and webhook_service is not None:
+            try:
+                await webhook_service.send_to(
+                    url=subnet.harness_url,
+                    secret=subnet.harness_secret,
+                    event=WebhookEventType.AGENT_JOINED_SUBNET,
+                    task_id=subnet_id,  # no task; use subnet_id for trace correlation
+                    data={
+                        "subnet_id": subnet_id,
+                        "agent_id": agent_id,
+                    },
+                )
+            except Exception as e:  # noqa: BLE001 - never break join on webhook failure
+                logger.warning(
+                    "subnet_harness_webhook_failed",
+                    subnet_id=subnet_id,
+                    agent_id=agent_id,
+                    webhook_event="agent.joined_subnet",
+                    error=str(e),
+                )
+
+        return {"status": "joined", "agent_id": agent_id, "subnet_id": subnet_id}
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_id},
+        ) from e
+    except ACNHTTPError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("join_subnet_failed", error=str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to join subnet") from e
+
+
+async def do_leave_subnet(
+    *,
+    agent_id: str,
+    subnet_id: str,
+    agent_info: dict,
+    subnet_service: SubnetService,
+    agent_service: AgentService,
+    webhook_service: WebhookService | None,
+) -> dict:
+    """Leave `subnet_id`. Mirrors `do_join_subnet` semantics."""
+    _require_self(agent_info, agent_id)
+
+    # Capture subnet up-front so we still know the harness_url even if the
+    # subnet later gets unmodified (it doesn't, but keeps symmetry with join).
+    try:
+        subnet = await subnet_service.get_subnet(subnet_id)
+    except SubnetNotFoundException:
+        subnet = None  # let downstream raise the canonical error
+
+    try:
+        await agent_service.leave_subnet(agent_id, subnet_id)
+        await subnet_service.remove_member(subnet_id, agent_id)
+
+        logger.info("agent_left_subnet", agent_id=agent_id, subnet_id=subnet_id)
+
+        if subnet and subnet.harness_url and webhook_service is not None:
+            try:
+                await webhook_service.send_to(
+                    url=subnet.harness_url,
+                    secret=subnet.harness_secret,
+                    event=WebhookEventType.AGENT_LEFT_SUBNET,
+                    task_id=subnet_id,
+                    data={
+                        "subnet_id": subnet_id,
+                        "agent_id": agent_id,
+                    },
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "subnet_harness_webhook_failed",
+                    subnet_id=subnet_id,
+                    agent_id=agent_id,
+                    webhook_event="agent.left_subnet",
+                    error=str(e),
+                )
+
+        return {"status": "left", "agent_id": agent_id, "subnet_id": subnet_id}
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_id},
+        ) from e
+    except SubnetNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            404,
+            details={"subnet_id": subnet_id},
+        ) from e
+    except ACNHTTPError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("leave_subnet_failed", error=str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to leave subnet") from e
+
+
+async def do_get_agent_subnets(
+    *,
+    agent_id: str,
+    agent_info: dict,
+    agent_service: AgentService,
+) -> dict:
+    """Return the list of subnets `agent_id` belongs to.
+
+    An agent may only query its own subnet membership.
+    """
+    _require_self(agent_info, agent_id)
+    try:
+        agent = await agent_service.get_agent(agent_id)
+        return {"agent_id": agent_id, "subnets": agent.subnet_ids}
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_id},
+        ) from e

--- a/acn/routes/agent_subnets.py
+++ b/acn/routes/agent_subnets.py
@@ -1,0 +1,108 @@
+"""Canonical agent-side subnet membership endpoints.
+
+These three endpoints live at the *correct* place in the URL tree —
+under `/api/v1/agents/{agent_id}/…` alongside every other agent-side
+operation (heartbeat / claim / transfer / wallets / …). They replace the
+legacy paths still served by `routes/subnets.py` at the awkward
+`/api/v1/subnets/{agent_id}/subnets/…` shape (kept for back-compat,
+marked `deprecated=True` in OpenAPI).
+
+Both surfaces call into `_subnet_membership.py` for the actual business
+logic, so they are guaranteed to be byte-for-byte identical. This file
+owns only the URL + OpenAPI metadata.
+"""
+
+from __future__ import annotations
+
+import structlog  # type: ignore[import-untyped]
+from fastapi import APIRouter
+
+from ..core.errors import ACN_DEFAULT_RESPONSES
+from ._subnet_membership import (
+    do_get_agent_subnets,
+    do_join_subnet,
+    do_leave_subnet,
+)
+from .dependencies import (  # type: ignore[import-untyped]
+    AgentApiKeyDep,
+    AgentIdPath,
+    AgentServiceDep,
+    SubnetIdPath,
+    SubnetServiceDep,
+    WebhookServiceDep,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter(
+    prefix="/api/v1/agents",
+    tags=["subnets"],
+    responses=ACN_DEFAULT_RESPONSES,
+)
+
+
+@router.post("/{agent_id}/subnets/{subnet_id}")
+async def join_subnet(
+    agent_id: AgentIdPath,
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
+    webhook_service: WebhookServiceDep = None,
+):
+    """Agent joins a subnet (requires Agent API Key).
+
+    The authenticated agent must match the path `agent_id`. On success the
+    subnet's `member_agent_ids` is updated and (if configured) the subnet's
+    Org Harness receives an `agent.joined_subnet` webhook.
+    """
+    return await do_join_subnet(
+        agent_id=agent_id,
+        subnet_id=subnet_id,
+        agent_info=agent_info,
+        subnet_service=subnet_service,
+        agent_service=agent_service,
+        webhook_service=webhook_service,
+    )
+
+
+@router.delete("/{agent_id}/subnets/{subnet_id}")
+async def leave_subnet(
+    agent_id: AgentIdPath,
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
+    webhook_service: WebhookServiceDep = None,
+):
+    """Agent leaves a subnet (requires Agent API Key).
+
+    Symmetric with `join_subnet`. Removes the agent from the subnet's
+    `member_agent_ids` and fires an `agent.left_subnet` webhook to the
+    subnet's Org Harness if one is registered.
+    """
+    return await do_leave_subnet(
+        agent_id=agent_id,
+        subnet_id=subnet_id,
+        agent_info=agent_info,
+        subnet_service=subnet_service,
+        agent_service=agent_service,
+        webhook_service=webhook_service,
+    )
+
+
+@router.get("/{agent_id}/subnets")
+async def get_agent_subnets(
+    agent_id: AgentIdPath,
+    agent_info: AgentApiKeyDep,
+    agent_service: AgentServiceDep = None,
+):
+    """Get the list of subnets `agent_id` belongs to (requires Agent API Key).
+
+    An agent may only query its own subnet membership.
+    """
+    return await do_get_agent_subnets(
+        agent_id=agent_id,
+        agent_info=agent_info,
+        agent_service=agent_service,
+    )

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -14,9 +14,13 @@ from pydantic import BaseModel, Field
 from ..auth.middleware import require_internal_or_permission, verify_token
 from ..config import get_settings
 from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
-from ..core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from ..core.exceptions import SubnetNotFoundException
 from ..models import SubnetCreateRequest, SubnetCreateResponse, SubnetInfo
-from ..protocols.ap2 import WebhookEventType
+from ._subnet_membership import (
+    do_get_agent_subnets,
+    do_join_subnet,
+    do_leave_subnet,
+)
 from .dependencies import (  # type: ignore[import-untyped]
     AgentApiKeyDep,
     AgentIdPath,
@@ -264,7 +268,35 @@ async def get_subnet_agents(
         raise HTTPException(status_code=500, detail="Failed to retrieve subnet agents") from e
 
 
-@router.post("/{agent_id}/subnets/{subnet_id}")
+# ---------------------------------------------------------------------------
+# Legacy agent-side membership endpoints.
+#
+# These three endpoints are *deprecated*: the canonical paths now live under
+# `/api/v1/agents/{agent_id}/subnets/…` (see `routes/agent_subnets.py`). The
+# old paths sit on the `subnets` router for accidental historical reasons —
+# the `{agent_id}` segment is awkwardly nested under `/api/v1/subnets/…`,
+# which produces the surprising shape `…/subnets/{agent_id}/subnets/{id}`.
+#
+# The handlers stay here to keep all existing callers working byte-for-byte,
+# but every request is logged at warn level and OpenAPI marks them
+# `deprecated`. Once telemetry shows zero traffic for ≥ one full release
+# cycle, this entire block can be deleted.
+#
+# Behaviour is implemented once in `_subnet_membership.py`; both the legacy
+# and canonical routes call the same helpers, so they cannot drift.
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{agent_id}/subnets/{subnet_id}",
+    deprecated=True,
+    summary="[Deprecated] Agent joins a subnet",
+    description=(
+        "**Deprecated.** Use `POST /api/v1/agents/{agent_id}/subnets/{subnet_id}` "
+        "instead. This path will be removed after telemetry shows zero traffic "
+        "for one full release cycle. Behaviour is identical."
+    ),
+)
 async def join_subnet(
     agent_id: AgentIdPath,
     subnet_id: SubnetIdPath,
@@ -273,79 +305,32 @@ async def join_subnet(
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
 ):
-    """Agent joins a subnet (requires Agent API Key)
-
-    The authenticated agent must match the path `agent_id`.
-    Clean Architecture: Route → Service → Repository
-    """
-    if agent_info["agent_id"] != agent_id:
-        raise ACNHTTPError(
-            ErrorCode.API_KEY_AGENT_MISMATCH,
-            403,
-            details={
-                "path_agent": agent_id,
-                "key_agent": agent_info["agent_id"],
-            },
-        )
-
-    # Verify subnet exists (and capture entity for harness-webhook delivery)
-    try:
-        subnet = await subnet_service.get_subnet(subnet_id)
-    except SubnetNotFoundException as e:
-        raise ACNHTTPError(
-            ErrorCode.SUBNET_NOT_FOUND,
-            404,
-            details={"subnet_id": subnet_id},
-        ) from e
-
-    # Verify agent exists and join subnet
-    try:
-        await agent_service.join_subnet(agent_id, subnet_id)
-
-        # Also update subnet members
-        await subnet_service.add_member(subnet_id, agent_id)
-
-        logger.info("agent_joined_subnet", agent_id=agent_id, subnet_id=subnet_id)
-
-        # Notify the subnet's Org Harness (if registered)
-        if subnet.harness_url and webhook_service is not None:
-            try:
-                await webhook_service.send_to(
-                    url=subnet.harness_url,
-                    secret=subnet.harness_secret,
-                    event=WebhookEventType.AGENT_JOINED_SUBNET,
-                    task_id=subnet_id,  # no task; use subnet_id for trace correlation
-                    data={
-                        "subnet_id": subnet_id,
-                        "agent_id": agent_id,
-                    },
-                )
-            except Exception as e:  # noqa: BLE001 - never break join on webhook failure
-                logger.warning(
-                    "subnet_harness_webhook_failed",
-                    subnet_id=subnet_id,
-                    agent_id=agent_id,
-                    webhook_event="agent.joined_subnet",
-                    error=str(e),
-                )
-
-        return {"status": "joined", "agent_id": agent_id, "subnet_id": subnet_id}
-    except AgentNotFoundException as e:
-        raise ACNHTTPError(
-            ErrorCode.AGENT_NOT_FOUND,
-            404,
-            details={"agent_id": agent_id},
-        ) from e
-    except ACNHTTPError:
-        raise
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("join_subnet_failed", error=str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to join subnet") from e
+    """[Deprecated] Use POST /api/v1/agents/{agent_id}/subnets/{subnet_id}."""
+    logger.warning(
+        "deprecated_route_called",
+        path="/api/v1/subnets/{agent_id}/subnets/{subnet_id}",
+        canonical="/api/v1/agents/{agent_id}/subnets/{subnet_id}",
+        agent_id=agent_id,
+    )
+    return await do_join_subnet(
+        agent_id=agent_id,
+        subnet_id=subnet_id,
+        agent_info=agent_info,
+        subnet_service=subnet_service,
+        agent_service=agent_service,
+        webhook_service=webhook_service,
+    )
 
 
-@router.delete("/{agent_id}/subnets/{subnet_id}")
+@router.delete(
+    "/{agent_id}/subnets/{subnet_id}",
+    deprecated=True,
+    summary="[Deprecated] Agent leaves a subnet",
+    description=(
+        "**Deprecated.** Use `DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}` "
+        "instead. Behaviour is identical."
+    ),
+)
 async def leave_subnet(
     agent_id: AgentIdPath,
     subnet_id: SubnetIdPath,
@@ -354,76 +339,21 @@ async def leave_subnet(
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
 ):
-    """Agent leaves a subnet (requires Agent API Key)
-
-    The authenticated agent must match the path `agent_id`.
-    Clean Architecture: Route → Service → Repository
-    """
-    if agent_info["agent_id"] != agent_id:
-        raise ACNHTTPError(
-            ErrorCode.API_KEY_AGENT_MISMATCH,
-            403,
-            details={
-                "path_agent": agent_id,
-                "key_agent": agent_info["agent_id"],
-            },
-        )
-
-    # Capture subnet up-front so we still know the harness_url even if the
-    # subnet later gets unmodified (it doesn't, but keeps symmetry with join).
-    try:
-        subnet = await subnet_service.get_subnet(subnet_id)
-    except SubnetNotFoundException:
-        subnet = None  # let downstream raise the canonical error
-
-    try:
-        await agent_service.leave_subnet(agent_id, subnet_id)
-        await subnet_service.remove_member(subnet_id, agent_id)
-
-        logger.info("agent_left_subnet", agent_id=agent_id, subnet_id=subnet_id)
-
-        # Notify the subnet's Org Harness (if registered)
-        if subnet and subnet.harness_url and webhook_service is not None:
-            try:
-                await webhook_service.send_to(
-                    url=subnet.harness_url,
-                    secret=subnet.harness_secret,
-                    event=WebhookEventType.AGENT_LEFT_SUBNET,
-                    task_id=subnet_id,
-                    data={
-                        "subnet_id": subnet_id,
-                        "agent_id": agent_id,
-                    },
-                )
-            except Exception as e:  # noqa: BLE001
-                logger.warning(
-                    "subnet_harness_webhook_failed",
-                    subnet_id=subnet_id,
-                    agent_id=agent_id,
-                    webhook_event="agent.left_subnet",
-                    error=str(e),
-                )
-
-        return {"status": "left", "agent_id": agent_id, "subnet_id": subnet_id}
-    except AgentNotFoundException as e:
-        raise ACNHTTPError(
-            ErrorCode.AGENT_NOT_FOUND,
-            404,
-            details={"agent_id": agent_id},
-        ) from e
-    except SubnetNotFoundException as e:
-        raise ACNHTTPError(
-            ErrorCode.SUBNET_NOT_FOUND,
-            404,
-            details={"subnet_id": subnet_id},
-        ) from e
-    except ACNHTTPError:
-        raise
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("leave_subnet_failed", error=str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to leave subnet") from e
+    """[Deprecated] Use DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}."""
+    logger.warning(
+        "deprecated_route_called",
+        path="/api/v1/subnets/{agent_id}/subnets/{subnet_id}",
+        canonical="/api/v1/agents/{agent_id}/subnets/{subnet_id}",
+        agent_id=agent_id,
+    )
+    return await do_leave_subnet(
+        agent_id=agent_id,
+        subnet_id=subnet_id,
+        agent_info=agent_info,
+        subnet_service=subnet_service,
+        agent_service=agent_service,
+        webhook_service=webhook_service,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -493,35 +423,32 @@ async def update_subnet_harness(
     }
 
 
-@router.get("/{agent_id}/subnets")
+@router.get(
+    "/{agent_id}/subnets",
+    deprecated=True,
+    summary="[Deprecated] Get subnets an agent belongs to",
+    description=(
+        "**Deprecated.** Use `GET /api/v1/agents/{agent_id}/subnets` instead. "
+        "Behaviour is identical."
+    ),
+)
 async def get_agent_subnets(
     agent_id: AgentIdPath,
     agent_info: AgentApiKeyDep,
     agent_service: AgentServiceDep = None,
 ):
-    """Get subnets an agent belongs to (requires Agent API Key)
-
-    An agent may only query its own subnet membership.
-    Clean Architecture: Route → AgentService → Repository
-    """
-    if agent_info["agent_id"] != agent_id:
-        raise ACNHTTPError(
-            ErrorCode.API_KEY_AGENT_MISMATCH,
-            403,
-            details={
-                "path_agent": agent_id,
-                "key_agent": agent_info["agent_id"],
-            },
-        )
-    try:
-        agent = await agent_service.get_agent(agent_id)
-        return {"agent_id": agent_id, "subnets": agent.subnet_ids}
-    except AgentNotFoundException as e:
-        raise ACNHTTPError(
-            ErrorCode.AGENT_NOT_FOUND,
-            404,
-            details={"agent_id": agent_id},
-        ) from e
+    """[Deprecated] Use GET /api/v1/agents/{agent_id}/subnets."""
+    logger.warning(
+        "deprecated_route_called",
+        path="/api/v1/subnets/{agent_id}/subnets",
+        canonical="/api/v1/agents/{agent_id}/subnets",
+        agent_id=agent_id,
+    )
+    return await do_get_agent_subnets(
+        agent_id=agent_id,
+        agent_info=agent_info,
+        agent_service=agent_service,
+    )
 
 
 @router.delete("/{subnet_id}")

--- a/tests/routes/test_agent_subnets.py
+++ b/tests/routes/test_agent_subnets.py
@@ -1,0 +1,435 @@
+"""Route-level tests for the canonical agent-side subnet membership API.
+
+Covers the new canonical paths introduced in this batch:
+- ``POST   /api/v1/agents/{agent_id}/subnets/{subnet_id}`` — join
+- ``DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}`` — leave
+- ``GET    /api/v1/agents/{agent_id}/subnets`` — list
+
+The legacy paths under ``/api/v1/subnets/{agent_id}/subnets/…`` are still
+served by ``routes/subnets.py`` (marked ``deprecated=True``); both
+surfaces share business logic via ``routes/_subnet_membership.py``. The
+last test in this file (``TestPathEquivalence``) is the explicit
+contract guard: same input → byte-for-byte same response, same
+side-effects, on both URL shapes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from acn.protocols.ap2.webhook import WebhookEventType
+from acn.routes.dependencies import (
+    get_agent_service,
+    get_subnet_service,
+    get_webhook_service,
+)
+from tests.routes.conftest import _assert_flat_shape
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/routes/test_subnets_harness.py for behavioural parity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_agent_service():
+    """``owner-key`` → ``agent-target``; ``other-key`` → ``agent-other``."""
+    svc = AsyncMock()
+
+    target = MagicMock()
+    target.agent_id = "agent-target"
+    target.name = "Target"
+    target.subnet_ids = ["subnet-1", "subnet-2"]
+
+    other = MagicMock()
+    other.agent_id = "agent-other"
+    other.name = "Other"
+
+    async def _by_api_key(key: str):
+        return {"owner-key": target, "other-key": other}.get(key)
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+    svc.get_agent = AsyncMock(return_value=target)
+    svc.join_subnet = AsyncMock(return_value=None)
+    svc.leave_subnet = AsyncMock(return_value=None)
+    return svc
+
+
+def _make_subnet_mock(
+    subnet_id: str = "subnet-1",
+    owner: str = "agent-target",
+    harness_url: str | None = None,
+    harness_secret: str | None = None,
+):
+    sn = MagicMock()
+    sn.subnet_id = subnet_id
+    sn.owner = owner
+    sn.harness_url = harness_url
+    sn.harness_secret = harness_secret
+    sn.is_private = False
+    sn.member_agent_ids = set()
+    return sn
+
+
+@pytest.fixture
+def stub_subnet_service():
+    svc = AsyncMock()
+    default = _make_subnet_mock()
+
+    async def _get_subnet(subnet_id: str):
+        if subnet_id == "subnet-1":
+            return default
+        raise SubnetNotFoundException(subnet_id)
+
+    svc.get_subnet = AsyncMock(side_effect=_get_subnet)
+    svc.add_member = AsyncMock(return_value=None)
+    svc.remove_member = AsyncMock(return_value=None)
+    svc._default_subnet = default
+    return svc
+
+
+@pytest.fixture
+def stub_webhook_service():
+    svc = AsyncMock()
+    svc.send_to = AsyncMock(return_value=True)
+    svc.send_event = AsyncMock(return_value=True)
+    return svc
+
+
+def _wire(agent_svc, subnet_svc, webhook_svc=None) -> None:
+    app.dependency_overrides[get_agent_service] = lambda: agent_svc
+    app.dependency_overrides[get_subnet_service] = lambda: subnet_svc
+    if webhook_svc is not None:
+        app.dependency_overrides[get_webhook_service] = lambda: webhook_svc
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/agents/{agent_id}/subnets/{subnet_id} — canonical join
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalJoin:
+    def test_join_succeeds_under_canonical_path(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body == {
+            "status": "joined",
+            "agent_id": "agent-target",
+            "subnet_id": "subnet-1",
+        }
+        # Both service-layer mutations must have been called exactly once
+        stub_agent_service.join_subnet.assert_awaited_once_with("agent-target", "subnet-1")
+        stub_subnet_service.add_member.assert_awaited_once_with("subnet-1", "agent-target")
+
+    def test_join_fires_agent_joined_webhook_when_harness_registered(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        stub_subnet_service._default_subnet.harness_url = "https://h.example/hook"
+        stub_subnet_service._default_subnet.harness_secret = "hs"
+
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200
+        stub_webhook_service.send_to.assert_awaited_once()
+        kw = stub_webhook_service.send_to.await_args.kwargs
+        assert kw["url"] == "https://h.example/hook"
+        assert kw["secret"] == "hs"
+        assert kw["event"] == WebhookEventType.AGENT_JOINED_SUBNET
+        assert kw["data"] == {"subnet_id": "subnet-1", "agent_id": "agent-target"}
+
+    def test_join_returns_403_when_path_agent_differs_from_api_key(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        """API key for `agent-target` cannot join `agent-other` into a subnet."""
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-other/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 403
+        body = r.json()
+        _assert_flat_shape(body)
+        assert body["error_code"] == "api_key_agent_mismatch"
+        # Side-effects must be guarded
+        stub_agent_service.join_subnet.assert_not_awaited()
+        stub_subnet_service.add_member.assert_not_awaited()
+
+    def test_join_returns_404_for_missing_subnet(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/subnets/ghost",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 404
+        body = r.json()
+        _assert_flat_shape(body)
+        assert body["error_code"] == "subnet_not_found"
+        assert body["details"] == {"subnet_id": "ghost"}
+
+    def test_join_returns_404_when_agent_not_found(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        stub_agent_service.join_subnet.side_effect = AgentNotFoundException("agent-target")
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body["error_code"] == "agent_not_found"
+
+    def test_join_unauthenticated_does_not_mutate(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post("/api/v1/agents/agent-target/subnets/subnet-1")
+
+        assert 400 <= r.status_code < 500
+        stub_agent_service.join_subnet.assert_not_awaited()
+        stub_subnet_service.add_member.assert_not_awaited()
+
+    def test_join_webhook_failure_does_not_500_the_response(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        """Dead harness URL must not poison a successful join."""
+        stub_subnet_service._default_subnet.harness_url = "https://dead.example"
+        stub_subnet_service._default_subnet.harness_secret = "k"
+        stub_webhook_service.send_to.side_effect = RuntimeError("conn refused")
+
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "joined"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id} — canonical leave
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalLeave:
+    def test_leave_succeeds_under_canonical_path(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "status": "left",
+            "agent_id": "agent-target",
+            "subnet_id": "subnet-1",
+        }
+        stub_agent_service.leave_subnet.assert_awaited_once_with("agent-target", "subnet-1")
+        stub_subnet_service.remove_member.assert_awaited_once_with("subnet-1", "agent-target")
+
+    def test_leave_fires_agent_left_webhook_when_harness_registered(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        stub_subnet_service._default_subnet.harness_url = "https://h.example/hook"
+        stub_subnet_service._default_subnet.harness_secret = None
+
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200
+        stub_webhook_service.send_to.assert_awaited_once()
+        kw = stub_webhook_service.send_to.await_args.kwargs
+        assert kw["event"] == WebhookEventType.AGENT_LEFT_SUBNET
+        assert kw["secret"] is None  # explicit unsigned
+
+    def test_leave_returns_403_when_path_agent_differs_from_api_key(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-other/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 403
+        stub_agent_service.leave_subnet.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/agents/{agent_id}/subnets — canonical list
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalListAgentSubnets:
+    def test_lists_own_subnet_memberships(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-target/subnets",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "agent_id": "agent-target",
+            "subnets": ["subnet-1", "subnet-2"],
+        }
+
+    def test_returns_403_when_querying_other_agents_subnets(
+        self, stub_agent_service, stub_subnet_service, stub_webhook_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-other/subnets",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 403
+        # Must not even reach the service layer
+        stub_agent_service.get_agent.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Path equivalence: canonical vs legacy must be byte-for-byte identical
+# ---------------------------------------------------------------------------
+
+
+class TestPathEquivalence:
+    """The new canonical paths and the legacy ones share `_subnet_membership.py`.
+
+    If they ever drift — same request, different response or different
+    side-effects — that's a regression in the shared helper. These tests
+    are the explicit contract guard.
+    """
+
+    @pytest.mark.parametrize(
+        ("verb", "canonical", "legacy"),
+        [
+            (
+                "POST",
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                "/api/v1/subnets/agent-target/subnets/subnet-1",
+            ),
+            (
+                "DELETE",
+                "/api/v1/agents/agent-target/subnets/subnet-1",
+                "/api/v1/subnets/agent-target/subnets/subnet-1",
+            ),
+            (
+                "GET",
+                "/api/v1/agents/agent-target/subnets",
+                "/api/v1/subnets/agent-target/subnets",
+            ),
+        ],
+    )
+    def test_canonical_and_legacy_paths_return_identical_response(
+        self,
+        stub_agent_service,
+        stub_subnet_service,
+        stub_webhook_service,
+        verb,
+        canonical,
+        legacy,
+    ):
+        _wire(stub_agent_service, stub_subnet_service, stub_webhook_service)
+
+        with TestClient(app) as client:
+            req = client.request
+            r_canon = req(verb, canonical, headers={"Authorization": "Bearer owner-key"})
+            r_legacy = req(verb, legacy, headers={"Authorization": "Bearer owner-key"})
+
+        assert r_canon.status_code == 200, r_canon.text
+        assert r_legacy.status_code == 200, r_legacy.text
+        assert r_canon.json() == r_legacy.json(), (
+            f"{verb} legacy vs canonical response body diverged: "
+            f"{r_legacy.json()!r} != {r_canon.json()!r}"
+        )
+
+    def test_legacy_paths_are_marked_deprecated_in_openapi(self):
+        """OpenAPI schema must flag every legacy agent-subnet path as deprecated.
+
+        Catches the regression where someone refactors `routes/subnets.py` and
+        accidentally drops the `deprecated=True` kwarg, defeating the whole
+        "tell callers to migrate" signal.
+        """
+        spec = app.openapi()
+        paths = spec["paths"]
+
+        legacy_membership_paths = {
+            "/api/v1/subnets/{agent_id}/subnets/{subnet_id}": ("post", "delete"),
+            "/api/v1/subnets/{agent_id}/subnets": ("get",),
+        }
+        for path, methods in legacy_membership_paths.items():
+            assert path in paths, f"legacy path missing from OpenAPI: {path}"
+            for method in methods:
+                op = paths[path].get(method)
+                assert op is not None, f"{method.upper()} {path} not in OpenAPI"
+                assert op.get("deprecated") is True, (
+                    f"{method.upper()} {path} must be marked deprecated"
+                )
+
+        canonical_membership_paths = {
+            "/api/v1/agents/{agent_id}/subnets/{subnet_id}": ("post", "delete"),
+            "/api/v1/agents/{agent_id}/subnets": ("get",),
+        }
+        for path, methods in canonical_membership_paths.items():
+            assert path in paths, f"canonical path missing from OpenAPI: {path}"
+            for method in methods:
+                op = paths[path].get(method)
+                assert op is not None, f"{method.upper()} {path} not in OpenAPI"
+                assert not op.get("deprecated"), (
+                    f"{method.upper()} {path} must NOT be marked deprecated"
+                )


### PR DESCRIPTION
## 背景

Agent-side subnet membership 一直挂在了 \`/api/v1/subnets/{agent_id}/subnets/{subnet_id}\` 这个奇怪的 URL 形状下——\`{agent_id}\` 段嵌在 \`subnets\` prefix 而不是 \`agents\` 之下，结果是 \`…/subnets/{agent_id}/subnets/{id}\` 这种奇怪的形状。

而所有其他 agent-side 操作（heartbeat / claim / transfer / wallets / follows / allowlist / …）都在 \`/api/v1/agents/{id}/…\` 下。Legacy shape 是历史遗留——这些 handler 当年被随手丢进了 \`routes/subnets.py\`。

接 #41 §8.8 follow-up #1。

## 改动

### 新增 canonical 路径（推荐）

- \`POST   /api/v1/agents/{agent_id}/subnets/{subnet_id}\`  — join
- \`DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}\`  — leave
- \`GET    /api/v1/agents/{agent_id}/subnets\`              — list

### 老路径继续工作（标 deprecated）

- \`POST   /api/v1/subnets/{agent_id}/subnets/{subnet_id}\`
- \`DELETE /api/v1/subnets/{agent_id}/subnets/{subnet_id}\`
- \`GET    /api/v1/subnets/{agent_id}/subnets\`

每个老路径在 OpenAPI 里 \`deprecated=True\`，并在每次被调时记一行 \`deprecated_route_called\` warn-level 日志。Telemetry 显示一个完整 release cycle 零流量后即可删除整个老 block。

### 共享业务逻辑

业务逻辑抽进 \`acn/routes/_subnet_membership.py\` 三个 standalone helper（\`do_join_subnet\` / \`do_leave_subnet\` / \`do_get_agent_subnets\`）。新老 router 都调同一组 helper，所以两个 URL surface 不可能漂移——每个 route 文件只 own URL + OpenAPI metadata。ACL guard、webhook delivery、response shape 只定义一次。

## 路由优先级坑（已修）

\`registry.router\` mount 了一个 A2A proxy catch-all \`POST/DELETE/PATCH/PUT/GET /api/v1/agents/{agent_id}/{rest_path:path}\`，会贪婪 swallow 新 canonical 路径并强制要求 \`X-ACN-Authorization\` header（结果是 422 而不是预期的 join/leave/list）。沿用 \`follows.router\` 和 \`allowlist.router\` 已经在用的相同 precedence 模式——\`agent_subnets.router\` 现在注册顺序在 \`registry.router\` **之前**。\`api.py\` 中加了注释让下一个人能直接看到。

## 测试

\`tests/routes/test_agent_subnets.py\` 16 个用例：

- ✅ Join / leave / list 在 canonical URL 下的 happy path
- ✅ canonical join 触发 \`AGENT_JOINED_SUBNET\` webhook、leave 触发 \`AGENT_LEFT_SUBNET\`
- ✅ API key 的 \`agent_id\` ≠ path \`agent_id\` 时 403 \`api_key_agent_mismatch\`（两个 route 都验证无副作用）
- ✅ 不存在的 subnet / agent → 404
- ✅ 未认证请求不产生 state 变更
- ✅ Webhook delivery 失败不让 join 500
- ✅ **路径等价性** parametrized：同样的请求在 POST / DELETE / GET 上，新老 URL 必须返回 byte-for-byte 完全一致的响应
- ✅ **OpenAPI contract guard**：老路径 MUST \`deprecated=True\`、新路径 MUST NOT — 防住未来"某人 refactor 时漏掉 \`deprecated=True\` kwarg"的回归

完整 subnet 回归套件：**88/88 pass**（canonical 16 + harness 12 + error_schema 16 + service/infra 6 + route_service_contracts 38）。

## 部署 / 兼容

- 老 callers：零行为变化（包括 \`acn-client@0.11.1\`，它现在指向老路径）
- 新 callers：可直接用 canonical URL
- 监控 \`deprecated_route_called\` 日志：可以看到谁还在用老路径，等归零再删

## Follow-up（不在本 PR 范围）

1. **\`acn-client\` SDK 0.11.2** — 把 \`joinSubnet\` / \`leaveSubnet\` / \`getAgentSubnets\` 路径切回 canonical \`/api/v1/agents/...\`。两边 backend 路径都能 work，所以无 breaking
2. **\`acn/auth/middleware.py\` 三处同 dev_mode bug** — #41 已修了 \`routes/tasks.py\`，middleware 的三个 helper 还在用同样模式。下轮一并扫

Made with [Cursor](https://cursor.com)