### PR TITLE
feat(subnets): ADR-0003 Phase 1 — nesting fields + repository indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ python3 scripts/smoke_backend_integration.py
 
 - **Agent IDs are ACN-managed** — never accept externally supplied IDs; always generate via `uuid4()`
 - **Redis key prefixes** — `agent:`, `task:`, `subnet:`, `metric:` (check existing patterns before adding new ones)
+- **Subnets nest at most one level** — a child subnet's `parent_subnet_id` must reference a top-level subnet (one whose own `parent_subnet_id` is `None`); validated at create time. Child membership must be ⊆ parent membership. `task_scoped` children auto-dissolve when their `linked_task_id` reaches a terminal state. See `docs/adr/0003-subnet-nesting-single-layer.md`.
 - **Idempotent registration** — same owner + endpoint combination always returns the same agent ID
 - **`dev_mode=false` is the default** — set `DEV_MODE=true` only for local development; it bypasses Auth0 and must never be enabled in production
 - **Failing fast** — `config.py` validates production settings at startup via `model_validator`

--- a/acn/core/entities/subnet.py
+++ b/acn/core/entities/subnet.py
@@ -5,6 +5,13 @@ Pure business logic for Subnet.
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Literal
+
+# Valid values for the ``Subnet.lifecycle`` field. ``Literal`` type hints are
+# not validated at runtime on a dataclass, so we mirror the set here and
+# enforce it in ``__post_init__``.
+_LIFECYCLE_VALUES: frozenset[str] = frozenset({"persistent", "task_scoped"})
+_RESERVED_SUBNET_IDS: frozenset[str] = frozenset({"public", "system"})
 
 
 @dataclass
@@ -12,7 +19,10 @@ class Subnet:
     """
     Subnet Domain Entity
 
-    Represents a logical network segment for agent grouping.
+    Represents a logical network segment for agent grouping. Subnets can
+    optionally nest one level deep — see ADR-0003. The three nesting
+    fields default to "top-level persistent subnet" so legacy callers
+    that don't touch them behave exactly as before.
     """
 
     subnet_id: str
@@ -26,6 +36,11 @@ class Subnet:
     metadata: dict = field(default_factory=dict)
     harness_url: str | None = None
     harness_secret: str | None = None
+    # Nesting fields (ADR-0003). All optional; defaults preserve legacy
+    # "flat top-level subnet" semantics.
+    parent_subnet_id: str | None = None
+    lifecycle: Literal["persistent", "task_scoped"] = "persistent"
+    linked_task_id: str | None = None
 
     def __post_init__(self):
         """Validate invariants"""
@@ -36,9 +51,31 @@ class Subnet:
         if not self.owner:
             raise ValueError("owner cannot be empty")
         # Reserved subnet IDs
-        if self.subnet_id in ["public", "system"]:
+        if self.subnet_id in _RESERVED_SUBNET_IDS:
             if self.owner != "system":
                 raise ValueError(f"Subnet '{self.subnet_id}' is reserved for system use")
+            # Reserved subnets can never participate in nesting — neither
+            # as child (would let attackers slot platform-owned IDs into a
+            # hierarchy) nor with a non-default lifecycle.
+            if self.parent_subnet_id is not None:
+                raise ValueError(
+                    f"Reserved subnet '{self.subnet_id}' cannot have a parent_subnet_id"
+                )
+
+        # ADR-0003 entity-layer invariants.
+        if self.lifecycle not in _LIFECYCLE_VALUES:
+            raise ValueError(
+                f"lifecycle must be one of {sorted(_LIFECYCLE_VALUES)}, got {self.lifecycle!r}"
+            )
+        # ``task_scoped`` ⇔ ``linked_task_id is not None`` is enforced both
+        # directions so callers can't construct a half-state.
+        if self.lifecycle == "task_scoped" and self.linked_task_id is None:
+            raise ValueError("lifecycle='task_scoped' requires linked_task_id to be set")
+        if self.lifecycle == "persistent" and self.linked_task_id is not None:
+            raise ValueError(
+                "lifecycle='persistent' must not carry a linked_task_id; "
+                "use lifecycle='task_scoped' or clear linked_task_id"
+            )
 
     def add_member(self, agent_id: str) -> None:
         """Add an agent to this subnet"""
@@ -82,6 +119,9 @@ class Subnet:
             "created_at": self.created_at.isoformat(),
             "metadata": self.metadata,
             "harness_url": self.harness_url,
+            "parent_subnet_id": self.parent_subnet_id,
+            "lifecycle": self.lifecycle,
+            "linked_task_id": self.linked_task_id,
         }
         if include_secret:
             out["harness_secret"] = self.harness_secret
@@ -89,7 +129,13 @@ class Subnet:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Subnet":
-        """Create Subnet from dictionary"""
+        """Create Subnet from dictionary.
+
+        Legacy stored rows that predate ADR-0003 don't carry the nesting
+        fields. ``**data`` would then pass nothing for them and the
+        dataclass defaults take over (top-level persistent subnet).
+        That's the intended migration path — no backfill needed.
+        """
         data = data.copy()
         if isinstance(data.get("created_at"), str):
             try:

--- a/acn/core/entities/subnet.py
+++ b/acn/core/entities/subnet.py
@@ -55,11 +55,18 @@ class Subnet:
             if self.owner != "system":
                 raise ValueError(f"Subnet '{self.subnet_id}' is reserved for system use")
             # Reserved subnets can never participate in nesting — neither
-            # as child (would let attackers slot platform-owned IDs into a
-            # hierarchy) nor with a non-default lifecycle.
+            # as a child (would let attackers slot platform-owned IDs into
+            # a hierarchy) nor with a task-bound lifecycle (would let a
+            # task termination auto-dissolve a platform-level subnet,
+            # breaking the implicit "always-on" guarantee that callers
+            # depend on for `public`).
             if self.parent_subnet_id is not None:
                 raise ValueError(
                     f"Reserved subnet '{self.subnet_id}' cannot have a parent_subnet_id"
+                )
+            if self.lifecycle == "task_scoped":
+                raise ValueError(
+                    f"Reserved subnet '{self.subnet_id}' cannot be task_scoped"
                 )
 
         # ADR-0003 entity-layer invariants.

--- a/acn/core/interfaces/subnet_repository.py
+++ b/acn/core/interfaces/subnet_repository.py
@@ -96,3 +96,52 @@ class ISubnetRepository(ABC):
             True if subnet exists
         """
         pass
+
+    # ------------------------------------------------------------------
+    # Nesting (ADR-0003)
+    # ------------------------------------------------------------------
+    # Shipped in Phase 1 so the persistence layer carries the indexes
+    # and lookup methods atomically with the schema change. Service /
+    # route consumers land in Phase 2 (parent lookup) and Phase 3
+    # (task-state cascade). Implementations must keep these methods
+    # consistent with ``save`` / ``delete`` — both maintain the
+    # underlying secondary index in the same transaction / pipeline.
+
+    @abstractmethod
+    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+        """
+        Find all child subnets nested under a given parent.
+
+        Returns the empty list when no children exist or the parent
+        itself is unknown — callers that need to distinguish "no
+        children" from "parent missing" should ``find_by_id`` the
+        parent separately.
+
+        Args:
+            parent_subnet_id: Parent subnet identifier
+
+        Returns:
+            List of subnets whose ``parent_subnet_id`` equals the
+            argument.
+        """
+        pass
+
+    @abstractmethod
+    async def find_by_linked_task(self, task_id: str) -> list[Subnet]:
+        """
+        Find all subnets bound to a given task via ``linked_task_id``.
+
+        Used by the task-state-machine cascade hook (Phase 3) to
+        dissolve ``task_scoped`` children when the linked task reaches
+        a terminal state. Includes both ``task_scoped`` and (defensively)
+        any ``persistent`` rows that still carry the field — callers
+        should filter by ``lifecycle`` themselves when that matters.
+
+        Args:
+            task_id: Task identifier
+
+        Returns:
+            List of subnets whose ``linked_task_id`` equals the
+            argument.
+        """
+        pass

--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -187,8 +187,36 @@ class SubnetModel(Base):
     subnet_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
     harness_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     harness_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Nesting fields (ADR-0003). Both ``default`` (Python / ORM path)
+    # and ``server_default`` (DDL path) are set on ``lifecycle`` so a
+    # fresh INSERT through the ORM matches a backfilled row inserted
+    # via Alembic — avoids the "ORM default ≠ DB default" drift trap.
+    parent_subnet_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    lifecycle: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        default="persistent",
+        server_default="persistent",
+    )
+    linked_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    __table_args__ = (
+        # Partial indexes for nesting lookups (ADR-0003). ``WHERE ...
+        # IS NOT NULL`` keeps the index small — top-level subnets
+        # without a parent / linked task don't contribute rows.
+        Index(
+            "subnets_parent_idx",
+            "parent_subnet_id",
+            postgresql_where=text("parent_subnet_id IS NOT NULL"),
+        ),
+        Index(
+            "subnets_linked_task_idx",
+            "linked_task_id",
+            postgresql_where=text("linked_task_id IS NOT NULL"),
+        ),
     )
 
 

--- a/acn/infrastructure/persistence/postgres/subnet_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_repository.py
@@ -30,6 +30,9 @@ class PostgresSubnetRepository(ISubnetRepository):
             metadata=meta,
             harness_url=row.harness_url,
             harness_secret=row.harness_secret,
+            parent_subnet_id=row.parent_subnet_id,
+            lifecycle=row.lifecycle,
+            linked_task_id=row.linked_task_id,
         )
 
     def _subnet_to_model(self, subnet: Subnet) -> SubnetModel:
@@ -48,6 +51,9 @@ class PostgresSubnetRepository(ISubnetRepository):
             subnet_metadata=subnet.metadata or None,
             harness_url=subnet.harness_url,
             harness_secret=subnet.harness_secret,
+            parent_subnet_id=subnet.parent_subnet_id,
+            lifecycle=subnet.lifecycle,
+            linked_task_id=subnet.linked_task_id,
             created_at=created,
         )
 
@@ -60,6 +66,11 @@ class PostgresSubnetRepository(ISubnetRepository):
         async with self._session_factory() as session:
             existing = await session.get(SubnetModel, subnet.subnet_id)
             if existing:
+                # Nesting fields are included in the UPDATE so promote
+                # paths (Phase 2) and any future mutation can fall
+                # through correctly. ``parent_subnet_id`` is immutable
+                # per ADR-0003 §5 — included here only for defence in
+                # depth (service layer rejects mismatched updates).
                 await session.execute(
                     update(SubnetModel)
                     .where(SubnetModel.subnet_id == subnet.subnet_id)
@@ -73,6 +84,9 @@ class PostgresSubnetRepository(ISubnetRepository):
                         subnet_metadata=model.subnet_metadata,
                         harness_url=model.harness_url,
                         harness_secret=model.harness_secret,
+                        parent_subnet_id=model.parent_subnet_id,
+                        lifecycle=model.lifecycle,
+                        linked_task_id=model.linked_task_id,
                     )
                 )
             else:
@@ -125,6 +139,40 @@ class PostgresSubnetRepository(ISubnetRepository):
             result = await session.execute(
                 select(SubnetModel).where(
                     SubnetModel.member_agent_ids.contains([agent_id])
+                )
+            )
+            return [self._model_to_subnet(r) for r in result.scalars().all()]
+
+    # ------------------------------------------------------------------
+    # Nesting lookups (ADR-0003)
+    # ------------------------------------------------------------------
+
+    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+        """Return all child subnets nested under a given parent.
+
+        Hits the ``subnets_parent_idx`` partial index for an O(k)
+        lookup (k = number of children). Returns the empty list when
+        no children exist or the parent itself is unknown.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetModel).where(
+                    SubnetModel.parent_subnet_id == parent_subnet_id
+                )
+            )
+            return [self._model_to_subnet(r) for r in result.scalars().all()]
+
+    async def find_by_linked_task(self, task_id: str) -> list[Subnet]:
+        """Return all subnets bound to a given task via ``linked_task_id``.
+
+        Hits the ``subnets_linked_task_idx`` partial index. Consumers
+        filter by ``lifecycle`` themselves if they only want
+        ``task_scoped`` rows (Phase 3 cascade hook does this).
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetModel).where(
+                    SubnetModel.linked_task_id == task_id
                 )
             )
             return [self._model_to_subnet(r) for r in result.scalars().all()]

--- a/acn/infrastructure/persistence/redis/subnet_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_repository.py
@@ -32,12 +32,33 @@ class RedisSubnetRepository(ISubnetRepository):
         self.redis = redis_client
 
     async def save(self, subnet: Subnet) -> None:
-        """Save or update a subnet in Redis"""
+        """Save or update a subnet in Redis.
+
+        Writes the main HASH first with a direct ``HSET`` (preserves
+        the legacy code path that existing tests pin), then batches
+        all secondary index mutations into a single
+        ``pipeline(transaction=False)``:
+
+        - ``acn:subnets:by_owner:{owner}`` — owner → subnet_id SET
+        - ``acn:subnets:children:{parent_id}`` — parent → child SET
+          (ADR-0003; absent when ``parent_subnet_id is None``)
+        - ``acn:subnets:by_linked_task:{task_id}`` — task → subnet_id
+          SET (ADR-0003; absent when ``linked_task_id is None``)
+
+        On update, the old row is read first so stale entries get
+        ``SREM``'d when ``parent_subnet_id`` or ``linked_task_id``
+        changes. ``parent_subnet_id`` is immutable per ADR-0003 §5
+        but ``linked_task_id`` flips to ``None`` when Phase 2's
+        ``promote_to_persistent`` lands — defensive incremental
+        update keeps the index honest either way.
+        """
         subnet_key = f"acn:subnets:info:{subnet.subnet_id}"
 
-        # Serialize subnet to dict (include harness_secret for persistence)
+        # Read existing row (if any) so we know which stale index
+        # entries to evict when nesting fields change.
+        old_subnet = await self.find_by_id(subnet.subnet_id)
+
         subnet_dict = subnet.to_dict(include_secret=True)
-        # Convert complex types to JSON
         subnet_dict["security_config"] = json.dumps(subnet_dict["security_config"])
         subnet_dict["metadata"] = json.dumps(subnet_dict["metadata"])
         subnet_dict["member_agent_ids"] = json.dumps(subnet_dict["member_agent_ids"])
@@ -48,17 +69,44 @@ class RedisSubnetRepository(ISubnetRepository):
             subnet_dict["harness_secret"] = ""
         if subnet_dict.get("description") is None:
             subnet_dict["description"] = ""
+        # Nesting fields: empty string ≡ NULL, same convention as
+        # description / harness_url. Parsed back to ``None`` in
+        # ``_dict_to_subnet``.
+        if subnet_dict.get("parent_subnet_id") is None:
+            subnet_dict["parent_subnet_id"] = ""
+        if subnet_dict.get("linked_task_id") is None:
+            subnet_dict["linked_task_id"] = ""
         # redis-py refuses raw bool values for HSET — round-trip via the
         # "True"/"False" string form that `_dict_to_subnet` already parses
         # (see `is_private` parser).
         subnet_dict["is_private"] = str(bool(subnet_dict.get("is_private", False)))
 
-        # Save to Redis hash
         await self.redis.hset(subnet_key, mapping=subnet_dict)  # type: ignore[arg-type]
 
-        # Update indices via pipeline
         async with self.redis.pipeline(transaction=False) as pipe:
             pipe.sadd(f"acn:subnets:by_owner:{subnet.owner}", subnet.subnet_id)
+            # Maintain children index: SREM old → SADD new when changed.
+            old_parent = old_subnet.parent_subnet_id if old_subnet else None
+            new_parent = subnet.parent_subnet_id
+            if old_parent and old_parent != new_parent:
+                pipe.srem(
+                    f"acn:subnets:children:{old_parent}", subnet.subnet_id
+                )
+            if new_parent:
+                pipe.sadd(
+                    f"acn:subnets:children:{new_parent}", subnet.subnet_id
+                )
+            # Maintain by_linked_task index identically.
+            old_task = old_subnet.linked_task_id if old_subnet else None
+            new_task = subnet.linked_task_id
+            if old_task and old_task != new_task:
+                pipe.srem(
+                    f"acn:subnets:by_linked_task:{old_task}", subnet.subnet_id
+                )
+            if new_task:
+                pipe.sadd(
+                    f"acn:subnets:by_linked_task:{new_task}", subnet.subnet_id
+                )
             await pipe.execute()
 
     async def find_by_id(self, subnet_id: str) -> Subnet | None:
@@ -96,23 +144,74 @@ class RedisSubnetRepository(ISubnetRepository):
         return [s for s in all_subnets if s.is_public()]
 
     async def delete(self, subnet_id: str) -> bool:
-        """Delete a subnet"""
+        """Delete a subnet and all its secondary index entries.
+
+        Reads the subnet first to know which index sets to clean up
+        (owner, parent, linked-task). All deletions are then batched
+        in a single pipeline.
+        """
         subnet = await self.find_by_id(subnet_id)
         if not subnet:
             return False
 
-        # Remove from Redis
         subnet_key = f"acn:subnets:info:{subnet_id}"
-        await self.redis.delete(subnet_key)
-
-        # Remove from owner index
-        await self.redis.srem(f"acn:subnets:by_owner:{subnet.owner}", subnet_id)
+        async with self.redis.pipeline(transaction=False) as pipe:
+            pipe.delete(subnet_key)
+            pipe.srem(f"acn:subnets:by_owner:{subnet.owner}", subnet_id)
+            if subnet.parent_subnet_id:
+                pipe.srem(
+                    f"acn:subnets:children:{subnet.parent_subnet_id}", subnet_id
+                )
+            if subnet.linked_task_id:
+                pipe.srem(
+                    f"acn:subnets:by_linked_task:{subnet.linked_task_id}", subnet_id
+                )
+            await pipe.execute()
 
         return True
 
     async def exists(self, subnet_id: str) -> bool:
         """Check if subnet exists"""
         return await self.redis.exists(f"acn:subnets:info:{subnet_id}") > 0
+
+    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+        """Return all child subnets of a given parent.
+
+        Reads the ``acn:subnets:children:{parent_id}`` index, then
+        ``find_by_id`` each member. Empty list when no children exist
+        or the parent itself is unknown.
+        """
+        subnet_ids = await self.redis.smembers(
+            f"acn:subnets:children:{parent_subnet_id}"
+        )
+        subnets: list[Subnet] = []
+        for sid in subnet_ids:
+            if isinstance(sid, bytes):
+                sid = sid.decode()
+            subnet = await self.find_by_id(sid)
+            if subnet:
+                subnets.append(subnet)
+        return subnets
+
+    async def find_by_linked_task(self, task_id: str) -> list[Subnet]:
+        """Return all subnets bound to a given task via ``linked_task_id``.
+
+        Reads the ``acn:subnets:by_linked_task:{task_id}`` index, then
+        ``find_by_id`` each member. Consumers (Phase 3 cascade hook)
+        filter by ``lifecycle`` themselves if they only want
+        ``task_scoped`` rows.
+        """
+        subnet_ids = await self.redis.smembers(
+            f"acn:subnets:by_linked_task:{task_id}"
+        )
+        subnets: list[Subnet] = []
+        for sid in subnet_ids:
+            if isinstance(sid, bytes):
+                sid = sid.decode()
+            subnet = await self.find_by_id(sid)
+            if subnet:
+                subnets.append(subnet)
+        return subnets
 
     @staticmethod
     def _safe_loads(raw: str | None, default):
@@ -141,11 +240,23 @@ class RedisSubnetRepository(ISubnetRepository):
             return default
 
     def _dict_to_subnet(self, subnet_dict: dict) -> Subnet:
-        """Convert Redis dict to Subnet entity"""
-        # Empty strings stored in Redis mean NULL — translate back to None.
+        """Convert Redis dict to Subnet entity.
+
+        Empty strings stored in Redis mean NULL — translate back to
+        ``None`` for the relevant fields (description, harness_url /
+        secret, parent_subnet_id, linked_task_id). Legacy rows that
+        predate ADR-0003 don't carry the nesting keys at all; the
+        ``.get("parent_subnet_id") or None`` pattern handles both
+        "missing key" and "empty string" identically.
+        """
         description = subnet_dict.get("description") or None
         harness_url = subnet_dict.get("harness_url") or None
         harness_secret = subnet_dict.get("harness_secret") or None
+        parent_subnet_id = subnet_dict.get("parent_subnet_id") or None
+        linked_task_id = subnet_dict.get("linked_task_id") or None
+        # ``lifecycle`` defaults to "persistent" both when key absent
+        # (legacy row) and when stored value is empty/falsy.
+        lifecycle = subnet_dict.get("lifecycle") or "persistent"
 
         data = {
             "subnet_id": subnet_dict["subnet_id"],
@@ -163,6 +274,9 @@ class RedisSubnetRepository(ISubnetRepository):
             "metadata": self._safe_loads(subnet_dict.get("metadata", "{}"), {}),
             "harness_url": harness_url,
             "harness_secret": harness_secret,
+            "parent_subnet_id": parent_subnet_id,
+            "lifecycle": lifecycle,
+            "linked_task_id": linked_task_id,
         }
 
         return Subnet(**data)

--- a/alembic/versions/e1f2a3b4c5d6_add_subnet_nesting_fields.py
+++ b/alembic/versions/e1f2a3b4c5d6_add_subnet_nesting_fields.py
@@ -1,0 +1,115 @@
+"""add subnet nesting fields (parent_subnet_id, lifecycle, linked_task_id)
+
+ADR-0003 Phase 1: extends the ``subnets`` table with three optional
+fields plus two partial indexes that let one subnet declare itself a
+child of another, optionally bound to a task that auto-dissolves it
+on terminal state.
+
+This migration only ships the schema and indexes. The service /
+route / cascade consumers land in Phase 2 (acnlabs/ACN#50) and
+Phase 3 (acnlabs/ACN#51). Until then the new columns can only be
+populated through their defaults, so legacy callers behave
+unchanged.
+
+Columns
+-------
+- ``parent_subnet_id VARCHAR NULL`` — the parent subnet's id, or
+  NULL for top-level. Immutable after insert per ADR-0003 §5.
+- ``lifecycle VARCHAR NOT NULL DEFAULT 'persistent'`` — either
+  ``'persistent'`` (default, original semantics) or
+  ``'task_scoped'`` (auto-dissolves when ``linked_task_id`` reaches
+  a terminal state).
+- ``linked_task_id VARCHAR NULL`` — the task id the subnet is bound
+  to when ``lifecycle = 'task_scoped'``. NULL otherwise.
+
+Indexes
+-------
+Partial indexes only — top-level subnets without a parent / linked
+task don't contribute rows, keeping the index size proportional to
+the actual nesting cardinality.
+
+- ``subnets_parent_idx`` ON ``parent_subnet_id`` WHERE NOT NULL
+- ``subnets_linked_task_idx`` ON ``linked_task_id`` WHERE NOT NULL
+
+Both are shipped here (not split across phases) so the schema
+change is a single atomic event — Phase 3's cascade lookups
+(``find_by_linked_task``) reuse the index without needing another
+migration.
+
+Backward compatibility
+----------------------
+``lifecycle`` carries a ``server_default`` that PostgreSQL fills in
+for every existing row at ALTER time, so no separate backfill is
+required. ``parent_subnet_id`` and ``linked_task_id`` are nullable
+with no default, so they read back as NULL on legacy rows — exactly
+matching the entity-layer default for "top-level persistent
+subnet". The ``Subnet.from_dict`` round-trip also tolerates missing
+keys, so Redis legacy rows behave identically.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-05-17 17:50:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: str | None = "d0e1f2a3b4c5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Columns: lifecycle carries a server_default so ALTER fills
+    # every existing row in a single statement; parent_subnet_id and
+    # linked_task_id stay NULL on legacy rows.
+    op.add_column(
+        "subnets",
+        sa.Column("parent_subnet_id", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "subnets",
+        sa.Column(
+            "lifecycle",
+            sa.String(),
+            nullable=False,
+            server_default="persistent",
+        ),
+    )
+    op.add_column(
+        "subnets",
+        sa.Column("linked_task_id", sa.String(), nullable=True),
+    )
+
+    # Partial indexes: only nesting rows contribute. The naming
+    # mirrors the SQLAlchemy ``Index(...)`` declarations on
+    # ``SubnetModel.__table_args__`` so drift between the model and
+    # the migration would surface as a diff during
+    # ``alembic revision --autogenerate`` review.
+    op.create_index(
+        "subnets_parent_idx",
+        "subnets",
+        ["parent_subnet_id"],
+        postgresql_where=sa.text("parent_subnet_id IS NOT NULL"),
+    )
+    op.create_index(
+        "subnets_linked_task_idx",
+        "subnets",
+        ["linked_task_id"],
+        postgresql_where=sa.text("linked_task_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # Drop indexes before columns — PostgreSQL won't allow dropping
+    # a column that an index still references.
+    op.drop_index("subnets_linked_task_idx", table_name="subnets")
+    op.drop_index("subnets_parent_idx", table_name="subnets")
+    op.drop_column("subnets", "linked_task_id")
+    op.drop_column("subnets", "lifecycle")
+    op.drop_column("subnets", "parent_subnet_id")

--- a/docs/adr/0003-subnet-nesting-single-layer.md
+++ b/docs/adr/0003-subnet-nesting-single-layer.md
@@ -1,0 +1,553 @@
+# ADR-0003: Subnet nesting — single-layer parent/child
+
+- **Status**: Proposed
+- **Date**: 2026-05-16
+- **Decision drivers**: in-network squad collaboration, minimal new
+  surface area, Org-Harness extensibility, ACL hygiene
+
+## Context
+
+ACN today exposes a flat `Subnet` primitive: an agent can belong to
+multiple subnets (`Agent.subnet_ids: list[str]`), but subnets
+themselves have no relationship to each other. They are peers in a
+flat namespace.
+
+A recurring user request — surfaced again during product
+discussion — is some form of **in-network team / squad**:
+
+> "Inside a big collaboration network, related agents should be able
+> to form a smaller working group to coordinate on a task while still
+> sharing the parent network's information."
+
+Concrete examples surfaced during that discussion:
+
+- An `engineering` subnet of ~20 agents wants a 3-5 agent
+  `payments-squad` to coordinate on a specific bugfix without
+  spamming the rest of `engineering`.
+- A `customer-support` subnet wants persistent topic-based squads
+  (`refunds`, `escalations`, `billing-disputes`) that agents
+  rotate through.
+
+Three obvious design directions were considered before this ADR:
+
+1. **Application-layer fan-out only**. Keep ACN flat; let consumers
+   create a fully independent `private` subnet for each squad,
+   stitched together by metadata fields (e.g.
+   `metadata.parent_subnet="engineering"`). Lowest cost, but the
+   relationship is purely convention — ACN cannot enforce that squad
+   membership ⊆ parent membership, cannot cascade-delete on parent
+   removal, and Org Harness has no signal that a "child" event
+   belongs to its parent's organisation.
+
+2. **New `Squad` first-class entity**. A separate entity dedicated to
+   intra-subnet collaboration: own service, repository, route prefix
+   (`/squads/...`), CLI verb (`acn squad ...`), Redis key pattern
+   (`acn:squads:{id}:*`), and PostgreSQL table. This was the first
+   draft. It was rejected during design review: the `Squad` data
+   model is structurally a subset of the existing `Subnet` model
+   (member set + owner + lifecycle + harness route). Introducing a
+   second entity duplicates code (~4 new modules: service, repo,
+   route, CLI) and forces SDK consumers to learn a new concept and
+   new endpoints, while delivering nothing the `Subnet` primitive
+   cannot model.
+
+3. **Extend `Subnet` with a parent reference and lifecycle hooks**.
+   Add three optional fields to the existing entity, enforce that
+   a "child" subnet's membership is a subset of its parent's, and
+   reuse every existing subnet primitive (CRUD, members, broadcast,
+   harness) for both layers.
+
+The discussion converged on option 3 because (a) the semantic
+extension of "logical grouping" → "logical grouping that can contain
+sub-groupings" lies entirely within the concept's existing
+boundaries, (b) it adds zero new top-level concepts to the SDK / CLI
+/ docs, and (c) it lets Org Harness opt into hierarchy by reading a
+single new payload field, with no new event types to handle.
+
+## Considered options
+
+### A. Extend `Subnet` with three optional fields (chosen)
+
+Add to the `Subnet` domain entity (`acn/core/entities/subnet.py`)
+and the persistence layer (`SubnetModel`, Redis repository):
+
+```python
+parent_subnet_id: str | None = None
+lifecycle: Literal["persistent", "task_scoped"] = "persistent"
+linked_task_id: str | None = None
+```
+
+Invariants enforced by `SubnetService`:
+
+1. **Single-layer only.** If `parent_subnet_id` is non-`None`, the
+   referenced parent's own `parent_subnet_id` must be `None`. This
+   caps tree depth at 1 to keep ACL composition O(1).
+2. **Membership subset.** When `parent_subnet_id` is set,
+   `add_member` rejects any `agent_id` not already in
+   `parent.member_agent_ids`. The reverse is *not* enforced (parent
+   members are not auto-added to children — squads are opt-in).
+3. **task_scoped requires linked task.** If
+   `lifecycle == "task_scoped"`, `linked_task_id` must be set at
+   creation time and refer to an existing task. When that task
+   reaches a terminal state (`COMPLETED` / `REJECTED` / `CANCELLED`),
+   the squad subnet is automatically dissolved.
+4. **Parent cascade.** Deleting a parent subnet cascade-deletes
+   all child subnets in the same transaction.
+5. **Reserved subnets cannot be children.** `public` and `system`
+   may not be used as `parent_subnet_id` (they are platform-owned
+   and have implicit "all agents" semantics that would make
+   "membership subset" trivially true and meaningless).
+
+API surface changes:
+
+- `POST /api/v1/subnets` accepts three new optional body fields
+  (`parent_subnet_id` / `lifecycle` / `linked_task_id`). Validation
+  errors surface as `ACNHTTPError` with `INVALID_REQUEST`.
+- `GET /api/v1/subnets?parent=<id>` filter parameter added.
+- `GET /api/v1/subnets/{id}/children` new convenience endpoint.
+- `POST /api/v1/subnets/{id}/promote` promotes a `task_scoped`
+  child to `persistent` (clears `linked_task_id`, flips
+  `lifecycle`).
+- Every other existing route (`/subnets/{id}/agents`,
+  `/subnets/{id}/broadcast`, `/subnets/{id}/harness`) works
+  unchanged for child subnets.
+
+CLI mirror:
+
+```bash
+acn subnet create --name "Payments Squad" \
+                  --parent <parent_subnet_id> \
+                  --task <task_id> \
+                  --lifecycle task_scoped
+acn subnet list --parent <subnet_id>
+acn subnet promote <subnet_id>
+```
+
+Org Harness integration: **zero new event types**. The existing
+events that fire on subnet-scoped activity — today
+`agent.joined_subnet` and `agent.left_subnet`, plus the task
+events already delivered — gain a `parent_subnet_id` field in
+their payload `data` block, set to `None` for top-level subnets
+and to the parent ID for child subnets. Harness implementations
+that don't care about hierarchy ignore the field; those that do
+can recursively look up `parent_subnet.harness_url` if they want
+fan-out (decided per harness, not by ACN). Adding new event types
+for subnet lifecycle (creation, deletion, dissolution) is
+deliberately out of scope here — see Out of scope below.
+
+**Pros**
+
+- Zero new concepts in API / CLI / SDK / docs.
+- Reuses every existing subnet primitive — `BroadcastService`,
+  `SubnetManager`, ACL helpers, Redis key patterns
+  (`acn:subnets:{id}:*`), PG table — automatically serves both
+  layers without code changes.
+- Membership subset invariant is enforceable at the service layer
+  (single `if parent_subnet_id and agent_id not in parent.members:
+  raise ValueError`).
+- Single-layer cap keeps ACL composition trivial: an agent's
+  effective subnets are still a flat list; "can talk to" is still
+  set-membership in `subnet.member_agent_ids`.
+- Backward compatible: existing subnets default to
+  `parent_subnet_id=None, lifecycle="persistent",
+  linked_task_id=None`. No migration needed for current callers.
+- Org Harness adoption is incremental — implementations work
+  unchanged until they choose to read the new field.
+
+**Cons**
+
+- The `Subnet` entity's semantic radius widens slightly: it no
+  longer represents only "flat logical group" but also "flat
+  logical group, optionally nested one level". The docs section
+  needs a new paragraph.
+- Validation logic adds a parent-lookup on `create_subnet` and
+  `add_member` for child subnets — one extra repository fetch per
+  call. Acceptable given the typical squad cardinality (handfuls,
+  not thousands).
+- `task_scoped` cascade dissolution requires a hook in three task
+  state-machine sites (`complete_task` / `reject_task` /
+  `cancel_task`). Discipline cost; documented in the implementation
+  guidance below.
+
+### B. New `Squad` entity (rejected)
+
+Rejected. Duplicates `Subnet`'s data model, forces a new top-level
+concept on every consumer, and offers nothing that option A cannot
+model. The asymmetry between "subnet" and "squad" would also need
+explanation in every doc that lists ACN's primitives — pure surface
+area, no semantic gain.
+
+### C. Multi-level subnet tree (rejected)
+
+Rejected as out of scope. Multi-level (depth ≥ 2) introduces ACL
+composition complexity (effective membership becomes a tree walk),
+demands cycle prevention on every `set_parent` operation, and is
+not supported by any user request we have today. Single-layer
+covers every concrete use case raised in the discussion thread.
+If a future user actually needs depth-2, a separate ADR can lift
+the single-layer cap with eyes open on the trade-offs.
+
+### D. Application-layer convention only (rejected)
+
+Rejected. `metadata.parent_subnet="..."` is opt-in convention with
+zero enforcement: any client can lie about the parent, membership
+subset isn't checked, parent deletion doesn't cascade, and Org
+Harness can't tell which events are sibling-related. Equivalent to
+"do nothing" with extra steps.
+
+## Decision
+
+**Adopt option A.** Extend the `Subnet` entity with three optional
+fields and enforce the five invariants listed above at the service
+layer. Reuse every existing route, repository, broadcast, and
+harness primitive for both top-level and child subnets. No new
+top-level entity. No new event types. Single-layer cap.
+
+Implementation guidance:
+
+1. **Domain entity** (`acn/core/entities/subnet.py`)
+   - Add `parent_subnet_id: str | None = None`,
+     `lifecycle: Literal["persistent", "task_scoped"] = "persistent"`,
+     `linked_task_id: str | None = None`.
+   - `__post_init__` validates two construction-time invariants:
+     (a) `lifecycle` is one of `{"persistent", "task_scoped"}` —
+     `Literal` type hints don't trigger runtime validation on a
+     dataclass; (b) `lifecycle == "task_scoped"`
+     ⇔ `linked_task_id is not None`. Both raise `ValueError` on
+     violation.
+   - `to_dict` / `from_dict` round-trip the new fields; `metadata`
+     dict reserved for callers, *not* used to smuggle hierarchy
+     state.
+
+2. **Service layer** (`acn/services/subnet_service.py`)
+   - **Dependency change.** `SubnetService.__init__` gains an
+     optional `task_repository: ITaskRepository | None = None`
+     parameter — needed solely by `create_subnet` to validate
+     `linked_task_id` existence. Optional preserves
+     backward-compat for callers that don't exercise nesting; the
+     `linked_task_not_found` rejection path requires it to be wired
+     in production. `api.py` lifespan composition supplies it.
+   - `create_subnet` accepts the three new optional params. When
+     `parent_subnet_id` is set, fetch parent and reject if (a)
+     parent itself has a non-`None` parent_subnet_id (single-layer
+     cap), or (b) parent is reserved (`public` / `system`).
+   - `add_member` rejects `agent_id` if `parent_subnet_id` is set
+     and `agent_id` not in `parent.member_agent_ids`.
+   - New method `list_children(parent_subnet_id: str, *, requester_id: str | None = None) -> list[Subnet]`:
+     applies the **same ACL as `list_subnets`** — private children
+     where `requester_id` is not a member are filtered out of the
+     response. Cross-tenant probes return the same empty-list shape
+     as legitimate "no children" results.
+   - New method `promote_to_persistent(subnet_id: str, owner: str) -> Subnet`:
+     flips `lifecycle` to `"persistent"` and clears
+     `linked_task_id`; only the subnet owner may call. **Does not
+     verify any current relationship between owner and parent** —
+     promote is a pure field-flip authorised by owner-only ACL, not
+     by parent membership (consistent with semantic decision #4).
+   - `delete_subnet` of a parent triggers a `find_children` →
+     batch `delete` cascade in the same repository transaction
+     where the underlying store supports it (PG: explicit
+     transaction; Redis: sequential `delete` calls with a clear
+     audit-log breadcrumb).
+
+3. **Repository** (`acn/core/interfaces/subnet_repository.py` +
+   Redis + Postgres impls)
+   - New methods
+     `find_by_parent(parent_subnet_id: str) -> list[Subnet]` and
+     `find_by_linked_task(task_id: str) -> list[Subnet]`.
+   - Redis: maintain two secondary indexes (key names mirror the
+     repository method names so call sites stay grep-able) —
+     `acn:subnets:children:{parent_id}` (SET, member = child
+     subnet_id, fed by `find_by_parent`) and
+     `acn:subnets:by_linked_task:{task_id}` (SET, member =
+     subnet_id, fed by `find_by_linked_task`) — both updated in a
+     single redis `pipeline` alongside the subnet HASH on save /
+     delete, to minimise the inconsistency window when a process
+     crashes between commands.
+   - Postgres: add `parent_subnet_id`, `lifecycle`,
+     `linked_task_id` columns to `SubnetModel`. Two indexes — a
+     partial index on `parent_subnet_id` (`WHERE parent_subnet_id
+     IS NOT NULL`) and a partial index on `linked_task_id`
+     (`WHERE linked_task_id IS NOT NULL`) — both added in the
+     **same Alembic migration as the columns**, so the schema
+     change is a single atomic event and Phase 3 needs no further
+     DDL. Defaults: `parent_subnet_id NULL`, `lifecycle NOT NULL
+     DEFAULT 'persistent'`, `linked_task_id NULL`.
+
+4. **Task state-machine hooks** (`acn/services/task_service.py`)
+   - `complete_task`, `reject_task`, and `cancel_task` each gain
+     a cascade hook **at the very end of the method, after the
+     full settlement Saga has run** (CAS, escrow release / refund,
+     activity record, harness webhook). Placing the hook last
+     keeps cascade failure cleanly separated from settlement
+     correctness: if cascade raises, escrow + activity + webhook
+     are already durable.
+   - The hook looks up any subnet where
+     `linked_task_id == task_id` (via the `find_by_linked_task`
+     repository method shipped in the same migration as the
+     index), filters to `lifecycle == "task_scoped"`, then calls
+     `subnet_service.delete_subnet(subnet_id, owner="system")`.
+   - **No new service API needed.** The cascade reuses
+     `SubnetService.delete_subnet`'s existing `owner == "system"`
+     superuser branch (`subnet.owner != owner and owner != "system"`
+     guard, established for platform-internal callers). The hook
+     just passes `"system"`.
+   - **Idempotency on concurrent dissolution.** Two paths may try
+     to dissolve the same subnet concurrently (e.g. two
+     participations both flipping to terminal state, or an ops
+     manual `delete_subnet` racing the cascade). The cascade
+     catches `SubnetNotFoundException` from `delete_subnet` and
+     logs at `debug` level — *not* `warning` — treating it as a
+     successful no-op. Other exceptions still log `warning`.
+   - Failures in the cascade are logged at `warning` level and do
+     **not** roll back the task transition — the cascade is
+     best-effort cleanup, not part of the task settlement Saga.
+     A periodic sweeper (future ADR if scale requires it) can
+     reconcile leftover `task_scoped` subnets whose linked task
+     is in a terminal state.
+
+5. **Routes** (`acn/routes/subnets.py`)
+   - `POST /api/v1/subnets` request model gains three optional
+     fields. Validation errors map to `INVALID_REQUEST` with
+     `details.reason` ∈ `{"parent_not_found",
+     "parent_is_reserved", "parent_is_nested",
+     "task_scoped_requires_linked_task",
+     "linked_task_not_found"}`.
+   - `GET /api/v1/subnets?parent=<id>` filter. **ACL alignment:**
+     reuses the same visibility filter as the existing
+     `list_subnets` / `list_public_subnets` paths — private
+     children not visible to the caller are filtered out. No new
+     enumeration surface vs. existing routes.
+   - `GET /api/v1/subnets/{id}/children` returns
+     `{"count": int, "subnets": [SubnetInfo]}`. **Same ACL** as
+     above; anonymous or non-member callers see only public
+     children. Cross-tenant probes return the same shape as
+     legitimate empty results — no existence leak.
+   - `POST /api/v1/subnets/{id}/promote` returns the updated
+     `SubnetInfo`. Owner-only (`OWNERSHIP_MISMATCH` on others).
+   - All four new / extended endpoints use existing
+     `ACN_DEFAULT_RESPONSES` block.
+
+6. **Webhook payloads** (`acn/protocols/ap2/webhook.py`)
+   - No new `WebhookEventType` values.
+   - The sole existing caller of `WebhookService.send_to` for
+     subnet-scoped events is
+     `routes/_subnet_membership.py::do_join_subnet` (firing
+     `AGENT_JOINED_SUBNET` / `AGENT_LEFT_SUBNET`). It includes
+     `parent_subnet_id` in the payload `data` dict — `None` when
+     the subnet is top-level, the parent ID when it's a child.
+   - `routes/subnets.py::create_subnet` / `delete_subnet` do **not**
+     emit webhooks today and are not touched by this ADR. If a
+     follow-up ADR adds `subnet.created` / `subnet.deleted`
+     events, the same `parent_subnet_id` convention applies.
+
+7. **CLI** (`acn/clients/cli`)
+   - `acn subnet create` gains `--parent`, `--task`,
+     `--lifecycle` flags (mutually validated client-side as a
+     pre-check; server still enforces).
+   - `acn subnet list` gains `--parent <id>` filter.
+   - `acn subnet promote <subnet_id>` new verb.
+
+8. **SDK** (`acn/clients/python/acn_client`)
+   - `SubnetInfo` / `SubnetCreateRequest` models add the three
+     optional fields.
+   - `Client.create_subnet` accepts the new params.
+   - `Client.list_subnets(parent_subnet_id=None)` and
+     `Client.list_children(parent_subnet_id)`.
+   - `Client.promote_subnet(subnet_id)`.
+
+## Semantic decisions
+
+The following are minor decisions that don't deserve their own
+section in "Considered options" but need to be locked down before
+implementation so reviewers don't have to re-litigate them per PR.
+
+1. **subnet_id naming is uniform.** Child subnets use the same
+   `subnet-{slug}-{rand6}` pattern as top-level subnets. No
+   `squad-...` prefix or other lifecycle-encoded ID. Lifecycle
+   lives in fields, not in identifiers.
+2. **`promote_to_persistent` is idempotent.** Calling it on a
+   subnet that is already `persistent` returns the unchanged
+   `Subnet` (HTTP 200, not 4xx). Callers can promote unconditionally
+   without a precondition check.
+3. **Child subnets register harnesses independently.** A child's
+   `harness_url` / `harness_secret` is independent of its parent's.
+   ACN does not fan out events between parent and child harnesses;
+   each `subnet.harness_url` only receives events for its own
+   subnet. Harness implementations that want a parent-includes-
+   children view do the fan-out themselves by reading the new
+   `parent_subnet_id` field on incoming events.
+4. **Owner is independent of membership.** A subnet's `owner` may
+   leave the subnet (or, for a child subnet, the parent) without
+   losing ownership. The dual-store invariant from ADR-0001
+   guarantees the owner is a member *at creation*; subsequent
+   `remove_member` does not affect ownership. This matches existing
+   top-level subnet semantics; nesting does not change it.
+   **Edge case** — when a child subnet's owner is later removed
+   from the parent, ownership is retained but membership-subset
+   invariant naturally constrains the owner: they cannot
+   `add_member(self)` back into the child (the parent-membership
+   check would reject it). They retain owner-only powers
+   (`delete_subnet`, `promote_to_persistent`, `update_harness`)
+   that don't widen membership. This is acceptable emergent
+   governance, not a bug; explicit "owner must leave child on
+   parent-leave" auto-cascade is deliberately not added
+   (operators handle re-ownership / cleanup manually if needed).
+5. **`parent_subnet_id` is immutable after creation.** No PATCH
+   route exposes it for mutation. The only way to "move" a child
+   under a different parent is `delete_subnet` + `create_subnet`.
+   This keeps audit trails clean and the membership-subset invariant
+   trivially preserved over the subnet's lifetime.
+6. **Orphan child subnets behave as `persistent` subnets.** If the
+   best-effort cascade in `complete_task` / `reject_task` /
+   `cancel_task` fails (e.g. Redis transient unavailability), the
+   leftover child subnet remains addressable like any other
+   `persistent` subnet — its `task_scoped` `lifecycle` value
+   becomes informational only. Operator runbook for cleanup: same
+   `delete_subnet` call the cascade would have made, run manually
+   or via the future reconciler.
+7. **Reserved subnets stay reserved.** `public` and `system` can
+   neither be parents (rejected with `parent_is_reserved`) nor
+   children (their `parent_subnet_id` must be `None`; the existing
+   `__post_init__` reserved-ID check is extended to cover this).
+
+## Consequences
+
+### Immediate
+
+- Existing subnets continue to behave exactly as today
+  (`parent_subnet_id=None`, `lifecycle="persistent"`).
+- Subnet broadcasts, member lists, and harness routing
+  automatically respect the child-subnet boundary because they
+  already key off the subnet's own `member_agent_ids` — no
+  per-route changes needed.
+- Org Harness implementations that ignore the new
+  `parent_subnet_id` field continue to work unchanged.
+
+### Migration
+
+- Alembic migration adds three nullable columns to `subnets` with
+  PG defaults matching the entity defaults
+  (`parent_subnet_id=NULL`, `lifecycle='persistent'`,
+  `linked_task_id=NULL`).
+- Redis subnets are read through `Subnet.from_dict` which already
+  tolerates missing fields (the existing `data.copy()` +
+  `cls(**data)` pattern); legacy rows naturally inherit the
+  defaults on first read.
+- No backfill needed. No data is invalidated.
+
+### Tests
+
+- `tests/core/test_subnet.py` (new) pins the entity-level
+  invariants:
+  - `lifecycle` value check rejects strings outside
+    `{"persistent", "task_scoped"}` at construction
+  - `lifecycle == "task_scoped"` ↔ `linked_task_id is not None`
+    pairing enforced at construction
+  - Reserved IDs (`public` / `system`) must have
+    `parent_subnet_id is None`
+  - Single-layer cap and membership subset are *not* enforced at
+    the entity layer (those are service-layer concerns)
+- `tests/services/test_subnet_service_nesting.py` (new) pins:
+  - single-layer cap (parent with non-`None` `parent_subnet_id`
+    rejects child create with `parent_is_nested`)
+  - reserved-parent rejection (`public` / `system` as parent
+    rejected with `parent_is_reserved`)
+  - membership subset (adding agent not in parent → rejected)
+  - promote_to_persistent (owner-only, flips fields, idempotent
+    on already-persistent input)
+- `tests/services/test_subnet_service_cascade.py` (new) pins:
+  - parent-delete cascades children in a single PG transaction
+    (or sequential with breadcrumb on Redis)
+  - cascade is atomic: parent deletion rolled back if any child
+    deletion errors on the PG path
+  - `find_by_linked_task` round-trip on both backends
+- `tests/services/test_task_service_squad_cascade.py` (new) pins:
+  - `complete_task` / `reject_task` / `cancel_task` each dissolve
+    matching `task_scoped` subnets
+  - cascade failure does not roll back task transition
+- `tests/routes/test_subnets_nesting.py` (new) pins HTTP layer:
+  - `POST /subnets` with `parent_subnet_id` happy path + each
+    of the 5 `details.reason` rejection variants
+  - `GET /subnets?parent=<id>` filter
+  - `GET /subnets/{id}/children`
+  - `POST /subnets/{id}/promote`
+
+### Documentation
+
+- `acn/skills/acn/SKILL.md` adds a "Nested subnets" subsection
+  under the existing "Build your own subnet" workflow, with a
+  short example creating a task-scoped child for an existing
+  task.
+- `acn/docs/architecture.md` (if it documents subnet model)
+  gets a paragraph on the single-layer cap and the three
+  optional fields.
+- `acn/AGENTS.md` "Conventions" gains (landed alongside this ADR):
+  > **Subnets nest at most one level** — a child subnet's
+  > `parent_subnet_id` must reference a top-level subnet (one whose
+  > own `parent_subnet_id` is `None`); validated at create time.
+  > Child membership must be ⊆ parent membership. `task_scoped`
+  > children auto-dissolve when their `linked_task_id` reaches a
+  > terminal state.
+
+## Out of scope (deliberately deferred)
+
+- **Depth ≥ 2 nesting.** Not supported. Single-layer covers every
+  surfaced use case. If a future user needs depth-2, a follow-up
+  ADR lifts the cap with eyes-open on ACL composition costs
+  (effective membership becomes a tree walk, cycle prevention
+  required on every parent reassignment).
+- **Cross-parent move.** Once created, a child's
+  `parent_subnet_id` is immutable. Achieving the same outcome
+  requires `delete_subnet` + `create_subnet` under the new parent.
+  Mutating parent reference would complicate audit trails and
+  membership-subset enforcement for no concrete use case.
+- **Demote (persistent → task_scoped).** `promote_to_persistent`
+  is one-way. The reverse — binding an existing persistent subnet
+  to a specific task and arming auto-dissolve — has no surfaced
+  use case. If a future caller needs it, the same shape as
+  `promote_to_persistent` (owner-only, idempotent, single field
+  flip + linked-task validation) can be added without disturbing
+  the rest of this design.
+- **Auto-add children members from parent.** Squad membership is
+  explicit / opt-in. Parent membership is necessary but not
+  sufficient. Auto-add would defeat the "small focused team"
+  goal that motivated the feature.
+- **Periodic sweeper for orphan task_scoped subnets.** The
+  best-effort cascade in `complete_task` / `reject_task` /
+  `cancel_task` is the primary mechanism. A periodic reconciler
+  is a future scale concern, similar in spirit to the
+  `manifest_ttl_refund_worker` for unrefunded attention fees.
+- **Squad-internal chat / state board / file sharing.** These
+  belong to Org Harness, not ACN. ACN delivers the squad's
+  membership events (`agent.joined_subnet` /
+  `agent.left_subnet`); the harness builds whatever interaction
+  surface it wants on top of those.
+- **New webhook event types for subnet lifecycle** (e.g.
+  `subnet.created`, `subnet.deleted`, `subnet.dissolved`).
+  Deferred to a separate ADR scoped to subnet-lifecycle events
+  in general, not to nesting. Today's harnesses observe
+  subnets only via membership events; expanding that vocabulary
+  is a worthwhile-but-orthogonal concern.
+
+## References
+
+- [ADR-0001](./0001-subnet-creator-must-be-member.md) — establishes
+  the dual-store membership pattern this ADR builds on.
+- `acn/acn/core/entities/subnet.py` — `Subnet` entity that gains
+  three optional fields.
+- `acn/acn/services/subnet_service.py` — service layer where the
+  five invariants are enforced.
+- `acn/acn/services/task_service.py::complete_task` (L1305),
+  `::reject_task` (L1549), `::cancel_task` (L1611) — the three
+  task terminal-state sites that need the cascade hook.
+- `acn/acn/infrastructure/persistence/postgres/models.py::SubnetModel`
+  (L177) — the PG table that gains three nullable columns via
+  Alembic migration.
+- `acn/acn/protocols/ap2/webhook.py::WebhookService.send_to` —
+  reused as-is; payload `data` block gains `parent_subnet_id`
+  field when relevant.
+- `acn/acn/routes/subnets.py` — route module that gains the new
+  endpoints and extends `POST /subnets` request schema.
+- `acn/skills/acn/SKILL.md` — agent-facing docs that need the
+  nested subnet workflow example.

--- a/docs/adr/0003-subnet-nesting-single-layer.md
+++ b/docs/adr/0003-subnet-nesting-single-layer.md
@@ -408,8 +408,12 @@ implementation so reviewers don't have to re-litigate them per PR.
    or via the future reconciler.
 7. **Reserved subnets stay reserved.** `public` and `system` can
    neither be parents (rejected with `parent_is_reserved`) nor
-   children (their `parent_subnet_id` must be `None`; the existing
-   `__post_init__` reserved-ID check is extended to cover this).
+   children (their `parent_subnet_id` must be `None`), and they
+   cannot carry a `task_scoped` lifecycle — a task termination
+   would otherwise auto-dissolve a platform-level subnet that
+   callers depend on as always-on. The existing
+   `__post_init__` reserved-ID check is extended to cover all three
+   prohibitions in Phase 1.
 
 ## Consequences
 

--- a/tests/core/test_subnet.py
+++ b/tests/core/test_subnet.py
@@ -191,6 +191,33 @@ class TestReservedSubnetNestingGuard:
         assert subnet.parent_subnet_id is None
         assert subnet.lifecycle == "persistent"
 
+    def test_reserved_subnet_cannot_be_task_scoped(self):
+        # Reserved subnets are platform-owned with implicit "always-on"
+        # semantics — a task_scoped lifecycle would let an arbitrary
+        # task termination dissolve a platform subnet, breaking every
+        # caller that assumes `public` is durable. Reject at
+        # construction so we never persist the misshapen row.
+        with pytest.raises(
+            ValueError, match="Reserved subnet 'public' cannot be task_scoped"
+        ):
+            Subnet(
+                subnet_id="public",
+                name="Public",
+                owner="system",
+                lifecycle="task_scoped",
+                linked_task_id="task-evil",
+            )
+        with pytest.raises(
+            ValueError, match="Reserved subnet 'system' cannot be task_scoped"
+        ):
+            Subnet(
+                subnet_id="system",
+                name="System",
+                owner="system",
+                lifecycle="task_scoped",
+                linked_task_id="task-evil",
+            )
+
 
 class TestSingleLayerCapNotEnforcedAtEntity:
     """ADR-0003 §A invariant 1 — single-layer cap — is intentionally

--- a/tests/core/test_subnet.py
+++ b/tests/core/test_subnet.py
@@ -1,0 +1,212 @@
+"""Unit Tests for Subnet Entity (ADR-0003 Phase 1)
+
+Pins entity-layer invariants for the nesting fields shipped in
+Phase 1. Single-layer cap and membership subset are enforced at
+the *service* layer (Phase 2) so they live in
+``tests/services/test_subnet_service_nesting.py`` rather than here.
+
+Coverage strategy
+-----------------
+- Existing pre-nesting invariants (subnet_id / name / owner non-empty,
+  reserved-ID owner rule) are not repeated here — they're already
+  covered by integration tests through the service / route layer.
+  This file pins the *new* contracts introduced by ADR-0003.
+
+- Each invariant gets one happy-path case and one or more violation
+  cases. Construction-time ``ValueError`` is the contract; the
+  message text is matched loosely with ``match=`` so refactors that
+  rephrase the error don't trigger spurious test churn.
+"""
+
+import pytest
+
+from acn.core.entities.subnet import Subnet
+
+
+class TestSubnetNestingDefaults:
+    """Default construction yields a top-level persistent subnet —
+    the legacy semantics. This is the contract for callers that
+    don't touch the new fields."""
+
+    def test_defaults_to_top_level_persistent(self):
+        subnet = Subnet(subnet_id="subnet-a", name="A", owner="agent-1")
+
+        assert subnet.parent_subnet_id is None
+        assert subnet.lifecycle == "persistent"
+        assert subnet.linked_task_id is None
+
+    def test_to_dict_round_trips_new_fields(self):
+        subnet = Subnet(
+            subnet_id="subnet-child",
+            name="Child",
+            owner="agent-1",
+            parent_subnet_id="subnet-parent",
+            lifecycle="task_scoped",
+            linked_task_id="task-xyz",
+        )
+
+        d = subnet.to_dict()
+
+        assert d["parent_subnet_id"] == "subnet-parent"
+        assert d["lifecycle"] == "task_scoped"
+        assert d["linked_task_id"] == "task-xyz"
+
+    def test_from_dict_tolerates_missing_nesting_keys(self):
+        """Legacy stored rows predate ADR-0003 — their dict form
+        lacks the three nesting keys entirely. ``from_dict`` must
+        fall through to entity defaults rather than KeyError."""
+        legacy_data = {
+            "subnet_id": "subnet-legacy",
+            "name": "Legacy",
+            "owner": "agent-1",
+        }
+
+        subnet = Subnet.from_dict(legacy_data)
+
+        assert subnet.parent_subnet_id is None
+        assert subnet.lifecycle == "persistent"
+        assert subnet.linked_task_id is None
+
+    def test_from_dict_round_trips_new_fields(self):
+        original = Subnet(
+            subnet_id="subnet-child",
+            name="Child",
+            owner="agent-1",
+            parent_subnet_id="subnet-parent",
+            lifecycle="task_scoped",
+            linked_task_id="task-xyz",
+        )
+
+        rebuilt = Subnet.from_dict(original.to_dict())
+
+        assert rebuilt.parent_subnet_id == "subnet-parent"
+        assert rebuilt.lifecycle == "task_scoped"
+        assert rebuilt.linked_task_id == "task-xyz"
+
+
+class TestLifecycleValueValidation:
+    """``lifecycle`` is typed ``Literal["persistent", "task_scoped"]``
+    but Python's Literal does not validate at runtime on a
+    dataclass. ``__post_init__`` is the guard."""
+
+    def test_persistent_is_accepted(self):
+        Subnet(
+            subnet_id="subnet-a",
+            name="A",
+            owner="agent-1",
+            lifecycle="persistent",
+        )
+
+    def test_task_scoped_is_accepted_with_linked_task(self):
+        Subnet(
+            subnet_id="subnet-a",
+            name="A",
+            owner="agent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-xyz",
+        )
+
+    def test_unknown_lifecycle_value_rejected(self):
+        with pytest.raises(ValueError, match="lifecycle must be one of"):
+            Subnet(
+                subnet_id="subnet-a",
+                name="A",
+                owner="agent-1",
+                lifecycle="permanent",  # typo of "persistent"
+            )
+
+    def test_empty_lifecycle_rejected(self):
+        # Falsy strings should still fail validation, not silently
+        # default — callers that want the default omit the kwarg.
+        with pytest.raises(ValueError, match="lifecycle must be one of"):
+            Subnet(
+                subnet_id="subnet-a",
+                name="A",
+                owner="agent-1",
+                lifecycle="",
+            )
+
+
+class TestTaskScopedLinkedTaskPairing:
+    """``lifecycle == "task_scoped"`` ⇔ ``linked_task_id is not None``
+    is enforced both directions so callers can't construct a
+    half-state. This is the entity-layer guarantee Phase 3's
+    cascade hook relies on."""
+
+    def test_task_scoped_without_linked_task_rejected(self):
+        with pytest.raises(
+            ValueError, match="task_scoped.*requires linked_task_id"
+        ):
+            Subnet(
+                subnet_id="subnet-a",
+                name="A",
+                owner="agent-1",
+                lifecycle="task_scoped",
+                linked_task_id=None,
+            )
+
+    def test_persistent_with_linked_task_rejected(self):
+        # The reverse direction — a "persistent" subnet shouldn't
+        # carry a linked task. ``promote_to_persistent`` (Phase 2)
+        # is responsible for clearing the field at the same time
+        # as flipping the lifecycle; allowing one without the other
+        # would let the by_linked_task index lie about what's
+        # cascade-eligible.
+        with pytest.raises(
+            ValueError, match="persistent.*must not carry a linked_task_id"
+        ):
+            Subnet(
+                subnet_id="subnet-a",
+                name="A",
+                owner="agent-1",
+                lifecycle="persistent",
+                linked_task_id="task-leftover",
+            )
+
+
+class TestReservedSubnetNestingGuard:
+    """Reserved subnets (``public`` / ``system``) can never become
+    children — they're platform-owned with implicit "all agents"
+    semantics that make the membership-subset invariant meaningless.
+    The existing reserved-ID guard is extended to forbid
+    ``parent_subnet_id`` on reserved IDs."""
+
+    def test_reserved_subnet_cannot_have_parent(self):
+        # ``public`` must be owned by ``system`` (existing rule);
+        # adding a parent on top should still be rejected.
+        with pytest.raises(
+            ValueError, match="Reserved subnet 'public' cannot have a parent_subnet_id"
+        ):
+            Subnet(
+                subnet_id="public",
+                name="Public",
+                owner="system",
+                parent_subnet_id="some-parent",
+            )
+
+    def test_reserved_subnet_can_still_be_constructed_with_defaults(self):
+        # Sanity: the new guard doesn't break the legacy "system
+        # constructs reserved subnets at bootstrap" path.
+        subnet = Subnet(subnet_id="public", name="Public", owner="system")
+        assert subnet.parent_subnet_id is None
+        assert subnet.lifecycle == "persistent"
+
+
+class TestSingleLayerCapNotEnforcedAtEntity:
+    """ADR-0003 §A invariant 1 — single-layer cap — is intentionally
+    a *service-layer* concern (it requires looking up the parent
+    to check its own ``parent_subnet_id``). The entity must accept
+    a child pointing to any string ID without doing that lookup;
+    Phase 2 tests in ``test_subnet_service_nesting.py`` pin the
+    actual cap enforcement."""
+
+    def test_entity_accepts_child_pointing_to_arbitrary_parent_id(self):
+        # No parent existence check, no nesting depth check at the
+        # entity layer. The entity is a passive data carrier here.
+        subnet = Subnet(
+            subnet_id="subnet-grandchild",
+            name="GC",
+            owner="agent-1",
+            parent_subnet_id="subnet-some-parent",
+        )
+        assert subnet.parent_subnet_id == "subnet-some-parent"

--- a/tests/infrastructure/test_alembic_subnet_nesting_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_nesting_migration.py
@@ -1,0 +1,187 @@
+"""Alembic migration ``e1f2a3b4c5d6_add_subnet_nesting_fields`` regressions.
+
+The full DDL is exercised against a real PostgreSQL in CI's
+``alembic upgrade head`` job; this file pins the migration's
+*structure* in unit-test land so contributors can catch obvious
+mistakes (missing column, missing index, drop ordering) without
+spinning up a database.
+
+What we check
+-------------
+- ``revision`` / ``down_revision`` form a single-parent edge
+  pointing at the previous head (``d0e1f2a3b4c5``).
+- ``upgrade()`` adds the three columns *and* both partial indexes.
+- ``downgrade()`` removes them in reverse order — indexes first
+  (PostgreSQL refuses to drop a column an index still references)
+  and ``parent_subnet_id`` last (mirrors the ``upgrade`` order).
+- The partial-index ``postgresql_where`` clauses target the right
+  column (``parent_subnet_id IS NOT NULL`` /
+  ``linked_task_id IS NOT NULL``).
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def migration_module():
+    """Load the migration file as an isolated module.
+
+    Alembic's ``versions/`` directory is not a Python package (no
+    ``__init__.py``) — ``alembic`` loads each revision dynamically
+    via ``ScriptDirectory``. Tests have to mirror that pattern via
+    ``importlib.util.spec_from_file_location`` rather than importing
+    by dotted name.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    migration_path = (
+        repo_root
+        / "alembic"
+        / "versions"
+        / "e1f2a3b4c5d6_add_subnet_nesting_fields.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_migration_e1f2a3b4c5d6", migration_path
+    )
+    assert spec is not None and spec.loader is not None, (
+        f"failed to build module spec for {migration_path}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_revision_and_down_revision(migration_module):
+    assert migration_module.revision == "e1f2a3b4c5d6"
+    assert migration_module.down_revision == "d0e1f2a3b4c5"
+
+
+def test_upgrade_adds_three_columns_and_two_indexes(migration_module):
+    """``upgrade()`` must add exactly the three nesting columns and
+    create the two partial indexes — and nothing else (no spurious
+    DDL slipping in)."""
+    with (
+        patch.object(migration_module, "op") as mock_op,
+    ):
+        migration_module.upgrade()
+
+    column_calls = mock_op.add_column.call_args_list
+    column_names = [
+        call.args[1].name for call in column_calls
+    ]
+    assert column_names == [
+        "parent_subnet_id",
+        "lifecycle",
+        "linked_task_id",
+    ], f"unexpected upgrade() column order: {column_names!r}"
+
+    index_calls = mock_op.create_index.call_args_list
+    index_names = [call.args[0] for call in index_calls]
+    assert index_names == [
+        "subnets_parent_idx",
+        "subnets_linked_task_idx",
+    ], f"unexpected upgrade() index order: {index_names!r}"
+
+
+def test_upgrade_lifecycle_column_carries_server_default(migration_module):
+    """``lifecycle`` ALTER must use ``server_default='persistent'`` so
+    existing rows backfill in one statement — otherwise a NOT NULL
+    column would fail to ALTER on a non-empty table."""
+    with patch.object(migration_module, "op") as mock_op:
+        migration_module.upgrade()
+
+    lifecycle_call = next(
+        c
+        for c in mock_op.add_column.call_args_list
+        if c.args[1].name == "lifecycle"
+    )
+    column = lifecycle_call.args[1]
+    assert column.nullable is False, "lifecycle should be NOT NULL"
+    # server_default is wrapped in sa.DefaultClause-shaped object — its
+    # ``.arg`` attribute holds the literal text.
+    assert column.server_default is not None
+    default_text = (
+        column.server_default.arg.text
+        if hasattr(column.server_default.arg, "text")
+        else str(column.server_default.arg)
+    )
+    assert default_text == "persistent", (
+        f"lifecycle server_default mismatch: {default_text!r}"
+    )
+
+
+def test_upgrade_indexes_use_partial_where_on_correct_columns(migration_module):
+    with patch.object(migration_module, "op") as mock_op:
+        migration_module.upgrade()
+
+    parent_idx_call = next(
+        c
+        for c in mock_op.create_index.call_args_list
+        if c.args[0] == "subnets_parent_idx"
+    )
+    where_clause = parent_idx_call.kwargs["postgresql_where"]
+    assert "parent_subnet_id IS NOT NULL" in str(where_clause), (
+        f"subnets_parent_idx WHERE clause wrong: {where_clause}"
+    )
+
+    linked_task_idx_call = next(
+        c
+        for c in mock_op.create_index.call_args_list
+        if c.args[0] == "subnets_linked_task_idx"
+    )
+    where_clause = linked_task_idx_call.kwargs["postgresql_where"]
+    assert "linked_task_id IS NOT NULL" in str(where_clause), (
+        f"subnets_linked_task_idx WHERE clause wrong: {where_clause}"
+    )
+
+
+def test_downgrade_drops_indexes_before_columns(migration_module):
+    """PostgreSQL refuses to drop a column that still has an index
+    on it. ``downgrade()`` must therefore call ``drop_index`` for
+    both nesting indexes *before* any ``drop_column``."""
+    with patch.object(migration_module, "op") as mock_op:
+        migration_module.downgrade()
+
+    # Reconstruct the call order across drop_index / drop_column
+    # so we can assert "all drop_index calls come before any
+    # drop_column call".
+    call_log = []
+    for call in mock_op.drop_index.call_args_list:
+        call_log.append(("drop_index", call.args[0]))
+    for call in mock_op.drop_column.call_args_list:
+        call_log.append(("drop_column", call.args[1]))
+    # ``mock_calls`` preserves global ordering across both methods;
+    # use it instead of the per-method lists above for the actual
+    # ordering check.
+    ordered = [
+        (c[0].split(".")[-1], c[1][1] if c[0].split(".")[-1] == "drop_column" else c[1][0])
+        for c in mock_op.mock_calls
+        if c[0].split(".")[-1] in {"drop_index", "drop_column"}
+    ]
+    drop_index_idxs = [i for i, (verb, _) in enumerate(ordered) if verb == "drop_index"]
+    drop_column_idxs = [i for i, (verb, _) in enumerate(ordered) if verb == "drop_column"]
+    assert drop_index_idxs and drop_column_idxs, (
+        f"missing drop_index or drop_column calls: {ordered!r}"
+    )
+    assert max(drop_index_idxs) < min(drop_column_idxs), (
+        f"drop_index must precede drop_column; actual order: {ordered!r}"
+    )
+
+
+def test_downgrade_drops_columns_in_reverse_of_upgrade(migration_module):
+    """Symmetric reversal of ``upgrade()`` — the last column added
+    is the first dropped. Keeps the migration cleanly reversible
+    in the rare case someone bisects through it."""
+    with patch.object(migration_module, "op") as mock_op:
+        migration_module.downgrade()
+
+    column_calls = mock_op.drop_column.call_args_list
+    column_names = [call.args[1] for call in column_calls]
+    assert column_names == [
+        "linked_task_id",
+        "lifecycle",
+        "parent_subnet_id",
+    ], f"unexpected downgrade() column order: {column_names!r}"

--- a/tests/infrastructure/test_postgres_subnet_repository_nesting.py
+++ b/tests/infrastructure/test_postgres_subnet_repository_nesting.py
@@ -1,0 +1,236 @@
+"""PostgresSubnetRepository — ADR-0003 nesting field regressions.
+
+Three contracts pinned here:
+
+1. ``_subnet_to_model`` / ``_model_to_subnet`` round-trip the three
+   nesting fields without dropping or mangling them.
+2. ``save()`` 's UPDATE branch carries the new columns — otherwise
+   ``promote_to_persistent`` (Phase 2) would silently no-op on rows
+   already in the DB.
+3. ``find_by_parent`` / ``find_by_linked_task`` filter on the right
+   column. We don't pin the exact SQL string (SQLAlchemy may
+   rephrase between releases), only the column reference inside
+   the WHERE clause.
+
+The repository is exercised against an in-memory mock session — no
+PostgreSQL needed. Schema correctness lives in the Alembic upgrade
+test (``test_alembic_subnet_nesting_migration.py``).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.sql import Select, Update
+
+from acn.core.entities import Subnet
+from acn.infrastructure.persistence.postgres.models import SubnetModel
+from acn.infrastructure.persistence.postgres.subnet_repository import (
+    PostgresSubnetRepository,
+)
+
+
+def _make_session_factory(execute_results: list | None = None):
+    """Build a mock ``async_sessionmaker`` that yields a recorded session.
+
+    ``execute_results`` lets a caller queue scripted return values for
+    ``session.execute(...)`` — used by ``find_by_parent`` tests that
+    need ``.scalars().all()`` to return a list.
+    """
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+
+    if execute_results is not None:
+        session.execute.side_effect = execute_results
+
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+# ---------------------------------------------------------------------------
+# 1. Mapper round-trip — entity ↔ model
+# ---------------------------------------------------------------------------
+
+
+def test_subnet_to_model_carries_nesting_fields():
+    factory, _ = _make_session_factory()
+    repo = PostgresSubnetRepository(session_factory=factory)
+    subnet = Subnet(
+        subnet_id="subnet-child",
+        name="child",
+        owner="agent-owner",
+        parent_subnet_id="subnet-parent",
+        lifecycle="task_scoped",
+        linked_task_id="task-xyz",
+    )
+
+    model = repo._subnet_to_model(subnet)
+
+    assert model.parent_subnet_id == "subnet-parent"
+    assert model.lifecycle == "task_scoped"
+    assert model.linked_task_id == "task-xyz"
+
+
+def test_model_to_subnet_carries_nesting_fields():
+    factory, _ = _make_session_factory()
+    repo = PostgresSubnetRepository(session_factory=factory)
+    model = SubnetModel(
+        subnet_id="subnet-child",
+        name="child",
+        owner="agent-owner",
+        description=None,
+        is_private=False,
+        security_config=None,
+        member_agent_ids=None,
+        subnet_metadata=None,
+        harness_url=None,
+        harness_secret=None,
+        parent_subnet_id="subnet-parent",
+        lifecycle="task_scoped",
+        linked_task_id="task-xyz",
+        created_at=datetime.now(UTC),
+    )
+
+    subnet = repo._model_to_subnet(model)
+
+    assert subnet.parent_subnet_id == "subnet-parent"
+    assert subnet.lifecycle == "task_scoped"
+    assert subnet.linked_task_id == "task-xyz"
+
+
+def test_model_to_subnet_defaults_for_legacy_row():
+    """Existing rows pre-ADR-0003 carry the new columns as their DB
+    defaults (``parent_subnet_id=NULL``, ``lifecycle='persistent'``,
+    ``linked_task_id=NULL``) — the mapper must surface them as
+    "top-level persistent" semantics, not raise on missing fields."""
+    factory, _ = _make_session_factory()
+    repo = PostgresSubnetRepository(session_factory=factory)
+    model = SubnetModel(
+        subnet_id="subnet-legacy",
+        name="legacy",
+        owner="agent-owner",
+        description=None,
+        is_private=False,
+        security_config=None,
+        member_agent_ids=None,
+        subnet_metadata=None,
+        harness_url=None,
+        harness_secret=None,
+        parent_subnet_id=None,
+        lifecycle="persistent",
+        linked_task_id=None,
+        created_at=datetime.now(UTC),
+    )
+
+    subnet = repo._model_to_subnet(model)
+
+    assert subnet.parent_subnet_id is None
+    assert subnet.lifecycle == "persistent"
+    assert subnet.linked_task_id is None
+
+
+# ---------------------------------------------------------------------------
+# 2. save() UPDATE branch — new columns are carried
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_update_path_includes_nesting_columns():
+    """When the row already exists, ``save()`` issues an UPDATE. The
+    set of columns mutated must include the three nesting fields so
+    Phase 2's ``promote_to_persistent`` (which only flips
+    ``lifecycle`` / ``linked_task_id``) actually persists through
+    SQLAlchemy."""
+
+    # First call is ``session.get()`` for the existence check — return
+    # a sentinel model so the UPDATE branch fires.
+    existing_model = MagicMock(spec=SubnetModel)
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    session.get.return_value = existing_model
+
+    factory = MagicMock(return_value=session)
+    repo = PostgresSubnetRepository(session_factory=factory)
+
+    subnet = Subnet(
+        subnet_id="subnet-rt",
+        name="rt",
+        owner="agent-owner",
+        parent_subnet_id="subnet-parent",
+        lifecycle="task_scoped",
+        linked_task_id="task-xyz",
+    )
+
+    await repo.save(subnet)
+
+    session.execute.assert_awaited_once()
+    stmt = session.execute.await_args_list[0].args[0]
+    assert isinstance(stmt, Update)
+    # ``Update`` stores SET targets in ``_values`` (Column → BindParameter)
+    set_columns = {col.name for col in stmt._values.keys()}  # type: ignore[attr-defined]
+    assert "parent_subnet_id" in set_columns
+    assert "lifecycle" in set_columns
+    assert "linked_task_id" in set_columns
+
+
+# ---------------------------------------------------------------------------
+# 3. find_by_parent / find_by_linked_task — column targeting
+# ---------------------------------------------------------------------------
+
+
+def _stmt_column_names(stmt: Select) -> set[str]:
+    """Walk the WHERE clause of a SELECT and collect the column
+    names it references. Robust against SQLAlchemy expression-tree
+    rephrasing between releases."""
+    names: set[str] = set()
+    where_clause = stmt.whereclause
+    if where_clause is None:
+        return names
+
+    def _visit(node):
+        # Column / ColumnClause both expose ``.name``.
+        if hasattr(node, "name") and not hasattr(node, "left"):
+            names.add(node.name)
+        for child in getattr(node, "get_children", lambda: [])():
+            _visit(child)
+
+    _visit(where_clause)
+    return names
+
+
+@pytest.mark.asyncio
+async def test_find_by_parent_filters_on_parent_subnet_id_column():
+    select_result = MagicMock()
+    select_result.scalars.return_value.all.return_value = []
+    factory, session = _make_session_factory(execute_results=[select_result])
+    repo = PostgresSubnetRepository(session_factory=factory)
+
+    rows = await repo.find_by_parent("subnet-parent")
+
+    assert rows == []
+    session.execute.assert_awaited_once()
+    stmt = session.execute.await_args_list[0].args[0]
+    assert isinstance(stmt, Select)
+    assert "parent_subnet_id" in _stmt_column_names(stmt), (
+        f"WHERE clause did not target parent_subnet_id; got {_stmt_column_names(stmt)!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_by_linked_task_filters_on_linked_task_id_column():
+    select_result = MagicMock()
+    select_result.scalars.return_value.all.return_value = []
+    factory, session = _make_session_factory(execute_results=[select_result])
+    repo = PostgresSubnetRepository(session_factory=factory)
+
+    rows = await repo.find_by_linked_task("task-xyz")
+
+    assert rows == []
+    session.execute.assert_awaited_once()
+    stmt = session.execute.await_args_list[0].args[0]
+    assert isinstance(stmt, Select)
+    assert "linked_task_id" in _stmt_column_names(stmt), (
+        f"WHERE clause did not target linked_task_id; got {_stmt_column_names(stmt)!r}"
+    )

--- a/tests/infrastructure/test_subnet_repository_redis_nesting.py
+++ b/tests/infrastructure/test_subnet_repository_redis_nesting.py
@@ -1,0 +1,358 @@
+"""Redis subnet repository — ADR-0003 nesting index regressions.
+
+Pins the contract that ``save`` / ``delete`` maintain the two
+secondary indexes used by ``find_by_parent`` and
+``find_by_linked_task``:
+
+- ``acn:subnets:children:{parent_id}`` SET
+- ``acn:subnets:by_linked_task:{task_id}`` SET
+
+Index maintenance happens inside a single ``pipeline`` per write
+so a process crash between the main HSET and the index update is
+the only failure mode that can desync them — same weak-atomicity
+profile ACN already accepts for the owner index.
+
+Uses the same AsyncMock pipeline-proxy pattern as
+``test_subnet_repository_redis_save.py``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.infrastructure.persistence.redis.subnet_repository import (
+    RedisSubnetRepository,
+)
+
+
+class _PipeProxy:
+    """Pipeline proxy that records ``sadd`` / ``srem`` / ``execute``
+    invocations as ``(verb, args, kwargs)`` tuples."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def sadd(self, *args, **kwargs):
+        self.calls.append(("sadd", args, kwargs))
+
+    def srem(self, *args, **kwargs):
+        self.calls.append(("srem", args, kwargs))
+
+    def delete(self, *args, **kwargs):
+        self.calls.append(("delete", args, kwargs))
+
+    async def execute(self):
+        self.calls.append(("execute", (), {}))
+        return []
+
+
+def _make_redis_mock() -> AsyncMock:
+    """AsyncMock client wired so ``hgetall`` defaults to ``{}`` (new
+    subnet path) and ``pipeline()`` returns a fresh ``_PipeProxy``
+    each call."""
+    redis = AsyncMock()
+    redis.hgetall.return_value = {}
+
+    pipes: list[_PipeProxy] = []
+
+    def _new_pipe(*args, **kwargs):
+        p = _PipeProxy()
+        pipes.append(p)
+        return p
+
+    redis.pipeline = MagicMock(side_effect=_new_pipe)
+    redis._pipes = pipes  # expose for assertions
+    return redis
+
+
+def _pipe_verbs(pipes: list[_PipeProxy], verb: str) -> list[tuple]:
+    """Flatten all ``verb`` calls across recorded pipeline contexts."""
+    return [args for pipe in pipes for v, args, _ in pipe.calls if v == verb]
+
+
+# ---------------------------------------------------------------------------
+# save() — index population on insert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_child_subnet_adds_to_children_index() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    child = Subnet(
+        subnet_id="subnet-child",
+        name="child",
+        owner="agent-owner",
+        parent_subnet_id="subnet-parent",
+    )
+
+    await repo.save(child)
+
+    sadd_calls = _pipe_verbs(redis._pipes, "sadd")
+    assert (
+        "acn:subnets:children:subnet-parent",
+        "subnet-child",
+    ) in sadd_calls, (
+        f"children index SADD missing; recorded sadd calls: {sadd_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_task_scoped_subnet_adds_to_linked_task_index() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    scoped = Subnet(
+        subnet_id="subnet-scoped",
+        name="scoped",
+        owner="agent-owner",
+        parent_subnet_id="subnet-parent",
+        lifecycle="task_scoped",
+        linked_task_id="task-xyz",
+    )
+
+    await repo.save(scoped)
+
+    sadd_calls = _pipe_verbs(redis._pipes, "sadd")
+    assert (
+        "acn:subnets:by_linked_task:task-xyz",
+        "subnet-scoped",
+    ) in sadd_calls, (
+        f"by_linked_task index SADD missing; recorded sadd calls: {sadd_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_top_level_subnet_does_not_touch_nesting_indexes() -> None:
+    """Top-level persistent subnets must not pollute the nesting
+    indexes — keeps the partial-index sizes bounded by the actual
+    nesting cardinality."""
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    flat = Subnet(
+        subnet_id="subnet-flat",
+        name="flat",
+        owner="agent-owner",
+    )
+
+    await repo.save(flat)
+
+    sadd_calls = _pipe_verbs(redis._pipes, "sadd")
+    for key, _ in sadd_calls:
+        assert not key.startswith("acn:subnets:children:"), (
+            f"unexpected children-index SADD on top-level subnet: {key}"
+        )
+        assert not key.startswith("acn:subnets:by_linked_task:"), (
+            f"unexpected linked-task-index SADD on top-level subnet: {key}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# delete() — index eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_child_subnet_removes_from_children_index() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+
+    # Wire ``find_by_id`` (via hgetall) to return a stored child row
+    # so ``delete`` actually proceeds past its existence guard.
+    redis.hgetall.return_value = {
+        "subnet_id": "subnet-child",
+        "name": "child",
+        "owner": "agent-owner",
+        "is_private": "False",
+        "security_config": "{}",
+        "member_agent_ids": "[]",
+        "metadata": "{}",
+        "description": "",
+        "harness_url": "",
+        "harness_secret": "",
+        "parent_subnet_id": "subnet-parent",
+        "lifecycle": "persistent",
+        "linked_task_id": "",
+    }
+
+    deleted = await repo.delete("subnet-child")
+
+    assert deleted is True
+    srem_calls = _pipe_verbs(redis._pipes, "srem")
+    assert (
+        "acn:subnets:children:subnet-parent",
+        "subnet-child",
+    ) in srem_calls, (
+        f"children index SREM missing; recorded srem calls: {srem_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_task_scoped_subnet_removes_from_linked_task_index() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    redis.hgetall.return_value = {
+        "subnet_id": "subnet-scoped",
+        "name": "scoped",
+        "owner": "agent-owner",
+        "is_private": "False",
+        "security_config": "{}",
+        "member_agent_ids": "[]",
+        "metadata": "{}",
+        "description": "",
+        "harness_url": "",
+        "harness_secret": "",
+        "parent_subnet_id": "subnet-parent",
+        "lifecycle": "task_scoped",
+        "linked_task_id": "task-xyz",
+    }
+
+    deleted = await repo.delete("subnet-scoped")
+
+    assert deleted is True
+    srem_calls = _pipe_verbs(redis._pipes, "srem")
+    assert (
+        "acn:subnets:by_linked_task:task-xyz",
+        "subnet-scoped",
+    ) in srem_calls, (
+        f"by_linked_task index SREM missing; recorded srem calls: {srem_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_by_parent / find_by_linked_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_by_parent_reads_children_index_and_hydrates() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    redis.smembers.return_value = {"subnet-a", "subnet-b"}
+
+    # Each ``find_by_id`` call inside the loop hits ``hgetall`` —
+    # return a minimal row that satisfies ``_dict_to_subnet``. The
+    # same payload comes back for both subnet IDs; ``find_by_parent``
+    # only cares that hydration happens, not which row is which.
+    redis.hgetall.return_value = {
+        "subnet_id": "subnet-a",
+        "name": "a",
+        "owner": "agent-owner",
+        "is_private": "False",
+        "security_config": "{}",
+        "member_agent_ids": "[]",
+        "metadata": "{}",
+        "description": "",
+        "harness_url": "",
+        "harness_secret": "",
+        "parent_subnet_id": "subnet-parent",
+        "lifecycle": "persistent",
+        "linked_task_id": "",
+    }
+
+    children = await repo.find_by_parent("subnet-parent")
+
+    redis.smembers.assert_awaited_with("acn:subnets:children:subnet-parent")
+    assert len(children) == 2
+
+
+@pytest.mark.asyncio
+async def test_find_by_linked_task_reads_index_and_hydrates() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    redis.smembers.return_value = {"subnet-scoped"}
+    redis.hgetall.return_value = {
+        "subnet_id": "subnet-scoped",
+        "name": "scoped",
+        "owner": "agent-owner",
+        "is_private": "False",
+        "security_config": "{}",
+        "member_agent_ids": "[]",
+        "metadata": "{}",
+        "description": "",
+        "harness_url": "",
+        "harness_secret": "",
+        "parent_subnet_id": "subnet-parent",
+        "lifecycle": "task_scoped",
+        "linked_task_id": "task-xyz",
+    }
+
+    subnets = await repo.find_by_linked_task("task-xyz")
+
+    redis.smembers.assert_awaited_with("acn:subnets:by_linked_task:task-xyz")
+    assert len(subnets) == 1
+    assert subnets[0].linked_task_id == "task-xyz"
+
+
+@pytest.mark.asyncio
+async def test_find_by_parent_returns_empty_when_no_children() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    redis.smembers.return_value = set()
+
+    children = await repo.find_by_parent("subnet-childless")
+
+    assert children == []
+
+
+# ---------------------------------------------------------------------------
+# round-trip — to_dict / _dict_to_subnet preserve nesting fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_round_trip_preserves_nesting_fields() -> None:
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    scoped = Subnet(
+        subnet_id="subnet-rt",
+        name="rt",
+        owner="agent-owner",
+        parent_subnet_id="subnet-parent",
+        lifecycle="task_scoped",
+        linked_task_id="task-rt",
+    )
+
+    await repo.save(scoped)
+
+    _, kwargs = redis.hset.await_args
+    mapping = kwargs["mapping"]
+    loaded = repo._dict_to_subnet(mapping)
+
+    assert loaded.parent_subnet_id == "subnet-parent"
+    assert loaded.lifecycle == "task_scoped"
+    assert loaded.linked_task_id == "task-rt"
+
+
+def test_dict_to_subnet_tolerates_legacy_rows_without_nesting_keys() -> None:
+    """A Redis row written before ADR-0003 contains no
+    ``parent_subnet_id`` / ``lifecycle`` / ``linked_task_id`` keys.
+    ``_dict_to_subnet`` must fall through to entity defaults rather
+    than ``KeyError`` — otherwise upgrading the binary against an
+    un-migrated Redis would crash on first read."""
+    redis = _make_redis_mock()
+    repo = RedisSubnetRepository(redis)
+    legacy = {
+        "subnet_id": "subnet-legacy",
+        "name": "legacy",
+        "owner": "agent-owner",
+        "is_private": "False",
+        "security_config": "{}",
+        "member_agent_ids": "[]",
+        "metadata": "{}",
+        "description": "",
+        "harness_url": "",
+        "harness_secret": "",
+    }
+
+    subnet = repo._dict_to_subnet(legacy)
+
+    assert subnet.parent_subnet_id is None
+    assert subnet.lifecycle == "persistent"
+    assert subnet.linked_task_id is None

--- a/tests/infrastructure/test_subnet_repository_redis_save.py
+++ b/tests/infrastructure/test_subnet_repository_redis_save.py
@@ -27,9 +27,15 @@ def _make_redis_mock() -> AsyncMock:
     """Build a redis-py async client mock that:
     - records calls to ``hset``;
     - exposes an awaitable ``pipeline()`` async context manager that
-      itself records ``sadd`` / ``execute`` calls.
+      itself records ``sadd`` / ``srem`` / ``execute`` calls.
+
+    ``hgetall`` is wired to default to ``{}`` so ``save()`` 's
+    "read old row first" lookup (ADR-0003 incremental index
+    maintenance) cleanly returns "no existing subnet" without
+    needing every test to override it.
     """
     redis = AsyncMock()
+    redis.hgetall.return_value = {}
 
     class _PipeProxy:
         def __init__(self) -> None:
@@ -43,6 +49,9 @@ def _make_redis_mock() -> AsyncMock:
 
         def sadd(self, *args, **kwargs):
             self.calls.append(("sadd", args, kwargs))
+
+        def srem(self, *args, **kwargs):
+            self.calls.append(("srem", args, kwargs))
 
         async def execute(self):
             self.calls.append(("execute", (), {}))


### PR DESCRIPTION
## Summary

Phase 1 of [ADR-0003 single-layer subnet nesting](docs/adr/0003-subnet-nesting-single-layer.md) — extends the `Subnet` entity and persistence layer so a child subnet can declare itself nested under a parent and optionally bound to a task that auto-dissolves it on terminal state.

This PR ships only the data model + indexes + tests. Service / route / cascade consumers land in Phase 2 (#50) and Phase 3 (#51) — until those PRs land, the new fields are only reachable through their defaults, so legacy callers behave unchanged.

Closes #49.

## Scope (Phase 1)

| Layer | Change |
|---|---|
| `Subnet` entity | three new optional fields — `parent_subnet_id`, `lifecycle ∈ {persistent, task_scoped}`, `linked_task_id` — with `__post_init__` enforcing lifecycle ↔ linked_task_id pairing and the reserved-ID guard |
| `Subnet.to_dict` / `from_dict` | round-trip the new fields; tolerates legacy rows missing the keys |
| `ISubnetRepository` | new methods — `find_by_parent`, `find_by_linked_task` |
| `RedisSubnetRepository` | two new secondary indexes — `acn:subnets:children:{parent}`, `acn:subnets:by_linked_task:{task}` — maintained with incremental SREM/SADD inside the existing pipeline |
| `PostgresSubnetRepository` / `SubnetModel` | three new columns + two partial indexes (`subnets_parent_idx`, `subnets_linked_task_idx`, both `WHERE col IS NOT NULL`) |
| Alembic migration `e1f2a3b4c5d6` | columns + both indexes in one revision on top of `d0e1f2a3b4c5`; `lifecycle` carries both `default` (ORM) and `server_default` (DDL) |

## Invariants enforced at the entity layer

- `lifecycle ∈ {"persistent", "task_scoped"}` (Literal type hint is not runtime-checked on dataclasses, so `__post_init__` guards it).
- `lifecycle == "task_scoped"` ⇔ `linked_task_id is not None` (both directions — a "persistent" subnet carrying a leftover `linked_task_id` is also rejected, so the `by_linked_task` index can't lie about what's cascade-eligible).
- Reserved subnets (`public`, `system`) cannot have a `parent_subnet_id`.

Single-layer cap and membership-subset invariants are *service-layer* concerns (they require parent lookup) — pinned in Phase 2's tests, not this PR.

## Tests

198 tests pass — 38 new, 160 pre-existing subnet-touching tests still green:

- `tests/core/test_subnet.py` — entity invariants (lifecycle value, pairing both directions, reserved-subnet guard, defaults preserve legacy semantics).
- `tests/infrastructure/test_subnet_repository_redis_nesting.py` — index SADD on save, SREM on delete, hydration via the new lookups, legacy-row tolerance in `_dict_to_subnet`.
- `tests/infrastructure/test_postgres_subnet_repository_nesting.py` — mapper round-trip, UPDATE branch carries new columns, WHERE clause targets the right column.
- `tests/infrastructure/test_alembic_subnet_nesting_migration.py` — revision chain, column/index DDL, partial-index WHERE predicate, `server_default` on `lifecycle`, downgrade order (indexes before columns, reverse upgrade order).
- `tests/infrastructure/test_subnet_repository_redis_save.py` — extended fixture to default `hgetall` → `{}` (incremental index maintenance reads the old row first).

```
ruff:          All checks passed!
basedpyright:  0 errors, 0 warnings, 0 notes
pytest -k subnet:  160 passed
pytest <new files>: 38 passed
```

## Backward compatibility

- Legacy callers that ignore the new fields behave unchanged — `Subnet(subnet_id=..., name=..., owner=...)` still constructs a top-level persistent subnet.
- Existing PostgreSQL rows backfill via `server_default='persistent'` in one ALTER — no separate migration step needed.
- Legacy Redis hashes lacking the nesting keys deserialise to entity defaults — `_dict_to_subnet` tolerates missing keys via `dict.get(...) or None`.

## Out of scope (Phase 2/3)

- `SubnetService.create_subnet` signature changes (Phase 2)
- Single-layer-cap and membership-subset invariant enforcement at the service layer (Phase 2)
- `list_children` service method + `GET /subnets?parent=<id>` (Phase 2)
- `promote_to_persistent` (Phase 2)
- Cascade-dissolve `task_scoped` children when linked task terminates (Phase 3)
- New subnet-lifecycle webhook event types — extending existing `agent.joined_subnet` payloads is in Phase 3, but new event names are deferred to a future ADR

## Test plan

- [x] `ruff check` clean across changed files and the whole repo
- [x] `basedpyright` clean across changed source files
- [x] `pytest -k subnet --no-cov` — 160 existing tests pass
- [x] `pytest <new files> --no-cov` — 38 new tests pass
- [ ] CI: `alembic upgrade head` against a real PostgreSQL (handled by the existing migration job)
- [ ] Manual sanity in staging: create + delete a child subnet, observe Redis index hygiene via `MONITOR`

Made with [Cursor](https://cursor.com)