### PR TITLE
fix(auth/middleware): dev_mode must resolve acn_* keys to agent UUID

### DIFF
--- a/acn/auth/middleware.py
+++ b/acn/auth/middleware.py
@@ -84,6 +84,31 @@ def _get_settings():
     return get_settings()
 
 
+async def _resolve_agent_id_from_api_key(token: str | None) -> str | None:
+    """Best-effort: turn an ``acn_*`` API key into its owning agent's UUID.
+
+    Used by the ``dev_mode`` short-circuits below so that downstream ACLs
+    (which compare against agent UUIDs — subnet membership, task ownership,
+    ...) keep working when callers authenticate with a raw API key instead
+    of a JWT. Without this resolver, ``sub`` ends up being the literal
+    ``acn_…`` string and every UUID-keyed permission check 403s.
+
+    Lazy-imports the agent service to avoid a routes -> auth circular
+    import (see file header for the same constraint on ``_peer_ip``).
+    Returns ``None`` on any failure — the caller falls back to the
+    pre-existing dev_mode behaviour (raw token as ``sub``).
+    """
+    if not token or not token.startswith("acn_"):
+        return None
+    try:
+        from ..routes.dependencies import get_agent_service
+
+        agent = await get_agent_service().get_agent_by_api_key(token)
+        return agent.agent_id if agent else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _load_jwks_from_env() -> dict | None:
     """Load JWKS from AUTH0_JWKS environment variable if present.
 
@@ -304,11 +329,20 @@ async def verify_token(
 
     if settings.dev_mode:
         # In dev mode: accept any credential (API keys, stub tokens, etc.)
-        # as a convenience shortcut — no Auth0 verification.
-        sub = "dev@clients"
-        if credentials is not None:
-            # Use the token value as subject so agents remain distinguishable
-            sub = credentials.credentials
+        # as a convenience shortcut — no Auth0 verification. If the bearer
+        # is an actual ``acn_*`` agent API key, resolve it to that agent's
+        # UUID so downstream ACLs (subnet membership, task ownership, ...)
+        # keep working; otherwise fall back to the raw token string.
+        resolved = await _resolve_agent_id_from_api_key(
+            credentials.credentials if credentials is not None else None
+        )
+        if resolved is not None:
+            return {
+                "sub": resolved,
+                "type": "agent",
+                "permissions": ["acn:read", "acn:write", "acn:admin"],
+            }
+        sub = credentials.credentials if credentials is not None else "dev@clients"
         return {"sub": sub, "permissions": ["acn:read", "acn:write", "acn:admin"]}
 
     if credentials is None:
@@ -375,11 +409,20 @@ def require_internal_or_permission(permission: str):
     ) -> dict:
         settings = _get_settings()
 
-        # Dev mode: accept anything
+        # Dev mode: accept anything — but resolve ``acn_*`` API keys to the
+        # owning agent's UUID so UUID-keyed ACLs still work (see
+        # ``_resolve_agent_id_from_api_key`` for the why).
         if settings.dev_mode:
-            sub = "dev@clients"
-            if credentials is not None:
-                sub = credentials.credentials
+            resolved = await _resolve_agent_id_from_api_key(
+                credentials.credentials if credentials is not None else None
+            )
+            if resolved is not None:
+                return {
+                    "sub": resolved,
+                    "type": "agent",
+                    "permissions": ["acn:read", "acn:write", "acn:admin"],
+                }
+            sub = credentials.credentials if credentials is not None else "dev@clients"
             return {"sub": sub, "permissions": ["acn:read", "acn:write", "acn:admin"]}
 
         # Internal token: trusted backend service call. Use constant-time
@@ -426,7 +469,11 @@ async def get_subject(
     if settings.dev_mode:
         if credentials is None:
             return "dev@clients"
-        return credentials.credentials
+        # Resolve ``acn_*`` API keys to the owning agent's UUID so callers
+        # that key off ``get_subject`` (e.g. ownership checks) line up with
+        # the agent identity rather than the raw token value.
+        resolved = await _resolve_agent_id_from_api_key(credentials.credentials)
+        return resolved if resolved is not None else credentials.credentials
 
     payload = await verify_token(request, credentials)
     return payload.get("sub", "unknown")

--- a/tests/auth/test_middleware_dev_mode_agent_id.py
+++ b/tests/auth/test_middleware_dev_mode_agent_id.py
@@ -1,0 +1,273 @@
+"""Regression tests: ``dev_mode`` must resolve ``acn_*`` API keys to the
+owning agent's UUID (not return the raw token as ``sub``).
+
+The shared dev-mode short-circuit in ``acn.auth.middleware`` used to set
+``sub = credentials.credentials`` unconditionally. That made downstream
+ACL checks — every one of which compares against the agent's UUID
+(subnet membership, task ownership, ...) — trivially fail with the
+literal ``acn_…`` string treated as the agent id. This was the same
+class of bug fixed in ``acn/routes/tasks.py::require_task_write_auth``
+during PR #41; this test file pins the matching fix for the three
+middleware helpers (``verify_token``, ``require_internal_or_permission``,
+``get_subject``) so future refactors can't silently regress them.
+
+We don't go through the HTTP layer here: dev_mode is short-circuit
+synchronous, the helpers expose Python-native signatures, and the only
+external dependency (``get_agent_service``) is monkeypatched. This keeps
+the tests fast and isolated from FastAPI routing/Auth0 wiring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+from acn.auth import middleware as mw
+from acn.core.entities import Agent, AgentStatus
+
+
+def _make_agent(agent_id: str = "agent-uuid-abc") -> Agent:
+    """Minimal agent for ``get_agent_by_api_key`` to return."""
+    return Agent(
+        agent_id=agent_id,
+        owner="owner-1",
+        name="Test Agent",
+        endpoint="https://agent.example.com",
+        description="x",
+        tags=[],
+        subnet_ids=[],
+        status=AgentStatus.ONLINE,
+        metadata={},
+    )
+
+
+def _bearer(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _stub_request() -> MagicMock:
+    """The dev_mode path doesn't touch ``request`` — just give it
+    something so the signature is satisfied."""
+    return MagicMock(name="Request")
+
+
+@pytest.fixture(autouse=True)
+def _force_dev_mode(monkeypatch):
+    """Tests in this file are *about* the dev_mode branch; pin it on
+    regardless of env state."""
+    fake_settings = MagicMock()
+    fake_settings.dev_mode = True
+    fake_settings.internal_api_token = "x" * 32  # placate prod path checks
+    monkeypatch.setattr(mw, "_get_settings", lambda: fake_settings)
+    return fake_settings
+
+
+def _patch_agent_service(monkeypatch, *, returns: Agent | None, raises: Exception | None = None):
+    """Install a fake ``get_agent_service`` in the same module the
+    middleware lazy-imports from."""
+    service = MagicMock()
+    if raises is not None:
+        service.get_agent_by_api_key = AsyncMock(side_effect=raises)
+    else:
+        service.get_agent_by_api_key = AsyncMock(return_value=returns)
+
+    from acn.routes import dependencies as deps
+
+    monkeypatch.setattr(deps, "get_agent_service", lambda: service)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Helper: _resolve_agent_id_from_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAgentIdFromApiKey:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_none_token(self):
+        assert await mw._resolve_agent_id_from_api_key(None) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_empty_token(self):
+        assert await mw._resolve_agent_id_from_api_key("") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_api_key(self):
+        # JWT-shaped tokens, dev stubs, etc. must short-circuit *before*
+        # we hit the agent service — agent keys are uniquely prefixed.
+        assert await mw._resolve_agent_id_from_api_key("eyJhbGciOi…") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_agent_id_for_valid_api_key(self, monkeypatch):
+        service = _patch_agent_service(monkeypatch, returns=_make_agent("agent-xyz"))
+
+        resolved = await mw._resolve_agent_id_from_api_key("acn_real-key")
+
+        assert resolved == "agent-xyz"
+        service.get_agent_by_api_key.assert_awaited_once_with("acn_real-key")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_agent_not_found(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=None)
+        assert await mw._resolve_agent_id_from_api_key("acn_unknown") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_service_uninitialised(self, monkeypatch):
+        # ``get_agent_service`` raises ``RuntimeError`` at app boot before
+        # ``initialize_services`` runs. The resolver must swallow it —
+        # the dev-mode caller falls back to legacy behaviour.
+        from acn.routes import dependencies as deps
+
+        def _raise():
+            raise RuntimeError("AgentService not initialized")
+
+        monkeypatch.setattr(deps, "get_agent_service", _raise)
+        assert await mw._resolve_agent_id_from_api_key("acn_anything") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_lookup_raises(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=None, raises=RuntimeError("db down"))
+        assert await mw._resolve_agent_id_from_api_key("acn_anything") is None
+
+
+# ---------------------------------------------------------------------------
+# verify_token
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenDevMode:
+    @pytest.mark.asyncio
+    async def test_acn_key_resolves_to_agent_id(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-1"))
+
+        payload = await mw.verify_token(_stub_request(), _bearer("acn_valid"))
+
+        assert payload["sub"] == "agent-1"
+        assert payload.get("type") == "agent"
+        assert set(payload["permissions"]) >= {"acn:read", "acn:write", "acn:admin"}
+
+    @pytest.mark.asyncio
+    async def test_acn_key_unknown_agent_falls_back_to_raw_token(self, monkeypatch):
+        # Preserves the pre-fix legacy behaviour for orphaned tokens —
+        # we don't want to start 401'ing dev_mode callers who used to
+        # work. The downstream ACL still fails, but explicitly with a
+        # missing-member error, not silently against a UUID-shaped sub.
+        _patch_agent_service(monkeypatch, returns=None)
+
+        payload = await mw.verify_token(_stub_request(), _bearer("acn_orphan"))
+
+        assert payload["sub"] == "acn_orphan"
+
+    @pytest.mark.asyncio
+    async def test_non_api_key_falls_back_to_raw_token(self, monkeypatch):
+        # Doesn't need agent service patched — but install one that
+        # would fail the test if called, to pin the short-circuit.
+        service = _patch_agent_service(monkeypatch, returns=_make_agent("should-not-be-returned"))
+
+        payload = await mw.verify_token(_stub_request(), _bearer("dev-stub-token"))
+
+        assert payload["sub"] == "dev-stub-token"
+        service.get_agent_by_api_key.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_dev_clients(self):
+        payload = await mw.verify_token(_stub_request(), None)
+        assert payload["sub"] == "dev@clients"
+
+    @pytest.mark.asyncio
+    async def test_service_unavailable_falls_back_to_raw_token(self, monkeypatch):
+        from acn.routes import dependencies as deps
+
+        def _raise():
+            raise RuntimeError("AgentService not initialized")
+
+        monkeypatch.setattr(deps, "get_agent_service", _raise)
+
+        payload = await mw.verify_token(_stub_request(), _bearer("acn_pre_boot"))
+
+        # Without an initialised service we can't resolve — legacy
+        # fallback so callers don't 500 during early boot.
+        assert payload["sub"] == "acn_pre_boot"
+
+
+# ---------------------------------------------------------------------------
+# require_internal_or_permission
+# ---------------------------------------------------------------------------
+
+
+class TestRequireInternalOrPermissionDevMode:
+    @pytest.mark.asyncio
+    async def test_acn_key_resolves_to_agent_id(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-rip-1"))
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), _bearer("acn_xx"), None)
+
+        assert payload["sub"] == "agent-rip-1"
+        assert payload.get("type") == "agent"
+
+    @pytest.mark.asyncio
+    async def test_acn_key_unknown_agent_falls_back(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=None)
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), _bearer("acn_unknown"), None)
+
+        assert payload["sub"] == "acn_unknown"
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_dev_clients(self):
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), None, None)
+
+        assert payload["sub"] == "dev@clients"
+
+    @pytest.mark.asyncio
+    async def test_non_api_key_falls_back_to_raw_token(self, monkeypatch):
+        service = _patch_agent_service(monkeypatch, returns=_make_agent("nope"))
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), _bearer("dev-stub"), None)
+
+        assert payload["sub"] == "dev-stub"
+        service.get_agent_by_api_key.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_subject
+# ---------------------------------------------------------------------------
+
+
+class TestGetSubjectDevMode:
+    @pytest.mark.asyncio
+    async def test_acn_key_returns_agent_id(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-gs-1"))
+
+        sub = await mw.get_subject(_stub_request(), _bearer("acn_xx"))
+
+        assert sub == "agent-gs-1"
+
+    @pytest.mark.asyncio
+    async def test_acn_key_unknown_agent_falls_back(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=None)
+
+        sub = await mw.get_subject(_stub_request(), _bearer("acn_unknown"))
+
+        assert sub == "acn_unknown"
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_dev_clients(self):
+        sub = await mw.get_subject(_stub_request(), None)
+        assert sub == "dev@clients"
+
+    @pytest.mark.asyncio
+    async def test_non_api_key_returns_raw_token(self, monkeypatch):
+        service = _patch_agent_service(monkeypatch, returns=_make_agent("nope"))
+
+        sub = await mw.get_subject(_stub_request(), _bearer("jwt-like-token"))
+
+        assert sub == "jwt-like-token"
+        service.get_agent_by_api_key.assert_not_awaited()


### PR DESCRIPTION
## Summary

Ports the PR #41 dev_mode fix (`routes/tasks.py::require_task_write_auth`) to the three middleware helpers in `acn/auth/middleware.py` — `verify_token`, `require_internal_or_permission`, and `get_subject` — which all had the same bug: in `dev_mode`, the raw bearer token was set as `sub` unconditionally, so when callers authenticated with an `acn_*` API key every downstream ACL that compares against agent UUID (subnet membership, task ownership, ...) 403'd them against their own resources.

## Changes

- **`acn/auth/middleware.py`**
  - New private helper `_resolve_agent_id_from_api_key(token)`: turns an `acn_*` API key into the owning agent's UUID via `AgentService.get_agent_by_api_key`. Lazy-imports `routes.dependencies` to avoid the routes -> auth circular import (the file already takes that constraint on `_peer_ip`, see header comment). Returns `None` on any failure (missing token, non-`acn_` prefix, service uninitialised, lookup error) so callers can fall back to legacy behaviour without 500s during boot.
  - All three `dev_mode` short-circuits now call the resolver first. On hit they return `{sub: <agent_uuid>, type: "agent", permissions: [...]}`; on miss they preserve the pre-fix legacy behaviour (`sub = credentials.credentials` or `"dev@clients"`) so unrelated dev_mode callers (JWT-shaped stubs, plain strings) don't regress.

- **`tests/auth/test_middleware_dev_mode_agent_id.py`** (new — also adds `tests/auth/__init__.py`)
  - 7 cases on the resolver helper covering happy path, None/empty/non-`acn_` tokens, missing agent, uninitialised service (RuntimeError), and lookup exceptions.
  - 5 cases on `verify_token` dev_mode (valid acn_ key, unknown acn_ key, non-acn token, no credentials, service unavailable).
  - 4 cases on `require_internal_or_permission` dev_mode.
  - 4 cases on `get_subject` dev_mode.
  - Total: 20 new tests, all green locally. Existing 86 auth/route tests (incl. PR #41's dev_mode contracts in `test_tasks_error_schema.py` / `test_tasks_rate_limit_h7.py` / `test_get_task_h8_auth.py` / `test_auth_failure_audit_h_audit.py` / `test_agent_subnets.py`) still pass — verified.

## Why three call sites had the same bug

`verify_token` is the FastAPI dep most routes use. `require_internal_or_permission` is its variant that also accepts the internal-service token — needed by routes called by the org-harness / payment backplane. `get_subject` is the bare "give me a sub claim" sugar used by a handful of analytics + activity endpoints. All three branched independently in `dev_mode`, so the fix has to be applied three times (extracted into the shared resolver helper to keep them in sync).

## Risk

Low. The resolver is best-effort and never raises; on any failure the helper returns `None` and the dev_mode branch falls through to the **exact same** legacy code path it had before (raw bearer as `sub`, or `"dev@clients"` when missing). The only observable behaviour change for existing dev_mode callers is when the bearer happens to be an `acn_*` key that resolves to a real agent — which is the bug we're fixing.

Production (`dev_mode=False`) paths are not touched.

## Follow-up

Closes the `acn_middleware_dev_mode` follow-up from PR #41 (last remaining ACN-side cleanup from the paperclip-acn-plugin smoke-test findings).

## Test plan

- [x] `uv run pytest tests/auth/ -xvs` — 20/20 pass
- [x] `uv run pytest tests/routes/test_tasks_error_schema.py tests/routes/test_tasks_rate_limit_h7.py tests/routes/test_get_task_h8_auth.py tests/routes/test_auth_failure_audit_h_audit.py tests/routes/test_agent_subnets.py tests/middleware/ -q` — 106/106 pass (no regression on PR #41 dev_mode contracts)
- [ ] CI green

Made with [Cursor](https://cursor.com)