### PR TITLE
fix(subnets): clear agent.subnet_ids back-refs on delete_subnet (#56)

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -301,9 +301,15 @@ async def lifespan(app: FastAPI):
     # ``task_scoped`` child subnets (``linked_task_not_found``
     # rejection path). Always supplied in production composition;
     # legacy test fixtures may instantiate without it.
+    # ``agent_repository`` is wired so ``SubnetService.delete_subnet``
+    # can clear ``agent.subnet_ids`` back-references on every member
+    # before the subnet record is removed (issue #56). Without this
+    # wiring, agent-side dust accumulates and gets amplified by every
+    # parent-delete cascade.
     subnet_service_instance = SubnetService(
         subnet_repository,
         task_repository=task_repository,
+        agent_repository=agent_repository,
     )
 
     # Phase 1 communication_policy gateway: a single PolicyCheckService

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -10,7 +10,7 @@ import structlog  # type: ignore[import-untyped]
 
 from ..core.entities import Subnet
 from ..core.exceptions import SubnetNotFoundException
-from ..core.interfaces import ISubnetRepository
+from ..core.interfaces import IAgentRepository, ISubnetRepository
 from ..core.interfaces.task_repository import ITaskRepository
 
 logger = structlog.get_logger()
@@ -57,12 +57,20 @@ class SubnetService:
     it — the ``linked_task_not_found`` path falls back to "skip
     task existence check" when the repository is missing, which
     keeps non-nesting code paths green.
+
+    Optionally accepts an :class:`IAgentRepository` so
+    ``delete_subnet`` can clear ``agent.subnet_ids`` back-references
+    on every member before tearing down the subnet record (issue
+    #56). Production wiring supplies one; legacy fixtures that omit
+    it get the pre-#56 behaviour (stale agent-side dust survives
+    the delete) — best-effort and backward-compatible.
     """
 
     def __init__(
         self,
         subnet_repository: ISubnetRepository,
         task_repository: ITaskRepository | None = None,
+        agent_repository: IAgentRepository | None = None,
     ):
         """
         Initialize Subnet Service
@@ -73,9 +81,15 @@ class SubnetService:
                 by the ``linked_task_not_found`` validation path in
                 ``create_subnet``. Omit for legacy fixtures that
                 don't exercise nesting.
+            agent_repository: Optional agent repository — used by
+                ``delete_subnet`` to remove the deleted subnet's id
+                from each member's ``agent.subnet_ids`` set. Omit
+                for legacy fixtures; production must supply one to
+                avoid agent-side stale dust (issue #56).
         """
         self.repository = subnet_repository
         self.task_repository = task_repository
+        self.agent_repository = agent_repository
 
     async def create_subnet(
         self,
@@ -367,9 +381,26 @@ class SubnetService:
         # to recurse. The repository's ``delete_with_children`` owns
         # the atomicity guarantee — service no longer loops over
         # individual ``delete()`` calls (issue #54).
+        #
+        # Issue #56: before removing any subnet record, clear the
+        # ``subnet_id`` back-reference from each member's
+        # ``agent.subnet_ids`` set. Doing this **before** the delete
+        # means a partial-failure cascade leaves agents pointing at
+        # subnets that still exist (recoverable) rather than at
+        # subnets that have already been deleted (orphan dust).
         if subnet.parent_subnet_id is None:
             children = await self.repository.find_by_parent(subnet_id)
             if children:
+                # Clear back-references for every child first, then
+                # the parent. Order mirrors the cascade delete order
+                # the repository will execute next.
+                for child in children:
+                    await self._clear_agent_back_references(
+                        child.subnet_id, child.member_agent_ids
+                    )
+                await self._clear_agent_back_references(
+                    subnet_id, subnet.member_agent_ids
+                )
                 child_ids = [c.subnet_id for c in children]
                 logger.info(
                     "delete_subnet_cascade",
@@ -381,8 +412,80 @@ class SubnetService:
                     subnet_id, child_ids
                 )
 
+        # No-cascade path: child subnet direct-delete OR top-level
+        # subnet with zero children. Either way, clean up this one
+        # subnet's back-references then drop the record.
+        await self._clear_agent_back_references(
+            subnet_id, subnet.member_agent_ids
+        )
         logger.info("delete_subnet", subnet_id=subnet_id)
         return await self.repository.delete(subnet_id)
+
+    async def _clear_agent_back_references(
+        self,
+        subnet_id: str,
+        member_agent_ids: set[str],
+    ) -> None:
+        """Remove ``subnet_id`` from each member's
+        ``agent.subnet_ids`` set (issue #56).
+
+        Best-effort with a structured summary log: per-agent failure
+        is logged at ``warning`` level and **does not** abort the
+        caller (the subnet delete still proceeds). This matches the
+        existing weak-atomicity profile of the dual-store membership
+        invariant (ADR-0001) — agent-side dust is "harmless" but
+        amplifies under cascade, so we clean it on a best-effort
+        basis instead of layering a distributed transaction.
+
+        Silent no-op when:
+
+        - ``agent_repository`` was not wired (legacy test fixtures)
+        - ``member_agent_ids`` is empty (orphan or just-created subnet)
+        - An individual agent no longer exists (already deleted)
+        - The agent doesn't carry ``subnet_id`` in its ``subnet_ids``
+          (already cleaned by an earlier explicit ``leave_subnet``)
+
+        Args:
+            subnet_id: Subnet being deleted; this id will be removed
+                from every visited agent's ``subnet_ids``.
+            member_agent_ids: Snapshot of the subnet's members at
+                the moment of delete. May contain ids whose agents
+                no longer exist — they're skipped.
+        """
+        if self.agent_repository is None or not member_agent_ids:
+            return
+
+        cleaned = 0
+        failed = 0
+        for agent_id in member_agent_ids:
+            try:
+                agent = await self.agent_repository.find_by_id(agent_id)
+                if agent is None:
+                    continue
+                if subnet_id not in agent.subnet_ids:
+                    continue
+                agent.remove_from_subnet(subnet_id)
+                await self.agent_repository.save(agent)
+                cleaned += 1
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                # Per-agent failure must not abort the cascade. Log
+                # enough context that ops can re-run a manual
+                # ``leave_subnet`` for the affected pair.
+                logger.warning(
+                    "subnet_back_reference_cleanup_failed",
+                    subnet_id=subnet_id,
+                    agent_id=agent_id,
+                    error=str(exc),
+                )
+                failed += 1
+
+        logger.info(
+            "subnet_back_reference_cleanup",
+            subnet_id=subnet_id,
+            member_count=len(member_agent_ids),
+            cleaned=cleaned,
+            failed=failed,
+        )
 
     async def add_member(self, subnet_id: str, agent_id: str) -> Subnet:
         """

--- a/docs/adr/0001-subnet-creator-must-be-member.md
+++ b/docs/adr/0001-subnet-creator-must-be-member.md
@@ -249,3 +249,12 @@ the same SQL transaction shape — `DELETE` for demo/inert, two
 - `agentplanet/frontend/src/app/world/_components/SubnetCanvas.tsx` —
   Networks graph view (acceptance: no `member_count=0` nodes appear
   in this view post-A + backfill).
+
+## Related work
+
+- **Issue #56 / PR #60** — symmetric fix on the **delete** side.
+  This ADR closed the create-side dual-store gap; #56 closes the
+  delete-side one (`delete_subnet` now also clears the
+  `agent.subnet_ids` back-reference for every member before
+  removing the subnet record, amplified in importance by the
+  ADR-0003 cascade delete path).

--- a/tests/services/test_subnet_service_back_refs.py
+++ b/tests/services/test_subnet_service_back_refs.py
@@ -1,0 +1,428 @@
+"""SubnetService — agent-side back-reference cleanup on delete (issue #56).
+
+Pins the contract that ``delete_subnet`` symmetrically clears the
+``subnet_id`` from each member's ``agent.subnet_ids`` set before the
+subnet record itself is removed. Without this cleanup, ADR-0003
+cascade deletes amplify pre-existing dual-store dust (per-child member
+× per-subnet) into a much larger orphan surface.
+
+Three behavioural contracts pinned here:
+
+1. **Single-subnet delete** — every member's ``subnet_ids`` loses the
+   deleted subnet's id; ``agent_repository.save`` is awaited once per
+   member.
+2. **Cascade delete** — back-reference cleanup runs for each child
+   subnet's members AND the parent's members, in that order, BEFORE
+   the repository cascade fires.
+3. **Best-effort** — a single agent's cleanup failure is logged at
+   ``warning`` and does not abort the subnet delete (the deletion is
+   the primary side-effect; agent-side dust is secondary).
+4. **Backward compatibility** — when no ``agent_repository`` is wired
+   (legacy fixtures), ``delete_subnet`` retains its pre-#56 behaviour:
+   no cleanup, no error, subnet removed.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Agent, Subnet
+from acn.core.interfaces import IAgentRepository, ISubnetRepository
+from acn.services.subnet_service import SubnetService
+
+
+def _make_subnet(
+    subnet_id: str,
+    owner: str = "alice",
+    parent_subnet_id: str | None = None,
+    members: set[str] | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        parent_subnet_id=parent_subnet_id,
+        member_agent_ids=members if members is not None else {owner},
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_agent(agent_id: str, subnet_ids: list[str]) -> Agent:
+    """Build an Agent stub. Note: Agent.__post_init__ falls back to
+    ``["public"]`` when ``subnet_ids`` ends up empty, so pin the
+    subnet_ids we want to see in the test."""
+    return Agent(
+        agent_id=agent_id,
+        name=agent_id,
+        description="test",
+        tags=[],
+        endpoint=f"http://example.com/{agent_id}",
+        owner="owner-of-" + agent_id,
+        subnet_ids=list(subnet_ids),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Single-subnet delete cleans every member
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSubnetDeleteClearsBackRefs:
+    @pytest.mark.asyncio
+    async def test_three_member_subnet_clears_all_three_agents(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """3-member subnet → 3 ``find_by_id`` + 3 ``save`` calls with
+        the subnet id removed from each agent's ``subnet_ids`` list."""
+        subnet = _make_subnet(
+            "team-a",
+            owner="alice",
+            members={"alice", "bob", "carol"},
+        )
+        agents = {
+            "alice": _make_agent("alice", ["public", "team-a"]),
+            "bob": _make_agent("bob", ["public", "team-a", "team-b"]),
+            "carol": _make_agent("carol", ["team-a"]),
+        }
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+
+        ok = await service.delete_subnet("team-a", owner="alice")
+
+        assert ok is True
+        # 3 lookups for the 3 members.
+        assert mock_agent_repository.find_by_id.await_count == 3
+        # 3 saves — one per member.
+        assert mock_agent_repository.save.await_count == 3
+        # Every saved agent has ``team-a`` removed from its subnet_ids.
+        for call in mock_agent_repository.save.await_args_list:
+            saved = call.args[0]
+            assert "team-a" not in saved.subnet_ids, (
+                f"agent {saved.agent_id} still carries team-a"
+            )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skips_agents_already_missing_subnet(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """If an agent's ``subnet_ids`` doesn't contain the subnet id
+        (e.g. they explicitly left earlier), the cleanup skips the
+        ``save`` — no redundant write."""
+        subnet = _make_subnet("team-a", members={"alice"})
+        # alice's subnet_ids no longer carries team-a (concurrent leave).
+        agents = {"alice": _make_agent("alice", ["public"])}
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+        await service.delete_subnet("team-a", owner="alice")
+
+        mock_agent_repository.find_by_id.assert_awaited_once_with("alice")
+        # No save — nothing to clean.
+        mock_agent_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skips_missing_agents(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """Members may have been deleted between subnet membership
+        and subnet delete. ``find_by_id`` returning ``None`` must not
+        crash the cleanup."""
+        subnet = _make_subnet("team-a", members={"alice", "ghost"})
+        agents = {"alice": _make_agent("alice", ["team-a"])}  # no ghost
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+        ok = await service.delete_subnet("team-a", owner="alice")
+
+        assert ok is True
+        # Both members looked up — ghost returned None and was skipped.
+        assert mock_agent_repository.find_by_id.await_count == 2
+        # Only alice triggered a save.
+        mock_agent_repository.save.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. Cascade delete cleans children's members + parent's members
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDeleteClearsBackRefs:
+    @pytest.mark.asyncio
+    async def test_parent_cascade_cleans_each_child_then_parent(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """Parent with two children:
+
+        - child-1 members: {alice, bob}
+        - child-2 members: {carol}
+        - parent members: {alice, bob, carol, dave}
+
+        Expectation: each child's members cleaned first, then the
+        parent's. ``delete_with_children`` fires AFTER all cleanup.
+        Order matters because the repo cascade order is
+        children-first, parent-last — agent-side cleanup mirrors
+        that to keep the recovery story symmetric.
+        """
+        parent = _make_subnet(
+            "team",
+            owner="alice",
+            members={"alice", "bob", "carol", "dave"},
+        )
+        children = [
+            _make_subnet(
+                "squad-1",
+                owner="alice",
+                parent_subnet_id="team",
+                members={"alice", "bob"},
+            ),
+            _make_subnet(
+                "squad-2",
+                owner="carol",
+                parent_subnet_id="team",
+                members={"carol"},
+            ),
+        ]
+        # Agents — every member carries the relevant subnet_ids.
+        agents = {
+            "alice": _make_agent("alice", ["public", "team", "squad-1"]),
+            "bob": _make_agent("bob", ["team", "squad-1"]),
+            "carol": _make_agent("carol", ["team", "squad-2"]),
+            "dave": _make_agent("dave", ["team"]),
+        }
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = children
+        mock_subnet_repository.delete_with_children.return_value = True
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+        ok = await service.delete_subnet("team", owner="alice")
+
+        assert ok is True
+        # Repository cascade still fires with the right child ids.
+        mock_subnet_repository.delete_with_children.assert_awaited_once_with(
+            "team", ["squad-1", "squad-2"]
+        )
+        # Saved agents' subnet_ids must NOT contain any of the three
+        # subnets that were deleted (this is the user-visible signal
+        # the back-ref cleanup did its job).
+        saved_by_id: dict[str, Agent] = {}
+        for call in mock_agent_repository.save.await_args_list:
+            saved = call.args[0]
+            saved_by_id[saved.agent_id] = saved
+        for agent_id, saved in saved_by_id.items():
+            assert "team" not in saved.subnet_ids, agent_id
+            assert "squad-1" not in saved.subnet_ids, agent_id
+            assert "squad-2" not in saved.subnet_ids, agent_id
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_before_repository_cascade(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """Strict ordering: every ``agent_repository.save`` must
+        finish BEFORE ``delete_with_children`` is awaited. Otherwise
+        a cascade failure could leave agents pointing at
+        already-deleted subnets — strictly worse than the inverse."""
+        parent = _make_subnet(
+            "team", owner="alice", members={"alice", "bob"}
+        )
+        children = [
+            _make_subnet(
+                "squad-1",
+                owner="alice",
+                parent_subnet_id="team",
+                members={"alice"},
+            ),
+        ]
+        agents = {
+            "alice": _make_agent("alice", ["team", "squad-1"]),
+            "bob": _make_agent("bob", ["team"]),
+        }
+
+        call_order: list[str] = []
+
+        async def _record_save(agent: Agent) -> None:
+            call_order.append(f"save:{agent.agent_id}")
+
+        async def _record_cascade(
+            parent_id: str, child_ids: list[str]
+        ) -> bool:
+            call_order.append("delete_with_children")
+            return True
+
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = children
+        mock_subnet_repository.delete_with_children = AsyncMock(
+            side_effect=_record_cascade
+        )
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+        mock_agent_repository.save = AsyncMock(side_effect=_record_save)
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+        await service.delete_subnet("team", owner="alice")
+
+        # Every save must precede the cascade.
+        cascade_idx = call_order.index("delete_with_children")
+        save_indices = [
+            i for i, ev in enumerate(call_order) if ev.startswith("save:")
+        ]
+        assert all(i < cascade_idx for i in save_indices), call_order
+
+
+# ---------------------------------------------------------------------------
+# 3. Best-effort — per-agent failure does not abort the delete
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupBestEffort:
+    @pytest.mark.asyncio
+    async def test_single_agent_save_failure_logs_warning_and_continues(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+        caplog,
+    ):
+        """If one agent's ``save`` raises, the other members are
+        still cleaned and the subnet is still deleted. A
+        ``subnet_back_reference_cleanup_failed`` warning carries the
+        offending agent id for ops follow-up."""
+        subnet = _make_subnet(
+            "team-a", owner="alice", members={"alice", "bob"}
+        )
+        agents = {
+            "alice": _make_agent("alice", ["team-a"]),
+            "bob": _make_agent("bob", ["team-a"]),
+        }
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        # bob's save raises; alice's save succeeds.
+        async def _save(agent: Agent) -> None:
+            if agent.agent_id == "bob":
+                raise RuntimeError("redis unavailable for bob")
+
+        mock_agent_repository.save = AsyncMock(side_effect=_save)
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+
+        ok = await service.delete_subnet("team-a", owner="alice")
+
+        # Subnet delete must succeed despite the per-agent failure.
+        assert ok is True
+        mock_subnet_repository.delete.assert_awaited_once_with("team-a")
+        # Both members were attempted; one succeeded, one failed.
+        assert mock_agent_repository.save.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_find_by_id_failure_also_treated_as_warning(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """``find_by_id`` failure (e.g. transient PG hiccup) is
+        likewise non-fatal — log warning, keep going."""
+        subnet = _make_subnet(
+            "team-a", owner="alice", members={"alice", "bob"}
+        )
+
+        async def _find(aid: str) -> Agent | None:
+            if aid == "bob":
+                raise RuntimeError("transient lookup failure")
+            return _make_agent("alice", ["team-a"])
+
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+        mock_agent_repository.find_by_id.side_effect = _find
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+
+        ok = await service.delete_subnet("team-a", owner="alice")
+        assert ok is True
+        # alice's save still happened; bob never reached the save step.
+        mock_agent_repository.save.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. Backward compatibility — no agent_repository wired
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatNoAgentRepository:
+    @pytest.mark.asyncio
+    async def test_delete_works_without_agent_repository(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Legacy fixtures that don't wire an ``agent_repository``
+        retain their pre-#56 behaviour: subnet is deleted, no
+        agent-side cleanup attempted, no error raised. Agent-side
+        dust survives (acceptable for legacy tests; production
+        composition always wires the repo)."""
+        subnet = _make_subnet(
+            "team-a", owner="alice", members={"alice", "bob"}
+        )
+        mock_subnet_repository.find_by_id.return_value = subnet
+        mock_subnet_repository.find_by_parent.return_value = []
+        mock_subnet_repository.delete.return_value = True
+
+        service = SubnetService(mock_subnet_repository)
+        # No agent_repository wired — must not crash even though
+        # ``subnet.member_agent_ids`` is non-empty.
+        ok = await service.delete_subnet("team-a", owner="alice")
+        assert ok is True
+        mock_subnet_repository.delete.assert_awaited_once_with("team-a")

--- a/tests/services/test_subnet_service_back_refs.py
+++ b/tests/services/test_subnet_service_back_refs.py
@@ -366,6 +366,71 @@ class TestCleanupBestEffort:
         assert mock_agent_repository.save.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_cleanup_completes_even_when_cascade_raises(
+        self,
+        mock_subnet_repository: ISubnetRepository,
+        mock_agent_repository: IAgentRepository,
+    ):
+        """When the repository cascade raises (e.g. Redis breadcrumb
+        path returns failure or PG transaction aborts), the back-ref
+        cleanup already ran to completion BEFORE the cascade was
+        invoked. This pins the documented ordering rationale: agents
+        end up pointing at subnets that still exist (recoverable)
+        rather than at already-deleted subnets (the dust this PR
+        fixes). The cascade exception then propagates to the caller
+        as expected."""
+        parent = _make_subnet("team", owner="alice", members={"alice", "bob"})
+        children = [
+            _make_subnet(
+                "squad-1",
+                owner="alice",
+                parent_subnet_id="team",
+                members={"alice"},
+            ),
+        ]
+        agents = {
+            "alice": _make_agent("alice", ["team", "squad-1"]),
+            "bob": _make_agent("bob", ["team"]),
+        }
+        mock_subnet_repository.find_by_id.return_value = parent
+        mock_subnet_repository.find_by_parent.return_value = children
+        # Cascade fails after cleanup has already done its job —
+        # simulates either the Redis breadcrumb path or a PG
+        # transaction abort.
+        mock_subnet_repository.delete_with_children.side_effect = RuntimeError(
+            "simulated cascade failure"
+        )
+        mock_agent_repository.find_by_id.side_effect = (
+            lambda aid: agents.get(aid)
+        )
+
+        service = SubnetService(
+            mock_subnet_repository,
+            agent_repository=mock_agent_repository,
+        )
+
+        with pytest.raises(RuntimeError, match="simulated cascade failure"):
+            await service.delete_subnet("team", owner="alice")
+
+        # Cleanup ran fully before the cascade raised — 3 distinct
+        # agents (squad-1: alice; parent: alice, bob) saw save()
+        # with the relevant subnet ids stripped. Alice may be saved
+        # twice (once per subnet she belonged to) which is the
+        # cleanup's natural shape; assert on the SET of agents
+        # touched rather than exact call count.
+        saved_agent_ids = {
+            call.args[0].agent_id
+            for call in mock_agent_repository.save.await_args_list
+        }
+        assert saved_agent_ids == {"alice", "bob"}
+        # And every save carried the right shape — no agent still
+        # carries any of the about-to-be-deleted subnet ids.
+        for call in mock_agent_repository.save.await_args_list:
+            saved = call.args[0]
+            assert "team" not in saved.subnet_ids
+            assert "squad-1" not in saved.subnet_ids
+
+    @pytest.mark.asyncio
     async def test_find_by_id_failure_also_treated_as_warning(
         self,
         mock_subnet_repository: ISubnetRepository,


### PR DESCRIPTION
## Summary

Closes #56. Makes ``SubnetService.delete_subnet`` symmetric with ``leave_subnet`` by clearing the deleted subnet's id from every member's ``agent.subnet_ids`` set. The pre-ADR-0003 quirk (stale agent-side back-references) was "harmless dust" in isolation but ADR-0003 cascade deletes amplify the surface area — every parent-delete now drops N child subnets, each with its own members carrying stale entries.

### Acceptance criteria from #56

- [x] ``delete_subnet`` clears ``agent.subnet_ids`` for every member before the subnet record is removed
- [x] Cascade path repeats the cleanup for each child subnet (children-first, then parent — mirrors ``delete_with_children`` order)
- [x] Per-agent failure logged at ``warning`` but does NOT abort the deletion (best-effort, ADR-0001 weak atomicity profile)
- [x] Test: ``delete_subnet`` of subnet with 3 members → all 3 agents have ``subnet_id`` removed from their ``subnet_ids``
- [x] Test: parent cascade delete cleans each child's members + parent's members

## What changed

### Service layer

- ``SubnetService.__init__`` accepts a new optional ``agent_repository: IAgentRepository | None``. Legacy fixtures may omit; production composition in ``api.py`` always supplies one.
- New private helper ``_clear_agent_back_references(subnet_id, member_agent_ids)``:
  - silent no-op when ``agent_repository`` is missing or member set is empty
  - skips agents that no longer exist (race with agent delete)
  - skips agents whose ``subnet_ids`` no longer contains the id (already cleaned by an explicit ``leave_subnet``)
  - per-agent ``find_by_id`` / ``save`` failure → ``subnet_back_reference_cleanup_failed`` warning, continues
  - single ``subnet_back_reference_cleanup`` summary log with ``cleaned`` / ``failed`` counts
- ``delete_subnet`` invokes the helper BEFORE the repository delete in all three branches:
  - cascade with children: clean each child's members first, then parent's members, then ``delete_with_children``
  - top-level with no children: clean parent's members, then ``delete``
  - direct child delete: clean child's members, then ``delete``

### Wiring

- ``acn/api.py`` lifespan: pass ``agent_repository=agent_repository`` when constructing ``SubnetService``.

### Tests

``tests/services/test_subnet_service_back_refs.py`` — 8 cases:

1. **Single-subnet cleanup**
   - 3-member subnet → 3 ``find_by_id`` + 3 ``save`` (subnet id removed from each)
   - agent whose ``subnet_ids`` doesn't contain the id → no redundant ``save``
   - missing agent (returns ``None``) → silently skipped
2. **Cascade cleanup**
   - parent + 2 children → every member's ``subnet_ids`` cleaned of all three subnet ids
   - strict ordering: every ``save`` precedes ``delete_with_children`` (otherwise cascade failure could leave agents pointing at already-deleted subnets)
3. **Best-effort failure isolation**
   - one agent's ``save`` raises → other members still cleaned, subnet still deleted
   - ``find_by_id`` raises → same behaviour
4. **Backward compatibility**
   - no ``agent_repository`` wired → ``delete_subnet`` works exactly as pre-#56

## Ordering rationale

``cleanup → delete`` (not the other way):

- On partial failure, agents end up pointing at subnets that **still exist** (recoverable — operator or agent can retry ``leave_subnet``)
- The inverse would leave agents pointing at **already-deleted** subnets, which is exactly the dust this issue fixes — strictly worse failure mode

## Known limitation (out of scope)

Back-reference cleanup is NOT in the same PG transaction as the cascade delete. Consistent with ADR-0001's weak-atomicity profile for dual-store membership. A future ticket can extend ``delete_with_children`` to accept a member-map and clean back-refs transactionally if scale demands it. Not blocking — the best-effort path is robust under partial failure and the summary log makes reconciliation observable.

## Test plan

- [x] 8 new ``test_subnet_service_back_refs.py`` cases pass
- [x] Full regression: **1420** tests pass (105 core + 1277 service/route/infra/protocol + 38 SDK)
- [x] ``ruff`` + ``basedpyright`` clean on touched files


Made with [Cursor](https://cursor.com)