### PR TITLE
test(integration): real-PG tests for delete_with_children rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly run at 02:00 UTC — executes the real-PG integration suite
+    - cron: "0 2 * * *"
 
 jobs:
   # ===========================================
@@ -185,4 +188,61 @@ jobs:
           tags: acn:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ===========================================
+  # Integration — real-PG tests (opt-in)
+  # Triggered by:
+  #   • PR label "run-integration-tests"
+  #   • Nightly schedule on main (02:00 UTC)
+  # Skipped on normal PRs to keep CI fast.
+  # See docs/integration-testing.md for local usage.
+  # ===========================================
+  integration:
+    name: Integration (real-PG)
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'run-integration-tests'))
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: acn
+          POSTGRES_PASSWORD: acn
+          POSTGRES_DB: acn_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U acn"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: |
+          cd acn
+          uv sync --all-extras
+
+      - name: Run real-PG integration tests
+        env:
+          ACN_INTEGRATION_PG_URL: postgresql+asyncpg://acn:acn@localhost:5432/acn_test
+          INTERNAL_API_TOKEN: test-internal-token-must-be-at-least-32-characters-long
+          DEV_MODE: "true"
+          HOST: "127.0.0.1"
+        run: |
+          cd acn
+          uv run pytest -m integration -v --tb=short
 

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -1,0 +1,92 @@
+# Running the Real-PostgreSQL Integration Test Suite
+
+## Overview
+
+Most ACN tests use in-memory fakes or mock repositories and run entirely
+without a real database.  A small subset of tests — marked
+`pytest.mark.integration` — require a live PostgreSQL instance because
+they validate behaviour that only a real engine can exercise:
+
+| Test file | What it guards |
+|-----------|---------------|
+| `tests/integration/test_settlement_outbox_pg.py` | `SKIP LOCKED` prevents double-claim; same-tx atomicity of outbox enqueue |
+| `tests/integration/test_pg_subnet_cascade.py` | `delete_with_children` atomically commits or rolls back under real Postgres (ADR-0003 §A.4) |
+
+## Prerequisites
+
+* Docker (or a locally running PostgreSQL ≥ 14)
+* Python environment with `asyncpg` (already in `pyproject.toml`)
+
+## Quickstart — Docker one-liner
+
+```bash
+# Start a throwaway Postgres container
+docker run --rm -d \
+  --name acn-test-pg \
+  -e POSTGRES_USER=acn \
+  -e POSTGRES_PASSWORD=acn \
+  -e POSTGRES_DB=acn_test \
+  -p 5432:5432 \
+  postgres:16-alpine
+
+# Wait for PG to be ready (usually 2–3 s)
+sleep 3
+
+# Point the integration suite at it
+export ACN_INTEGRATION_PG_URL="postgresql+asyncpg://acn:acn@localhost:5432/acn_test"
+
+# Run only integration tests (the rest of the suite is unaffected)
+cd acn
+uv run pytest -m integration -v
+
+# Tear down
+docker stop acn-test-pg
+```
+
+## Running all tests (unit + integration) together
+
+```bash
+export ACN_INTEGRATION_PG_URL="postgresql+asyncpg://acn:acn@localhost:5432/acn_test"
+cd acn
+uv run pytest -v
+```
+
+Without `ACN_INTEGRATION_PG_URL` the integration tests emit a `SKIP`
+and the default `pytest` run stays fast.
+
+## CI strategy
+
+The standard CI job (`python` in `.github/workflows/ci.yml`) does NOT
+set `ACN_INTEGRATION_PG_URL`, so integration tests are skipped on every
+PR.
+
+A separate opt-in **Integration** job in `.github/workflows/ci.yml` runs
+the full real-PG suite.  It is triggered by:
+
+* A PR label `run-integration-tests` being added, **or**
+* The nightly scheduled run (daily at 02:00 UTC on `main`).
+
+To trigger integration tests on your PR:
+
+```
+gh pr edit <pr-number> --add-label run-integration-tests
+```
+
+## What each integration test does
+
+### `test_pg_subnet_cascade.py`
+
+| Test | Scenario |
+|------|----------|
+| `test_delete_with_children_happy_path` | Inserts parent + 3 children; calls `delete_with_children`; asserts all 4 rows are gone and the return value is `True`. |
+| `test_delete_with_children_rollback_on_mid_cascade_failure` | Injects a `RuntimeError` on the **second** `session.execute` call inside `session.begin()`; asserts the exception propagates AND all rows still exist (full ROLLBACK). |
+| `test_delete_with_children_parent_absent` | Calls `delete_with_children` when neither parent nor children exist; asserts `False` is returned without raising. |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `asyncpg.InvalidCatalogNameError` | `acn_test` DB not created | `createdb acn_test` or pass a different DB name |
+| `asyncpg.InvalidPasswordError` | Wrong credentials in DSN | Update `ACN_INTEGRATION_PG_URL` |
+| `connection refused` | PG not running or wrong port | Check `docker ps` / port mapping |
+| Index-already-exists DDL error | Stale schema from a previous aborted run | The fixture DROPs indexes before the table; if the DROP is skipped, manually run `DROP INDEX IF EXISTS subnets_parent_idx, subnets_linked_task_idx;` |

--- a/tests/integration/test_pg_subnet_cascade.py
+++ b/tests/integration/test_pg_subnet_cascade.py
@@ -1,0 +1,249 @@
+"""Real-PostgreSQL integration tests for PostgresSubnetRepository.delete_with_children.
+
+The mock-based tests in
+``tests/infrastructure/test_postgres_subnet_repository_cascade.py``
+verify that the implementation *calls* ``session.begin()`` and that
+``__aexit__`` is invoked with the exception on a mid-cascade failure —
+i.e. the *idiom* is correct.  These tests verify the *end-to-end
+behaviour*: that SQLAlchemy + asyncpg + real Postgres actually roll back
+when the context manager receives an exception, and that a successful
+cascade commits atomically.
+
+**Gating**: tests are skipped silently unless
+``ACN_INTEGRATION_PG_URL`` is set to an async-capable DSN, e.g.::
+
+    postgresql+asyncpg://acn:acn@localhost:5432/acn_test
+
+See ``docs/integration-testing.md`` for instructions on how to spin up
+a local Postgres instance suitable for this suite.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from acn.infrastructure.persistence.postgres.models import SubnetModel
+from acn.infrastructure.persistence.postgres.subnet_repository import (
+    PostgresSubnetRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level marker — skip silently when no real PG is available
+# ---------------------------------------------------------------------------
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ACN_INTEGRATION_PG_URL"),
+        reason="needs ACN_INTEGRATION_PG_URL pointing at a disposable async PG",
+    ),
+]
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def pg(request: Any):
+    """Create engine + session factory, (re)create the subnets table.
+
+    The table is DROPPED before each test and re-created fresh so tests
+    are fully isolated without requiring a transaction rollback at the
+    fixture level (which could mask the very rollback behaviour under
+    test).
+    """
+    url = os.environ["ACN_INTEGRATION_PG_URL"]
+    engine = create_async_engine(url, future=True, pool_pre_ping=True)
+
+    async with engine.begin() as conn:
+        # Drop dependent indexes first to avoid DDL errors on re-create.
+        await conn.execute(
+            text("DROP INDEX IF EXISTS subnets_parent_idx")
+        )
+        await conn.execute(
+            text("DROP INDEX IF EXISTS subnets_linked_task_idx")
+        )
+        await conn.run_sync(
+            lambda c: SubnetModel.__table__.drop(c, checkfirst=True)
+        )
+        await conn.run_sync(
+            lambda c: SubnetModel.__table__.create(c, checkfirst=True)
+        )
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _row(
+    subnet_id: str,
+    parent_id: str | None = None,
+) -> SubnetModel:
+    """Build a minimal SubnetModel row suitable for direct INSERT."""
+    return SubnetModel(
+        subnet_id=subnet_id,
+        name=f"subnet-{subnet_id}",
+        owner="test-owner",
+        description=None,
+        is_private=False,
+        security_config=None,
+        member_agent_ids=None,
+        subnet_metadata=None,
+        harness_url=None,
+        harness_secret=None,
+        parent_subnet_id=parent_id,
+        lifecycle="persistent",
+        linked_task_id=None,
+        created_at=datetime.now(UTC),
+    )
+
+
+async def _exists(factory: async_sessionmaker, subnet_id: str) -> bool:
+    """Return True if a subnet row with *subnet_id* is present."""
+    async with factory() as session:
+        result = await session.execute(
+            select(SubnetModel).where(SubnetModel.subnet_id == subnet_id)
+        )
+        return result.scalar_one_or_none() is not None
+
+
+# =============================================================================
+# 1. Positive path — full cascade commits atomically
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_with_children_happy_path(pg: async_sessionmaker) -> None:
+    """All rows (parent + children) are removed in a single committed transaction.
+
+    Verifies end-to-end:
+    - Rows are inserted through a real PG session.
+    - ``delete_with_children`` returns ``True``.
+    - Every row (parent and all 3 children) is gone after the call.
+    """
+    parent_id = "pg-parent-happy"
+    child_ids = ["pg-child-1", "pg-child-2", "pg-child-3"]
+
+    async with pg() as session:
+        async with session.begin():
+            session.add(_row(parent_id))
+            for cid in child_ids:
+                session.add(_row(cid, parent_id=parent_id))
+
+    repo = PostgresSubnetRepository(session_factory=pg)
+    result = await repo.delete_with_children(parent_id, child_ids)
+
+    assert result is True, "delete_with_children should return True when parent existed"
+
+    assert not await _exists(pg, parent_id), "parent must be gone"
+    for cid in child_ids:
+        assert not await _exists(pg, cid), f"child {cid} must be gone"
+
+
+# =============================================================================
+# 2. Rollback path — mid-cascade execute raise preserves all rows
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_with_children_rollback_on_mid_cascade_failure(
+    pg: async_sessionmaker,
+) -> None:
+    """A simulated error on the second DELETE causes a full ROLLBACK.
+
+    This is the key regression guard: if SQLAlchemy's ``session.begin()``
+    ever stopped calling ``ROLLBACK`` on a mid-block exception, the
+    parent and any already-deleted children would be gone — violating the
+    atomicity guarantee documented in ADR-0003 §A.4.
+
+    Strategy: monkey-patch ``session.execute`` so the *second* call
+    (i.e. after the first child DELETE succeeds) raises ``RuntimeError``.
+    We patch at the ``async_sessionmaker`` level by wrapping the factory
+    to inject the patched session.
+    """
+    parent_id = "pg-parent-rollback"
+    child_ids = ["pg-child-r1", "pg-child-r2", "pg-child-r3"]
+
+    async with pg() as session:
+        async with session.begin():
+            session.add(_row(parent_id))
+            for cid in child_ids:
+                session.add(_row(cid, parent_id=parent_id))
+
+    # ---------------------------------------------------------------------------
+    # Wrap the session factory so that the real session's ``execute`` method
+    # raises on its second call (the second child DELETE).
+    # ---------------------------------------------------------------------------
+    original_factory = pg
+
+    class _BombSession:
+        """Thin async context-manager wrapper that injects the execute bomb."""
+
+        def __init__(self) -> None:
+            self._inner: AsyncSession | None = None
+            self._call_count = 0
+
+        async def __aenter__(self) -> _BombSession:
+            self._inner = await original_factory().__aenter__()
+            original_execute = self._inner.execute  # type: ignore[attr-defined]
+
+            async def _execute_bomb(*args: Any, **kwargs: Any) -> Any:
+                self._call_count += 1
+                if self._call_count == 2:
+                    raise RuntimeError("injected failure on second execute")
+                return await original_execute(*args, **kwargs)
+
+            self._inner.execute = _execute_bomb  # type: ignore[method-assign]
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> bool | None:
+            assert self._inner is not None
+            return await self._inner.__aexit__(*exc_info)
+
+        # Proxy ``begin()`` to the real session so ``session.begin()`` works.
+        def begin(self) -> Any:
+            assert self._inner is not None
+            return self._inner.begin()
+
+    patched_factory = AsyncMock()
+    patched_factory.return_value = _BombSession()
+
+    repo = PostgresSubnetRepository(session_factory=patched_factory)
+
+    with pytest.raises(RuntimeError, match="injected failure on second execute"):
+        await repo.delete_with_children(parent_id, child_ids)
+
+    # All rows must still exist — ROLLBACK was triggered by session.begin().__aexit__
+    assert await _exists(pg, parent_id), "parent must survive the failed cascade"
+    for cid in child_ids:
+        assert await _exists(pg, cid), f"child {cid} must survive the failed cascade"
+
+
+# =============================================================================
+# 3. Idempotent — parent already absent returns False, no error
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_with_children_parent_absent(pg: async_sessionmaker) -> None:
+    """Returns False and does not raise when the parent row does not exist.
+
+    Children listed may also be absent (they are simply skipped).
+    """
+    repo = PostgresSubnetRepository(session_factory=pg)
+    result = await repo.delete_with_children(
+        "no-such-parent", ["no-such-child-1", "no-such-child-2"]
+    )
+    assert result is False


### PR DESCRIPTION
## Summary

- Add 3 real-PostgreSQL integration tests for `PostgresSubnetRepository.delete_with_children`
- Add `docs/integration-testing.md` — how to run the real-PG suite locally
- Wire an opt-in **Integration** CI job (nightly + PR label)

## Why

The mock-based tests in `tests/infrastructure/test_postgres_subnet_repository_cascade.py`
verify the *idiom* (session.begin() is called, __aexit__ gets the exception).
They cannot catch a hypothetical future SQLAlchemy change where `session.begin()`
stops calling ROLLBACK on exception.  These integration tests exercise the real
SQLAlchemy+asyncpg+Postgres stack end-to-end.

## Test cases

| Test | What it verifies |
|------|-----------------|
| `test_delete_with_children_happy_path` | Parent + 3 children deleted atomically; returns `True` |
| `test_delete_with_children_rollback_on_mid_cascade_failure` | RuntimeError injected on 2nd `execute`; all rows survive (real ROLLBACK) |
| `test_delete_with_children_parent_absent` | Missing parent returns `False`, no raise |

All 3 tests skip silently on a normal `pytest` run unless `ACN_INTEGRATION_PG_URL` is set.

## CI strategy

- Default CI (`python` job): unchanged — integration tests skipped, suite stays fast
- New **Integration** job: triggered by nightly schedule (02:00 UTC) **or** PR label `run-integration-tests`
- Runs `postgres:16-alpine` as a service container

## Test plan

- [x] `ruff check` — clean (2 auto-fixed)
- [x] `basedpyright` — 0 errors
- [x] `pytest -m integration` (no PG) — 7 skipped, 0 errors

Closes #59

Made with [Cursor](https://cursor.com)