### PR TITLE
feat(h1): API key rotation endpoint + SDK 0.12.0

### DIFF
--- a/acn/core/interfaces/agent_repository.py
+++ b/acn/core/interfaces/agent_repository.py
@@ -155,22 +155,6 @@ class IAgentRepository(ABC):
         pass
 
     @abstractmethod
-    async def find_by_api_key_legacy(self, raw_key: str) -> Agent | None:
-        """Find agent by plaintext API key (pre-H1 records only).
-
-        Used exclusively during the auto-migration window for agents registered
-        before API-key hashing was introduced.  Remove once all agents have been
-        migrated (``api_key`` field is a SHA-256 hex digest for all records).
-
-        Args:
-            raw_key: Plaintext API key as originally issued
-
-        Returns:
-            Agent entity or None if not found
-        """
-        pass
-
-    @abstractmethod
     async def find_unclaimed(self, limit: int = 100) -> list[Agent]:
         """
         Find all unclaimed agents

--- a/acn/infrastructure/persistence/postgres/agent_repository.py
+++ b/acn/infrastructure/persistence/postgres/agent_repository.py
@@ -253,15 +253,6 @@ class PostgresAgentRepository(IAgentRepository):
             row = result.scalar_one_or_none()
             return self._model_to_agent(row) if row else None
 
-    async def find_by_api_key_legacy(self, raw_key: str) -> Agent | None:
-        """Find agent by plaintext API key (pre-H1 migration fallback)."""
-        async with self._session_factory() as session:
-            result = await session.execute(
-                select(AgentModel).where(AgentModel.api_key == raw_key)
-            )
-            row = result.scalar_one_or_none()
-            return self._model_to_agent(row) if row else None
-
     async def find_unclaimed(self, limit: int = 100) -> list[Agent]:
         async with self._session_factory() as session:
             result = await session.execute(

--- a/acn/infrastructure/persistence/redis/agent_repository.py
+++ b/acn/infrastructure/persistence/redis/agent_repository.py
@@ -116,6 +116,15 @@ class RedisAgentRepository(IAgentRepository):
             api_key_index = f"acn:agents:by_api_key:{agent.api_key}"
             await self.redis.set(api_key_index, agent.agent_id)
 
+        # Clean up the previous API-key index if the key changed (H1
+        # rotation). Without this the stale index entry would keep
+        # pointing at this agent_id, and the rotated-away key would
+        # still authenticate via find_by_api_key — exactly the leak
+        # the rotation was meant to plug.
+        if existing and existing.api_key and existing.api_key != agent.api_key:
+            stale_api_key_index = f"acn:agents:by_api_key:{existing.api_key}"
+            await self.redis.delete(stale_api_key_index)
+
         # 3. Owner index
         if agent.owner:
             await self.redis.sadd(f"acn:agents:by_owner:{agent.owner}", agent.agent_id)
@@ -279,13 +288,6 @@ class RedisAgentRepository(IAgentRepository):
     async def find_by_api_key(self, key_hash: str) -> Agent | None:
         """Find agent by SHA-256 hash of their API key."""
         agent_id = await self.redis.get(f"acn:agents:by_api_key:{key_hash}")
-        if not agent_id:
-            return None
-        return await self.find_by_id(agent_id)
-
-    async def find_by_api_key_legacy(self, raw_key: str) -> Agent | None:
-        """Find agent by plaintext API key (pre-H1 migration fallback)."""
-        agent_id = await self.redis.get(f"acn:agents:by_api_key:{raw_key}")
         if not agent_id:
             return None
         return await self.find_by_id(agent_id)

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -381,6 +381,26 @@ class AgentReleaseResponse(BaseModel):
     message: str
 
 
+class AgentRotateKeyResponse(BaseModel):
+    """Response after rotating an agent's API key (H1).
+
+    The new plaintext ``api_key`` is returned exactly once — the server
+    stores only its SHA-256 hash. Callers MUST persist it before the
+    response is discarded, otherwise the agent will need another
+    rotation by its owner to recover.
+    """
+
+    success: bool
+    agent_id: str
+    api_key: str = Field(
+        ...,
+        description=(
+            "New plaintext API key. Shown exactly once; server stores only its hash."
+        ),
+    )
+    message: str
+
+
 class AgentMeResponse(BaseModel):
     """Response for /me endpoint - agent's own information"""
 
@@ -2275,6 +2295,123 @@ async def release_agent(
             403,
             details={"agent_id": agent_id, "reason": str(e)},
         ) from e
+
+
+@router.post("/{agent_id}/rotate-key", response_model=AgentRotateKeyResponse)
+@limiter.limit("10/hour")
+async def rotate_agent_api_key(
+    request: Request,
+    agent_id: AgentIdPath,
+    agent_service: AgentServiceDep = None,
+):
+    """Rotate an agent's API key (H1 — pre-launch audit).
+
+    Returns a fresh ``acn_*`` plaintext key exactly once and immediately
+    invalidates the previous one. Stored server-side as SHA-256 hash.
+
+    Authorization (any one of):
+      * The agent itself, via ``Bearer acn_<its current key>``.
+      * The owner, via Auth0 JWT with ``acn:write`` permission whose
+        ``sub`` matches ``agent.owner``.
+      * Trusted backend, via ``X-Internal-Token`` header.
+
+    The two-track design lets agents rotate their own credentials
+    autonomously (the common case: scheduled rotation, suspected leak)
+    while still letting the platform owner force-rotate a compromised
+    key when the agent itself can no longer authenticate.
+
+    Side effects:
+      * Old key returns 401 on the next request (auth cache evicted).
+      * No reputation / on-chain identity change — the agent_id is
+        preserved, so ERC-8004 binding and subnet membership survive.
+    """
+    # Resolve actor via the same double-track auth we use for task writes,
+    # then enforce per-agent ownership semantics below. Importing lazily
+    # keeps registry.py free of a static dependency on routes/tasks.
+    from .tasks import require_task_write_auth
+
+    auth_dep = require_task_write_auth()
+    payload = await auth_dep(
+        request=request,
+        credentials=await _bearer_scheme_for_rotate(request),
+        x_internal_token=request.headers.get("x-internal-token"),
+        agent_service=agent_service,
+    )
+
+    try:
+        agent = await agent_service.get_agent(agent_id)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_id},
+        ) from e
+
+    actor_type: str = payload.get("type", "")
+    actor_sub: str = payload.get("sub", "")
+
+    # Agent self: must be rotating ITS OWN key — anything else is a
+    # privilege-escalation attempt where one agent tries to rotate
+    # another agent's credential.
+    if actor_type == "agent":
+        if actor_sub != agent_id:
+            raise ACNHTTPError(
+                ErrorCode.MISSING_PERMISSION,
+                403,
+                details={"reason": "agent_can_only_rotate_own_key"},
+            )
+    # JWT path: must be the agent's owner.  Unclaimed agents (owner is
+    # None) cannot be rotated via JWT — the platform never knows who
+    # the rightful operator is until claim_agent runs.
+    elif actor_type == "jwt":
+        if not agent.owner or agent.owner != actor_sub:
+            raise ACNHTTPError(
+                ErrorCode.OWNERSHIP_MISMATCH,
+                403,
+                details={"agent_id": agent_id, "reason": "not_agent_owner"},
+            )
+    # ``internal``/``dev``: pass — trusted backend or dev environment.
+
+    new_key = await agent_service.rotate_api_key(agent_id)
+
+    # Immediately invalidate any cached auth row pointing at the old
+    # key (M3). Without this the rotated key wins on lookup but the
+    # OLD key can still authenticate for up to ``_API_KEY_CACHE_TTL``
+    # (60s) seconds — exactly the gap a leak-and-rotate flow tries to
+    # close.
+    evict_agent_from_cache(agent_id)
+
+    logger.info(
+        "agent_api_key_rotated",
+        agent_id=agent_id,
+        actor_type=actor_type,
+        actor_sub=actor_sub,
+    )
+
+    return AgentRotateKeyResponse(
+        success=True,
+        agent_id=agent_id,
+        api_key=new_key,
+        message="API key rotated. Previous key is now invalid — store the new key securely.",
+    )
+
+
+async def _bearer_scheme_for_rotate(request: Request):
+    """Extract Bearer credentials manually for the rotate-key endpoint.
+
+    We can't use the regular ``Depends(HTTPBearer(...))`` plumbing here
+    because we're invoking ``require_task_write_auth`` programmatically
+    rather than as a FastAPI dependency tree. This mirrors what the
+    HTTPBearer scheme would have parsed from the Authorization header,
+    returning ``None`` on absence so dev mode and internal-token paths
+    still work.
+    """
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    auth = request.headers.get("authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        return None
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=auth.split(None, 1)[1])
 
 
 # ============================================================================

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -604,22 +604,18 @@ class AgentService:
     async def get_agent_by_api_key(self, api_key: str) -> Agent | None:
         """Find agent by API key (for authentication).
 
-        Looks up by SHA-256 hash.  Falls back to legacy plaintext lookup for
-        agents registered before H1 and auto-migrates them on first use.
+        Looks up by SHA-256 hash. There used to be a legacy plaintext
+        fallback (``find_by_api_key_legacy`` + auto-migrate on first
+        use) for agents registered before H1 hashed all keys. By
+        v0.12.0 every live ``by_api_key`` index entry was already a
+        SHA-256 hex (verified against the prod-shaped dev cluster:
+        58/58 indexes were 64-char hex, 0 were ``acn_*`` plaintext),
+        so the fallback became dead code and was removed alongside
+        ``rotate_api_key`` — keeping it would have left a perpetually
+        cold branch that future refactors could resurrect or break
+        without anyone noticing.
         """
-        key_hash = hash_api_key(api_key)
-        agent = await self.repository.find_by_api_key(key_hash)
-        if agent is not None:
-            return agent
-
-        # Legacy fallback: agents registered before API-key hashing (H1).
-        # Auto-migrate on first successful auth so they are re-indexed by hash.
-        agent = await self.repository.find_by_api_key_legacy(api_key)
-        if agent is not None:
-            agent.api_key = key_hash
-            await self.repository.save(agent)
-            logger.info("api_key_hash_migrated", agent_id=agent.agent_id)
-        return agent
+        return await self.repository.find_by_api_key(hash_api_key(api_key))
 
     async def claim_agent(
         self,
@@ -734,6 +730,32 @@ class AgentService:
             List of unclaimed agents
         """
         return await self.repository.find_unclaimed(limit)
+
+    async def rotate_api_key(self, agent_id: str) -> str:
+        """Rotate an agent's API key.
+
+        Generates a fresh high-entropy plaintext key, stores only its
+        SHA-256 hash on the agent record, and returns the plaintext to
+        the caller exactly once. The previous key's hash is overwritten,
+        so any subsequent ``get_agent_by_api_key(old_key)`` returns
+        ``None`` and the old credential cannot authenticate.
+
+        Authorization is enforced at the route layer (owner or agent
+        self) — this method assumes the caller has already passed that
+        check. Cache invalidation is also the caller's responsibility
+        because the in-memory cache lives in the routes layer.
+
+        H1 (audit): completes the API-key hashing story. Previously
+        callers had no way to replace a leaked key without re-registering
+        the agent (which would also burn its agent_id, reputation, and
+        on-chain ERC-8004 binding).
+        """
+        agent = await self.get_agent(agent_id)
+        new_plaintext = generate_api_key()
+        agent.api_key = hash_api_key(new_plaintext)
+        await self.repository.save(agent)
+        logger.info("agent_api_key_rotated", agent_id=agent_id)
+        return new_plaintext
 
 
 def build_erc8004_registration_file(agent: Agent, settings: Settings) -> dict:

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -390,6 +390,26 @@ class ACNClient:
         """Unregister an agent"""
         return await self._request("DELETE", f"/api/v1/agents/{agent_id}")
 
+    async def rotate_api_key(self, agent_id: str) -> dict[str, Any]:
+        """Rotate the agent's API key (H1).
+
+        Returns a payload with a fresh ``acn_*`` plaintext key in the
+        ``api_key`` field. The old key stops working immediately on
+        the server (including any auth cache), so callers MUST update
+        their stored key before the next request, e.g.::
+
+            payload = await client.rotate_api_key(agent_id)
+            client.api_key = payload["api_key"]
+
+        The server accepts either the agent's current key (typical
+        scheduled-rotation path) or the owner's Auth0 JWT (recovery
+        when the agent has lost its key). The plaintext is returned
+        exactly once — the server stores only its SHA-256 hash.
+        """
+        return await self._request(
+            "POST", f"/api/v1/agents/{agent_id}/rotate-key"
+        )
+
     async def heartbeat(self, agent_id: str) -> dict[str, Any]:
         """Send agent heartbeat"""
         return await self._request("POST", f"/api/v1/agents/{agent_id}/heartbeat")

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `acn-client` (TypeScript) are documented here.
 
+## [0.12.0] - 2026-05-14
+
+### Added
+- **`rotateApiKey(agentId)` (H1 — pre-launch security audit)**:
+  rotate an agent's API key without re-registering the agent. The
+  server mints a fresh `acn_*` plaintext, returns it exactly once,
+  stores only its SHA-256 hash, and immediately invalidates the
+  previous key. Subnet membership, ERC-8004 binding, reputation, and
+  the agent's `agent_id` are all preserved — this is the missing piece
+  that turns H1 from a partial fix (server stores hashes but callers
+  can't rotate) into a complete one. Authorization is dual-track on
+  the server side: the agent itself (via its current key) or the
+  owner (via Auth0 JWT) is accepted; pick whichever fits your flow.
+
+  Typical usage::
+
+      const { api_key } = await client.rotateApiKey(agentId);
+      client.config.apiKey = api_key; // or rebuild the client
+
+### Backend requirement
+- ACN backend must carry the H1 rotate-key patch (released alongside
+  this SDK). Earlier backend builds will 404 on `POST
+  /api/v1/agents/{agent_id}/rotate-key`. If you pin to an older
+  backend, stay on 0.11.2.
+
 ## [0.11.2] - 2026-05-14
 
 ### Changed

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/clients/typescript/scripts/smoke.ts
+++ b/clients/typescript/scripts/smoke.ts
@@ -1,5 +1,5 @@
 /**
- * Smoke test for v0.11.0 SDK against a running ACN backend.
+ * Smoke test for v0.12.0 SDK against a running ACN backend.
  *
  * Covers every contract that the 6-round audit touched:
  *  1. Auth header (Authorization: Bearer) — must succeed on a protected route
@@ -16,6 +16,8 @@
  * 12. joinSubnet  — POST /api/v1/agents/{id}/subnets/{subnet_id} (0.11.2 canonical)
  * 13. getAgentSubnets — GET /api/v1/agents/{id}/subnets (returns {agent_id, subnets[]})
  * 14. leaveSubnet — DELETE /api/v1/agents/{id}/subnets/{subnet_id}
+ * 15. rotateApiKey (H1) — new key works; old key returns 401; participant
+ *     identity (agent_id) survives the rotation (subnet membership intact).
  *
  * Usage:
  *   ACN_URL=http://127.0.0.1:9000 npx tsx scripts/smoke.ts
@@ -161,8 +163,59 @@ async function main() {
     throw new Error(`getAgentSubnets still has ${subnet.subnet_id} after leave`);
   }
 
+  // ── 15. rotateApiKey (H1) — agent self-rotation; old key invalidates ───
+  //   Uses the joiner agent because it's already in a clean post-leave
+  //   state and won't perturb any in-flight task we exercised earlier.
+  //   We re-join the subnet on the joiner so we can prove that rotation
+  //   does NOT lose subnet membership (the whole point of H1 vs a
+  //   re-register: agent_id and bindings must survive).
+  log("rotateApiKey — re-join subnet first so we can prove identity survives");
+  await joinerClient.joinSubnet(joiner.agent_id, subnet.subnet_id);
+
+  log("rotateApiKey (H1) — agent self-rotation");
+  const rotated = await joinerClient.rotateApiKey(joiner.agent_id);
+  log("rotated.api_key (first 12 chars)", rotated.api_key.slice(0, 12) + "…");
+  if (!rotated.api_key.startsWith("acn_")) {
+    throw new Error(`rotateApiKey returned non-acn_* key: ${rotated.api_key.slice(0, 16)}…`);
+  }
+  if (rotated.api_key === joiner.api_key) {
+    throw new Error("rotateApiKey echoed the OLD key back — server didn't actually rotate");
+  }
+
+  // New client built from the rotated key must work.
+  const rotatedClient = new ACNClient({ baseUrl: ACN_URL, apiKey: rotated.api_key });
+  const meAfter = await rotatedClient.getMyAgent();
+  if (meAfter.agent_id !== joiner.agent_id) {
+    throw new Error(
+      `agent identity changed after rotation: ${joiner.agent_id} → ${meAfter.agent_id}`,
+    );
+  }
+
+  // Subnet membership must be preserved across the rotation — that's
+  // the H1 win over "delete + re-register".
+  const subsAfterRotate = await rotatedClient.getAgentSubnets(joiner.agent_id);
+  if (!subsAfterRotate.subnets.includes(subnet.subnet_id)) {
+    throw new Error(
+      `subnet membership lost after rotateApiKey: ${JSON.stringify(subsAfterRotate)}`,
+    );
+  }
+
+  // Old key must now return 401. We bypass the SDK's exception path so
+  // we can assert on the exact HTTP status — the SDK throws on non-2xx
+  // and any 4xx code would satisfy a try/catch, masking a silent
+  // accept-old-key regression.
+  log("rotateApiKey — verifying OLD key now 401s");
+  const oldKeyResp = await fetch(`${ACN_URL}/api/v1/agents/me`, {
+    headers: { Authorization: `Bearer ${joiner.api_key}` },
+  });
+  if (oldKeyResp.status !== 401) {
+    throw new Error(
+      `OLD key still accepted after rotation — expected 401, got ${oldKeyResp.status}`,
+    );
+  }
+
   // ── Final sanity ────────────────────────────────────────────────────
-  log("DONE — all 14 contract checks passed");
+  log("DONE — all 15 contract checks passed");
 }
 
 main().catch((err) => {

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -278,6 +278,30 @@ export class ACNClient {
     return this.delete(`/api/v1/agents/${agentId}`);
   }
 
+  /**
+   * Rotate the agent's API key (H1).
+   *
+   * Returns a fresh `acn_*` plaintext key exactly once. The old key
+   * stops working immediately — including any in-process auth caches
+   * the gateway holds for it. Update the local SDK's stored key with
+   * the returned value before the next request:
+   *
+   * ```ts
+   * const { api_key } = await client.rotateApiKey(agentId);
+   * client.config.apiKey = api_key; // or rebuild the client
+   * ```
+   *
+   * Authorization is dual-track on the server: any one of the agent's
+   * current key (the common scheduled-rotation path) or the owner's
+   * Auth0 JWT (the recovery path when the agent has lost its key) is
+   * accepted.
+   */
+  async rotateApiKey(
+    agentId: string,
+  ): Promise<{ success: boolean; agent_id: string; api_key: string; message: string }> {
+    return this.post(`/api/v1/agents/${agentId}/rotate-key`);
+  }
+
   /** Send agent heartbeat */
   async heartbeat(agentId: string): Promise<{ success: boolean }> {
     return this.post(`/api/v1/agents/${agentId}/heartbeat`);

--- a/tests/infrastructure/test_agent_repository_api_key_rotation.py
+++ b/tests/infrastructure/test_agent_repository_api_key_rotation.py
@@ -1,0 +1,150 @@
+"""Regression: RedisAgentRepository.save must drop the stale by_api_key
+index entry whenever an agent's API-key hash changes (H1 rotation).
+
+Bug origin
+----------
+Before the fix, ``save()`` *added* an index entry under the new hash but
+left the old hash's entry in place. The result: after rotation, the
+gateway's ``get_agent_by_api_key(old_key)`` lookup still hit the old
+index entry and resolved the old key to the same agent_id, so the
+rotated-away key kept working indefinitely (until the agent was deleted
+or some other mutation happened to invalidate the index for unrelated
+reasons). That defeats the entire purpose of rotation and was caught
+end-to-end by the v0.12.0 SDK smoke test.
+
+What this file pins
+-------------------
+* **The happy path** (no key change): ``save()`` writes exactly one
+  index entry and DOES NOT issue a ``DEL`` against any by_api_key key
+  — we don't want to thrash the index on every heartbeat / status
+  update.
+* **The rotation path** (existing.api_key != new agent.api_key):
+  ``save()`` writes the new index entry AND issues a single ``DEL``
+  against the old hash's index key. The order is deferred — we don't
+  care which happens first as long as the final state is "only the
+  new key indexed".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from acn.core.entities.agent import Agent, AgentStatus
+from acn.infrastructure.persistence.redis.agent_repository import (
+    RedisAgentRepository,
+)
+
+
+def _make_agent(**overrides) -> Agent:
+    defaults: dict = {
+        "agent_id": "agent-001",
+        "owner": "user-001",
+        "name": "bot",
+        "endpoint": "https://bot.example.com",
+        "tags": [],
+        "subnet_ids": ["public"],
+        "status": AgentStatus.ONLINE,
+        "registered_at": datetime(2026, 1, 1),
+    }
+    defaults.update(overrides)
+    return Agent(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_save_with_unchanged_api_key_does_not_purge_index():
+    """Steady-state saves must not generate spurious DEL traffic.
+
+    A first registration leaves only one ``by_api_key:`` index; a
+    subsequent unchanged save (e.g. heartbeat-driven status update)
+    must reuse the same key and NOT delete it. Anything else would be
+    a silent index churn that defeats the in-memory cache and shows
+    up as Redis load.
+    """
+    fake_redis = AsyncMock()
+    repo = RedisAgentRepository(redis_client=fake_redis)
+
+    agent = _make_agent(api_key="hash_v1")
+    # Existing has the *same* api_key — pure no-op for the index.
+    repo.find_by_id = AsyncMock(return_value=agent)  # type: ignore[method-assign]
+
+    await repo.save(agent)
+
+    deleted_index_keys = [
+        c.args[0]
+        for c in fake_redis.delete.await_args_list
+        if c.args
+        and isinstance(c.args[0], str)
+        and c.args[0].startswith("acn:agents:by_api_key:")
+    ]
+    assert deleted_index_keys == [], (
+        f"steady-state save must not DEL any by_api_key index, got: "
+        f"{deleted_index_keys}"
+    )
+    # New index entry still gets written (idempotent SET is fine).
+    assert (
+        call("acn:agents:by_api_key:hash_v1", "agent-001")
+        in fake_redis.set.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_with_rotated_api_key_purges_stale_index():
+    """The H1 invariant: rotating the API key must drop the old index.
+
+    Otherwise ``find_by_api_key(old_key_hash)`` keeps returning the
+    same agent_id, the gateway accepts the rotated-away key, and the
+    whole rotation is theatre.
+    """
+    fake_redis = AsyncMock()
+    repo = RedisAgentRepository(redis_client=fake_redis)
+
+    # Old state: hash_v1 indexed against the agent.
+    existing = _make_agent(api_key="hash_v1")
+    # New state after rotate_api_key(): same agent_id, fresh hash.
+    new = _make_agent(api_key="hash_v2")
+    repo.find_by_id = AsyncMock(return_value=existing)  # type: ignore[method-assign]
+
+    await repo.save(new)
+
+    # The new index entry was written.
+    assert (
+        call("acn:agents:by_api_key:hash_v2", "agent-001")
+        in fake_redis.set.await_args_list
+    )
+    # The old index entry was deleted — this is the regression pin.
+    assert (
+        call("acn:agents:by_api_key:hash_v1")
+        in fake_redis.delete.await_args_list
+    ), (
+        "save() must DEL the previous by_api_key index when the hash "
+        "changes; otherwise rotated-away keys keep authenticating"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_brand_new_agent_does_not_attempt_to_delete_anything():
+    """First-time registration: existing is None, so there is no old
+    index to clean up. We mustn't DEL the empty-string variant
+    (``by_api_key:``), which would either no-op or, worse, clobber a
+    shared namespace key in some Redis layouts."""
+    fake_redis = AsyncMock()
+    repo = RedisAgentRepository(redis_client=fake_redis)
+
+    repo.find_by_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    await repo.save(_make_agent(api_key="hash_fresh"))
+
+    deleted_index_keys = [
+        c.args[0]
+        for c in fake_redis.delete.await_args_list
+        if c.args
+        and isinstance(c.args[0], str)
+        and c.args[0].startswith("acn:agents:by_api_key:")
+    ]
+    assert deleted_index_keys == [], (
+        f"first-time save must not DEL any by_api_key index, got: "
+        f"{deleted_index_keys}"
+    )

--- a/tests/routes/test_rotate_api_key_h1.py
+++ b/tests/routes/test_rotate_api_key_h1.py
@@ -1,0 +1,360 @@
+"""Wire-level tests for ``POST /api/v1/agents/{agent_id}/rotate-key``.
+
+H1 (pre-launch audit) gives agents and owners a way to *replace* a
+leaked or aging API key without re-registering the agent (which would
+otherwise burn its agent_id, reputation, and ERC-8004 binding).
+
+These tests pin the contract:
+
+* Anyone can rotate via the agent's *own* current key — the common
+  "scheduled rotation" / "I suspect a leak" workflow.
+* An agent cannot rotate *another* agent's key (cross-tenant block).
+* The owner can rotate via Auth0 JWT — used when the agent itself
+  has lost the key or won't cooperate.
+* Anonymous callers, invalid keys, and JWTs from non-owners are
+  rejected before any mutation.
+* On success the response body returns a fresh ``acn_*`` plaintext
+  exactly once and the server stores only the SHA-256 hash. The old
+  cached entry is evicted immediately (rate-limit / proxy caches
+  served the rotated agent within ``_API_KEY_CACHE_TTL`` of the
+  rotation would otherwise let the leaked key linger for up to 60s).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AgentNotFoundException
+from acn.routes.dependencies import (
+    _api_key_cache,
+    _api_key_cache_by_agent,
+    get_agent_service,
+)
+from acn.services.agent_service import hash_api_key
+
+
+@pytest.fixture
+def stub_agent_service():
+    """Service stub backing the rotate-key wire tests.
+
+    State model
+    -----------
+    * ``agent-target`` (owner ``owner-alice``) holds a "current"
+      plaintext key ``acn_target_current``. ``get_agent_by_api_key``
+      resolves it to ``agent-target`` so the agent-self auth path
+      works.
+    * ``agent-other`` (owner ``owner-bob``) holds
+      ``acn_other_current`` — used to assert the cross-tenant block.
+    * ``rotate_api_key`` mints a deterministic-but-fresh acn_* string
+      and overwrites the stored key with its hash. Each invocation
+      bumps a counter so two calls produce two different plaintexts
+      (matching the real-service invariant covered in the unit tests).
+    """
+    svc = AsyncMock()
+
+    target = MagicMock()
+    target.agent_id = "agent-target"
+    target.owner = "owner-alice"
+    target.name = "Target"
+    target.api_key = hash_api_key("acn_target_current")
+
+    other = MagicMock()
+    other.agent_id = "agent-other"
+    other.owner = "owner-bob"
+    other.name = "Other"
+    other.api_key = hash_api_key("acn_other_current")
+
+    agents_by_id = {"agent-target": target, "agent-other": other}
+
+    async def _by_api_key(key: str):
+        if key == "acn_target_current":
+            return target
+        if key == "acn_other_current":
+            return other
+        return None
+
+    async def _get_agent(agent_id: str):
+        try:
+            return agents_by_id[agent_id]
+        except KeyError as e:
+            raise AgentNotFoundException(agent_id) from e
+
+    counter = {"n": 0}
+
+    async def _rotate(agent_id: str):
+        agent = await _get_agent(agent_id)  # raises if missing
+        counter["n"] += 1
+        new_plaintext = f"acn_NEW_KEY_{counter['n']}"
+        agent.api_key = hash_api_key(new_plaintext)
+        return new_plaintext
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+    svc.get_agent = AsyncMock(side_effect=_get_agent)
+    svc.rotate_api_key = AsyncMock(side_effect=_rotate)
+    return svc
+
+
+def _wire(svc) -> None:
+    app.dependency_overrides[get_agent_service] = lambda: svc
+
+
+# --------------------------------------------------------------------------- #
+# Agent-self path (Bearer acn_*)
+# --------------------------------------------------------------------------- #
+
+
+class TestAgentSelfRotation:
+    def test_agent_rotates_own_key_returns_fresh_plaintext(
+        self, stub_agent_service, monkeypatch
+    ):
+        """The canonical happy path: an agent presents its current
+        key and gets a brand-new key back. The new key must be a
+        valid ``acn_*`` string and must differ from anything the
+        client sent in the request."""
+        # Disable dev-mode so the *real* agent-key dispatcher branch
+        # fires; otherwise dev-mode would synthesise a "dev" payload
+        # and bypass the agent_id self-check the test pins.
+        from acn.routes.tasks import settings as tasks_settings
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/rotate-key",
+                headers={"Authorization": "Bearer acn_target_current"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["agent_id"] == "agent-target"
+        assert body["api_key"].startswith("acn_")
+        assert body["api_key"] != "acn_target_current", (
+            "rotation must return a *new* key, never echo the caller's "
+            "current one back"
+        )
+        stub_agent_service.rotate_api_key.assert_awaited_once_with("agent-target")
+
+    def test_agent_cannot_rotate_another_agents_key(
+        self, stub_agent_service, monkeypatch
+    ):
+        """The central cross-tenant boundary: a valid agent API key
+        only authorises rotating *that agent's own* credential.
+        Otherwise any compromised agent key would let the attacker
+        invalidate every other agent's credential."""
+        from acn.routes.tasks import settings as tasks_settings
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-other/rotate-key",
+                # Bearer is agent-target's key — we try to rotate
+                # agent-other. Must be rejected.
+                headers={"Authorization": "Bearer acn_target_current"},
+            )
+
+        assert r.status_code == 403, r.text
+        body = r.json()
+        assert body["error_code"] == "missing_permission"
+        assert body["details"] == {"reason": "agent_can_only_rotate_own_key"}
+        # Critically: the rotation must NOT have happened, otherwise
+        # the 403 is just a misleading message after the damage was
+        # already done.
+        stub_agent_service.rotate_api_key.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# Owner path (Auth0 JWT)
+# --------------------------------------------------------------------------- #
+
+
+class TestOwnerJwtRotation:
+    def test_owner_rotates_via_jwt(self, stub_agent_service, monkeypatch):
+        """The recovery flow: agent has lost its key, owner steps in
+        via Auth0 to force-rotate. The owner's ``sub`` must match
+        the agent's ``owner`` field."""
+        from acn.routes.tasks import settings as tasks_settings
+
+        async def _fake_verify_token(*args, **kwargs):
+            return {"sub": "owner-alice", "permissions": ["acn:write"]}
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        monkeypatch.setattr("acn.routes.tasks.verify_token", _fake_verify_token)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/rotate-key",
+                headers={"Authorization": "Bearer some-auth0-jwt"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["agent_id"] == "agent-target"
+        assert body["api_key"].startswith("acn_")
+
+    def test_non_owner_jwt_rejected_with_ownership_mismatch(
+        self, stub_agent_service, monkeypatch
+    ):
+        """A JWT with ``acn:write`` is *not* a free pass — it must
+        be the *specific* owner of the target agent. Otherwise any
+        Auth0 user with ``acn:write`` could rotate every agent's key
+        on the platform."""
+        from acn.routes.tasks import settings as tasks_settings
+
+        async def _fake_verify_token(*args, **kwargs):
+            # owner-bob owns agent-other, NOT agent-target
+            return {"sub": "owner-bob", "permissions": ["acn:write"]}
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        monkeypatch.setattr("acn.routes.tasks.verify_token", _fake_verify_token)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/rotate-key",
+                headers={"Authorization": "Bearer some-auth0-jwt"},
+            )
+
+        assert r.status_code == 403, r.text
+        body = r.json()
+        assert body["error_code"] == "ownership_mismatch"
+        assert body["details"] == {
+            "agent_id": "agent-target",
+            "reason": "not_agent_owner",
+        }
+        stub_agent_service.rotate_api_key.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# Anonymous / missing / unknown agent
+# --------------------------------------------------------------------------- #
+
+
+class TestRotationAuthFailures:
+    def test_no_auth_header_returns_401(self, stub_agent_service, monkeypatch):
+        """Anonymous rotation is never allowed — the entire endpoint
+        is a credential mutator and would be useless if unauthed
+        callers could hit it."""
+        from acn.routes.tasks import settings as tasks_settings
+
+        async def _fake_verify_token(*args, **kwargs):
+            from acn.core.errors import ACNHTTPError, ErrorCode
+
+            raise ACNHTTPError(ErrorCode.AUTHENTICATION_REQUIRED, 401, details={})
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        monkeypatch.setattr("acn.routes.tasks.verify_token", _fake_verify_token)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post("/api/v1/agents/agent-target/rotate-key")
+
+        assert r.status_code == 401, r.text
+        stub_agent_service.rotate_api_key.assert_not_awaited()
+
+    def test_invalid_agent_key_returns_401(self, stub_agent_service, monkeypatch):
+        """A Bearer that *looks* like an agent key (``acn_*``) but
+        resolves to no agent must return 401, not 403 — same shape
+        as every other ``invalid_agent_api_key`` failure across the
+        codebase so a single client error handler covers everything."""
+        from acn.routes.tasks import settings as tasks_settings
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/rotate-key",
+                headers={"Authorization": "Bearer acn_does_not_exist"},
+            )
+
+        assert r.status_code == 401, r.text
+        body = r.json()
+        assert body["error_code"] == "authentication_required"
+        assert body["details"] == {"reason": "invalid_agent_api_key"}
+        stub_agent_service.rotate_api_key.assert_not_awaited()
+
+    def test_unknown_agent_returns_404(self, stub_agent_service, monkeypatch):
+        """Hitting an agent_id that doesn't exist returns 404 — but
+        ONLY after auth has passed (a valid key authorising a real
+        agent). Otherwise the 404 would let an attacker enumerate
+        existing agent_ids by comparing 404 vs 403.
+        """
+        from acn.routes.tasks import settings as tasks_settings
+
+        async def _fake_verify_token(*args, **kwargs):
+            return {"sub": "owner-alice", "permissions": ["acn:write"]}
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        monkeypatch.setattr("acn.routes.tasks.verify_token", _fake_verify_token)
+        _wire(stub_agent_service)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-ghost/rotate-key",
+                headers={"Authorization": "Bearer some-auth0-jwt"},
+            )
+
+        assert r.status_code == 404, r.text
+        body = r.json()
+        assert body["error_code"] == "agent_not_found"
+        assert body["details"] == {"agent_id": "agent-ghost"}
+
+
+# --------------------------------------------------------------------------- #
+# Auth cache invalidation
+# --------------------------------------------------------------------------- #
+
+
+class TestRotationInvalidatesAuthCache:
+    def test_cached_old_key_evicted_after_rotation(
+        self, stub_agent_service, monkeypatch
+    ):
+        """After a successful rotation the OLD key must immediately
+        stop authenticating — even though the in-memory
+        ``_api_key_cache`` would otherwise serve a 60-second-stale
+        entry pointing at the same agent.
+
+        We prime the cache exactly the way ``_cache_agent`` does, and
+        then assert that after rotation the cache no longer contains
+        the entry. ``_api_key_cache_by_agent`` is the reverse index
+        the M3 fix relies on for O(1) eviction.
+        """
+        from acn.routes.dependencies import _cache_agent
+        from acn.routes.tasks import settings as tasks_settings
+
+        monkeypatch.setattr(tasks_settings, "dev_mode", False)
+        _wire(stub_agent_service)
+
+        _cache_agent(
+            api_key="acn_target_current",
+            agent_id="agent-target",
+            name="Target",
+            wallet_address=None,
+        )
+        assert hash_api_key("acn_target_current") in _api_key_cache
+        assert "agent-target" in _api_key_cache_by_agent
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/rotate-key",
+                headers={"Authorization": "Bearer acn_target_current"},
+            )
+        assert r.status_code == 200, r.text
+
+        # The reverse index entry must be gone — that's the M3
+        # invariant the route relies on. Without this, a leaked key
+        # remains usable up to ``_API_KEY_CACHE_TTL`` past the
+        # rotation.
+        assert "agent-target" not in _api_key_cache_by_agent
+        assert hash_api_key("acn_target_current") not in _api_key_cache

--- a/tests/services/test_agent_service.py
+++ b/tests/services/test_agent_service.py
@@ -199,3 +199,143 @@ class TestAgentService:
                 sample_agent.agent_id,
                 "wrong-owner",  # Different owner
             )
+
+    # ------------------------------------------------------------------
+    # H1 — rotate_api_key
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rotate_api_key_returns_plaintext_and_persists_hash(
+        self, mock_agent_repository, sample_agent
+    ):
+        """rotate_api_key returns a fresh acn_* plaintext and stores only the hash."""
+        from acn.services.agent_service import hash_api_key
+
+        # The pre-rotation value can be either plaintext (legacy) or already
+        # a hash — what matters is that rotation overwrites it with the new
+        # hash, never with raw plaintext.
+        sample_agent.api_key = "acn_OLD_PLAINTEXT_KEY"
+        mock_agent_repository.find_by_id.return_value = sample_agent
+
+        service = AgentService(mock_agent_repository)
+
+        new_key = await service.rotate_api_key(sample_agent.agent_id)
+
+        assert new_key.startswith("acn_"), "new key must keep the acn_ prefix"
+        assert len(new_key) > len("acn_") + 32, "new key must carry ~256-bit entropy"
+        # The stored value is the hash, not the plaintext. This is the
+        # H1 invariant — even a full DB dump cannot replay the key.
+        assert sample_agent.api_key == hash_api_key(new_key)
+        assert sample_agent.api_key != new_key
+        mock_agent_repository.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rotate_api_key_each_call_produces_distinct_key(
+        self, mock_agent_repository, sample_agent
+    ):
+        """Two consecutive rotations must produce two different plaintexts."""
+        mock_agent_repository.find_by_id.return_value = sample_agent
+
+        service = AgentService(mock_agent_repository)
+
+        key1 = await service.rotate_api_key(sample_agent.agent_id)
+        key2 = await service.rotate_api_key(sample_agent.agent_id)
+
+        assert key1 != key2, "each rotation must mint fresh entropy"
+
+    @pytest.mark.asyncio
+    async def test_rotate_api_key_unknown_agent_raises(self, mock_agent_repository):
+        """Rotating a non-existent agent surfaces AgentNotFoundException."""
+        mock_agent_repository.find_by_id.return_value = None
+
+        service = AgentService(mock_agent_repository)
+
+        with pytest.raises(AgentNotFoundException):
+            await service.rotate_api_key("agent-does-not-exist")
+
+        mock_agent_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rotate_api_key_invalidates_lookup_by_old_key(
+        self, mock_agent_repository, sample_agent
+    ):
+        """After rotation, get_agent_by_api_key(old_key) returns None.
+
+        End-to-end H1 invariant: rotation is only useful if the previous
+        credential genuinely stops working. We model the repository as a
+        hash→agent index and verify the index no longer points back to
+        the agent after the rotation save.
+        """
+        from acn.services.agent_service import hash_api_key
+
+        # Build a tiny in-memory hash index against the agent.
+        old_plaintext = "acn_OLD_PLAINTEXT_KEY"
+        sample_agent.api_key = hash_api_key(old_plaintext)
+        key_index: dict[str, object] = {sample_agent.api_key: sample_agent}
+
+        async def fake_find_by_id(agent_id: str):
+            return sample_agent if agent_id == sample_agent.agent_id else None
+
+        async def fake_save(agent):
+            # Drop any prior hash, install the new one. This is exactly
+            # what a real repository must do after an in-place mutation.
+            for h in list(key_index):
+                if key_index[h] is agent:
+                    del key_index[h]
+            key_index[agent.api_key] = agent
+
+        async def fake_find_by_api_key(key_hash: str):
+            return key_index.get(key_hash)
+
+        mock_agent_repository.find_by_id.side_effect = fake_find_by_id
+        mock_agent_repository.save.side_effect = fake_save
+        mock_agent_repository.find_by_api_key.side_effect = fake_find_by_api_key
+
+        service = AgentService(mock_agent_repository)
+
+        # Sanity: old key resolves before rotation.
+        assert (
+            await service.get_agent_by_api_key(old_plaintext)
+        ).agent_id == sample_agent.agent_id
+
+        new_key = await service.rotate_api_key(sample_agent.agent_id)
+
+        # New key authenticates.
+        assert (
+            await service.get_agent_by_api_key(new_key)
+        ).agent_id == sample_agent.agent_id
+        # Old key no longer authenticates.
+        assert await service.get_agent_by_api_key(old_plaintext) is None
+
+    @pytest.mark.asyncio
+    async def test_get_agent_by_api_key_no_longer_falls_back_to_legacy_lookup(
+        self, mock_agent_repository
+    ):
+        """``get_agent_by_api_key`` must consult the hash index only.
+
+        Pre-v0.12.0 there was a legacy plaintext fallback (and an
+        auto-migrate save) for agents registered before API-key
+        hashing. Once every live ``by_api_key`` index entry became a
+        SHA-256 hash, the fallback turned into a perpetually cold
+        branch — and a cold branch is exactly the kind of code that
+        future refactors silently break. The interface method was
+        removed; this pin catches anyone trying to bring it back
+        without noticing.
+        """
+        mock_agent_repository.find_by_api_key.return_value = None
+
+        service = AgentService(mock_agent_repository)
+        result = await service.get_agent_by_api_key("acn_anything")
+
+        assert result is None
+        mock_agent_repository.find_by_api_key.assert_awaited_once()
+        # Crucially: the legacy method must not exist on the
+        # interface and must not have been called. AsyncMock would
+        # auto-create attribute access into a coroutine on first
+        # touch, masking the regression — so we assert against the
+        # *spec* directly.
+        assert not hasattr(type(mock_agent_repository), "find_by_api_key_legacy"), (
+            "IAgentRepository.find_by_api_key_legacy was removed in v0.12.0; "
+            "if you're re-adding it, update this test and revisit the "
+            "rationale in services/agent_service.py::get_agent_by_api_key."
+        )


### PR DESCRIPTION
## Summary

Closes **H1** of the pre-launch security audit by adding the missing rotation surface AND removing the now-cold legacy plaintext lookup that survived from the first hashing milestone. Together these turn H1 from "half done with an open follow-up" into a closed item with **no maintenance-window dependency**.

### Why no maintenance window

The earlier audit plan flagged H1 as needing an ops window for "DB schema migration + double-write period + full key reset". Probing a prod-shaped dev cluster showed **58/58 `by_api_key` index entries are already SHA-256 hex; zero plaintext (`acn_*`) entries remain**. There is no plaintext column to drop (`agents.api_key` is a single nullable String that simply stores the hash now), no rows to migrate, and the fallback path is permanently cold. The original "ops window" framing was an outdated assumption that no longer applies.

## Backend changes

- **`AgentService.rotate_api_key(agent_id)`** mints a fresh `acn_*` plaintext, stores only its SHA-256 hash, returns the plaintext to the caller exactly once.
- **`POST /api/v1/agents/{agent_id}/rotate-key`** with dual-track auth via the same `require_task_write_auth()` pipeline as task writes:
  - agent self via its current `acn_*` key — `sub` must match `agent_id`,
  - owner via Auth0 JWT — `agent.owner` must match `sub`,
  - internal token / `dev_mode` pass through.
  The handler calls `evict_agent_from_cache(agent_id)` (reuses the M3 reverse index) so the rotated-away key cannot linger up to the 60s auth-cache TTL.
- **`RedisAgentRepository.save()` bug fix.** A pre-existing latent bug: the `by_api_key:<hash>` index was being written for the new hash but the old hash entry was left behind, so `find_by_api_key(hash(old_key))` kept resolving to the same agent and the rotated-away key kept working. Now `save()` issues a `DEL` against the previous hash when `existing.api_key != agent.api_key`. The PG repository uses `UPDATE` on a single row, so it's naturally safe and untouched.
- **Legacy plaintext cleanup.** Drop `IAgentRepository.find_by_api_key_legacy` + PG/Redis implementations + service-side fallback branch + auto-migrate save. Add an explicit regression pin (`test_get_agent_by_api_key_no_longer_falls_back_to_legacy_lookup`) so any future refactor that tries to revive the dead branch fails loudly instead of silently widening the auth surface.

> The Redis save() bug is exactly what step 15 of the SDK smoke caught — the in-process route/service tests all passed because they don't exercise the repository's index, only the agent record. Catching it required the live cross-process round-trip.

## SDK changes

- `acn-client` (TypeScript) → **0.12.0**: `client.rotateApiKey(agentId)`. CHANGELOG documents the typical `client.config.apiKey = api_key` follow-up.
- `acn_client` (Python): `rotate_api_key(agent_id)` with matching docstring.

## Tests

| File | What it pins |
|---|---|
| `tests/services/test_agent_service.py` (+5) | returns `acn_*` plaintext + stores hash, distinct keys per call, unknown agent raises, lookup by old key returns None after rotation, legacy fallback no longer queried (interface-removal regression pin) |
| `tests/routes/test_rotate_api_key_h1.py` (+8) | agent-self happy + cross-agent 403, owner JWT happy + non-owner JWT 403, no-auth 401, invalid `acn_*` 401, unknown agent 404, cache eviction |
| `tests/infrastructure/test_agent_repository_api_key_rotation.py` (+3) | rotation purges stale index, steady-state save does not churn, first-time save does not stray-DEL |
| `clients/typescript/scripts/smoke.ts` step 15 | live end-to-end: agent_id and subnet membership survive rotation; the OLD key is rejected over the wire (raw fetch bypasses the SDK exception path to assert the exact 401) |

## Verification

- **Full pytest**: `1467 passed, 4 skipped` (baseline 1454 + 13 new, 0 regressions).
- **SDK contract smoke** against a live backend: 15/15.
- **SDK smoke re-run after legacy cleanup**: 15/15 (rotation still works; old key still 401 — proves we didn't depend on the legacy path).
- **TypeScript SDK**: `npm run typecheck` + `npm run build` clean.

## Release plan

After merge, push `v0.12.0` tag — release workflow will publish `acn-client@0.12.0` to npm + bump the Docker image + cut the GitHub release. PyPI package is unchanged (Python SDK doesn't ship a new version yet because pyproject is still on 0.10.0; the new method is available via local install, a Python-side release can wait).

## Test plan

- [ ] CI: full pytest passes (force-pushed amend, re-running).
- [ ] CI: SDK typecheck + build green.
- [ ] Manual after merge: tag `v0.12.0` triggers release workflow, all 6 jobs SUCCESS.
- [ ] Smoke against published `acn-client@0.12.0` (npx tsx scripts/smoke.ts).