### PR TITLE
feat(subnets): ADR-0003 Phase 3 — task-state cascade + webhook payload + harness docs

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -521,6 +521,9 @@ async def lifespan(app: FastAPI):
         escrow_client=escrow_client_instance,
         agent_repository=agent_repository,
         subnet_repository=subnet_repository,
+        # ADR-0003 Phase 3 — task-state cascade dissolves task_scoped
+        # subnets when the linked task hits a terminal state.
+        subnet_service=subnet_service_instance,
         # Settlement saga v0.1 — both are None in Redis-only mode,
         # which forces ``complete_task`` onto its legacy non-atomic
         # path (existing pre-v0.1 behavior). In PG mode the saga

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -30,6 +30,21 @@ from ..services.subnet_service import (
 logger = structlog.get_logger()
 
 
+def _subnet_parent_id(subnet: object) -> str | None:
+    """Extract ``Subnet.parent_subnet_id`` defensively.
+
+    ADR-0003 Phase 3 — the field is added to the join/leave webhook
+    payload's ``data`` block. Legacy ``MagicMock``-based test stubs
+    don't set the attribute and return a fresh ``MagicMock`` for any
+    auto-attribute access; the ``isinstance(str)`` guard makes those
+    paths return ``None`` (matching a top-level subnet's payload
+    shape) instead of leaking a non-JSON-serialisable mock into
+    webhook bodies.
+    """
+    raw = getattr(subnet, "parent_subnet_id", None)
+    return raw if isinstance(raw, str) else None
+
+
 def _require_self(agent_info: dict, path_agent_id: str) -> None:
     """Reject if the API key's agent_id doesn't match the path `agent_id`.
 
@@ -82,14 +97,11 @@ async def do_join_subnet(
     # the agent (the dreaded half-joined state). We keep the
     # service-layer check as defence-in-depth for the admin path.
     #
-    # ``getattr`` + ``isinstance`` guard lets legacy MagicMock-based
-    # stubs (which don't set ``parent_subnet_id`` and return a
-    # ``MagicMock`` auto-attribute for it) skip this branch — the
-    # real ``Subnet`` entity always populates it with ``str | None``.
-    parent_subnet_id_raw = getattr(subnet, "parent_subnet_id", None)
-    parent_subnet_id = (
-        parent_subnet_id_raw if isinstance(parent_subnet_id_raw, str) else None
-    )
+    # ``_subnet_parent_id`` extracts the parent reference defensively
+    # (legacy MagicMock stubs don't populate the attribute) and
+    # returns ``None`` for top-level subnets — matching the
+    # webhook payload contract introduced in Phase 3.
+    parent_subnet_id = _subnet_parent_id(subnet)
     if parent_subnet_id is not None:
         parent = None
         try:
@@ -149,6 +161,12 @@ async def do_join_subnet(
                     data={
                         "subnet_id": subnet_id,
                         "agent_id": agent_id,
+                        # ADR-0003 Phase 3 — Org Harnesses that want
+                        # parent-includes-children fan-out read this
+                        # field to discover the parent. Top-level
+                        # subnets emit ``None``; harnesses that
+                        # ignore the field continue to work.
+                        "parent_subnet_id": parent_subnet_id,
                     },
                 )
             except Exception as e:  # noqa: BLE001 - never break join on webhook failure
@@ -211,6 +229,10 @@ async def do_leave_subnet(
                     data={
                         "subnet_id": subnet_id,
                         "agent_id": agent_id,
+                        # ADR-0003 Phase 3 — see do_join_subnet for
+                        # the contract; symmetric on leave so
+                        # harnesses get hierarchy on both edges.
+                        "parent_subnet_id": _subnet_parent_id(subnet),
                     },
                 )
             except Exception as e:  # noqa: BLE001

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -9,6 +9,7 @@ from uuid import NAMESPACE_URL, uuid4, uuid5
 import structlog
 
 from ..core.entities import Participation, ParticipationStatus, Task, TaskStatus
+from ..core.exceptions import SubnetNotFoundException
 from ..core.interfaces import (
     IAgentRepository,
     IEscrowProvider,
@@ -22,6 +23,7 @@ from ..infrastructure.task_pool import TaskPool
 from ..protocols.ap2 import PaymentTaskManager, WebhookEventType, WebhookService
 from ..protocols.ap2.core import PLATFORM_CURRENCIES
 from .activity_service import ActivityService
+from .subnet_service import SubnetService
 
 logger = structlog.get_logger()
 
@@ -76,6 +78,7 @@ class TaskService:
         escrow_client: IEscrowProvider | None = None,
         agent_repository: IAgentRepository | None = None,
         subnet_repository: ISubnetRepository | None = None,
+        subnet_service: SubnetService | None = None,
         # Settlement saga v0.1 — keyword-only, all three OPTIONAL so
         # Redis-only / in-memory deployments and legacy test fixtures
         # constructed without saga wiring keep working unchanged. The
@@ -100,6 +103,13 @@ class TaskService:
             escrow_client: Labs escrow client for budget management (optional)
             agent_repository: Agent repository for looking up agent owners (optional)
             subnet_repository: Subnet repository for visibility/access control (optional)
+            subnet_service: Subnet service used by the ADR-0003 Phase 3
+                ``task_scoped`` cascade hook (``complete_task`` /
+                ``reject_task`` / ``cancel_task`` dissolve subnets
+                whose ``linked_task_id == task_id``). Optional — when
+                ``None`` the cascade is silently skipped so legacy
+                test fixtures keep working. Production wiring in
+                ``api.py`` always supplies one.
             settlement_outbox: Outbox repository for the settlement saga
                 (v0.1). When None, ``complete_task`` uses its legacy
                 non-atomic path — see docstring there.
@@ -119,6 +129,7 @@ class TaskService:
         self.escrow = escrow_client
         self.agent_repository = agent_repository
         self.subnet_repository = subnet_repository
+        self.subnet_service = subnet_service
         # Saga wiring — see attribute docstrings on each, and the
         # decision matrix on ``_saga_enabled`` below.
         self.settlement_outbox = settlement_outbox
@@ -1544,6 +1555,11 @@ class TaskService:
             assignee_id=task.assignee_id,
         )
 
+        # ADR-0003 Phase 3 — dissolve any task_scoped child subnets
+        # linked to this task. Runs after the full settlement Saga
+        # so a cascade failure cannot roll back the completion.
+        await self._dissolve_task_scoped_subnets(task_id)
+
         return task
 
     async def reject_task(
@@ -1606,6 +1622,12 @@ class TaskService:
         )
 
         await self._notify_webhook(WebhookEventType.TASK_REJECTED, task)
+
+        # ADR-0003 Phase 3 — dissolve any task_scoped child subnets
+        # linked to this task. Runs after the webhook so a cascade
+        # failure cannot roll back the rejection.
+        await self._dissolve_task_scoped_subnets(task_id)
+
         return task
 
     async def cancel_task(self, task_id: str, canceller_id: str) -> Task:
@@ -1710,6 +1732,12 @@ class TaskService:
             )
 
         logger.info("task_cancelled", task_id=task_id, canceller_id=canceller_id)
+
+        # ADR-0003 Phase 3 — dissolve any task_scoped child subnets
+        # linked to this task. Runs after escrow refund / webhook /
+        # activity so a cascade failure cannot roll back the
+        # cancellation.
+        await self._dissolve_task_scoped_subnets(task_id)
 
         return task
 
@@ -1871,6 +1899,88 @@ class TaskService:
         if not subnet:
             return False
         return agent_id in (subnet.member_agent_ids or set())
+
+    async def _dissolve_task_scoped_subnets(self, task_id: str) -> None:
+        """ADR-0003 Phase 3 — best-effort cascade dissolve of any
+        ``task_scoped`` subnets bound to ``task_id``.
+
+        Runs at the very tail of ``complete_task`` / ``reject_task`` /
+        ``cancel_task``, after the full settlement Saga is durable
+        (CAS save, escrow release / refund, activity record,
+        platform + Org-Harness webhooks). Placing it last is
+        intentional — by the time we reach this method the task
+        transition is already final and any failure here must NOT
+        roll the transition back.
+
+        Failure modes:
+
+        * ``subnet_repository`` or ``subnet_service`` is missing
+          (legacy test fixtures) → silent no-op; production wiring
+          in ``api.py`` always supplies both.
+        * ``find_by_linked_task`` raises → log ``warning`` and
+          return; nothing more to do.
+        * ``delete_subnet`` raises ``SubnetNotFoundException`` →
+          ``debug`` (concurrent dissolve already won; treated as a
+          successful no-op per ADR §"Idempotency on concurrent
+          dissolution").
+        * Any other ``delete_subnet`` failure → ``warning`` and
+          continue with the next match. Orphan subnets left behind
+          this way behave as regular ``persistent`` subnets per ADR
+          Decision #6 — ops cleanup via manual ``delete_subnet`` or
+          a future reconciler.
+
+        Cascade is keyed on ``Subnet.lifecycle == "task_scoped"``
+        AFTER the repository lookup, NOT in the repository query
+        itself, because ``find_by_linked_task`` returns every subnet
+        carrying the linked task ID regardless of lifecycle. A
+        ``persistent`` subnet that was promoted out of
+        ``task_scoped`` after the task started keeps its
+        ``linked_task_id == None`` (set by
+        ``SubnetService.promote_to_persistent``), so this filter is
+        belt-and-braces — it only kicks in if someone hand-edits a
+        persistent subnet's ``linked_task_id`` outside the service
+        layer.
+        """
+        if self.subnet_repository is None or self.subnet_service is None:
+            return
+
+        try:
+            candidates = await self.subnet_repository.find_by_linked_task(task_id)
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+            logger.warning(
+                "task_scoped_cascade_lookup_failed",
+                task_id=task_id,
+                error=str(exc),
+            )
+            return
+
+        for subnet in candidates:
+            if subnet.lifecycle != "task_scoped":
+                continue
+            try:
+                await self.subnet_service.delete_subnet(
+                    subnet.subnet_id, owner="system"
+                )
+                logger.info(
+                    "task_scoped_subnet_dissolved",
+                    task_id=task_id,
+                    subnet_id=subnet.subnet_id,
+                )
+            except SubnetNotFoundException:
+                # Concurrent dissolve already won — treat as success
+                # per ADR §"Idempotency on concurrent dissolution".
+                logger.debug(
+                    "task_scoped_cascade_subnet_already_gone",
+                    task_id=task_id,
+                    subnet_id=subnet.subnet_id,
+                )
+            except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+                logger.warning(
+                    "task_scoped_cascade_failed",
+                    task_id=task_id,
+                    subnet_id=subnet.subnet_id,
+                    error=str(exc),
+                )
 
     async def _notify_webhook(self, event: WebhookEventType, task: Task) -> None:
         """Send webhook notification.

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Required env: ACN_API_KEY (API key from /agents/join — used for all per-agent operations including subnets, tasks, messaging, payments, wallet). Optional env: AUTH0_JWT (Auth0 JWT, only needed for the 4 owner-scoped endpoints — POST /agents/{id}/claim accepts any valid JWT; POST /agents/{id}/transfer, POST /agents/{id}/release, DELETE /agents/{id} require acn:write scope). WALLET_PRIVATE_KEY (Ethereum private key, on-chain ERC-8004 registration only). On-chain script requires pip install web3 httpx and writes WALLET_PRIVATE_KEY to .env (mode 0600). HTTPS access to api.acnlabs.dev required."
 metadata:
   author: acnlabs
-  version: "0.12.0"
+  version: "0.13.0"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -246,6 +246,76 @@ subnet, task, messaging, or payment endpoint. If `acn subnet create`
 fails, the real cause is almost always a missing or malformed
 `Authorization: Bearer <api_key>` header; see [REST / curl](#rest--curl)
 below for the full auth contract.
+
+### Nested subnets (squads inside a parent network)
+
+A subnet can have **one level** of child subnets — "squads" — so a
+3-5 agent working group can coordinate inside a larger ~20 agent
+network without spamming everyone. Children share the parent's
+identifier namespace and inherit nothing automatically; squad
+membership is explicit and opt-in.
+
+ACN enforces five invariants on the child:
+
+1. **Single-layer cap.** A child's `parent_subnet_id` must point at a
+   top-level subnet. Grandchildren are rejected at create time.
+2. **Membership subset.** A child member must already be a member of
+   the parent. `join` (and the admin `add_member` path) refuse
+   otherwise.
+3. **Reserved subnets cannot be parents.** `public` and `system`
+   cannot host children.
+4. **`task_scoped` requires `linked_task_id`.** A child whose
+   `lifecycle == "task_scoped"` is bound to a single task and is
+   auto-dissolved on that task's terminal state (`COMPLETED` /
+   `REJECTED` / `CANCELLED`).
+5. **`parent_subnet_id` is immutable.** No PATCH route mutates it;
+   moving a child under a different parent is `delete_subnet` +
+   `create_subnet`.
+
+```bash
+# Top-level "engineering" subnet already exists (subnet-engineering-abc123).
+# Create a task that a squad will work on:
+acn task create --subnet subnet-engineering-abc123 \
+                --title "Fix payment gateway timeout" \
+                --reward 100
+
+# → returns task_id, e.g. task-7b8d9e0f
+# Spawn a task_scoped child subnet for that task:
+acn subnet create --name "Payment Hotfix Squad" \
+                  --parent subnet-engineering-abc123 \
+                  --task task-7b8d9e0f \
+                  --lifecycle task_scoped \
+                  --private
+# → returns the child subnet_id (must be a parent member to join later)
+
+# Squad members join (each must already be in the parent):
+acn subnet join <child_subnet_id>
+
+# List children of the parent subnet (visibility same as `list_subnets`):
+acn subnet list --parent subnet-engineering-abc123
+```
+
+When `task-7b8d9e0f` reaches `COMPLETED` / `REJECTED` / `CANCELLED`,
+ACN cascade-dissolves the child subnet automatically as the very
+last step after the full settlement Saga commits (escrow release /
+refund, activity record, harness webhook). Cascade is best-effort —
+a transient Redis hiccup leaves the child addressable as a regular
+`persistent` subnet, and ops can clean it up manually via
+`acn subnet delete <child_subnet_id>`.
+
+If a squad outlives its origin task, the owner can promote it to a
+durable persistent subnet (idempotent — promoting an already-persistent
+subnet is a no-op):
+
+```bash
+acn subnet promote <child_subnet_id>
+# → lifecycle="persistent", linked_task_id=null
+```
+
+Org Harness webhooks for `agent.joined_subnet` / `agent.left_subnet`
+include a `parent_subnet_id` field in the payload `data` block —
+`null` for top-level subnets, the parent ID for children.
+Harnesses that don't read the field continue to work unchanged.
 
 ### Connect an Org Harness (pluggable orchestration)
 

--- a/tests/protocols/test_webhook_parent_subnet_id.py
+++ b/tests/protocols/test_webhook_parent_subnet_id.py
@@ -1,0 +1,265 @@
+"""Webhook payload ``parent_subnet_id`` field — ADR-0003 Phase 3.
+
+The ADR adds a single new field (``parent_subnet_id``) to the
+``data`` block of two existing webhook events —
+``AGENT_JOINED_SUBNET`` and ``AGENT_LEFT_SUBNET`` — fired by
+``routes/_subnet_membership.py::do_join_subnet`` /
+``::do_leave_subnet`` when a subnet has ``harness_url`` registered.
+
+Contract pinned here:
+
+* Top-level subnet (``Subnet.parent_subnet_id is None``) →
+  ``payload.data["parent_subnet_id"] is None``.
+* Child subnet (``Subnet.parent_subnet_id == "<parent_id>"``) →
+  ``payload.data["parent_subnet_id"] == "<parent_id>"``.
+* All other ``data`` fields stay byte-identical to the pre-Phase-3
+  shape so harnesses that ignore the new field continue to work.
+* No new ``WebhookEventType`` values are added — events used are
+  still ``AGENT_JOINED_SUBNET`` / ``AGENT_LEFT_SUBNET``.
+
+Placed under ``tests/protocols/`` alongside the other protocol-level
+tests; the ADR refers to a hypothetical ``ap2/`` subdirectory but
+no such subdirectory exists yet in this repo, and creating one for
+a single file would diverge from the established layout convention.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.protocols.ap2 import WebhookEventType
+from acn.routes._subnet_membership import do_join_subnet, do_leave_subnet
+
+
+def _make_subnet(
+    subnet_id: str = "subnet-1",
+    *,
+    parent_subnet_id: str | None = None,
+    owner: str = "alice",
+    member_agent_ids: set[str] | None = None,
+    harness_url: str = "https://harness.example/webhook",
+    harness_secret: str | None = "s3cr3t",
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        parent_subnet_id=parent_subnet_id,
+        member_agent_ids=member_agent_ids or {owner},
+        harness_url=harness_url,
+        harness_secret=harness_secret,
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def webhook_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.send_to = AsyncMock(return_value=None)
+    return svc
+
+
+@pytest.fixture
+def agent_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.join_subnet = AsyncMock(return_value=None)
+    svc.leave_subnet = AsyncMock(return_value=None)
+    return svc
+
+
+def _build_subnet_service_for_join(
+    subnet: Subnet,
+    *,
+    parent_subnet: Subnet | None = None,
+) -> AsyncMock:
+    """Build a ``SubnetService`` mock that returns ``subnet`` (and a
+    parent subnet when ``parent_subnet_id`` is set).
+
+    For child subnets, ``do_join_subnet`` performs a parent-membership
+    pre-check via ``subnet_service.get_subnet(parent_subnet_id)``; we
+    need to seed that response too so the join doesn't reject with
+    ``NOT_SUBNET_MEMBER`` before reaching the webhook.
+    """
+    svc = AsyncMock()
+
+    async def _get_subnet(sid: str):
+        if sid == subnet.subnet_id:
+            return subnet
+        if parent_subnet is not None and sid == parent_subnet.subnet_id:
+            return parent_subnet
+        raise AssertionError(f"unexpected get_subnet({sid!r})")
+
+    svc.get_subnet = AsyncMock(side_effect=_get_subnet)
+    svc.add_member = AsyncMock(return_value=subnet)
+    svc.remove_member = AsyncMock(return_value=subnet)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# AGENT_JOINED_SUBNET — payload.data.parent_subnet_id
+# ---------------------------------------------------------------------------
+
+
+class TestJoinSubnetWebhookParentField:
+    @pytest.mark.asyncio
+    async def test_top_level_subnet_emits_null_parent(
+        self,
+        webhook_service,
+        agent_service,
+    ):
+        subnet = _make_subnet(parent_subnet_id=None)
+        subnet_service = _build_subnet_service_for_join(subnet)
+
+        await do_join_subnet(
+            agent_id="alice",
+            subnet_id="subnet-1",
+            agent_info={"agent_id": "alice"},
+            subnet_service=subnet_service,
+            agent_service=agent_service,
+            webhook_service=webhook_service,
+        )
+
+        webhook_service.send_to.assert_awaited_once()
+        call = webhook_service.send_to.await_args
+        assert call.kwargs["event"] == WebhookEventType.AGENT_JOINED_SUBNET
+        data = call.kwargs["data"]
+        assert data == {
+            "subnet_id": "subnet-1",
+            "agent_id": "alice",
+            "parent_subnet_id": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_child_subnet_emits_parent_id(
+        self,
+        webhook_service,
+        agent_service,
+    ):
+        child = _make_subnet(
+            subnet_id="squad-1",
+            parent_subnet_id="parent-1",
+            member_agent_ids={"alice"},
+        )
+        parent = _make_subnet(
+            subnet_id="parent-1",
+            parent_subnet_id=None,
+            member_agent_ids={"alice"},  # alice is in parent → join allowed
+            harness_url=None,  # parent doesn't need a harness for this test
+            harness_secret=None,
+        )
+        subnet_service = _build_subnet_service_for_join(child, parent_subnet=parent)
+
+        await do_join_subnet(
+            agent_id="alice",
+            subnet_id="squad-1",
+            agent_info={"agent_id": "alice"},
+            subnet_service=subnet_service,
+            agent_service=agent_service,
+            webhook_service=webhook_service,
+        )
+
+        webhook_service.send_to.assert_awaited_once()
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data == {
+            "subnet_id": "squad-1",
+            "agent_id": "alice",
+            "parent_subnet_id": "parent-1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_harness_no_webhook_delivery(
+        self,
+        webhook_service,
+        agent_service,
+    ):
+        """Sanity check — subnets without ``harness_url`` do NOT emit
+        a webhook regardless of the parent_subnet_id field. Phase 3
+        does not change this gate."""
+        subnet = _make_subnet(
+            parent_subnet_id=None,
+            harness_url=None,
+            harness_secret=None,
+        )
+        subnet_service = _build_subnet_service_for_join(subnet)
+
+        await do_join_subnet(
+            agent_id="alice",
+            subnet_id="subnet-1",
+            agent_info={"agent_id": "alice"},
+            subnet_service=subnet_service,
+            agent_service=agent_service,
+            webhook_service=webhook_service,
+        )
+
+        webhook_service.send_to.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# AGENT_LEFT_SUBNET — symmetric pin
+# ---------------------------------------------------------------------------
+
+
+class TestLeaveSubnetWebhookParentField:
+    @pytest.mark.asyncio
+    async def test_top_level_subnet_leave_emits_null_parent(
+        self,
+        webhook_service,
+        agent_service,
+    ):
+        subnet = _make_subnet(parent_subnet_id=None)
+        subnet_service = _build_subnet_service_for_join(subnet)
+
+        await do_leave_subnet(
+            agent_id="alice",
+            subnet_id="subnet-1",
+            agent_info={"agent_id": "alice"},
+            subnet_service=subnet_service,
+            agent_service=agent_service,
+            webhook_service=webhook_service,
+        )
+
+        webhook_service.send_to.assert_awaited_once()
+        call = webhook_service.send_to.await_args
+        assert call.kwargs["event"] == WebhookEventType.AGENT_LEFT_SUBNET
+        data = call.kwargs["data"]
+        assert data == {
+            "subnet_id": "subnet-1",
+            "agent_id": "alice",
+            "parent_subnet_id": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_child_subnet_leave_emits_parent_id(
+        self,
+        webhook_service,
+        agent_service,
+    ):
+        child = _make_subnet(
+            subnet_id="squad-1",
+            parent_subnet_id="parent-1",
+        )
+        # do_leave_subnet does NOT do the parent-membership pre-check
+        # (that's join-only), so we don't need to seed a parent
+        # response on the subnet_service stub.
+        subnet_service = _build_subnet_service_for_join(child)
+
+        await do_leave_subnet(
+            agent_id="alice",
+            subnet_id="squad-1",
+            agent_info={"agent_id": "alice"},
+            subnet_service=subnet_service,
+            agent_service=agent_service,
+            webhook_service=webhook_service,
+        )
+
+        webhook_service.send_to.assert_awaited_once()
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data == {
+            "subnet_id": "squad-1",
+            "agent_id": "alice",
+            "parent_subnet_id": "parent-1",
+        }

--- a/tests/routes/test_agent_subnets.py
+++ b/tests/routes/test_agent_subnets.py
@@ -155,7 +155,15 @@ class TestCanonicalJoin:
         assert kw["url"] == "https://h.example/hook"
         assert kw["secret"] == "hs"
         assert kw["event"] == WebhookEventType.AGENT_JOINED_SUBNET
-        assert kw["data"] == {"subnet_id": "subnet-1", "agent_id": "agent-target"}
+        # ADR-0003 Phase 3 added ``parent_subnet_id`` to the payload.
+        # ``_default_subnet`` is a MagicMock stub, so the helper's
+        # ``isinstance(str)`` guard returns ``None`` — matching the
+        # contract for a top-level subnet.
+        assert kw["data"] == {
+            "subnet_id": "subnet-1",
+            "agent_id": "agent-target",
+            "parent_subnet_id": None,
+        }
 
     def test_join_returns_403_when_path_agent_differs_from_api_key(
         self, stub_agent_service, stub_subnet_service, stub_webhook_service

--- a/tests/services/test_task_service_squad_cascade.py
+++ b/tests/services/test_task_service_squad_cascade.py
@@ -1,0 +1,624 @@
+"""Task termination → ``task_scoped`` subnet cascade unit tests
+(ADR-0003 Phase 3).
+
+Pins the cascade hook behaviour on the three task-terminal paths
+(``complete_task`` / ``reject_task`` / ``cancel_task``):
+
+* Matching ``task_scoped`` subnet is dissolved via
+  ``SubnetService.delete_subnet(..., owner="system")``.
+* A subnet whose ``linked_task_id`` doesn't match is left untouched.
+* A ``persistent`` subnet that happens to carry the same
+  ``linked_task_id`` is filtered out by the cascade — only
+  ``lifecycle == "task_scoped"`` is dissolved.
+* Cascade failure logs a warning but does **NOT** roll back the
+  task transition: the task remains in its terminal state and
+  the method returns normally.
+* Cascade runs **after** the settlement-Saga side effects
+  (``_notify_webhook`` / ``activity.record_*`` / escrow refund).
+  We pin the ordering by recording every awaited call onto a
+  shared ``MagicMock`` and asserting the call sequence.
+
+Mocks all external dependencies (no Redis / PG / network). Forces
+the legacy non-saga path on ``complete_task`` by leaving
+``settlement_outbox`` / ``unit_of_work`` as ``None`` — exercising
+``_dissolve_task_scoped_subnets`` is what this file is about, not
+the saga branch (which is covered in
+``test_task_service_settlement.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.core.entities.task import Task, TaskStatus
+from acn.core.exceptions import SubnetNotFoundException
+from acn.core.interfaces import IAgentRepository, ISubnetRepository, ITaskRepository
+from acn.infrastructure.task_pool import TaskPool
+from acn.services.subnet_service import SubnetService
+from acn.services.task_service import TaskService
+
+# ---------------------------------------------------------------------------
+# Entity builders — keep the test data minimal so each test reads top-down
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    task_id: str = "task-42",
+    *,
+    creator_id: str = "creator-001",
+    assignee_id: str | None = "agent-001",
+    status: TaskStatus = TaskStatus.SUBMITTED,
+) -> Task:
+    """Build a Task that takes the simple path through every terminal
+    method: no payment, no escrow currency, single-participant."""
+    return Task(
+        task_id=task_id,
+        creator_type="human",
+        creator_id=creator_id,
+        creator_name="Alice",
+        title=f"Task {task_id}",
+        description="Test task",
+        # ``"usd"`` is NOT in PLATFORM_CURRENCIES — skips reward
+        # distribution / escrow refund and keeps the test mock surface tiny.
+        reward="50",
+        reward_currency="usd",
+        max_participants=1,
+        assignee_id=assignee_id,
+        status=status,
+    )
+
+
+def _make_subnet(
+    subnet_id: str,
+    *,
+    owner: str = "alice",
+    lifecycle: str = "task_scoped",
+    linked_task_id: str | None = "task-42",
+    parent_subnet_id: str | None = "parent-1",
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        parent_subnet_id=parent_subnet_id,
+        lifecycle=lifecycle,  # type: ignore[arg-type]
+        linked_task_id=linked_task_id,
+        member_agent_ids={owner},
+        created_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — shared TaskService wired with cascade dependencies
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_task_repo() -> AsyncMock:
+    return AsyncMock(spec=ITaskRepository)
+
+
+@pytest.fixture
+def mock_task_pool(mock_task_repo) -> AsyncMock:
+    pool = AsyncMock(spec=TaskPool)
+    pool.repository = mock_task_repo
+    return pool
+
+
+@pytest.fixture
+def mock_subnet_repository() -> AsyncMock:
+    return AsyncMock(spec=ISubnetRepository)
+
+
+@pytest.fixture
+def mock_subnet_service() -> AsyncMock:
+    return AsyncMock(spec=SubnetService)
+
+
+@pytest.fixture
+def mock_webhook_service() -> AsyncMock:
+    """Stub webhook target — task_service uses ``_notify_webhook`` which
+    calls ``webhook.send_event``; we record those for ordering assertions."""
+    svc = MagicMock()
+    svc.send_event = AsyncMock(return_value=None)
+    return svc
+
+
+@pytest.fixture
+def mock_activity_service() -> AsyncMock:
+    """ActivityService — also recorded for ordering assertions."""
+    svc = AsyncMock()
+    svc.record_task_approved = AsyncMock(return_value=None)
+    svc.record_task_rejected = AsyncMock(return_value=None)
+    svc.record_task_cancelled = AsyncMock(return_value=None)
+    return svc
+
+
+@pytest.fixture
+def call_order_recorder() -> MagicMock:
+    """Shared sink that all the relevant mocks tee their call markers
+    to, so the test can assert relative ordering between webhook,
+    activity, and the cascade hook in a single sequence."""
+    return MagicMock()
+
+
+@pytest.fixture
+def service(
+    mock_task_repo,
+    mock_task_pool,
+    mock_subnet_repository,
+    mock_subnet_service,
+    mock_webhook_service,
+    mock_activity_service,
+    call_order_recorder,
+) -> TaskService:
+    """TaskService wired with the cascade dependencies.
+
+    ``settlement_outbox`` / ``unit_of_work`` are intentionally left
+    ``None`` so ``complete_task`` falls onto the legacy synchronous
+    path — what this file's tests exercise. The cascade hook is
+    independent of which path produces the CAS save, so the legacy
+    branch is sufficient pinning.
+    """
+    svc = TaskService(
+        repository=mock_task_repo,
+        task_pool=mock_task_pool,
+        payment_manager=None,
+        webhook_service=mock_webhook_service,
+        activity_service=mock_activity_service,
+        escrow_client=None,
+        agent_repository=AsyncMock(spec=IAgentRepository),
+        subnet_repository=mock_subnet_repository,
+        subnet_service=mock_subnet_service,
+    )
+
+    # Tee every call we care about (webhook, activity, cascade) onto
+    # ``call_order_recorder`` so a single ``mock_calls`` sequence
+    # captures the relative ordering between them. Each side-effect
+    # also returns whatever the underlying ``AsyncMock`` would normally
+    # return (None for these methods).
+    def _record(label: str):
+        async def _hit(*args, **kwargs):
+            call_order_recorder(label)
+
+        return _hit
+
+    mock_webhook_service.send_event.side_effect = _record("webhook")
+    mock_activity_service.record_task_approved.side_effect = _record("activity")
+    mock_activity_service.record_task_rejected.side_effect = _record("activity")
+    mock_activity_service.record_task_cancelled.side_effect = _record("activity")
+    mock_subnet_service.delete_subnet.side_effect = _record("cascade")
+
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# complete_task — three sub-cases + ordering + failure
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteTaskCascade:
+    """ADR-0003 §3 — task termination on completion dissolves task_scoped subnets."""
+
+    @pytest.mark.asyncio
+    async def test_matching_task_scoped_subnet_is_dissolved(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        squad = _make_subnet(
+            "squad-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        mock_subnet_repository.find_by_linked_task.return_value = [squad]
+
+        result = await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        assert result.status == TaskStatus.COMPLETED
+        mock_subnet_repository.find_by_linked_task.assert_awaited_once_with("task-42")
+        mock_subnet_service.delete_subnet.assert_awaited_once_with(
+            "squad-1", owner="system"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subnet_with_different_linked_task_is_left_intact(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        """``find_by_linked_task`` is keyed on the exact task_id; a
+        subnet bound to a different task should not surface here at
+        all. We pin the contract by returning an empty result."""
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = []
+
+        await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        mock_subnet_service.delete_subnet.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persistent_subnet_with_same_link_is_filtered_out(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        """Belt-and-braces — if a row carries ``linked_task_id ==
+        task_id`` but its ``lifecycle`` has somehow been flipped to
+        ``persistent`` (out-of-band edit, or a future schema where
+        the link survives promotion), the cascade still filters it
+        out and only ``task_scoped`` rows are dissolved.
+        """
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        persistent_match = _make_subnet(
+            "persistent-1",
+            lifecycle="persistent",
+            linked_task_id=None,  # entity invariant — persistent forbids non-None
+        )
+        # Hand-craft a Subnet that violates the entity invariant on
+        # purpose to exercise the lifecycle filter — we bypass
+        # ``__post_init__`` via ``object.__setattr__`` on the
+        # returned mock subnet rather than constructing one (which
+        # would raise).
+        rogue = _make_subnet(
+            "rogue-persistent",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        # Now flip ``lifecycle`` after construction; setattr on a
+        # dataclass instance is legal and does NOT trigger
+        # ``__post_init__`` re-validation (see ADR review notes).
+        rogue.lifecycle = "persistent"  # type: ignore[assignment]
+
+        squad = _make_subnet(
+            "squad-1",
+            lifecycle="task_scoped",
+            linked_task_id="task-42",
+        )
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            rogue,
+            persistent_match,
+            squad,
+        ]
+
+        await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        # Only ``squad-1`` is dissolved; the two persistent rows are
+        # skipped by the lifecycle filter.
+        mock_subnet_service.delete_subnet.assert_awaited_once_with(
+            "squad-1", owner="system"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cascade_failure_does_not_roll_back_completion(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1")
+        ]
+        mock_subnet_service.delete_subnet.side_effect = RuntimeError(
+            "redis connection lost"
+        )
+
+        # Cascade explodes — but the method returns successfully and
+        # the task remains in COMPLETED. Cascade is best-effort.
+        result = await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        assert result.status == TaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_subnet_already_deleted_is_silent_success(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        """Concurrent dissolve race — another path already deleted
+        the subnet. ``delete_subnet`` raises
+        ``SubnetNotFoundException``; cascade swallows it as a
+        successful no-op (ADR §"Idempotency on concurrent dissolution")."""
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-gone")
+        ]
+        mock_subnet_service.delete_subnet.side_effect = SubnetNotFoundException(
+            "squad-gone"
+        )
+
+        result = await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        assert result.status == TaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_cascade_runs_after_webhook_and_activity(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        call_order_recorder,
+    ):
+        """ADR §3 — cascade must fire AFTER the settlement Saga (here:
+        platform webhook + activity record). Asserted via the
+        relative ordering of recorded marker calls."""
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1")
+        ]
+
+        await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        labels = [c.args[0] for c in call_order_recorder.call_args_list]
+        # Required ordering: webhook → activity → cascade.
+        assert labels.index("cascade") > labels.index("webhook")
+        assert labels.index("cascade") > labels.index("activity")
+
+
+# ---------------------------------------------------------------------------
+# reject_task — single comprehensive pin
+# ---------------------------------------------------------------------------
+
+
+class TestRejectTaskCascade:
+    @pytest.mark.asyncio
+    async def test_reject_dissolves_task_scoped_subnet_after_webhook(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+        call_order_recorder,
+    ):
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1"),
+        ]
+
+        result = await service.reject_task(
+            task_id="task-42",
+            reviewer_id="creator-001",
+            notes="not good enough",
+        )
+
+        assert result.status == TaskStatus.REJECTED
+        mock_subnet_service.delete_subnet.assert_awaited_once_with(
+            "squad-1", owner="system"
+        )
+        labels = [c.args[0] for c in call_order_recorder.call_args_list]
+        assert labels.index("cascade") > labels.index("webhook")
+
+    @pytest.mark.asyncio
+    async def test_reject_cascade_failure_does_not_roll_back(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1")
+        ]
+        mock_subnet_service.delete_subnet.side_effect = RuntimeError(
+            "transient repo error"
+        )
+
+        result = await service.reject_task(
+            task_id="task-42",
+            reviewer_id="creator-001",
+        )
+        assert result.status == TaskStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# cancel_task — single comprehensive pin
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTaskCascade:
+    @pytest.mark.asyncio
+    async def test_cancel_dissolves_task_scoped_subnet_after_webhook(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+        mock_webhook_service,
+        call_order_recorder,
+    ):
+        # A task in OPEN status is cancelable.
+        task = _make_task(task_id="task-42", status=TaskStatus.OPEN, assignee_id=None)
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1"),
+        ]
+
+        result = await service.cancel_task(
+            task_id="task-42",
+            canceller_id="creator-001",
+        )
+
+        assert result.status == TaskStatus.CANCELLED
+        mock_subnet_service.delete_subnet.assert_awaited_once_with(
+            "squad-1", owner="system"
+        )
+        labels = [c.args[0] for c in call_order_recorder.call_args_list]
+        assert labels.index("cascade") > labels.index("webhook")
+
+    @pytest.mark.asyncio
+    async def test_cancel_cascade_failure_does_not_roll_back(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        task = _make_task(task_id="task-42", status=TaskStatus.OPEN, assignee_id=None)
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1")
+        ]
+        mock_subnet_service.delete_subnet.side_effect = RuntimeError("boom")
+
+        result = await service.cancel_task(
+            task_id="task-42",
+            canceller_id="creator-001",
+        )
+        assert result.status == TaskStatus.CANCELLED
+
+
+# ---------------------------------------------------------------------------
+# Defence-in-depth — missing dependencies degrade silently
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDegradesGracefully:
+    @pytest.mark.asyncio
+    async def test_no_subnet_repository_skips_cascade(
+        self,
+        mock_task_repo,
+        mock_task_pool,
+        mock_webhook_service,
+        mock_activity_service,
+    ):
+        """Legacy fixtures that don't wire ``subnet_repository`` /
+        ``subnet_service`` must still complete tasks — the cascade
+        is a silent no-op."""
+        svc = TaskService(
+            repository=mock_task_repo,
+            task_pool=mock_task_pool,
+            payment_manager=None,
+            webhook_service=mock_webhook_service,
+            activity_service=mock_activity_service,
+            escrow_client=None,
+            subnet_repository=None,
+            subnet_service=None,
+        )
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+
+        result = await svc.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+        assert result.status == TaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_swallowed(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        """``find_by_linked_task`` exploding (e.g. Redis down at the
+        tail of complete) must not break the task transition."""
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.side_effect = RuntimeError(
+            "redis down"
+        )
+
+        result = await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+
+        assert result.status == TaskStatus.COMPLETED
+        # No subnet was ever dissolved because lookup never returned.
+        mock_subnet_service.delete_subnet.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Multiple matches — cascade walks the full list even when one fails
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeIteratesAllMatches:
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_block_others(
+        self,
+        service,
+        mock_task_repo,
+        mock_subnet_repository,
+        mock_subnet_service,
+    ):
+        task = _make_task(task_id="task-42")
+        mock_task_repo.find_by_id.return_value = task
+        mock_task_repo.compare_and_save.return_value = True
+        mock_subnet_repository.find_by_linked_task.return_value = [
+            _make_subnet("squad-1"),
+            _make_subnet("squad-2"),
+            _make_subnet("squad-3"),
+        ]
+        # Second delete fails; first and third still attempted.
+        mock_subnet_service.delete_subnet.side_effect = [
+            None,
+            RuntimeError("flaky"),
+            None,
+        ]
+
+        result = await service.complete_task(
+            task_id="task-42",
+            approver_id="creator-001",
+        )
+        assert result.status == TaskStatus.COMPLETED
+        assert mock_subnet_service.delete_subnet.await_count == 3
+        attempted_ids = [
+            c.args[0] for c in mock_subnet_service.delete_subnet.await_args_list
+        ]
+        assert attempted_ids == ["squad-1", "squad-2", "squad-3"]


### PR DESCRIPTION
## Summary

Phase 3 of [ADR-0003 single-layer subnet nesting](../blob/main/docs/adr/0003-subnet-nesting-single-layer.md), tracked in #51. Closes out the feature by wiring the **task-state-machine cascade** for `task_scoped` children, extending the existing membership webhook payloads with `parent_subnet_id`, and refreshing the agent-facing skill docs.

Builds on Phase 1 (#52, entity + repo + migration) and Phase 2 (#53, service + routes + CLI + SDK), both already merged.

## Acceptance criteria covered

### Task-state cascade (`acn/services/task_service.py`)

- [x] `TaskService.__init__` gains optional `subnet_service: SubnetService | None` (kw-only); `api.py` wires `subnet_service_instance` in
- [x] New private helper `_dissolve_task_scoped_subnets(task_id)`:
  - calls `subnet_repository.find_by_linked_task(task_id)` (Phase 1 index)
  - filters to `lifecycle == "task_scoped"`
  - dissolves via `SubnetService.delete_subnet(..., owner="system")`
- [x] `complete_task` / `reject_task` / `cancel_task` each call the helper at the very end, after CAS + escrow + activity + webhook
- [x] Cascade failure logs `warning` and does **NOT** roll back the task transition
- [x] Concurrent dissolve race (`SubnetNotFoundException`) → `debug` log, treated as success
- [x] Orphan child subnets behave as regular `persistent` subnets per ADR Decision §6 — no special runtime handling

### Webhook payloads (`acn/routes/_subnet_membership.py`)

- [x] **No new `WebhookEventType` values** — only existing `AGENT_JOINED_SUBNET` / `AGENT_LEFT_SUBNET` events extended
- [x] `data` block gains `parent_subnet_id` — `None` for top-level subnets, parent ID for children
- [x] Mock-safe extraction helper `_subnet_parent_id` (`getattr` + `isinstance(str)` guard) so legacy MagicMock stubs degrade to `None`
- [x] Backward-compat: receivers that ignore the new field continue to work

### Tests

- [x] `tests/services/test_task_service_squad_cascade.py` (14 pins):
  - Per `complete_task` / `reject_task` / `cancel_task`: matching task_scoped dissolved, different `linked_task_id` left intact, `persistent` filtered out, cascade failure does not roll back, idempotent on concurrent dissolve, ordering pin (cascade runs AFTER webhook + activity)
  - Graceful degradation when deps missing
  - Lookup failure swallowed
  - Multiple matches: one failure does not block others
- [x] `tests/protocols/test_webhook_parent_subnet_id.py` (5 pins): top-level + child shape on join + leave + no-harness sanity check
- [x] `tests/routes/test_agent_subnets.py` — one existing exact-dict assertion updated with the new field (field-accessor tests elsewhere were already forward-compatible)

### Docs (`skills/acn/SKILL.md`)

- [x] New "Nested subnets" subsection under "Build your own subnet" with a worked example (create task → create `task_scoped` child → join → observe auto-dissolve → promote alternative)
- [x] All five ADR invariants spelled out (single-layer cap, membership subset, reserved-as-parent, task_scoped requires linked task, `parent_subnet_id` immutable)
- [x] Documents the new webhook `parent_subnet_id` field
- [x] Skill version bumped `0.12.0 → 0.13.0`

## Test plan

- [x] `pytest tests/services/test_task_service_*.py tests/services/test_subnet_service_*.py tests/services/test_org_harness.py tests/routes/test_subnets_*.py tests/routes/test_agent_subnets.py tests/protocols/test_webhook_parent_subnet_id.py tests/core/test_subnet.py tests/infrastructure/test_subnet_repository_redis_*.py` — **202 passed**
- [x] `pytest clients/python/tests/test_subnet_nesting.py` — 9 passed (SDK regression — Phase 3 surface untouched)
- [x] `ruff check` — clean on all touched paths
- [x] `basedpyright` — 0 errors on service / routes / api
- [x] CLI `npm run typecheck` — clean (unchanged surface)

## Backward compatibility

- New `parent_subnet_id` field is additive; harnesses that don't read it keep working unchanged
- `TaskService(...)` without `subnet_service` keeps pre-Phase-3 behaviour (cascade is a silent no-op); production `api.py` always wires it
- No new event types, no new endpoints — only existing surfaces extended

## Test file placement

The ADR text refers to a hypothetical `tests/protocols/ap2/` subdirectory; the new webhook contract test is placed directly under `tests/protocols/` to match this repo's actual existing layout (no `ap2/` subdir exists today, and creating one for a single file would diverge from convention). The placement is the only intentional minor deviation from the ADR's literal phrasing.

Closes #51.
