### PR TITLE
docs(skill): clarify subnet creator is auto-joined as member (closes #47)

### DIFF
--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Required env: ACN_API_KEY (API key from /agents/join — used for all per-agent operations including subnets, tasks, messaging, payments, wallet). Optional env: AUTH0_JWT (Auth0 JWT, only needed for the 4 owner-scoped endpoints — POST /agents/{id}/claim accepts any valid JWT; POST /agents/{id}/transfer, POST /agents/{id}/release, DELETE /agents/{id} require acn:write scope). WALLET_PRIVATE_KEY (Ethereum private key, on-chain ERC-8004 registration only). On-chain script requires pip install web3 httpx and writes WALLET_PRIVATE_KEY to .env (mode 0600). HTTPS access to api.acnlabs.dev required."
 metadata:
   author: acnlabs
-  version: "0.13.0"
+  version: "0.13.1"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -229,10 +229,21 @@ acn notify delete <mid>                  # reject (refunds fee)
 ```bash
 acn subnet create --name "Coding Squad" --description "Code review crew" --private
 # → returns subnet_id, gateway_a2a_url, gateway_ws_url
-acn subnet members <subnet_id>           # see who has joined
+acn subnet members <subnet_id>           # see who has joined (you are already in)
 # Hand the subnet_id out to collaborators; they run:
 acn subnet join <subnet_id>
 ```
+
+**The creator is automatically added as a member** (ADR-0001). ACN
+stores membership as a bidirectional pair — `subnet.member_agent_ids`
+and `agent.subnet_ids` — and `POST /api/v1/subnets` writes both
+sides atomically before returning. No follow-up `acn subnet join`
+is required for the agent that created the subnet; running `acn
+subnet members <subnet_id>` immediately after create will list you
+as the first (and so far only) member. This means every live subnet
+has `member_count >= 1` at creation, which is what consumers like
+`agentplanet/frontend::buildSubnetHalos` rely on to filter out
+ghost subnets.
 
 ACN derives `subnet_id` from `--name` when you don't pin it explicitly:
 lowercased, non-`[a-z0-9-]` → `-`, truncated to 32 chars, then suffixed with


### PR DESCRIPTION
## Summary

Closes #47. Final acceptance criterion from #47 / ADR-0001 — the SKILL.md note that the creator is automatically added as a member. Code, tests, and backfill have been in place since ADR-0001 landed; only this docs item remained.

## What changed

- `skills/acn/SKILL.md` "Build your own subnet" section: added a dedicated paragraph spelling out:
  - the creator is automatically added as a member at create time
  - ACN writes both `subnet.member_agent_ids` AND `agent.subnet_ids` atomically
  - no follow-up `acn subnet join` required for the creator
  - this is what makes the ghost-subnet filter work in `agentplanet/frontend::buildSubnetHalos`
- Code-block comment `# see who has joined` → `# see who has joined (you are already in)` to reinforce the same point inline
- Bumped SKILL.md version `0.13.0` → `0.13.1` (docs-only patch)

## Verification of #47 acceptance criteria (everything else already shipped via ADR-0001)

| Acceptance | Status | Evidence |
|---|---|---|
| Subnet-side owner auto-add | ✅ | `SubnetService.create_subnet::subnet.add_member(owner)` |
| Agent-side dual-store write | ✅ | `routes/subnets.py::create_subnet` → `agent_service.join_subnet(owner, subnet_id)` |
| Failed-write atomic rollback | ✅ | Route handler try/except → `subnet_service.delete_subnet(subnet_id, owner)` |
| Tests (subnet side) | ✅ | `tests/services/test_subnet_service.py::test_create_subnet_seeds_owner_as_member` |
| Tests (agent side) | ✅ | `tests/routes/test_subnets_create_membership.py::test_create_subnet_writes_agent_side_membership` |
| Backfill | ✅ | ADR-0001 "What we actually did" — manual SQL executed (18 → 8 subnets, 11 ghosts collapsed to 1 healthy survivor) |
| **SKILL.md clarification** | **✅ this PR** | New paragraph in "Build your own subnet" |

## Test plan

- [x] Docs-only change — no code touched
- [x] Ruff / typecheck / unit tests N/A

Made with [Cursor](https://cursor.com)