### PR TITLE
refactor(subnets): rename SubnetNestingError → SubnetInvariantError (closes #69)

### DIFF
--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -24,7 +24,7 @@ from ..protocols.ap2.webhook import WebhookService
 from ..services import AgentService, SubnetService
 from ..services.subnet_service import (
     REASON_NOT_PARENT_MEMBER,
-    SubnetNestingError,
+    SubnetInvariantError,
 )
 
 logger = structlog.get_logger()
@@ -124,7 +124,7 @@ async def do_join_subnet(
         await agent_service.join_subnet(agent_id, subnet_id)
         try:
             await subnet_service.add_member(subnet_id, agent_id)
-        except SubnetNestingError as nest_err:
+        except SubnetInvariantError as nest_err:
             # Race window between the pre-check above and the
             # service-layer write (parent membership changed
             # concurrently). Roll back the agent-side write so we

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -17,7 +17,7 @@ from ..config import get_settings
 from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
 from ..core.exceptions import SubnetNotFoundException
 from ..models import SubnetCreateRequest, SubnetCreateResponse, SubnetInfo
-from ..services.subnet_service import SubnetNestingError
+from ..services.subnet_service import SubnetInvariantError
 from ._subnet_membership import (
     do_get_agent_subnets,
     do_join_subnet,
@@ -110,11 +110,11 @@ def _subnet_entity_to_info(subnet) -> SubnetInfo:
     )
 
 
-def _nesting_error_to_acn(
-    exc: SubnetNestingError,
+def _invariant_error_to_acn(
+    exc: SubnetInvariantError,
     extra_details: dict | None = None,
 ) -> ACNHTTPError:
-    """Map a service-layer ``SubnetNestingError`` to the wire-format
+    """Map a service-layer ``SubnetInvariantError`` to the wire-format
     ``INVALID_REQUEST`` ACN error with the stable ``details.reason``
     string the route contract tests pin.
 
@@ -133,6 +133,12 @@ def _nesting_error_to_acn(
             ErrorCode.NOT_SUBNET_MEMBER, 403, details=details
         )
     return ACNHTTPError(ErrorCode.INVALID_REQUEST, 400, details=details)
+
+
+# Deprecated alias kept for one release cycle. Out-of-tree callers
+# importing ``_nesting_error_to_acn`` keep working; new code should
+# use ``_invariant_error_to_acn`` directly.
+_nesting_error_to_acn = _invariant_error_to_acn
 
 
 def _generate_subnet_id(name: str) -> str:
@@ -185,7 +191,7 @@ async def create_subnet(
             security_config=security_cfg,
             metadata={},
             # ADR-0003 nesting fields — service-layer validates the
-            # five invariant variants and raises ``SubnetNestingError``
+            # five invariant variants and raises ``SubnetInvariantError``
             # with a stable ``reason`` string.
             parent_subnet_id=body.parent_subnet_id,
             lifecycle=body.lifecycle,
@@ -194,7 +200,7 @@ async def create_subnet(
             # the service infer from ``is_private``; explicit values
             # go straight through and the
             # ``visibility_policy_conflict`` rejection surfaces via
-            # ``SubnetNestingError`` → ``_nesting_error_to_acn``.
+            # ``SubnetInvariantError`` → ``_invariant_error_to_acn``.
             join_policy=body.join_policy,
         )
 
@@ -244,11 +250,11 @@ async def create_subnet(
             # inferred (ADR-0004).
             join_policy=subnet.join_policy,
         )
-    except SubnetNestingError as e:
+    except SubnetInvariantError as e:
         # ADR-0003 invariant rejection — surface with the stable
         # ``details.reason`` token clients (route contract tests,
         # CLI / SDK error parsers) pin against.
-        raise _nesting_error_to_acn(e) from e
+        raise _invariant_error_to_acn(e) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
@@ -805,11 +811,11 @@ async def admin_add_subnet_member(
             404,
             details={"subnet_id": subnet_id},
         ) from e
-    except SubnetNestingError as e:
+    except SubnetInvariantError as e:
         # ADR-0003 child-subnet membership-subset rejection
         # propagated even through the internal admin path — keeps
         # the invariant uniformly enforced regardless of caller.
-        raise _nesting_error_to_acn(
+        raise _invariant_error_to_acn(
             e, extra_details={"subnet_id": subnet_id, "agent_id": agent_id}
         ) from e
     except ACNHTTPError:

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -33,18 +33,20 @@ REASON_NOT_PARENT_MEMBER = "not_parent_member"
 REASON_VISIBILITY_POLICY_CONFLICT = "visibility_policy_conflict"
 
 
-class SubnetNestingError(ValueError):
+class SubnetInvariantError(ValueError):
     """Raised by ``SubnetService`` when a subnet construction-time
     invariant rejects a request. Carries a stable ``reason`` string
     (one of the ``REASON_*`` constants above) that the route layer
     surfaces as ``details.reason`` for client / CLI / SDK parsers.
 
-    The class name is a historical artefact of ADR-0003 (which only
-    raised nesting-related rejections through it). ADR-0004 extends
-    its use to the ``visibility_policy_conflict`` invariant; future
-    ADRs are expected to keep piling stable reasons onto the same
-    exception class rather than fork it, so the route layer can keep
-    a single ``_nesting_error_to_acn`` switch.
+    Previously named ``SubnetNestingError`` (ADR-0003 only raised
+    nesting-related rejections through it). ADR-0004 broadened its
+    scope to also carry ``visibility_policy_conflict``; future ADRs
+    are expected to keep piling stable reasons onto this same class
+    rather than fork it, so the route layer can keep a single
+    ``_invariant_error_to_acn`` switch. The legacy name is still
+    re-exported via the module ``__getattr__`` below with a
+    ``DeprecationWarning``.
 
     Kept as a ``ValueError`` subclass so legacy callers that catch
     ``ValueError`` (e.g. ``routes/subnets.py::create_subnet``) keep
@@ -54,6 +56,31 @@ class SubnetNestingError(ValueError):
     def __init__(self, reason: str, message: str | None = None) -> None:
         self.reason = reason
         super().__init__(message or reason)
+
+
+def __getattr__(name: str):
+    """Module-level ``__getattr__`` for the deprecated
+    ``SubnetNestingError`` alias (PEP 562).
+
+    Resolving ``acn.services.subnet_service.SubnetNestingError`` —
+    whether at import time (``from .subnet_service import
+    SubnetNestingError``) or as an attribute access — returns the
+    renamed :class:`SubnetInvariantError` and emits a
+    ``DeprecationWarning`` so out-of-tree consumers see a one-cycle
+    migration window before the alias is dropped.
+    """
+    if name == "SubnetNestingError":
+        import warnings
+
+        warnings.warn(
+            "SubnetNestingError is deprecated; use SubnetInvariantError "
+            "instead. The legacy alias will be removed in a future "
+            "release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return SubnetInvariantError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class SubnetService:
@@ -148,7 +175,7 @@ class SubnetService:
           with ``is_private=True`` knowingly, the service rejects
           with ``visibility_policy_conflict`` rather than letting
           the entity's bare ``ValueError`` bubble up — the route
-          layer's ``_nesting_error_to_acn`` already maps it to
+          layer's ``_invariant_error_to_acn`` already maps it to
           ``INVALID_REQUEST 400 {"details": {"reason":
           "visibility_policy_conflict"}}``.
         - The other three combinations (``public+open``,
@@ -174,7 +201,7 @@ class SubnetService:
 
         Raises:
             ValueError: If subnet already exists
-            SubnetNestingError: On any of the five ADR-0003 invariant
+            SubnetInvariantError: On any of the five ADR-0003 invariant
                 rejections, or the ADR-0004
                 ``visibility_policy_conflict`` rejection.
         """
@@ -203,7 +230,7 @@ class SubnetService:
             # Surfaced with a stable reason so the route layer's
             # contract test can pin the exact error code without
             # depending on the (English) message text.
-            raise SubnetNestingError(
+            raise SubnetInvariantError(
                 REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
                 "lifecycle='task_scoped' requires linked_task_id",
             )
@@ -211,7 +238,7 @@ class SubnetService:
         if parent_subnet_id is not None:
             parent = await self.repository.find_by_id(parent_subnet_id)
             if parent is None:
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_PARENT_NOT_FOUND,
                     f"Parent subnet '{parent_subnet_id}' does not exist",
                 )
@@ -220,13 +247,13 @@ class SubnetService:
             # ``system`` owner literal is the platform escape hatch
             # and any subnet under it is treated as platform-owned.
             if parent_subnet_id in {"public", "system"} or parent.owner == "system":
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_PARENT_IS_RESERVED,
                     f"Parent subnet '{parent_subnet_id}' is reserved",
                 )
             # Single-layer cap — parent must itself be top-level.
             if parent.parent_subnet_id is not None:
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_PARENT_IS_NESTED,
                     f"Parent subnet '{parent_subnet_id}' is itself nested; "
                     "single-layer cap enforced",
@@ -239,7 +266,7 @@ class SubnetService:
             # in ``api.py`` always supplies one.
             task_exists = await self.task_repository.exists(linked_task_id)
             if not task_exists:
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_LINKED_TASK_NOT_FOUND,
                     f"Linked task '{linked_task_id}' does not exist",
                 )
@@ -252,10 +279,10 @@ class SubnetService:
         # automatically.
         #
         # When the caller explicitly passes the conflicting combination
-        # we raise a structured ``SubnetNestingError`` with a stable
+        # we raise a structured ``SubnetInvariantError`` with a stable
         # ``reason`` token rather than letting the entity's bare
         # ``ValueError`` bubble up through the route's generic catch —
-        # the route's existing ``_nesting_error_to_acn`` switch already
+        # the route's existing ``_invariant_error_to_acn`` switch already
         # maps unknown reasons to ``INVALID_REQUEST 400``, so this gives
         # clients a clean parseable token instead of a free-form message.
         if join_policy is None:
@@ -265,7 +292,7 @@ class SubnetService:
         else:
             effective_join_policy = join_policy
             if is_private and effective_join_policy == "open":
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_VISIBILITY_POLICY_CONFLICT,
                     "is_private=True requires join_policy='approval' "
                     "(omit join_policy to let the service default it)",
@@ -582,7 +609,7 @@ class SubnetService:
             Updated subnet entity
 
         Raises:
-            SubnetNestingError: If subnet is a child and ``agent_id``
+            SubnetInvariantError: If subnet is a child and ``agent_id``
                 is not a member of the parent.
         """
         subnet = await self.get_subnet(subnet_id)
@@ -594,7 +621,7 @@ class SubnetService:
             # dangling child would silently bypass the subset
             # invariant. Ops should ``delete_subnet`` the orphan.
             if parent is None or agent_id not in parent.member_agent_ids:
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_NOT_PARENT_MEMBER,
                     f"Agent '{agent_id}' is not a member of parent subnet "
                     f"'{subnet.parent_subnet_id}'",

--- a/docs/adr/0004-subnet-join-policy.md
+++ b/docs/adr/0004-subnet-join-policy.md
@@ -947,7 +947,7 @@ verbatim. All three approval entry paths converge on
 `SubnetService.add_member` once `status` reaches `approved`. For a
 child subnet, `add_member` performs the existing parent-membership
 check before mutating state. If the check fails, the call raises
-`SubnetNestingError(reason="not_parent_member")`, the route layer
+`SubnetInvariantError(reason="not_parent_member")`, the route layer
 catches it, and the request row is updated to `rejected` with
 `decided_by="system"` and `note="not_parent_member"`. This makes
 "agent A approved into child subnet C but A is not in parent P" a
@@ -1176,7 +1176,7 @@ becomes a candidate for a follow-up ADR with its own scope.
 - `tests/services/test_subnet_service_join_policy_nesting.py`
   (new) — ADR-0003 cross-cut: approve / accept / allowlist-hit
   on a child subnet where the agent is not in the parent →
-  `add_member` raises `SubnetNestingError`, route layer flips
+  `add_member` raises `SubnetInvariantError`, route layer flips
   the row to `rejected` with `note="not_parent_member"`.
 
 ### Integration

--- a/tests/routes/test_subnets_join_policy.py
+++ b/tests/routes/test_subnets_join_policy.py
@@ -41,7 +41,7 @@ from acn.routes.dependencies import (
 )
 from acn.services.subnet_service import (
     REASON_VISIBILITY_POLICY_CONFLICT,
-    SubnetNestingError,
+    SubnetInvariantError,
 )
 
 
@@ -94,7 +94,7 @@ def stub_subnet_service():
             effective = "approval" if is_private else "open"
         else:
             if is_private and join_policy == "open":
-                raise SubnetNestingError(
+                raise SubnetInvariantError(
                     REASON_VISIBILITY_POLICY_CONFLICT,
                     "is_private=True requires join_policy='approval'",
                 )

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -33,7 +33,7 @@ from acn.services.subnet_service import (
     REASON_PARENT_IS_RESERVED,
     REASON_PARENT_NOT_FOUND,
     REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
-    SubnetNestingError,
+    SubnetInvariantError,
 )
 
 # ---------------------------------------------------------------------------
@@ -118,13 +118,13 @@ def test_create_subnet_invariant_rejection(reason, stub_agent_service):
     """One test per ``details.reason`` string the service raises.
 
     Each variant is exercised by stubbing ``create_subnet`` to raise
-    ``SubnetNestingError(reason)`` and asserting the route maps it to
+    ``SubnetInvariantError(reason)`` and asserting the route maps it to
     ``ACNHTTPError(INVALID_REQUEST, 400, details={"reason": <token>})``.
     """
     expected_status, expected_code = _REASON_ERROR_CODE_MAP[reason]
     subnet_svc = AsyncMock()
     subnet_svc.create_subnet = AsyncMock(
-        side_effect=SubnetNestingError(reason, f"test reason: {reason}")
+        side_effect=SubnetInvariantError(reason, f"test reason: {reason}")
     )
     _wire(stub_agent_service, subnet_svc)
 
@@ -390,7 +390,7 @@ class TestAdminAddSubnetMemberNesting:
     ):
         """The membership-subset invariant fires through the admin
         path too. Surfaced as ``NOT_SUBNET_MEMBER`` (403), not
-        ``INVALID_REQUEST`` — see ``_nesting_error_to_acn``.
+        ``INVALID_REQUEST`` — see ``_invariant_error_to_acn``.
         """
         # Disable internal-token / acn:admin gate so the test
         # exercises the body of the handler.
@@ -405,7 +405,7 @@ class TestAdminAddSubnetMemberNesting:
 
         subnet_svc = AsyncMock()
         subnet_svc.add_member = AsyncMock(
-            side_effect=SubnetNestingError(REASON_NOT_PARENT_MEMBER, "test")
+            side_effect=SubnetInvariantError(REASON_NOT_PARENT_MEMBER, "test")
         )
         _wire(stub_agent_service, subnet_svc)
 

--- a/tests/services/test_subnet_invariant_error_alias.py
+++ b/tests/services/test_subnet_invariant_error_alias.py
@@ -1,0 +1,96 @@
+"""Pins the deprecated ``SubnetNestingError`` alias contract.
+
+After the rename (``SubnetNestingError`` → ``SubnetInvariantError``)
+the legacy name is re-exported via the module's ``__getattr__`` so
+out-of-tree consumers — other agentplanet worktrees, downstream
+SDKs, ad-hoc scripts — get a one-cycle migration window instead of
+an ``ImportError`` on the next ``pip install``.
+
+This test pins three properties of that alias so a future PR that
+"cleans up" the ``__getattr__`` can't silently drop the migration
+window:
+
+1. The alias resolves to the same class object as
+   ``SubnetInvariantError`` (so ``isinstance`` checks against either
+   name still work cross-codebase).
+2. Accessing the alias emits a ``DeprecationWarning`` with a stable
+   pointer at the new name.
+3. Accessing an unrelated nonexistent attribute still raises
+   ``AttributeError`` — the ``__getattr__`` must be a targeted
+   bridge, not a permissive catch-all that would silently swallow
+   typos.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+from acn.services import subnet_service
+
+
+class TestSubnetNestingErrorAlias:
+    def test_alias_resolves_to_same_class_as_new_name(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = subnet_service.SubnetNestingError
+
+        assert legacy is subnet_service.SubnetInvariantError
+
+    def test_alias_attribute_access_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = subnet_service.SubnetNestingError
+
+        deprecations = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecations, (
+            "accessing SubnetNestingError must emit a DeprecationWarning"
+        )
+        msg = str(deprecations[0].message)
+        assert "SubnetNestingError" in msg
+        assert "SubnetInvariantError" in msg, (
+            "warning must point callers at the new name"
+        )
+
+    def test_alias_import_emits_deprecation_warning(self):
+        """``from acn.services.subnet_service import SubnetNestingError``
+        — the most common downstream usage shape — also triggers the
+        warning, not just attribute access."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            # ``module.SubnetNestingError`` exercises the same
+            # ``__getattr__`` code path that ``from ... import
+            # SubnetNestingError`` triggers internally (CPython
+            # falls back to the module's ``__getattr__`` after the
+            # primary lookup misses — PEP 562).
+            mod = importlib.import_module("acn.services.subnet_service")
+            _ = mod.SubnetNestingError  # type: ignore[attr-defined]
+
+        assert any(
+            issubclass(w.category, DeprecationWarning) for w in caught
+        )
+
+    def test_legacy_alias_raised_instance_isinstance_works_against_both_names(
+        self,
+    ):
+        """The whole point of the alias: downstream code that does
+        ``except SubnetNestingError`` keeps catching exceptions our
+        service raises under the new name."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            LegacyName = subnet_service.SubnetNestingError
+
+        raised = subnet_service.SubnetInvariantError("test_reason", "test msg")
+
+        assert isinstance(raised, LegacyName)
+        assert isinstance(raised, subnet_service.SubnetInvariantError)
+
+    def test_unknown_attribute_still_raises_attributeerror(self):
+        """``__getattr__`` is a targeted bridge — it must not turn
+        every typo into a silent ``None``-equivalent."""
+        with pytest.raises(AttributeError):
+            _ = subnet_service.SubnetNestingErrorrr  # type: ignore[attr-defined]

--- a/tests/services/test_subnet_service.py
+++ b/tests/services/test_subnet_service.py
@@ -8,7 +8,7 @@ import pytest
 from acn.services import SubnetService
 from acn.services.subnet_service import (
     REASON_VISIBILITY_POLICY_CONFLICT,
-    SubnetNestingError,
+    SubnetInvariantError,
 )
 
 
@@ -130,7 +130,7 @@ class TestSubnetServiceADR0004JoinPolicy:
        500 on the entity-layer invariant.
     2. **Forward-aware clients** — pass ``join_policy`` explicitly.
        The service trusts the explicit value but raises a structured
-       ``SubnetNestingError(visibility_policy_conflict)`` if the
+       ``SubnetInvariantError(visibility_policy_conflict)`` if the
        caller knowingly sends the rejected combination, instead of
        letting the entity's bare ``ValueError`` bubble up as a
        free-form message.
@@ -198,13 +198,13 @@ class TestSubnetServiceADR0004JoinPolicy:
         self, mock_subnet_repository
     ):
         """The ``visibility_policy_conflict`` rejection surfaces as a
-        ``SubnetNestingError`` with the stable reason token — clients
+        ``SubnetInvariantError`` with the stable reason token — clients
         / CLI / SDK parsers pin against ``details.reason`` and must
         not have to scrape a free-form message."""
         mock_subnet_repository.exists.return_value = False
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc_info:
+        with pytest.raises(SubnetInvariantError) as exc_info:
             await service.create_subnet(
                 subnet_id="subnet-priv-open",
                 name="Private Open",

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -20,7 +20,7 @@ from acn.services.subnet_service import (
     REASON_PARENT_IS_RESERVED,
     REASON_PARENT_NOT_FOUND,
     REASON_TASK_SCOPED_REQUIRES_LINKED_TASK,
-    SubnetNestingError,
+    SubnetInvariantError,
     SubnetService,
 )
 
@@ -59,7 +59,7 @@ class TestCreateSubnetNestingInvariants:
         mock_subnet_repository.find_by_id.return_value = None
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="child-1",
                 name="Squad",
@@ -84,7 +84,7 @@ class TestCreateSubnetNestingInvariants:
             subnet_id="public", owner="system"
         )
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="child-1",
                 name="Squad",
@@ -106,7 +106,7 @@ class TestCreateSubnetNestingInvariants:
         )
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="child-1",
                 name="Squad",
@@ -128,7 +128,7 @@ class TestCreateSubnetNestingInvariants:
         )
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="grandchild",
                 name="Too deep",
@@ -144,7 +144,7 @@ class TestCreateSubnetNestingInvariants:
         mock_subnet_repository.exists.return_value = False
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="task-squad",
                 name="Task Squad",
@@ -169,7 +169,7 @@ class TestCreateSubnetNestingInvariants:
             mock_subnet_repository, task_repository=mock_task_repository
         )
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
                 subnet_id="task-squad",
                 name="Task Squad",
@@ -264,7 +264,7 @@ class TestAddMemberMembershipSubset:
         mock_subnet_repository.find_by_id.side_effect = [child, parent]
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.add_member("child-1", "bob")
         assert exc.value.reason == REASON_NOT_PARENT_MEMBER
         mock_subnet_repository.save.assert_not_called()
@@ -306,7 +306,7 @@ class TestAddMemberMembershipSubset:
         mock_subnet_repository.find_by_id.side_effect = [child, None]
         service = SubnetService(mock_subnet_repository)
 
-        with pytest.raises(SubnetNestingError) as exc:
+        with pytest.raises(SubnetInvariantError) as exc:
             await service.add_member("child-1", "bob")
         assert exc.value.reason == REASON_NOT_PARENT_MEMBER
 


### PR DESCRIPTION
## Summary

Closes #69. Rename `SubnetNestingError` → `SubnetInvariantError` across all callsites; keep a deprecated alias for one release cycle.

**Why now**: the class name was a historical artefact of ADR-0003 (which only raised nesting-related rejections through it). ADR-0004 broadened its scope to also carry `visibility_policy_conflict`, and future ADRs will keep piling stable reasons onto the same class — the name should reflect the actual contract.

## Stacked on #67

**Base = `feat/adr-0004-subnet-join-policy` (PR #67)**, not `main`. Reasoning:

- PR #67 is the most recent code to touch every affected file; rebasing this rename onto an unreviewed ADR-0004 branch is cheaper than re-resolving the same conflicts twice.
- Once #67 merges, GitHub will automatically rebase this branch's diff against `main` — the result will be a clean rename-only patch with no Phase-1 noise.
- Review can happen now (the rename is self-contained and independent of Phase 1 review feedback).

## Migration window

Out-of-tree consumers (other agentplanet worktrees, downstream SDKs, ad-hoc scripts) keep working unchanged:

- `from acn.services.subnet_service import SubnetNestingError` — resolved via PEP 562 module-level `__getattr__`, emits `DeprecationWarning` pointing at `SubnetInvariantError`.
- `from acn.routes.subnets import _nesting_error_to_acn` — kept as a module-level alias for one cycle.

A follow-up PR drops both aliases once the warning has been visible in release notes for one cycle.

## Changes

- `acn/services/subnet_service.py` — class renamed, 7 raise sites + 2 docstring blocks updated, new `__getattr__` for the alias.
- `acn/routes/subnets.py` — helper renamed, import + 2 catch sites + 2 raise sites updated, legacy helper alias kept.
- `acn/routes/_subnet_membership.py` — import + 1 except clause updated.
- `tests/services/test_subnet_service.py`, `test_subnet_service_nesting.py`, `tests/routes/test_subnets_nesting.py`, `tests/routes/test_subnets_join_policy.py` — imports + `pytest.raises` + docstrings updated.
- `docs/adr/0004-subnet-join-policy.md` — 2 stale references updated.

## New tests

`tests/services/test_subnet_invariant_error_alias.py` (5 tests) pins three properties of the migration alias so a future "cleanup" PR can't silently drop the migration window:

1. Alias resolves to the same class object (`isinstance` keeps working against either name cross-codebase).
2. Attribute access emits `DeprecationWarning` with a stable pointer at the new name.
3. `from … import SubnetNestingError` shape — the most common downstream usage — triggers the warning too, not just attribute access.
4. Exceptions raised under the new name still match `except SubnetNestingError` in downstream code.
5. Unknown attribute access still raises `AttributeError` — the `__getattr__` is a targeted bridge, not a permissive catch-all that would swallow typos.

## Test plan

- [x] 68 / 68 impacted tests green (service / route / nesting / membership / join_policy / error_schema).
- [x] 5 / 5 new alias-contract tests green.
- [x] `ruff check` clean.
- [ ] CI green after push.

## Out of scope

- Worktree-only files (`acn-alive-worktree/`, `acn-rotate-key/`) — those branches will pick up the rename when they merge to `main` and hit the `DeprecationWarning`.
- Removing the alias — deferred to the post-release cycle.
