### PR TITLE
feat(subnets): ADR-0003 Phase 2 — service invariants + routes + CLI + SDK

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -296,7 +296,15 @@ async def lifespan(app: FastAPI):
         agent_repository,
         auth0_client=auth0_credential_client,
     )
-    subnet_service_instance = SubnetService(subnet_repository)
+    # ADR-0003: SubnetService now takes an optional task_repository
+    # used by ``create_subnet`` to validate ``linked_task_id`` on
+    # ``task_scoped`` child subnets (``linked_task_not_found``
+    # rejection path). Always supplied in production composition;
+    # legacy test fixtures may instantiate without it.
+    subnet_service_instance = SubnetService(
+        subnet_repository,
+        task_repository=task_repository,
+    )
 
     # Phase 1 communication_policy gateway: a single PolicyCheckService
     # instance is shared by both the HTTP-side MessageRouter and the

--- a/acn/models.py
+++ b/acn/models.py
@@ -6,6 +6,7 @@ Pydantic models for ACN service
 
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Literal
 
 from a2a.compat.v0_3.types import AgentCard as A2AAgentCard  # type: ignore[import-untyped]
 from a2a.compat.v0_3.types import AgentSkill as A2AAgentSkill  # type: ignore[import-untyped]
@@ -385,6 +386,24 @@ class SubnetInfo(BaseModel):
         False, description="Whether an Org Harness is registered for this subnet"
     )
 
+    # ADR-0003 nesting fields. ``parent_subnet_id`` is immutable
+    # after creation (no PATCH route exposes it). ``lifecycle`` is
+    # surfaced so consumers can render "auto-dissolving" UX hints
+    # and so prospective joiners can avoid task_scoped squads
+    # they'd rather not be auto-removed from.
+    parent_subnet_id: str | None = Field(
+        None,
+        description="Parent subnet ID for a child subnet (ADR-0003). None for top-level subnets.",
+    )
+    lifecycle: Literal["persistent", "task_scoped"] = Field(
+        "persistent",
+        description="Subnet lifecycle. 'task_scoped' subnets auto-dissolve when their linked task terminates.",
+    )
+    linked_task_id: str | None = Field(
+        None,
+        description="Linked task ID when lifecycle='task_scoped'. None otherwise.",
+    )
+
 
 class SubnetCreateRequest(BaseModel):
     """
@@ -438,6 +457,34 @@ class SubnetCreateRequest(BaseModel):
         None, max_length=10, description="Required security schemes. None = use first available"
     )
     metadata: dict = Field(default_factory=dict, description="Additional metadata")
+
+    # ADR-0003 nesting params — all optional, defaults preserve
+    # legacy "flat top-level persistent subnet" semantics.
+    parent_subnet_id: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Parent subnet ID for nested subnets (ADR-0003). Single-layer cap: "
+            "the parent itself must be top-level. Immutable after creation."
+        ),
+    )
+    lifecycle: Literal["persistent", "task_scoped"] = Field(
+        "persistent",
+        description=(
+            "Subnet lifecycle. 'task_scoped' subnets auto-dissolve when the "
+            "linked task reaches a terminal state. Defaults to 'persistent'."
+        ),
+    )
+    linked_task_id: str | None = Field(
+        None,
+        min_length=1,
+        max_length=128,
+        description=(
+            "Task ID to bind a 'task_scoped' subnet to. Required when "
+            "lifecycle='task_scoped'."
+        ),
+    )
 
     @model_validator(mode="after")
     def reject_unsupported_security_types(self) -> "SubnetCreateRequest":

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -22,6 +22,10 @@ from ..core.exceptions import AgentNotFoundException, SubnetNotFoundException
 from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
 from ..services import AgentService, SubnetService
+from ..services.subnet_service import (
+    REASON_NOT_PARENT_MEMBER,
+    SubnetNestingError,
+)
 
 logger = structlog.get_logger()
 
@@ -70,9 +74,68 @@ async def do_join_subnet(
             details={"subnet_id": subnet_id},
         ) from e
 
+    # ADR-0003 child-subnet pre-check. ``SubnetService.add_member``
+    # would reject the same way, but doing it *before* the
+    # agent-side ``join_subnet`` write keeps state consistent — a
+    # mid-flight rejection otherwise leaves ``agent.subnet_ids``
+    # containing a subnet whose ``member_agent_ids`` doesn't include
+    # the agent (the dreaded half-joined state). We keep the
+    # service-layer check as defence-in-depth for the admin path.
+    #
+    # ``getattr`` + ``isinstance`` guard lets legacy MagicMock-based
+    # stubs (which don't set ``parent_subnet_id`` and return a
+    # ``MagicMock`` auto-attribute for it) skip this branch — the
+    # real ``Subnet`` entity always populates it with ``str | None``.
+    parent_subnet_id_raw = getattr(subnet, "parent_subnet_id", None)
+    parent_subnet_id = (
+        parent_subnet_id_raw if isinstance(parent_subnet_id_raw, str) else None
+    )
+    if parent_subnet_id is not None:
+        parent = None
+        try:
+            parent = await subnet_service.get_subnet(parent_subnet_id)
+        except SubnetNotFoundException:
+            pass
+        if parent is None or agent_id not in parent.member_agent_ids:
+            raise ACNHTTPError(
+                ErrorCode.NOT_SUBNET_MEMBER,
+                403,
+                details={
+                    "reason": REASON_NOT_PARENT_MEMBER,
+                    "subnet_id": subnet_id,
+                    "agent_id": agent_id,
+                    "parent_subnet_id": parent_subnet_id,
+                },
+            )
+
     try:
         await agent_service.join_subnet(agent_id, subnet_id)
-        await subnet_service.add_member(subnet_id, agent_id)
+        try:
+            await subnet_service.add_member(subnet_id, agent_id)
+        except SubnetNestingError as nest_err:
+            # Race window between the pre-check above and the
+            # service-layer write (parent membership changed
+            # concurrently). Roll back the agent-side write so we
+            # don't leave a half-joined state, then surface the
+            # 403 with the same canonical reason as the pre-check.
+            try:
+                await agent_service.leave_subnet(agent_id, subnet_id)
+            except Exception as rollback_err:  # noqa: BLE001
+                logger.warning(
+                    "join_subnet_rollback_failed",
+                    agent_id=agent_id,
+                    subnet_id=subnet_id,
+                    error=str(rollback_err),
+                )
+            raise ACNHTTPError(
+                ErrorCode.NOT_SUBNET_MEMBER,
+                403,
+                details={
+                    "reason": nest_err.reason,
+                    "subnet_id": subnet_id,
+                    "agent_id": agent_id,
+                },
+            ) from nest_err
 
         logger.info("agent_joined_subnet", agent_id=agent_id, subnet_id=subnet_id)
 

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -59,9 +59,25 @@ def _coerce_optional_str(value: object) -> str | None:
 
 def _coerce_lifecycle(value: object) -> Literal["persistent", "task_scoped"]:
     """Same intent as ``_coerce_optional_str`` for the lifecycle
-    Literal. Defaults to ``"persistent"`` on any unexpected value."""
+    Literal. Defaults to ``"persistent"`` on any unexpected value.
+
+    A real ``Subnet`` entity always carries one of the two valid
+    strings (entity-layer ``__post_init__`` enforces it), so the
+    only "unexpected" path in practice is a legacy ``MagicMock``
+    stub returning a non-string auto-attribute. We silently degrade
+    those, but emit a warning for unexpected real-string values
+    so a future invalid persisted value surfaces in logs instead
+    of disappearing silently.
+    """
     if value == "task_scoped":
         return "task_scoped"
+    if value == "persistent":
+        return "persistent"
+    if isinstance(value, str):
+        logger.warning(
+            "subnet_info_unexpected_lifecycle",
+            lifecycle_value=value,
+        )
     return "persistent"
 
 

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -5,6 +5,7 @@ Clean Architecture implementation: Route → Service → Repository
 
 import re
 import secrets
+from typing import Literal
 
 import structlog  # type: ignore[import-untyped]
 from fastapi import APIRouter, Depends, HTTPException, Request, Security
@@ -16,6 +17,7 @@ from ..config import get_settings
 from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
 from ..core.exceptions import SubnetNotFoundException
 from ..models import SubnetCreateRequest, SubnetCreateResponse, SubnetInfo
+from ..services.subnet_service import SubnetNestingError
 from ._subnet_membership import (
     do_get_agent_subnets,
     do_join_subnet,
@@ -42,8 +44,35 @@ logger = structlog.get_logger()
 settings = get_settings()
 
 
+def _coerce_optional_str(value: object) -> str | None:
+    """Return ``value`` if it's a ``str``, else ``None``.
+
+    Boundary-layer coercion: lets ``_subnet_entity_to_info`` accept
+    both real ``Subnet`` entities (where the field types are guaranteed)
+    and legacy ``MagicMock``-based stub subnets used by older route
+    tests (where any auto-generated attribute returns a new
+    ``MagicMock`` rather than ``None``). The real entity dataclass
+    defaults to ``None`` so this coercion is a no-op in production.
+    """
+    return value if isinstance(value, str) else None
+
+
+def _coerce_lifecycle(value: object) -> Literal["persistent", "task_scoped"]:
+    """Same intent as ``_coerce_optional_str`` for the lifecycle
+    Literal. Defaults to ``"persistent"`` on any unexpected value."""
+    if value == "task_scoped":
+        return "task_scoped"
+    return "persistent"
+
+
 def _subnet_entity_to_info(subnet) -> SubnetInfo:
-    """Convert Subnet entity to SubnetInfo model"""
+    """Convert Subnet entity to SubnetInfo model.
+
+    ADR-0003 surfaces ``parent_subnet_id`` / ``lifecycle`` /
+    ``linked_task_id`` so consumers can render hierarchy / lifecycle
+    UI hints. ``harness_secret`` stays write-only — never exposed
+    through this conversion.
+    """
     return SubnetInfo(
         subnet_id=subnet.subnet_id,
         name=subnet.name,
@@ -55,7 +84,39 @@ def _subnet_entity_to_info(subnet) -> SubnetInfo:
         metadata=subnet.metadata,
         harness_url=subnet.harness_url,
         harness_registered=subnet.harness_url is not None,
+        parent_subnet_id=_coerce_optional_str(
+            getattr(subnet, "parent_subnet_id", None)
+        ),
+        lifecycle=_coerce_lifecycle(getattr(subnet, "lifecycle", "persistent")),
+        linked_task_id=_coerce_optional_str(
+            getattr(subnet, "linked_task_id", None)
+        ),
     )
+
+
+def _nesting_error_to_acn(
+    exc: SubnetNestingError,
+    extra_details: dict | None = None,
+) -> ACNHTTPError:
+    """Map a service-layer ``SubnetNestingError`` to the wire-format
+    ``INVALID_REQUEST`` ACN error with the stable ``details.reason``
+    string the route contract tests pin.
+
+    Membership-subset rejection (``not_parent_member``) is the one
+    case we surface as ``NOT_SUBNET_MEMBER`` instead — it's a
+    membership rather than a request-shape problem. Routes that
+    might raise it should call this helper with that variant set.
+    """
+    from ..services.subnet_service import REASON_NOT_PARENT_MEMBER
+
+    details = {"reason": exc.reason}
+    if extra_details:
+        details.update(extra_details)
+    if exc.reason == REASON_NOT_PARENT_MEMBER:
+        return ACNHTTPError(
+            ErrorCode.NOT_SUBNET_MEMBER, 403, details=details
+        )
+    return ACNHTTPError(ErrorCode.INVALID_REQUEST, 400, details=details)
 
 
 def _generate_subnet_id(name: str) -> str:
@@ -107,6 +168,12 @@ async def create_subnet(
             is_private=body.is_private,
             security_config=security_cfg,
             metadata={},
+            # ADR-0003 nesting fields — service-layer validates the
+            # five invariant variants and raises ``SubnetNestingError``
+            # with a stable ``reason`` string.
+            parent_subnet_id=body.parent_subnet_id,
+            lifecycle=body.lifecycle,
+            linked_task_id=body.linked_task_id,
         )
 
         # Mirror the subnet-side owner add into the agent store. Wrapped in
@@ -151,6 +218,11 @@ async def create_subnet(
             gateway_ws_url=gateway_ws_url,
             gateway_a2a_url=gateway_a2a_url,
         )
+    except SubnetNestingError as e:
+        # ADR-0003 invariant rejection — surface with the stable
+        # ``details.reason`` token clients (route contract tests,
+        # CLI / SDK error parsers) pin against.
+        raise _nesting_error_to_acn(e) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
@@ -176,17 +248,39 @@ async def create_subnet(
 async def list_subnets(
     request: Request,
     owner: str = None,
+    parent: str | None = None,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
 ):
-    """List all subnets
+    """List all subnets.
 
-    Clean Architecture: Route → SubnetService → Repository
-    When ?owner= is provided, authentication is required and the caller must
-    be the owner (or hold acn:admin permission).
+    Clean Architecture: Route → SubnetService → Repository.
+
+    Filters:
+    - ``?owner=`` filters by ownership. Requires authentication; the
+      caller must be that owner (or hold ``acn:admin``).
+    - ``?parent=`` filters to immediate children of the given parent
+      subnet (ADR-0003). Visibility is **aligned with the rest of
+      this endpoint** — anonymous callers see only public children,
+      and authenticated callers additionally see private children
+      they own or are members of. Returns an empty list when the
+      parent is unknown or has no visible children — cross-tenant
+      probes get the same shape as legitimate empty results
+      (no existence leak).
     """
     try:
-        if owner:
+        if parent is not None:
+            # ``?parent=`` filter takes precedence and gates on the
+            # same identity primitive used by ``list_children``.
+            requester_id: str | None = None
+            if credentials:
+                payload = await verify_token(request, credentials)
+                requester_id = payload.get("sub") or None
+            subnets = await subnet_service.list_children(
+                parent_subnet_id=parent,
+                requester_id=requester_id,
+            )
+        elif owner:
             # Require auth when filtering by owner to prevent private subnet enumeration
             if not credentials:
                 raise ACNHTTPError(
@@ -241,6 +335,118 @@ async def get_subnet(
             404,
             details={"subnet_id": subnet_id},
         ) from e
+
+
+@router.get("/{subnet_id}/children")
+async def get_subnet_children(
+    subnet_id: SubnetIdPath,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
+    subnet_service: SubnetServiceDep = None,
+):
+    """List immediate children of a subnet (ADR-0003).
+
+    Visibility matches ``GET /api/v1/subnets?parent=<id>``: anonymous
+    callers see only public children; authenticated callers
+    additionally see private children they own or are members of.
+
+    Returns ``SUBNET_NOT_FOUND`` if the parent itself does not exist.
+    Cross-tenant probes against an existing-but-not-visible parent
+    surface ``SUBNET_NOT_FOUND`` only when the parent itself is
+    missing — visible parents with zero authorised children return
+    ``{"count": 0, "subnets": []}`` (no enumeration of who-has-children
+    that the caller isn't entitled to see).
+    """
+    try:
+        # Verify the parent itself exists so callers don't silently
+        # paper over typos. Service ACL still filters the result set.
+        await subnet_service.get_subnet(subnet_id)
+    except SubnetNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            404,
+            details={"subnet_id": subnet_id},
+        ) from e
+
+    try:
+        requester_id: str | None = None
+        if credentials:
+            payload = await verify_token(request, credentials)
+            requester_id = payload.get("sub") or None
+        children = await subnet_service.list_children(
+            parent_subnet_id=subnet_id,
+            requester_id=requester_id,
+        )
+        subnet_infos = [_subnet_entity_to_info(s) for s in children]
+        return {"count": len(subnet_infos), "subnets": subnet_infos}
+    except ACNHTTPError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "get_subnet_children_failed",
+            subnet_id=subnet_id,
+            error=str(e),
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to list subnet children"
+        ) from e
+
+
+@router.post("/{subnet_id}/promote")
+@limiter.limit("10/minute")
+async def promote_subnet(
+    request: Request,
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Promote a ``task_scoped`` subnet to ``persistent`` (ADR-0003).
+
+    Owner-only. Idempotent — promoting an already-persistent subnet
+    returns its current state without modification. Side effects on
+    a task-scoped → persistent flip:
+
+    - ``lifecycle`` ← ``"persistent"``
+    - ``linked_task_id`` ← ``None`` (subnet outlives its origin task)
+
+    Per ADR-0003 semantic decision #4 the owner is *not* required
+    to currently be a member of the parent subnet; promote is a
+    pure field flip gated only by owner ACL.
+    """
+    owner = agent_info["agent_id"]
+    try:
+        subnet = await subnet_service.promote_to_persistent(
+            subnet_id=subnet_id,
+            owner=owner,
+        )
+        return _subnet_entity_to_info(subnet)
+    except SubnetNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            404,
+            details={"subnet_id": subnet_id},
+        ) from e
+    except PermissionError as e:
+        raise ACNHTTPError(
+            ErrorCode.OWNERSHIP_MISMATCH,
+            403,
+            details={"subnet_id": subnet_id, "reason": str(e)},
+        ) from e
+    except ACNHTTPError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "promote_subnet_failed",
+            subnet_id=subnet_id,
+            error=str(e),
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Failed to promote subnet") from e
 
 
 @router.get("/{subnet_id}/agents")
@@ -571,6 +777,13 @@ async def admin_add_subnet_member(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
             details={"subnet_id": subnet_id},
+        ) from e
+    except SubnetNestingError as e:
+        # ADR-0003 child-subnet membership-subset rejection
+        # propagated even through the internal admin path — keeps
+        # the invariant uniformly enforced regardless of caller.
+        raise _nesting_error_to_acn(
+            e, extra_details={"subnet_id": subnet_id, "agent_id": agent_id}
         ) from e
     except ACNHTTPError:
         raise

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -3,13 +3,43 @@
 Business logic for subnet management.
 """
 
+from typing import Literal
+
 import structlog  # type: ignore[import-untyped]
 
 from ..core.entities import Subnet
 from ..core.exceptions import SubnetNotFoundException
 from ..core.interfaces import ISubnetRepository
+from ..core.interfaces.task_repository import ITaskRepository
 
 logger = structlog.get_logger()
+
+# Sentinel error reasons surfaced to callers (route layer maps to
+# ``INVALID_REQUEST`` / ``NOT_SUBNET_MEMBER`` with this exact string
+# in ``details.reason``). Keep grep-able and stable — clients read
+# them programmatically.
+REASON_PARENT_NOT_FOUND = "parent_not_found"
+REASON_PARENT_IS_RESERVED = "parent_is_reserved"
+REASON_PARENT_IS_NESTED = "parent_is_nested"
+REASON_TASK_SCOPED_REQUIRES_LINKED_TASK = "task_scoped_requires_linked_task"
+REASON_LINKED_TASK_NOT_FOUND = "linked_task_not_found"
+REASON_NOT_PARENT_MEMBER = "not_parent_member"
+
+
+class SubnetNestingError(ValueError):
+    """Raised by ``SubnetService`` when a nesting invariant rejects a
+    request. Carries a stable ``reason`` string (one of the
+    ``REASON_*`` constants above) that the route layer surfaces as
+    ``details.reason``.
+
+    Kept as a ``ValueError`` subclass so legacy callers that catch
+    ``ValueError`` (e.g. ``routes/subnets.py::create_subnet``) keep
+    working — they just see a richer payload than a bare message.
+    """
+
+    def __init__(self, reason: str, message: str | None = None) -> None:
+        self.reason = reason
+        super().__init__(message or reason)
 
 
 class SubnetService:
@@ -18,16 +48,33 @@ class SubnetService:
 
     Orchestrates subnet-related business operations.
     Uses Repository pattern for persistence.
+
+    Optionally accepts an :class:`ITaskRepository` so
+    ``create_subnet`` can validate ``linked_task_id`` against the
+    task store. Production wiring (``api.py`` lifespan) supplies
+    one; legacy test fixtures that don't exercise nesting can omit
+    it — the ``linked_task_not_found`` path falls back to "skip
+    task existence check" when the repository is missing, which
+    keeps non-nesting code paths green.
     """
 
-    def __init__(self, subnet_repository: ISubnetRepository):
+    def __init__(
+        self,
+        subnet_repository: ISubnetRepository,
+        task_repository: ITaskRepository | None = None,
+    ):
         """
         Initialize Subnet Service
 
         Args:
             subnet_repository: Subnet repository implementation
+            task_repository: Optional task repository — required only
+                by the ``linked_task_not_found`` validation path in
+                ``create_subnet``. Omit for legacy fixtures that
+                don't exercise nesting.
         """
         self.repository = subnet_repository
+        self.task_repository = task_repository
 
     async def create_subnet(
         self,
@@ -38,9 +85,26 @@ class SubnetService:
         is_private: bool = False,
         security_config: dict | None = None,
         metadata: dict | None = None,
+        parent_subnet_id: str | None = None,
+        lifecycle: Literal["persistent", "task_scoped"] = "persistent",
+        linked_task_id: str | None = None,
     ) -> Subnet:
         """
-        Create a new subnet
+        Create a new subnet.
+
+        ADR-0003 invariants enforced when nesting params are set:
+
+        - ``parent_subnet_id`` must reference an existing subnet —
+          ``parent_not_found``.
+        - Parent must not be reserved (``public``/``system``) —
+          ``parent_is_reserved``. Catches both reserved IDs and
+          (defence in depth) any subnet whose owner is ``system``.
+        - Parent's own ``parent_subnet_id`` must be ``None`` (single-
+          layer cap) — ``parent_is_nested``.
+        - ``lifecycle == "task_scoped"`` requires
+          ``linked_task_id`` to be set — ``task_scoped_requires_linked_task``.
+        - ``linked_task_id`` must reference an existing task when a
+          ``task_repository`` is wired — ``linked_task_not_found``.
 
         Args:
             subnet_id: Subnet identifier
@@ -50,16 +114,71 @@ class SubnetService:
             is_private: Whether subnet is private
             security_config: Security configuration
             metadata: Additional metadata
+            parent_subnet_id: Optional parent subnet ID (ADR-0003)
+            lifecycle: ``"persistent"`` (default) or ``"task_scoped"``
+            linked_task_id: Required when ``lifecycle == "task_scoped"``
 
         Returns:
             Created subnet entity
 
         Raises:
             ValueError: If subnet already exists
+            SubnetNestingError: On any of the five invariant rejections
         """
         # Check if subnet already exists
         if await self.repository.exists(subnet_id):
             raise ValueError(f"Subnet {subnet_id} already exists")
+
+        # --- ADR-0003 nesting validations -----------------------------
+        # Entity-layer already enforces lifecycle ↔ linked_task_id
+        # pairing both directions, the reserved-ID rules, and lifecycle
+        # value validity. We layer the *service-only* invariants on
+        # top (parent existence + single-layer cap + linked task
+        # existence) because they require repository lookups.
+        if lifecycle == "task_scoped" and linked_task_id is None:
+            # Surfaced with a stable reason so the route layer's
+            # contract test can pin the exact error code without
+            # depending on the (English) message text.
+            raise SubnetNestingError(
+                REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
+                "lifecycle='task_scoped' requires linked_task_id",
+            )
+
+        if parent_subnet_id is not None:
+            parent = await self.repository.find_by_id(parent_subnet_id)
+            if parent is None:
+                raise SubnetNestingError(
+                    REASON_PARENT_NOT_FOUND,
+                    f"Parent subnet '{parent_subnet_id}' does not exist",
+                )
+            # ADR-0003 §A invariant 5 — reserved subnets cannot be
+            # parents. Catch by ID *and* (defensively) by owner: the
+            # ``system`` owner literal is the platform escape hatch
+            # and any subnet under it is treated as platform-owned.
+            if parent_subnet_id in {"public", "system"} or parent.owner == "system":
+                raise SubnetNestingError(
+                    REASON_PARENT_IS_RESERVED,
+                    f"Parent subnet '{parent_subnet_id}' is reserved",
+                )
+            # Single-layer cap — parent must itself be top-level.
+            if parent.parent_subnet_id is not None:
+                raise SubnetNestingError(
+                    REASON_PARENT_IS_NESTED,
+                    f"Parent subnet '{parent_subnet_id}' is itself nested; "
+                    "single-layer cap enforced",
+                )
+
+        if linked_task_id is not None and self.task_repository is not None:
+            # Skip the existence check when no task_repository is
+            # wired — preserves backward-compat for test fixtures
+            # that don't exercise nesting. Production composition
+            # in ``api.py`` always supplies one.
+            task_exists = await self.task_repository.exists(linked_task_id)
+            if not task_exists:
+                raise SubnetNestingError(
+                    REASON_LINKED_TASK_NOT_FOUND,
+                    f"Linked task '{linked_task_id}' does not exist",
+                )
 
         subnet = Subnet(
             subnet_id=subnet_id,
@@ -69,6 +188,9 @@ class SubnetService:
             is_private=is_private,
             security_config=security_config or {},
             metadata=metadata or {},
+            parent_subnet_id=parent_subnet_id,
+            lifecycle=lifecycle,
+            linked_task_id=linked_task_id,
         )
         # The owner is implicitly a member: every ACL that keys off
         # `subnet.member_agent_ids` (private GET /tasks/{id}, accept_task,
@@ -76,9 +198,29 @@ class SubnetService:
         # subnet they just created. Mirror this in the entity at construction
         # time so harness bootstrap (create_subnet → register_harness →
         # create_task) works without a follow-up join_subnet hack.
+        #
+        # Child-subnet edge case: the membership-subset invariant
+        # (``add_member`` rejects non-parent members) is *not* tripped
+        # here because the owner-add bypasses ``SubnetService.add_member``
+        # by calling the entity method directly. For a child subnet to
+        # be useful, the owner must already be a parent member —
+        # otherwise the only person who can do anything in the squad
+        # (the owner) cannot widen its membership. We deliberately do
+        # NOT enforce this at create-time: an owner who creates a
+        # child subnet they're not in is a valid governance pattern
+        # (delegated admin), and the membership-subset invariant
+        # naturally limits what they can do afterward.
         subnet.add_member(owner)
 
-        logger.info("create_subnet", subnet_id=subnet_id, name=name, owner=owner)
+        logger.info(
+            "create_subnet",
+            subnet_id=subnet_id,
+            name=name,
+            owner=owner,
+            parent_subnet_id=parent_subnet_id,
+            lifecycle=lifecycle,
+            linked_task_id=linked_task_id,
+        )
         await self.repository.save(subnet)
         return subnet
 
@@ -123,13 +265,66 @@ class SubnetService:
         """
         return await self.repository.find_public_subnets()
 
+    async def list_children(
+        self,
+        parent_subnet_id: str,
+        *,
+        requester_id: str | None = None,
+    ) -> list[Subnet]:
+        """
+        Return the immediate children of a subnet (ADR-0003).
+
+        ACL alignment with ``list_subnets``: private children where
+        ``requester_id`` is not the owner and not a member are
+        filtered out. Anonymous callers (``requester_id is None``)
+        see only public children. Cross-tenant probes return the
+        same empty-list shape as legitimate "no children" results —
+        no existence leak.
+
+        Args:
+            parent_subnet_id: Parent subnet identifier
+            requester_id: Authenticated caller's ``agent_id`` (or
+                ``None`` for anonymous / pre-auth contexts)
+
+        Returns:
+            List of visible child subnets. Empty when no children
+            exist, the parent is unknown, or every child is filtered
+            by ACL.
+        """
+        children = await self.repository.find_by_parent(parent_subnet_id)
+
+        def _visible(subnet: Subnet) -> bool:
+            if not subnet.is_private:
+                return True
+            if requester_id is None:
+                return False
+            return (
+                subnet.owner == requester_id
+                or requester_id in subnet.member_agent_ids
+            )
+
+        return [c for c in children if _visible(c)]
+
     async def delete_subnet(self, subnet_id: str, owner: str) -> bool:
         """
-        Delete a subnet
+        Delete a subnet, cascading to children when it has any
+        (ADR-0003 §A invariant 4).
+
+        Authorisation: the subnet's own ``owner`` may delete it; the
+        ``"system"`` literal is the platform escape hatch (used by
+        Phase 3's task-state cascade hook in ``task_service``).
+
+        Cascade order: children are deleted first, then the parent.
+        On Postgres this is a sequential best-effort —
+        ``ISubnetRepository`` is single-statement per call; there is
+        no shared transaction seam exposed yet, so a partial
+        failure leaves orphan children but **does NOT remove the
+        parent** (parent deletion only fires after all child
+        deletions succeed). Redis behaves identically.
 
         Args:
             subnet_id: Subnet identifier
-            owner: Owner identifier (for authorization check)
+            owner: Owner identifier (or ``"system"`` for cascade)
 
         Returns:
             True if deleted successfully
@@ -140,20 +335,61 @@ class SubnetService:
         """
         subnet = await self.get_subnet(subnet_id)
 
-        # Authorization check
+        # Authorization check — owner of the subnet, or platform.
         if subnet.owner != owner and owner != "system":
             raise PermissionError(f"Owner mismatch: {owner} != {subnet.owner}")
 
-        # Prevent deletion of system subnets
+        # Prevent deletion of system subnets — they are platform
+        # primitives. Cascade hook still uses ``owner="system"`` to
+        # delete *child* subnets, which is fine (children are never
+        # reserved per ADR-0003 §7).
         if subnet_id in ["public", "system"]:
             raise PermissionError(f"Cannot delete system subnet: {subnet_id}")
+
+        # Cascade to children first. Single-layer cap guarantees
+        # ``find_by_parent`` doesn't itself need to recurse.
+        if subnet.parent_subnet_id is None:
+            children = await self.repository.find_by_parent(subnet_id)
+            for child in children:
+                logger.info(
+                    "delete_subnet_cascade_child",
+                    parent_subnet_id=subnet_id,
+                    child_subnet_id=child.subnet_id,
+                )
+                # Use ``"system"`` so the cascade isn't blocked by
+                # mismatched per-child owners (squad subnets can be
+                # owned by different agents inside the same parent).
+                deleted = await self.repository.delete(child.subnet_id)
+                if not deleted:
+                    # Audit-log breadcrumb so ops can spot partial
+                    # cascade and re-run manually. We refuse to
+                    # delete the parent in this state — orphan
+                    # children pointing at a missing parent are
+                    # worse than orphan children pointing at a
+                    # still-present parent (the latter can be
+                    # cleaned up by retrying the parent delete).
+                    logger.warning(
+                        "delete_subnet_cascade_partial",
+                        parent_subnet_id=subnet_id,
+                        child_subnet_id=child.subnet_id,
+                        reason="repository_delete_returned_false",
+                    )
+                    raise RuntimeError(
+                        f"Cascade delete failed for child {child.subnet_id}; "
+                        f"refusing to delete parent {subnet_id}"
+                    )
 
         logger.info("delete_subnet", subnet_id=subnet_id)
         return await self.repository.delete(subnet_id)
 
     async def add_member(self, subnet_id: str, agent_id: str) -> Subnet:
         """
-        Add an agent to a subnet
+        Add an agent to a subnet.
+
+        ADR-0003 §A invariant 2 — when the subnet is a child
+        (``parent_subnet_id is not None``), the agent must already be
+        a member of the parent. Surfaced with
+        ``reason="not_parent_member"``.
 
         Args:
             subnet_id: Subnet identifier
@@ -161,8 +397,26 @@ class SubnetService:
 
         Returns:
             Updated subnet entity
+
+        Raises:
+            SubnetNestingError: If subnet is a child and ``agent_id``
+                is not a member of the parent.
         """
         subnet = await self.get_subnet(subnet_id)
+
+        if subnet.parent_subnet_id is not None:
+            parent = await self.repository.find_by_id(subnet.parent_subnet_id)
+            # If the parent has been deleted while this child still
+            # exists (orphan), reject the add — adding members to a
+            # dangling child would silently bypass the subset
+            # invariant. Ops should ``delete_subnet`` the orphan.
+            if parent is None or agent_id not in parent.member_agent_ids:
+                raise SubnetNestingError(
+                    REASON_NOT_PARENT_MEMBER,
+                    f"Agent '{agent_id}' is not a member of parent subnet "
+                    f"'{subnet.parent_subnet_id}'",
+                )
+
         subnet.add_member(agent_id)
         await self.repository.save(subnet)
         logger.info("subnet_member_added", subnet_id=subnet_id, agent_id=agent_id)
@@ -251,5 +505,66 @@ class SubnetService:
             subnet_id=subnet_id,
             has_url=harness_url is not None,
             has_secret=harness_secret is not None,
+        )
+        return subnet
+
+    async def promote_to_persistent(
+        self,
+        subnet_id: str,
+        owner: str,
+    ) -> Subnet:
+        """
+        Promote a ``task_scoped`` child subnet to ``persistent``
+        (ADR-0003 semantic decision #2).
+
+        Owner-only. **Idempotent** — calling on a subnet that is
+        already ``persistent`` returns it unchanged (no error, no
+        repository write). Per ADR semantic decision #4, the owner
+        is *not* required to currently be a member of the parent
+        subnet; promote is a pure field flip authorised by
+        owner-only ACL.
+
+        Side effects on success:
+        - ``lifecycle`` → ``"persistent"``
+        - ``linked_task_id`` → ``None``
+        - Repository ``save`` re-emits the secondary index update
+          (Redis pipeline SREM's the old ``by_linked_task`` entry).
+
+        Args:
+            subnet_id: Subnet identifier
+            owner: Authenticated agent making the request
+
+        Returns:
+            Updated subnet entity (or the unchanged entity on
+            idempotent invocation).
+
+        Raises:
+            SubnetNotFoundException: If subnet not found
+            PermissionError: If owner mismatch
+        """
+        subnet = await self.get_subnet(subnet_id)
+
+        if subnet.owner != owner and owner != "system":
+            raise PermissionError(f"Owner mismatch: {owner} != {subnet.owner}")
+
+        if subnet.lifecycle == "persistent":
+            # Idempotent — return unchanged. No repository write so
+            # callers can promote unconditionally without a
+            # precondition check, per ADR semantic decision #2.
+            logger.info(
+                "subnet_promote_noop",
+                subnet_id=subnet_id,
+                owner=owner,
+                reason="already_persistent",
+            )
+            return subnet
+
+        subnet.lifecycle = "persistent"
+        subnet.linked_task_id = None
+        await self.repository.save(subnet)
+        logger.info(
+            "subnet_promoted_to_persistent",
+            subnet_id=subnet_id,
+            owner=owner,
         )
         return subnet

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -3,6 +3,7 @@
 Business logic for subnet management.
 """
 
+import dataclasses
 from typing import Literal
 
 import structlog  # type: ignore[import-untyped]
@@ -559,12 +560,21 @@ class SubnetService:
             )
             return subnet
 
-        subnet.lifecycle = "persistent"
-        subnet.linked_task_id = None
-        await self.repository.save(subnet)
+        # Build the promoted entity via ``dataclasses.replace`` so the
+        # final state is re-validated by ``Subnet.__post_init__``
+        # (catches any future invariant additions automatically).
+        # Direct attribute assignment would silently bypass
+        # ``__post_init__`` and only persist a half-valid state if a
+        # bug ever set the fields out of order.
+        promoted = dataclasses.replace(
+            subnet,
+            lifecycle="persistent",
+            linked_task_id=None,
+        )
+        await self.repository.save(promoted)
         logger.info(
             "subnet_promoted_to_persistent",
             subnet_id=subnet_id,
             owner=owner,
         )
-        return subnet
+        return promoted

--- a/clients/cli/src/commands/subnet.ts
+++ b/clients/cli/src/commands/subnet.ts
@@ -13,6 +13,11 @@ interface SubnetInfo {
   harness_registered?: boolean;
   created_at?: string;
   metadata?: Record<string, unknown>;
+  // ADR-0003 nesting fields (optional + back-compat default
+  // tolerant — older servers may omit them).
+  parent_subnet_id?: string | null;
+  lifecycle?: 'persistent' | 'task_scoped';
+  linked_task_id?: string | null;
 }
 
 interface SubnetListResponse {
@@ -48,6 +53,13 @@ function formatSubnet(s: SubnetInfo, index?: number): string {
   if (s.owner) lines.push(`  Owner : ${s.owner}`);
   if (s.description) lines.push(`  Desc  : ${s.description}`);
   if (s.created_at) lines.push(`  Since : ${s.created_at}`);
+  if (s.parent_subnet_id) {
+    lines.push(`  Parent: ${s.parent_subnet_id}`);
+  }
+  if (s.lifecycle && s.lifecycle !== 'persistent') {
+    const task = s.linked_task_id ? ` (task=${s.linked_task_id})` : '';
+    lines.push(`  Lifecycle: ${s.lifecycle}${task}`);
+  }
   if (s.harness_registered) {
     lines.push(`  Harness: ${s.harness_url ?? '(registered)'}`);
   } else {
@@ -61,11 +73,33 @@ export function subnetCommand(): Command {
 
   cmd
     .command('list')
-    .description('List subnets. Without --all shows only subnets you have joined.')
+    .description(
+      'List subnets. Without --all/--parent shows only subnets you have joined.'
+    )
     .option('--all', 'Show all public subnets on ACN (not just your own)')
-    .option('-i, --agent-id <id>', 'Agent ID (defaults to config, ignored with --all)')
-    .action(async (opts: { all?: boolean; agentId?: string }) => {
+    .option(
+      '--parent <id>',
+      'Show only immediate children of the given parent subnet (ADR-0003)'
+    )
+    .option('-i, --agent-id <id>', 'Agent ID (defaults to config, ignored with --all/--parent)')
+    .action(async (opts: { all?: boolean; parent?: string; agentId?: string }) => {
       try {
+        if (opts.parent) {
+          const res = await acnGet<SubnetListResponse>(
+            `/subnets?parent=${encodeURIComponent(opts.parent)}`
+          );
+          const subnets = res.subnets ?? [];
+          if (subnets.length === 0) {
+            output(res, `No visible children of subnet ${opts.parent}.`);
+            return;
+          }
+          output(
+            res,
+            `${subnets.length} child subnet(s) of ${opts.parent}:\n\n` +
+              subnets.map((s, i) => formatSubnet(s, i)).join('\n\n')
+          );
+          return;
+        }
         if (opts.all) {
           const res = await acnGet<SubnetListResponse>('/subnets');
           const subnets = res.subnets ?? [];
@@ -161,17 +195,53 @@ export function subnetCommand(): Command {
     .option('--id <subnet_id>', 'Custom subnet ID (1-64 chars). Omit to let ACN auto-generate.')
     .option('-d, --description <text>', 'Subnet description (up to 500 chars)')
     .option('--private', 'Mark this subnet as private', false)
+    .option(
+      '--parent <id>',
+      'Parent subnet ID for a child/squad subnet (ADR-0003). Single-layer cap.'
+    )
+    .option(
+      '--lifecycle <mode>',
+      'Lifecycle mode: persistent (default) or task_scoped',
+      'persistent'
+    )
+    .option(
+      '--task <id>',
+      'Linked task ID. Required with --lifecycle task_scoped.'
+    )
     .action(
       async (opts: {
         name: string;
         id?: string;
         description?: string;
         private?: boolean;
+        parent?: string;
+        lifecycle?: string;
+        task?: string;
       }) => {
         const config = loadConfig();
         if (!config.api_key) {
           console.error('No API key found. Run `acn join` first.');
           process.exit(1);
+        }
+        const lifecycle = opts.lifecycle ?? 'persistent';
+        if (lifecycle !== 'persistent' && lifecycle !== 'task_scoped') {
+          console.error(
+            `Invalid --lifecycle '${lifecycle}'. Must be 'persistent' or 'task_scoped'.`
+          );
+          process.exit(2);
+        }
+        // Client-side pre-check matching ADR-0003 entity invariant —
+        // saves a round-trip + gives a nicer error than the server's
+        // ``task_scoped_requires_linked_task`` response.
+        if (lifecycle === 'task_scoped' && !opts.task) {
+          console.error('--lifecycle task_scoped requires --task <id>.');
+          process.exit(2);
+        }
+        if (lifecycle === 'persistent' && opts.task) {
+          console.error(
+            '--task is only valid with --lifecycle task_scoped (current: persistent).'
+          );
+          process.exit(2);
         }
         const body: Record<string, unknown> = {
           name: opts.name,
@@ -179,6 +249,9 @@ export function subnetCommand(): Command {
         };
         if (opts.id) body.subnet_id = opts.id;
         if (opts.description) body.description = opts.description;
+        if (opts.parent) body.parent_subnet_id = opts.parent;
+        body.lifecycle = lifecycle;
+        if (opts.task) body.linked_task_id = opts.task;
         try {
           const res = await acnPost<SubnetCreateResponse>('/subnets', body);
           const lines = [
@@ -187,12 +260,40 @@ export function subnetCommand(): Command {
             `  Gateway A2A: ${res.gateway_a2a_url}`,
             `  Gateway WS : ${res.gateway_ws_url}`,
           ];
+          if (opts.parent) lines.push(`  Parent     : ${opts.parent}`);
+          if (lifecycle !== 'persistent') {
+            lines.push(`  Lifecycle  : ${lifecycle}${opts.task ? ` (task=${opts.task})` : ''}`);
+          }
           output(res, lines.join('\n'));
         } catch (err) {
           handleError(err);
         }
       }
     );
+
+  cmd
+    .command('promote <subnet_id>')
+    .description(
+      'Promote a task_scoped subnet to persistent (ADR-0003). Owner-only; idempotent.'
+    )
+    .action(async (subnetId: string) => {
+      const config = loadConfig();
+      if (!config.api_key) {
+        console.error('No API key found. Run `acn join` first.');
+        process.exit(1);
+      }
+      try {
+        const res = await acnPost<SubnetInfo>(`/subnets/${subnetId}/promote`);
+        const lifecycle = res.lifecycle ?? 'persistent';
+        output(
+          res,
+          `Subnet ${res.subnet_id} lifecycle=${lifecycle}` +
+            (res.linked_task_id ? ` (still linked to task ${res.linked_task_id})` : '')
+        );
+      } catch (err) {
+        handleError(err);
+      }
+    });
 
   cmd
     .command('delete <subnet_id>')

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -435,10 +435,46 @@ class ACNClient:
             json=request.model_dump(exclude_none=True),
         )
 
-    async def list_subnets(self) -> list[SubnetInfo]:
-        """List all subnets"""
-        data = await self._request("GET", "/api/v1/subnets")
+    async def list_subnets(
+        self, parent_subnet_id: str | None = None
+    ) -> list[SubnetInfo]:
+        """List subnets.
+
+        Args:
+            parent_subnet_id: When set, filter to immediate children
+                of the given parent (ADR-0003). The server applies
+                the same ACL as the unfiltered list — private
+                children not visible to this client are silently
+                omitted.
+        """
+        params: dict[str, str] | None = None
+        if parent_subnet_id is not None:
+            params = {"parent": parent_subnet_id}
+        data = await self._request("GET", "/api/v1/subnets", params=params)
         return [SubnetInfo.model_validate(s) for s in data.get("subnets", [])]
+
+    async def list_children(self, parent_subnet_id: str) -> list[SubnetInfo]:
+        """List immediate children of a subnet (ADR-0003).
+
+        Convenience wrapper over the dedicated
+        ``GET /api/v1/subnets/{id}/children`` endpoint, which
+        returns ``SUBNET_NOT_FOUND`` when the parent itself is
+        missing. Visibility matches :meth:`list_subnets` —
+        non-visible private children are omitted.
+        """
+        data = await self._request(
+            "GET", f"/api/v1/subnets/{parent_subnet_id}/children"
+        )
+        return [SubnetInfo.model_validate(s) for s in data.get("subnets", [])]
+
+    async def promote_subnet(self, subnet_id: str) -> SubnetInfo:
+        """Promote a ``task_scoped`` subnet to ``persistent`` (ADR-0003).
+
+        Owner-only. Idempotent — promoting an already-persistent
+        subnet returns its current state unchanged.
+        """
+        data = await self._request("POST", f"/api/v1/subnets/{subnet_id}/promote")
+        return SubnetInfo.model_validate(data)
 
     async def get_subnet(self, subnet_id: str) -> SubnetInfo:
         """Get subnet by ID"""

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -278,13 +278,27 @@ class SubnetInfo(BaseModel):
     harness_url: str | None = None
     harness_registered: bool = False
 
+    # ADR-0003 nesting fields — optional + defaulted so older
+    # servers that don't yet emit them still parse cleanly.
+    parent_subnet_id: str | None = None
+    lifecycle: str = "persistent"
+    linked_task_id: str | None = None
+
 
 class SubnetCreateRequest(BaseModel):
-    """Subnet creation request"""
+    """Subnet creation request.
+
+    ADR-0003 nesting params (``parent_subnet_id`` / ``lifecycle`` /
+    ``linked_task_id``) are optional; defaults preserve the legacy
+    "flat top-level persistent subnet" shape.
+    """
 
     name: str
     description: str | None = None
     metadata: dict[str, Any] | None = None
+    parent_subnet_id: str | None = None
+    lifecycle: str = "persistent"
+    linked_task_id: str | None = None
 
 
 # ============================================

--- a/clients/python/tests/test_subnet_nesting.py
+++ b/clients/python/tests/test_subnet_nesting.py
@@ -1,0 +1,188 @@
+"""ADR-0003 Phase 2 — Python SDK subnet-nesting surface tests.
+
+Pin:
+- ``SubnetInfo`` / ``SubnetCreateRequest`` round-trip the three new
+  nesting fields (parent_subnet_id, lifecycle, linked_task_id).
+- ``Client.list_subnets(parent_subnet_id=...)`` issues the
+  ``?parent=...`` filter on the wire.
+- ``Client.list_children(...)`` hits the dedicated
+  ``/api/v1/subnets/{id}/children`` endpoint.
+- ``Client.promote_subnet(...)`` issues ``POST
+  /api/v1/subnets/{id}/promote`` and parses the returned
+  ``SubnetInfo``.
+- Back-compat: SDKs talking to an older server that omits the new
+  fields still parse cleanly (defaults preserved).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn_client.client import ACNClient
+from acn_client.models import SubnetCreateRequest, SubnetInfo
+
+
+def _server_subnet_payload(**overrides: Any) -> dict[str, Any]:
+    """Minimal subnet response payload as ACN would emit it."""
+    base = {
+        "subnet_id": "squad-1",
+        "name": "Squad 1",
+        "owner": "alice",
+        "is_private": False,
+        "parent_subnet_id": "parent-1",
+        "lifecycle": "task_scoped",
+        "linked_task_id": "task-42",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSubnetInfoNestingFields:
+    def test_parses_new_nesting_fields_from_server_payload(self):
+        payload = _server_subnet_payload()
+        info = SubnetInfo.model_validate(payload)
+        assert info.parent_subnet_id == "parent-1"
+        assert info.lifecycle == "task_scoped"
+        assert info.linked_task_id == "task-42"
+
+    def test_back_compat_with_legacy_server_omitting_fields(self):
+        """SDK talking to an older server: the three new fields are
+        absent from the JSON. Defaults must preserve a top-level
+        persistent subnet shape so legacy consumers don't crash."""
+        info = SubnetInfo.model_validate(
+            {"subnet_id": "legacy", "name": "Legacy"}
+        )
+        assert info.parent_subnet_id is None
+        assert info.lifecycle == "persistent"
+        assert info.linked_task_id is None
+
+
+class TestSubnetCreateRequestNestingFields:
+    def test_serialises_nesting_fields(self):
+        req = SubnetCreateRequest(
+            name="Bug Squad",
+            parent_subnet_id="parent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        dumped = req.model_dump(exclude_none=True)
+        assert dumped["parent_subnet_id"] == "parent-1"
+        assert dumped["lifecycle"] == "task_scoped"
+        assert dumped["linked_task_id"] == "task-42"
+
+    def test_back_compat_defaults_when_omitted(self):
+        req = SubnetCreateRequest(name="Plain")
+        dumped = req.model_dump(exclude_none=True)
+        # ``exclude_none`` drops None fields but keeps ``lifecycle``
+        # since it defaults to a non-None string. That's intentional —
+        # the server-side default is also ``persistent`` so the value
+        # is correct + makes the wire payload self-describing.
+        assert dumped.get("parent_subnet_id") is None
+        assert dumped["lifecycle"] == "persistent"
+        assert dumped.get("linked_task_id") is None
+
+
+def _make_client_with_stub(request_mock: AsyncMock) -> ACNClient:
+    """ACNClient with ``_request`` replaced by an awaitable stub."""
+    client = ACNClient(base_url="http://acn.test")
+    client._request = request_mock  # type: ignore[method-assign]
+    return client
+
+
+class TestSubnetClientMethods:
+    @pytest.mark.asyncio
+    async def test_list_subnets_with_parent_filter_passes_param(self):
+        request_mock = AsyncMock(
+            return_value={
+                "subnets": [_server_subnet_payload()],
+                "count": 1,
+            }
+        )
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.list_subnets(parent_subnet_id="parent-1")
+
+        assert len(result) == 1
+        assert result[0].parent_subnet_id == "parent-1"
+        request_mock.assert_awaited_once_with(
+            "GET", "/api/v1/subnets", params={"parent": "parent-1"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_subnets_without_filter_passes_no_params(self):
+        request_mock = AsyncMock(return_value={"subnets": [], "count": 0})
+        client = _make_client_with_stub(request_mock)
+
+        await client.list_subnets()
+
+        # ``params=None`` is required so the call signature matches
+        # legacy invocations (didn't pass ``params``) — older servers
+        # may reject unexpected query strings.
+        request_mock.assert_awaited_once_with(
+            "GET", "/api/v1/subnets", params=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_children_uses_dedicated_endpoint(self):
+        request_mock = AsyncMock(
+            return_value={
+                "count": 1,
+                "subnets": [_server_subnet_payload(subnet_id="child-1")],
+            }
+        )
+        client = _make_client_with_stub(request_mock)
+
+        children = await client.list_children("parent-1")
+
+        assert len(children) == 1
+        assert children[0].id == "child-1"
+        request_mock.assert_awaited_once_with(
+            "GET", "/api/v1/subnets/parent-1/children"
+        )
+
+    @pytest.mark.asyncio
+    async def test_promote_subnet_returns_updated_info(self):
+        promoted_payload = _server_subnet_payload(
+            lifecycle="persistent",
+            linked_task_id=None,
+        )
+        request_mock = AsyncMock(return_value=promoted_payload)
+        client = _make_client_with_stub(request_mock)
+
+        info = await client.promote_subnet("squad-1")
+
+        assert info.lifecycle == "persistent"
+        assert info.linked_task_id is None
+        request_mock.assert_awaited_once_with(
+            "POST", "/api/v1/subnets/squad-1/promote"
+        )
+
+
+class TestCreateSubnetWiresNestingFields:
+    """``create_subnet`` already accepts a ``SubnetCreateRequest`` —
+    the new field surface is end-to-end testable by inspecting the
+    JSON body the client emits."""
+
+    @pytest.mark.asyncio
+    async def test_create_subnet_body_carries_nesting_fields(self):
+        request_mock = AsyncMock(return_value={"status": "created"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.create_subnet(
+            SubnetCreateRequest(
+                name="Squad",
+                parent_subnet_id="parent-1",
+                lifecycle="task_scoped",
+                linked_task_id="task-42",
+            )
+        )
+
+        request_mock.assert_awaited_once()
+        call_kwargs = request_mock.await_args.kwargs
+        body = call_kwargs["json"]
+        assert body["parent_subnet_id"] == "parent-1"
+        assert body["lifecycle"] == "task_scoped"
+        assert body["linked_task_id"] == "task-42"

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -1,0 +1,421 @@
+"""Route-level contract tests for ADR-0003 Phase 2.
+
+Pins the five ``INVALID_REQUEST`` rejection variants on
+``POST /api/v1/subnets``, the new ``GET /api/v1/subnets?parent=<id>``
+filter, the new ``GET /api/v1/subnets/{id}/children`` endpoint, and
+the new ``POST /api/v1/subnets/{id}/promote`` endpoint.
+
+Each rejection variant pins ``error_code = "invalid_request"`` AND a
+stable ``details.reason`` string that the CLI / SDK error parsers
+match against — these names are part of the public contract and
+shouldn't drift.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.entities import Subnet
+from acn.core.exceptions import SubnetNotFoundException
+from acn.routes.dependencies import (
+    get_agent_service,
+    get_subnet_service,
+)
+from acn.services.subnet_service import (
+    REASON_LINKED_TASK_NOT_FOUND,
+    REASON_NOT_PARENT_MEMBER,
+    REASON_PARENT_IS_NESTED,
+    REASON_PARENT_IS_RESERVED,
+    REASON_PARENT_NOT_FOUND,
+    REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
+    SubnetNestingError,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_agent_service():
+    svc = AsyncMock()
+
+    target = MagicMock()
+    target.agent_id = "agent-target"
+    target.name = "Target"
+    target.subnet_ids = []
+
+    other = MagicMock()
+    other.agent_id = "agent-other"
+    other.name = "Other"
+
+    async def _by_api_key(key: str):
+        if key == "owner-key":
+            return target
+        if key == "other-key":
+            return other
+        return None
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+    svc.get_agent = AsyncMock(return_value=target)
+    svc.join_subnet = AsyncMock(return_value=None)
+    svc.leave_subnet = AsyncMock(return_value=None)
+    return svc
+
+
+def _make_subnet_entity(
+    subnet_id: str = "subnet-1",
+    owner: str = "agent-target",
+    *,
+    is_private: bool = False,
+    parent_subnet_id: str | None = None,
+    lifecycle: str = "persistent",
+    linked_task_id: str | None = None,
+    member_agent_ids: set[str] | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        is_private=is_private,
+        parent_subnet_id=parent_subnet_id,
+        lifecycle=lifecycle,  # type: ignore[arg-type]
+        linked_task_id=linked_task_id,
+        member_agent_ids=member_agent_ids or {owner},
+        created_at=datetime.now(UTC),
+    )
+
+
+def _wire(agent_svc, subnet_svc) -> None:
+    app.dependency_overrides[get_agent_service] = lambda: agent_svc
+    app.dependency_overrides[get_subnet_service] = lambda: subnet_svc
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/subnets — five rejection variants + happy path
+# ---------------------------------------------------------------------------
+
+
+_REASON_ERROR_CODE_MAP: dict[str, tuple[int, str]] = {
+    # (status_code, error_code) per rejection reason.
+    REASON_PARENT_NOT_FOUND: (400, "invalid_request"),
+    REASON_PARENT_IS_RESERVED: (400, "invalid_request"),
+    REASON_PARENT_IS_NESTED: (400, "invalid_request"),
+    REASON_TASK_SCOPED_REQUIRES_LINKED_TASK: (400, "invalid_request"),
+    REASON_LINKED_TASK_NOT_FOUND: (400, "invalid_request"),
+    # not_parent_member maps to 403 NOT_SUBNET_MEMBER, see the
+    # admin_add_subnet_member test below.
+}
+
+
+@pytest.mark.parametrize("reason", list(_REASON_ERROR_CODE_MAP))
+def test_create_subnet_invariant_rejection(reason, stub_agent_service):
+    """One test per ``details.reason`` string the service raises.
+
+    Each variant is exercised by stubbing ``create_subnet`` to raise
+    ``SubnetNestingError(reason)`` and asserting the route maps it to
+    ``ACNHTTPError(INVALID_REQUEST, 400, details={"reason": <token>})``.
+    """
+    expected_status, expected_code = _REASON_ERROR_CODE_MAP[reason]
+    subnet_svc = AsyncMock()
+    subnet_svc.create_subnet = AsyncMock(
+        side_effect=SubnetNestingError(reason, f"test reason: {reason}")
+    )
+    _wire(stub_agent_service, subnet_svc)
+
+    body: dict = {"name": "Squad", "subnet_id": "squad-1"}
+    # Send a body shape that *could* plausibly produce each reason —
+    # the stub raises regardless, but a realistic payload helps the
+    # contract test document each variant's intended call site.
+    if reason in {REASON_PARENT_NOT_FOUND, REASON_PARENT_IS_RESERVED,
+                  REASON_PARENT_IS_NESTED}:
+        body["parent_subnet_id"] = "some-parent"
+    if reason == REASON_TASK_SCOPED_REQUIRES_LINKED_TASK:
+        body["lifecycle"] = "task_scoped"
+    if reason == REASON_LINKED_TASK_NOT_FOUND:
+        body["lifecycle"] = "task_scoped"
+        body["linked_task_id"] = "task-ghost"
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/v1/subnets",
+            headers={"Authorization": "Bearer owner-key"},
+            json=body,
+        )
+
+    assert r.status_code == expected_status, r.text
+    payload = r.json()
+    assert payload["error_code"] == expected_code
+    assert payload["details"]["reason"] == reason
+    # Agent-side join must NOT fire when the create fails.
+    stub_agent_service.join_subnet.assert_not_awaited()
+
+
+def test_create_subnet_happy_path_with_nesting(stub_agent_service):
+    """Successful create with all three new fields surfaces them in
+    the gateway response chain and triggers the agent-side join."""
+    subnet_svc = AsyncMock()
+
+    async def _create(**kwargs):
+        return _make_subnet_entity(
+            subnet_id=kwargs["subnet_id"],
+            owner=kwargs["owner"],
+            parent_subnet_id=kwargs.get("parent_subnet_id"),
+            lifecycle=kwargs.get("lifecycle", "persistent"),
+            linked_task_id=kwargs.get("linked_task_id"),
+        )
+
+    subnet_svc.create_subnet = AsyncMock(side_effect=_create)
+    _wire(stub_agent_service, subnet_svc)
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/v1/subnets",
+            headers={"Authorization": "Bearer owner-key"},
+            json={
+                "name": "Bug Squad",
+                "subnet_id": "squad-1",
+                "parent_subnet_id": "parent-1",
+                "lifecycle": "task_scoped",
+                "linked_task_id": "task-42",
+            },
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["subnet_id"] == "squad-1"
+    # Service was called with the three nesting fields wired through
+    subnet_svc.create_subnet.assert_awaited_once()
+    call_kwargs = subnet_svc.create_subnet.await_args.kwargs
+    assert call_kwargs["parent_subnet_id"] == "parent-1"
+    assert call_kwargs["lifecycle"] == "task_scoped"
+    assert call_kwargs["linked_task_id"] == "task-42"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/subnets?parent=<id> — filter + ACL
+# ---------------------------------------------------------------------------
+
+
+class TestListSubnetsParentFilter:
+    def test_parent_filter_returns_children(self, stub_agent_service):
+        children = [
+            _make_subnet_entity(
+                subnet_id="child-1",
+                owner="agent-target",
+                parent_subnet_id="parent-1",
+            ),
+            _make_subnet_entity(
+                subnet_id="child-2",
+                owner="agent-target",
+                parent_subnet_id="parent-1",
+            ),
+        ]
+        subnet_svc = AsyncMock()
+        subnet_svc.list_children = AsyncMock(return_value=children)
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.get("/api/v1/subnets?parent=parent-1")
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["count"] == 2
+        ids = {s["subnet_id"] for s in body["subnets"]}
+        assert ids == {"child-1", "child-2"}
+        # ACL: anonymous → requester_id=None
+        subnet_svc.list_children.assert_awaited_once_with(
+            parent_subnet_id="parent-1", requester_id=None
+        )
+
+    def test_parent_filter_no_existence_leak_returns_empty(
+        self, stub_agent_service
+    ):
+        """Unknown parent returns ``{"count": 0, "subnets": []}`` —
+        same shape as a legitimate no-children result."""
+        subnet_svc = AsyncMock()
+        subnet_svc.list_children = AsyncMock(return_value=[])
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.get("/api/v1/subnets?parent=missing-parent")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"count": 0, "subnets": []}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/subnets/{id}/children
+# ---------------------------------------------------------------------------
+
+
+class TestGetSubnetChildren:
+    def test_children_endpoint_returns_count_and_subnets(self, stub_agent_service):
+        parent = _make_subnet_entity(subnet_id="parent-1")
+        children = [
+            _make_subnet_entity(
+                subnet_id="child-A",
+                parent_subnet_id="parent-1",
+            ),
+        ]
+        subnet_svc = AsyncMock()
+
+        async def _get_subnet(subnet_id: str):
+            if subnet_id == "parent-1":
+                return parent
+            raise SubnetNotFoundException(subnet_id)
+
+        subnet_svc.get_subnet = AsyncMock(side_effect=_get_subnet)
+        subnet_svc.list_children = AsyncMock(return_value=children)
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.get("/api/v1/subnets/parent-1/children")
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["count"] == 1
+        assert body["subnets"][0]["subnet_id"] == "child-A"
+        assert body["subnets"][0]["parent_subnet_id"] == "parent-1"
+
+    def test_children_endpoint_404_for_missing_parent(self, stub_agent_service):
+        subnet_svc = AsyncMock()
+        subnet_svc.get_subnet = AsyncMock(
+            side_effect=SubnetNotFoundException("parent-missing")
+        )
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.get("/api/v1/subnets/parent-missing/children")
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body["error_code"] == "subnet_not_found"
+        # ``list_children`` is NOT called when the parent itself is
+        # missing — confirms we 404 cleanly rather than leaking
+        # empty-list as "exists but no children".
+        subnet_svc.list_children.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/subnets/{id}/promote
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteSubnet:
+    def test_promote_returns_updated_subnet_info(self, stub_agent_service):
+        promoted = _make_subnet_entity(
+            subnet_id="squad-1",
+            parent_subnet_id="parent-1",
+            lifecycle="persistent",
+            linked_task_id=None,
+        )
+        subnet_svc = AsyncMock()
+        subnet_svc.promote_to_persistent = AsyncMock(return_value=promoted)
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/subnets/squad-1/promote",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["subnet_id"] == "squad-1"
+        assert body["lifecycle"] == "persistent"
+        assert body["linked_task_id"] is None
+        subnet_svc.promote_to_persistent.assert_awaited_once_with(
+            subnet_id="squad-1", owner="agent-target"
+        )
+
+    def test_promote_404_for_missing_subnet(self, stub_agent_service):
+        subnet_svc = AsyncMock()
+        subnet_svc.promote_to_persistent = AsyncMock(
+            side_effect=SubnetNotFoundException("squad-ghost")
+        )
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/subnets/squad-ghost/promote",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "subnet_not_found"
+
+    def test_promote_403_for_non_owner(self, stub_agent_service):
+        subnet_svc = AsyncMock()
+        subnet_svc.promote_to_persistent = AsyncMock(
+            side_effect=PermissionError("Owner mismatch")
+        )
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/subnets/squad-1/promote",
+                headers={"Authorization": "Bearer other-key"},
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "ownership_mismatch"
+
+    def test_promote_unauthenticated_rejected(self, stub_agent_service):
+        subnet_svc = AsyncMock()
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.post("/api/v1/subnets/squad-1/promote")
+
+        # API-key auth gate fires before the service is reached.
+        assert 400 <= r.status_code < 500
+        subnet_svc.promote_to_persistent.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# admin_add_subnet_member — NOT_SUBNET_MEMBER on child membership-subset
+# ---------------------------------------------------------------------------
+
+
+class TestAdminAddSubnetMemberNesting:
+    def test_admin_add_to_child_rejects_non_parent_member(
+        self, stub_agent_service, monkeypatch
+    ):
+        """The membership-subset invariant fires through the admin
+        path too. Surfaced as ``NOT_SUBNET_MEMBER`` (403), not
+        ``INVALID_REQUEST`` — see ``_nesting_error_to_acn``.
+        """
+        # Disable internal-token / acn:admin gate so the test
+        # exercises the body of the handler.
+        from acn.auth import middleware
+
+        async def _fake_authz(*args, **kwargs):
+            return {"sub": "system", "permissions": ["acn:admin"]}
+
+        monkeypatch.setattr(
+            middleware, "require_internal_or_permission", lambda _scope: _fake_authz
+        )
+
+        subnet_svc = AsyncMock()
+        subnet_svc.add_member = AsyncMock(
+            side_effect=SubnetNestingError(REASON_NOT_PARENT_MEMBER, "test")
+        )
+        _wire(stub_agent_service, subnet_svc)
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/subnets/child-1/members/bob",
+                headers={"X-Internal-Token": "test-internal-token-must-be-at-least-32-characters-long"},
+            )
+
+        assert r.status_code == 403, r.text
+        body = r.json()
+        assert body["error_code"] == "not_subnet_member"
+        assert body["details"]["reason"] == REASON_NOT_PARENT_MEMBER

--- a/tests/services/test_subnet_service_cascade.py
+++ b/tests/services/test_subnet_service_cascade.py
@@ -1,0 +1,136 @@
+"""SubnetService cascade-delete unit tests (ADR-0003 Phase 2).
+
+Pin ``delete_subnet`` of a top-level subnet cascading to children
+(``find_by_parent`` → delete each child → delete self) and the
+partial-failure breadcrumb path that refuses to delete the parent
+when a child delete fails.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.core.interfaces import ISubnetRepository
+from acn.services.subnet_service import SubnetService
+
+
+def _make_subnet(
+    subnet_id: str,
+    owner: str = "alice",
+    parent_subnet_id: str | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        parent_subnet_id=parent_subnet_id,
+        member_agent_ids={owner},
+        created_at=datetime.now(UTC),
+    )
+
+
+class TestDeleteSubnetCascade:
+    @pytest.mark.asyncio
+    async def test_top_level_deletes_children_first_then_self(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        parent = _make_subnet("parent")
+        children = [
+            _make_subnet("child-1", parent_subnet_id="parent"),
+            _make_subnet("child-2", parent_subnet_id="parent"),
+        ]
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = children
+        mock_subnet_repository.delete.return_value = True
+        service = SubnetService(mock_subnet_repository)
+
+        ok = await service.delete_subnet("parent", owner="alice")
+
+        assert ok is True
+        # Three delete() calls in order: child-1, child-2, parent.
+        delete_call_args = [
+            c.args[0] for c in mock_subnet_repository.delete.call_args_list
+        ]
+        assert delete_call_args == ["child-1", "child-2", "parent"]
+
+    @pytest.mark.asyncio
+    async def test_child_delete_no_recursive_cascade(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """When deleting a child subnet directly, the service does
+        NOT scan for grandchildren (single-layer cap means a child
+        cannot itself have children) — saves a redundant
+        ``find_by_parent`` round-trip.
+        """
+        child = _make_subnet("child-1", parent_subnet_id="parent")
+        mock_subnet_repository.find_by_id.return_value = child
+        mock_subnet_repository.delete.return_value = True
+        service = SubnetService(mock_subnet_repository)
+
+        await service.delete_subnet("child-1", owner="alice")
+
+        # Cascade only fires when ``parent_subnet_id is None``.
+        mock_subnet_repository.find_by_parent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_child_delete_failure_refuses_to_delete_parent(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """When repo.delete(child) returns False (e.g. concurrent
+        deletion), the cascade aborts BEFORE the parent delete —
+        ops will see the breadcrumb and clean up manually."""
+        parent = _make_subnet("parent")
+        children = [_make_subnet("child-1", parent_subnet_id="parent")]
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = children
+        # child delete fails, parent never reached.
+        mock_subnet_repository.delete.return_value = False
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(RuntimeError, match="Cascade delete failed"):
+            await service.delete_subnet("parent", owner="alice")
+
+        # Only the failing child delete was attempted — the parent
+        # was NOT removed (preserves a recoverable state).
+        delete_call_args = [
+            c.args[0] for c in mock_subnet_repository.delete.call_args_list
+        ]
+        assert delete_call_args == ["child-1"]
+
+    @pytest.mark.asyncio
+    async def test_top_level_with_no_children_deletes_self(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        parent = _make_subnet("lonely-parent")
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        service = SubnetService(mock_subnet_repository)
+
+        ok = await service.delete_subnet("lonely-parent", owner="alice")
+        assert ok is True
+
+        delete_call_args = [
+            c.args[0] for c in mock_subnet_repository.delete.call_args_list
+        ]
+        assert delete_call_args == ["lonely-parent"]
+
+    @pytest.mark.asyncio
+    async def test_reserved_subnet_cannot_be_deleted(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Cascade entry-point still blocks delete of reserved IDs."""
+        # Reserved subnets must have owner="system" (entity
+        # invariant), so we build it explicitly here.
+        public_subnet = Subnet(
+            subnet_id="public",
+            name="Public",
+            owner="system",
+        )
+        mock_subnet_repository.find_by_id.return_value = public_subnet
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(PermissionError, match="Cannot delete system subnet"):
+            await service.delete_subnet("public", owner="system")
+        mock_subnet_repository.delete.assert_not_called()

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -1,0 +1,503 @@
+"""SubnetService nesting unit tests (ADR-0003 Phase 2).
+
+Pin the five invariant rejections + membership-subset enforcement +
+``promote_to_persistent`` idempotency / owner-only ACL at the service
+layer. Repository is mocked so these are pure service-logic tests.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.core.interfaces import ISubnetRepository
+from acn.core.interfaces.task_repository import ITaskRepository
+from acn.services.subnet_service import (
+    REASON_LINKED_TASK_NOT_FOUND,
+    REASON_NOT_PARENT_MEMBER,
+    REASON_PARENT_IS_NESTED,
+    REASON_PARENT_IS_RESERVED,
+    REASON_PARENT_NOT_FOUND,
+    REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
+    SubnetNestingError,
+    SubnetService,
+)
+
+
+def _make_parent_subnet(
+    subnet_id: str = "parent",
+    owner: str = "alice",
+    members: set[str] | None = None,
+    parent_subnet_id: str | None = None,
+) -> Subnet:
+    """Build a parent ``Subnet`` entity for repository mocks.
+
+    Defaults to a top-level subnet owned by ``alice`` with just the
+    owner as a member. Override ``members`` to seed extra agents.
+    """
+    members = members or {owner}
+    return Subnet(
+        subnet_id=subnet_id,
+        name=f"Subnet {subnet_id}",
+        owner=owner,
+        member_agent_ids=members,
+        parent_subnet_id=parent_subnet_id,
+        created_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_subnet — five invariant rejections
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSubnetNestingInvariants:
+    @pytest.mark.asyncio
+    async def test_parent_not_found(self, mock_subnet_repository: ISubnetRepository):
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = None
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="child-1",
+                name="Squad",
+                owner="alice",
+                parent_subnet_id="missing-parent",
+            )
+        assert exc.value.reason == REASON_PARENT_NOT_FOUND
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_parent_is_reserved_public(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        mock_subnet_repository.exists.return_value = False
+        # Even if ``find_by_id`` returns *something*, the ID-based
+        # check rejects ``public``/``system`` parents up-front so
+        # we don't need to mock a reserved subnet entity.
+        service = SubnetService(mock_subnet_repository)
+        # Wire find_by_id to return a stub so the ID check is what
+        # rejects, not the existence check.
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="public", owner="system"
+        )
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="child-1",
+                name="Squad",
+                owner="alice",
+                parent_subnet_id="public",
+            )
+        assert exc.value.reason == REASON_PARENT_IS_RESERVED
+
+    @pytest.mark.asyncio
+    async def test_parent_is_reserved_by_owner(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Defence-in-depth: any subnet owned by ``system`` is treated
+        as a reserved parent even if its ID isn't on the literal
+        ``public``/``system`` list (future reserved subnets)."""
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="custom-system-subnet", owner="system"
+        )
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="child-1",
+                name="Squad",
+                owner="alice",
+                parent_subnet_id="custom-system-subnet",
+            )
+        assert exc.value.reason == REASON_PARENT_IS_RESERVED
+
+    @pytest.mark.asyncio
+    async def test_parent_is_nested(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Single-layer cap — the parent must itself be top-level."""
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="mid-level",
+            owner="alice",
+            parent_subnet_id="grand-parent",
+        )
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="grandchild",
+                name="Too deep",
+                owner="alice",
+                parent_subnet_id="mid-level",
+            )
+        assert exc.value.reason == REASON_PARENT_IS_NESTED
+
+    @pytest.mark.asyncio
+    async def test_task_scoped_requires_linked_task(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        mock_subnet_repository.exists.return_value = False
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="task-squad",
+                name="Task Squad",
+                owner="alice",
+                lifecycle="task_scoped",
+                linked_task_id=None,
+            )
+        assert exc.value.reason == REASON_TASK_SCOPED_REQUIRES_LINKED_TASK
+        # Service rejects before any repository write.
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_linked_task_not_found(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        mock_subnet_repository.exists.return_value = False
+        # We allow parent_subnet_id=None for this case — the
+        # linked_task_id check is independent of parenting.
+        mock_task_repository = AsyncMock(spec=ITaskRepository)
+        mock_task_repository.exists.return_value = False
+        service = SubnetService(
+            mock_subnet_repository, task_repository=mock_task_repository
+        )
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.create_subnet(
+                subnet_id="task-squad",
+                name="Task Squad",
+                owner="alice",
+                lifecycle="task_scoped",
+                linked_task_id="task-missing",
+            )
+        assert exc.value.reason == REASON_LINKED_TASK_NOT_FOUND
+        mock_task_repository.exists.assert_awaited_once_with("task-missing")
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_linked_task_check_skipped_when_no_task_repository(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Backward-compat: legacy fixtures without ``task_repository``
+        skip the existence check entirely (still required to pair
+        ``task_scoped`` with a non-None ``linked_task_id``, but the
+        task itself isn't verified). Production wiring in
+        ``api.py`` always supplies one."""
+        mock_subnet_repository.exists.return_value = False
+        service = SubnetService(mock_subnet_repository)
+
+        # No exception even though no task repository is wired.
+        subnet = await service.create_subnet(
+            subnet_id="task-squad",
+            name="Task Squad",
+            owner="alice",
+            lifecycle="task_scoped",
+            linked_task_id="task-unverified",
+        )
+        assert subnet.linked_task_id == "task-unverified"
+        assert subnet.lifecycle == "task_scoped"
+        mock_subnet_repository.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_child_subnet(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Valid nested + task_scoped create — service writes through."""
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="parent-1", owner="alice", members={"alice", "bob"}
+        )
+        mock_task_repository = AsyncMock(spec=ITaskRepository)
+        mock_task_repository.exists.return_value = True
+        service = SubnetService(
+            mock_subnet_repository, task_repository=mock_task_repository
+        )
+
+        subnet = await service.create_subnet(
+            subnet_id="squad-1",
+            name="Bug Squad",
+            owner="alice",
+            parent_subnet_id="parent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+
+        assert subnet.parent_subnet_id == "parent-1"
+        assert subnet.lifecycle == "task_scoped"
+        assert subnet.linked_task_id == "task-42"
+        # Owner-as-member invariant preserved for child subnets too.
+        assert "alice" in subnet.member_agent_ids
+        mock_subnet_repository.save.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# add_member — membership-subset invariant
+# ---------------------------------------------------------------------------
+
+
+class TestAddMemberMembershipSubset:
+    @pytest.mark.asyncio
+    async def test_add_to_child_rejects_non_parent_member(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """``add_member`` on a child subnet rejects agents who aren't
+        already members of the parent (ADR-0003 §A invariant 2)."""
+        child = _make_parent_subnet(
+            subnet_id="child-1",
+            owner="alice",
+            parent_subnet_id="parent-1",
+        )
+        parent = _make_parent_subnet(
+            subnet_id="parent-1",
+            owner="alice",
+            members={"alice"},  # bob is NOT in the parent
+        )
+        # find_by_id called twice: once for ``get_subnet(child)``,
+        # once for ``find_by_id(parent_subnet_id)`` inside add_member.
+        mock_subnet_repository.find_by_id.side_effect = [child, parent]
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.add_member("child-1", "bob")
+        assert exc.value.reason == REASON_NOT_PARENT_MEMBER
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_to_child_accepts_parent_member(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        child = _make_parent_subnet(
+            subnet_id="child-1",
+            owner="alice",
+            parent_subnet_id="parent-1",
+        )
+        parent = _make_parent_subnet(
+            subnet_id="parent-1",
+            owner="alice",
+            members={"alice", "bob"},  # bob IS in the parent
+        )
+        mock_subnet_repository.find_by_id.side_effect = [child, parent]
+        service = SubnetService(mock_subnet_repository)
+
+        updated = await service.add_member("child-1", "bob")
+
+        assert "bob" in updated.member_agent_ids
+        mock_subnet_repository.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_add_to_orphan_child_rejects(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Parent has been deleted out from under us — refuse the
+        add rather than silently bypass the subset invariant. Ops
+        should ``delete_subnet`` the orphan."""
+        child = _make_parent_subnet(
+            subnet_id="child-1",
+            owner="alice",
+            parent_subnet_id="parent-gone",
+        )
+        mock_subnet_repository.find_by_id.side_effect = [child, None]
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetNestingError) as exc:
+            await service.add_member("child-1", "bob")
+        assert exc.value.reason == REASON_NOT_PARENT_MEMBER
+
+    @pytest.mark.asyncio
+    async def test_add_to_top_level_subnet_unchanged(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Top-level subnets (no parent) skip the subset check entirely."""
+        top = _make_parent_subnet(subnet_id="top", owner="alice")
+        mock_subnet_repository.find_by_id.return_value = top
+        service = SubnetService(mock_subnet_repository)
+
+        updated = await service.add_member("top", "newbie")
+
+        assert "newbie" in updated.member_agent_ids
+        mock_subnet_repository.save.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# list_children — ACL parity with list_subnets
+# ---------------------------------------------------------------------------
+
+
+class TestListChildrenACL:
+    @pytest.mark.asyncio
+    async def test_anonymous_sees_only_public_children(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        children = [
+            Subnet(
+                subnet_id="public-child",
+                name="Public",
+                owner="alice",
+                is_private=False,
+                parent_subnet_id="parent-1",
+                member_agent_ids={"alice"},
+            ),
+            Subnet(
+                subnet_id="private-child",
+                name="Private",
+                owner="alice",
+                is_private=True,
+                parent_subnet_id="parent-1",
+                member_agent_ids={"alice"},
+            ),
+        ]
+        mock_subnet_repository.find_by_parent.return_value = children
+        service = SubnetService(mock_subnet_repository)
+
+        result = await service.list_children("parent-1", requester_id=None)
+        ids = {c.subnet_id for c in result}
+        assert ids == {"public-child"}
+
+    @pytest.mark.asyncio
+    async def test_member_sees_private_child_they_belong_to(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        children = [
+            Subnet(
+                subnet_id="private-mine",
+                name="Mine",
+                owner="alice",
+                is_private=True,
+                parent_subnet_id="parent-1",
+                member_agent_ids={"alice", "bob"},
+            ),
+            Subnet(
+                subnet_id="private-theirs",
+                name="Theirs",
+                owner="carol",
+                is_private=True,
+                parent_subnet_id="parent-1",
+                member_agent_ids={"carol"},
+            ),
+        ]
+        mock_subnet_repository.find_by_parent.return_value = children
+        service = SubnetService(mock_subnet_repository)
+
+        result = await service.list_children("parent-1", requester_id="bob")
+        ids = {c.subnet_id for c in result}
+        # Bob sees "private-mine" (member) but not "private-theirs".
+        assert ids == {"private-mine"}
+
+    @pytest.mark.asyncio
+    async def test_no_existence_leak_for_unknown_parent(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Unknown parent returns empty — same shape as legitimate
+        no-children result."""
+        mock_subnet_repository.find_by_parent.return_value = []
+        service = SubnetService(mock_subnet_repository)
+
+        result = await service.list_children("never-existed", requester_id="bob")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# promote_to_persistent — owner-only + idempotent
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteToPersistent:
+    @pytest.mark.asyncio
+    async def test_promote_flips_lifecycle_and_clears_linked_task(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        subnet = Subnet(
+            subnet_id="squad-1",
+            name="Squad",
+            owner="alice",
+            parent_subnet_id="parent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        mock_subnet_repository.find_by_id.return_value = subnet
+        service = SubnetService(mock_subnet_repository)
+
+        updated = await service.promote_to_persistent("squad-1", owner="alice")
+
+        assert updated.lifecycle == "persistent"
+        assert updated.linked_task_id is None
+        mock_subnet_repository.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_promote_already_persistent_is_idempotent(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Idempotent — no repository write, no error."""
+        subnet = Subnet(
+            subnet_id="persistent-1",
+            name="Persistent",
+            owner="alice",
+            lifecycle="persistent",
+        )
+        mock_subnet_repository.find_by_id.return_value = subnet
+        service = SubnetService(mock_subnet_repository)
+
+        result = await service.promote_to_persistent(
+            "persistent-1", owner="alice"
+        )
+        assert result.lifecycle == "persistent"
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_promote_owner_mismatch_raises_permission_error(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        subnet = Subnet(
+            subnet_id="squad-1",
+            name="Squad",
+            owner="alice",
+            parent_subnet_id="parent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        mock_subnet_repository.find_by_id.return_value = subnet
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(PermissionError):
+            await service.promote_to_persistent("squad-1", owner="mallory")
+        mock_subnet_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_promote_does_not_check_owner_parent_membership(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """ADR-0003 semantic decision #4: promote is a pure field
+        flip authorised by owner-only ACL. The owner is NOT
+        required to currently be a member of the parent subnet.
+
+        Regression target: a previous draft attempted to enforce a
+        ``parent.is_member(owner)`` check here, which broke
+        delegated-admin flows (squad created by a moderator who is
+        not themselves a parent member).
+        """
+        # Repository ``find_by_id`` is only called once — for the
+        # subnet being promoted. The parent is never fetched.
+        subnet = Subnet(
+            subnet_id="squad-1",
+            name="Squad",
+            owner="alice",
+            parent_subnet_id="parent-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        mock_subnet_repository.find_by_id.return_value = subnet
+        service = SubnetService(mock_subnet_repository)
+
+        result = await service.promote_to_persistent("squad-1", owner="alice")
+
+        assert result.lifecycle == "persistent"
+        # Critical: only ONE find_by_id call (for the subnet) —
+        # confirms no parent lookup happened.
+        assert mock_subnet_repository.find_by_id.await_count == 1


### PR DESCRIPTION
## Summary

Phase 2 of [ADR-0003 single-layer subnet nesting](../blob/main/docs/adr/0003-subnet-nesting-single-layer.md), tracked in #50. Opens the full **service / route / CLI / Python-SDK** surface and enforces every ADR-0003 §A invariant.

Phase 1 (#52) merged into `main` as 91c0402 + 11d1b49; this branch rebased on top.

Out of scope (deferred to Phase 3 / #51): task-state-machine cascade on terminal task states + webhook payload `parent_subnet_id` extension.

## Acceptance criteria covered

### Service (`acn/services/subnet_service.py`)
- [x] `SubnetService.__init__` gains optional `task_repository` dep; wired in `api.py` lifespan
- [x] `create_subnet` accepts `parent_subnet_id` / `lifecycle` / `linked_task_id`
- [x] Five rejection variants emit `SubnetNestingError` with stable `reason` tokens:
  - `parent_not_found` / `parent_is_reserved` / `parent_is_nested`
  - `task_scoped_requires_linked_task` / `linked_task_not_found`
- [x] `add_member` rejects non-parent members on child subnets (`not_parent_member`)
- [x] `delete_subnet` cascades children; partial failure refuses to delete parent + logs audit breadcrumb
- [x] `list_children(parent_subnet_id, *, requester_id=None)` — ACL aligned with `list_subnets`
- [x] `promote_to_persistent(subnet_id, owner)` — owner-only, idempotent, no parent-membership check (ADR §4)

### Routes (`acn/routes/subnets.py`)
- [x] `POST /api/v1/subnets` accepts three new fields; five rejection variants → `INVALID_REQUEST` (400) with `details.reason`
- [x] `GET /api/v1/subnets?parent=<id>` filter — same visibility as `list_subnets`
- [x] `GET /api/v1/subnets/{id}/children` — `{count, subnets}` shape; 404 on missing parent
- [x] `POST /api/v1/subnets/{id}/promote` — owner-only; 403 `OWNERSHIP_MISMATCH` for others
- [x] `parent_subnet_id` is NOT exposed via any PATCH (immutable after creation per ADR §5)
- [x] `do_join_subnet` pre-checks child membership-subset to avoid half-joined state; rolls back agent-side on rare race

### CLI (`clients/cli/src/commands/subnet.ts`)
- [x] `acn subnet create --parent <id> --task <id> --lifecycle persistent|task_scoped` with client-side pre-checks
- [x] `acn subnet list --parent <id>` filter
- [x] `acn subnet promote <subnet_id>` new verb
- [x] `formatSubnet` surfaces hierarchy / lifecycle hints

### Python SDK (`clients/python/acn_client/`)
- [x] `SubnetInfo` / `SubnetCreateRequest` gain the three optional fields with back-compat defaults
- [x] `Client.list_subnets(parent_subnet_id=...)` filter
- [x] `Client.list_children(parent_subnet_id) -> list[SubnetInfo]`
- [x] `Client.promote_subnet(subnet_id) -> SubnetInfo`
- [x] `Client.create_subnet` accepts the new params via the existing `SubnetCreateRequest` shape

### Tests (Python)
- [x] `tests/services/test_subnet_service_nesting.py` — five rejection variants + membership-subset + promote (idempotency, owner-only, no parent-membership check)
- [x] `tests/services/test_subnet_service_cascade.py` — cascade ordering + partial-failure refusal + reserved-subnet guard
- [x] `tests/routes/test_subnets_nesting.py` — parametric rejection pins + happy nesting path + parent filter + `/children` + `/promote`
- [x] `clients/python/tests/test_subnet_nesting.py` — model round-trip + back-compat + four `Client` methods

## Test plan

- [x] `pytest tests/services/test_subnet_service*.py tests/core/ tests/infrastructure/test_subnet_repository_redis_*.py tests/infrastructure/test_postgres_subnet_repository_nesting.py tests/infrastructure/test_alembic_subnet_nesting_migration.py tests/routes/test_subnets_*.py` — 202 passed
- [x] `pytest clients/python/tests/test_subnet_nesting.py` — 9 passed
- [x] `pytest tests/routes/test_agent_subnets.py tests/services/test_org_harness.py -k 'subnet or harness'` — 43 passed (regression sweep)
- [x] `ruff check` — clean on all touched paths
- [x] `basedpyright` — 0 errors on service / routes / models / api
- [x] CLI `npm run typecheck` — clean (no test infra yet; tracked as follow-up)

## Backward compatibility

- New fields default to flat-persistent semantics; older servers / clients see the legacy shape
- Legacy `MagicMock`-based stub subnets in existing route tests continue to work via `_coerce_optional_str` / `_coerce_lifecycle` boundary helpers + `isinstance` guards
- No PATCH surface exposes `parent_subnet_id` — immutable after creation per ADR
- All five new error tokens are documented as the public contract; CLI / SDK error parsers can pin against them

## Known limitations (intentional, tracked separately)

- **#54 — PG transactional cascade.** Issue #50 acceptance asked for `delete_subnet`
  to run as a single PG transaction (parent rolls back on child failure). Phase 2 ships
  sequential best-effort on both backends (`ISubnetRepository.delete` is single-statement);
  partial failure refuses to delete the parent and logs `delete_subnet_cascade_partial`.
  Atomic PG path needs a new `delete_with_children` (or UoW seam) on the repository —
  tracked in #54.
- **#55 — CLI test infrastructure.** The CLI ships TypeScript type checks only; no
  vitest infra exists yet. New subnet commands (`--parent` / `--lifecycle` / `promote`)
  are covered by manual smoke + Python route tests. Standing up vitest tracked in #55.
- **#56 — `delete_subnet` back-reference cleanup.** Pre-existing quirk: `delete_subnet`
  removes the subnet record but does not clear `agent.subnet_ids` on each member.
  Cascade amplifies the surface area; remediation tracked in #56.

## Self-review hardenings (commit 8860eb7)

Two additional fixes pushed after self-review:

- `SubnetService.promote_to_persistent` now builds the promoted entity via
  `dataclasses.replace` so the entity's `__post_init__` re-validates the
  final state (catches future invariant additions automatically; no more
  transient half-valid window)
- `_coerce_lifecycle` in `routes/subnets.py` explicitly accepts both valid
  literals and emits `subnet_info_unexpected_lifecycle` warning on real
  string outliers (MagicMock stubs still degrade silently — non-str branch)

## Follow-ups (out of scope)

- **Phase 3 (#51)** — task-state-machine cascade + webhook `parent_subnet_id` payload extension
- **#54** PG transactional cascade
- **#55** CLI test infrastructure
- **#56** `delete_subnet` back-reference cleanup

Closes #50.

Made with [Cursor](https://cursor.com)
