### PR TITLE
feat(adr-0004): Phase 2 Slice 2.1 — schema, entities, repos, cascade

### DIFF
--- a/acn/core/entities/__init__.py
+++ b/acn/core/entities/__init__.py
@@ -6,6 +6,8 @@ These represent the core business concepts of ACN.
 
 from .agent import Agent, ClaimStatus
 from .subnet import Subnet
+from .subnet_allowlist import SubnetAllowlist
+from .subnet_join_request import SYSTEM_ALLOWLIST_ACTOR, SubnetJoinRequest
 from .task import (
     Participation,
     ParticipationStatus,
@@ -20,11 +22,14 @@ from .task import (
 # import it from there if you need the response/SDK representation.
 
 __all__ = [
+    "SYSTEM_ALLOWLIST_ACTOR",
     "Agent",
     "ClaimStatus",
     "Participation",
     "ParticipationStatus",
     "Subnet",
+    "SubnetAllowlist",
+    "SubnetJoinRequest",
     "Task",
     "TaskStatus",
 ]

--- a/acn/core/entities/subnet_allowlist.py
+++ b/acn/core/entities/subnet_allowlist.py
@@ -1,0 +1,100 @@
+"""SubnetAllowlist Domain Entity (ADR-0004 Phase 2 Slice 2.1).
+
+A single ``(subnet_id, agent_id)`` entry in the subnet's
+admission-allowlist. Distinct from ``IAllowlistRepository`` (which
+governs **agent-to-agent communication** under
+``communication_policy.mode=allowlist``) — this entity governs
+**agent-to-subnet admission** under ``join_policy='approval'``. The
+namespace ambiguity is acknowledged but ADR-0004 keeps the term
+"allowlist" because both flows share the same semantic shape
+("preauthorised members of a trust set"); the prefix discipline
+(``SubnetAllowlist`` vs the agent-comm ``AllowlistEntry``) keeps
+them distinguishable in code and in error messages.
+
+Flat configuration set, no state machine. The ``join`` flow
+(ADR-0004 §join branch 4) checks for an entry, and on hit
+materialises a ``SubnetJoinRequest(kind='allowlist_auto',
+status='approved')`` audit row. Removal from the allowlist does
+NOT evict an already-joined member (ADR §State machine edges
+"Allowlist removal does not evict members") — it only changes the
+path future re-joins take.
+
+Why a dataclass, not a Pydantic model: same reasoning as ``Subnet``
+/ ``SubnetJoinRequest``. Pure domain object; framework wrapping
+happens at the API and ORM layers.
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class SubnetAllowlist:
+    """A single preauthorised ``(subnet_id, agent_id)`` admission entry."""
+
+    subnet_id: str
+    agent_id: str
+    added_by: str
+    added_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        """Enforce non-empty identity fields.
+
+        Schema-level constraints (composite PK on
+        ``(subnet_id, agent_id)``, FK against ``agents.agent_id``,
+        existence-check on ``subnet_id``) live at the persistence
+        layer; the entity only rejects the structurally impossible
+        shapes (empty strings) that the schema's NOT NULL doesn't
+        catch.
+
+        ``added_by`` is required because every allowlist mutation
+        is owner-audited — an empty actor makes the row
+        irreversibly anonymous, which defeats the whole audit
+        trail. The service layer is expected to set this to the
+        authenticated owner agent_id; allowlist add through an
+        admin path that lacks an owner identity should synthesise
+        a ``system:<reason>`` actor (matches the convention
+        ``SubnetJoinRequest.SYSTEM_ALLOWLIST_ACTOR`` uses).
+        """
+        if not self.subnet_id:
+            raise ValueError("subnet_id cannot be empty")
+        if not self.agent_id:
+            raise ValueError("agent_id cannot be empty")
+        if not self.added_by:
+            raise ValueError("added_by cannot be empty")
+
+    def to_dict(self) -> dict:
+        """Serialise to a flat dict for Redis HASH storage.
+
+        Stored in the parallel-meta HASH
+        ``acn:subnets:{subnet_id}:allowlist_meta:{agent_id}`` — the
+        primary membership SET ``acn:subnets:{subnet_id}:allowlist``
+        only carries the agent_ids; this meta HASH carries the
+        audit fields. Two-key layout instead of single-HASH because
+        ``SISMEMBER`` on the SET is the hot ``is_member`` check
+        and a HASH-only layout would force ``HEXISTS`` instead
+        (same cost, but loses the future ability to SDIFF /
+        SINTERSTORE the membership for batch operations).
+        """
+        return {
+            "subnet_id": self.subnet_id,
+            "agent_id": self.agent_id,
+            "added_by": self.added_by,
+            "added_at": self.added_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubnetAllowlist":
+        """Reconstitute from a Redis HASH dict.
+
+        Inverse of :meth:`to_dict`. All four fields are required —
+        unlike ``SubnetJoinRequest`` there are no nullable fields
+        and no legacy-row tolerance: an allowlist entry that's
+        missing ``added_by`` or ``added_at`` is a corrupt record,
+        not a backward-compat case."""
+        return cls(
+            subnet_id=data["subnet_id"],
+            agent_id=data["agent_id"],
+            added_by=data["added_by"],
+            added_at=datetime.fromisoformat(data["added_at"]),
+        )

--- a/acn/core/entities/subnet_join_request.py
+++ b/acn/core/entities/subnet_join_request.py
@@ -1,0 +1,234 @@
+"""SubnetJoinRequest Domain Entity (ADR-0004 Phase 2 Slice 2.1).
+
+A single row in the three-in-one ``subnet_join_requests`` table.
+Implements ADR-0004 §"Three approval entry paths, unified table
+model": one schema covers join_request (pull / applicant-initiated),
+invitation (push / owner-initiated), and allowlist_auto (system-
+materialised on allowlist hit). The ``kind`` discriminator is the
+only field that meaningfully differs across the three flows;
+everything else — status machine, audit fields, decision actor
+semantics — is uniform.
+
+State machine summary (full table in ADR §State transition table):
+
+* ``join_request``:   pending → approved (owner approve) / rejected
+                       (owner reject) / withdrawn (applicant withdraw)
+* ``invitation``:     pending → approved (invitee accept) / rejected
+                       (invitee reject) / withdrawn (owner cancel)
+* ``allowlist_auto``: born approved (no pending lifecycle); no edges
+                       out of ``approved``
+
+The entity enforces the **construction-time invariants** the table
+schema can't express — primarily the (kind, status, initiated_by,
+decided_by) coherence checks. State transitions themselves are
+service-layer concerns (CAS on ``status='pending'`` against the
+database); the entity refuses to materialise structurally
+impossible rows, but doesn't gate transitions on its own.
+
+Why a dataclass, not a Pydantic model: same reasoning as ``Subnet``.
+Pure domain object, no framework dep, framework wrapping happens at
+``acn/models.py`` (response shape) and the SQLAlchemy ORM
+(persistence shape).
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Literal
+
+# Valid ``kind`` values (the discriminator). ``Literal`` type hints
+# are not runtime-enforced on a dataclass; we mirror the set here so
+# ``__post_init__`` can reject typos at construction time before any
+# repository write reaches storage.
+_KIND_VALUES: frozenset[str] = frozenset(
+    {"join_request", "invitation", "allowlist_auto"}
+)
+
+# Valid ``status`` values. ``withdrawn`` is distinguished from
+# ``rejected`` so audit consumers can tell "withdrawn by the side
+# that asked" from "rejected by the side that decided" — see ADR
+# §State transition table for the per-kind decided_by mapping.
+_STATUS_VALUES: frozenset[str] = frozenset(
+    {"pending", "approved", "rejected", "withdrawn"}
+)
+
+# Reserved synthetic actor token for ``allowlist_auto`` rows. The
+# token shape ``system:<reason>`` mirrors the convention ADR-0003
+# established for system-generated audit actors (``system:cascade``,
+# ``system:reaper``). Reserved here so the entity-layer invariant
+# check can pin both ``initiated_by`` and ``decided_by`` against the
+# same literal — a typo in either field is caught at construction.
+SYSTEM_ALLOWLIST_ACTOR: str = "system:allowlist"
+
+# Note length cap matches ADR §SubnetJoinRequest schema (note ≤500
+# chars). Enforced at the entity layer so persistence-layer
+# truncation can never surprise a downstream reader.
+_NOTE_MAX_LEN: int = 500
+
+
+@dataclass
+class SubnetJoinRequest:
+    """A single row in ``subnet_join_requests``.
+
+    The ``agent_id`` semantics are uniform across all three kinds:
+    it is always **the agent who would (or did) become a member**.
+    Directionality (who initiated, who decided) lives in
+    ``initiated_by`` / ``decided_by`` — never in ``agent_id``.
+    """
+
+    request_id: str
+    subnet_id: str
+    agent_id: str
+    kind: Literal["join_request", "invitation", "allowlist_auto"]
+    status: Literal["pending", "approved", "rejected", "withdrawn"]
+    initiated_by: str
+    decided_by: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    decided_at: datetime | None = None
+    note: str | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce construction-time invariants.
+
+        The five invariants below are the ones the persistence
+        schema cannot express (or could only express via partial
+        indexes that don't compose cleanly with our dual-store
+        Postgres+Redis layout). Service-layer state transitions
+        re-derive these on every CAS, but rejecting structurally
+        impossible rows at the entity boundary means a single
+        ``service.repo.save(...)`` is the only place that can write
+        garbage — useful when the implementation eventually grows
+        an admin-side replay tool that constructs entities from
+        raw dicts.
+        """
+        if not self.request_id:
+            raise ValueError("request_id cannot be empty")
+        if not self.subnet_id:
+            raise ValueError("subnet_id cannot be empty")
+        if not self.agent_id:
+            raise ValueError("agent_id cannot be empty")
+        if not self.initiated_by:
+            raise ValueError("initiated_by cannot be empty")
+
+        if self.kind not in _KIND_VALUES:
+            raise ValueError(
+                f"kind must be one of {sorted(_KIND_VALUES)}, got {self.kind!r}"
+            )
+        if self.status not in _STATUS_VALUES:
+            raise ValueError(
+                f"status must be one of {sorted(_STATUS_VALUES)}, "
+                f"got {self.status!r}"
+            )
+
+        # ``pending`` rows must NOT carry a decision; non-``pending``
+        # rows MUST. The bidirectional check catches both "service
+        # forgot to clear decided_by on rollback" and "service
+        # forgot to set decided_by on transition out of pending".
+        if self.status == "pending":
+            if self.decided_by is not None or self.decided_at is not None:
+                raise ValueError(
+                    "pending rows must have decided_by=None and "
+                    "decided_at=None"
+                )
+        else:
+            if self.decided_by is None or self.decided_at is None:
+                raise ValueError(
+                    f"status={self.status!r} requires both decided_by and "
+                    f"decided_at to be set"
+                )
+
+        # ``allowlist_auto`` is born approved by the system. Per ADR
+        # §State transition table the only legal shape is
+        # (status=approved, initiated_by=decided_by=SYSTEM_ALLOWLIST_ACTOR).
+        # No pending lifecycle, no other status values — anything
+        # else means a route or service layer is mis-using the
+        # discriminator.
+        if self.kind == "allowlist_auto":
+            if self.status != "approved":
+                raise ValueError(
+                    "allowlist_auto rows must be born approved "
+                    f"(got status={self.status!r})"
+                )
+            if self.initiated_by != SYSTEM_ALLOWLIST_ACTOR:
+                raise ValueError(
+                    "allowlist_auto rows must have "
+                    f"initiated_by={SYSTEM_ALLOWLIST_ACTOR!r} "
+                    f"(got {self.initiated_by!r})"
+                )
+            if self.decided_by != SYSTEM_ALLOWLIST_ACTOR:
+                raise ValueError(
+                    "allowlist_auto rows must have "
+                    f"decided_by={SYSTEM_ALLOWLIST_ACTOR!r} "
+                    f"(got {self.decided_by!r})"
+                )
+
+        if self.note is not None and len(self.note) > _NOTE_MAX_LEN:
+            raise ValueError(
+                f"note exceeds {_NOTE_MAX_LEN}-char limit "
+                f"(got {len(self.note)} chars)"
+            )
+
+    @property
+    def is_pending(self) -> bool:
+        """True iff this row blocks future ``(subnet_id, agent_id)``
+        request creation under the unique partial index
+        ``WHERE status='pending'``."""
+        return self.status == "pending"
+
+    @property
+    def is_terminal(self) -> bool:
+        """True iff no further state transitions are legal. Both
+        ``approved`` and ``rejected``/``withdrawn`` are terminal —
+        the service layer's re-apply path (ADR §State machine edges)
+        creates a *new* request_id rather than re-opening the old."""
+        return self.status != "pending"
+
+    def to_dict(self) -> dict:
+        """Serialise to a flat dict for Redis HASH storage.
+
+        ``datetime`` fields are emitted as ISO 8601 strings so the
+        Redis HASH stays string-only (matches the convention
+        ``Subnet.to_dict`` established for harness URLs etc.).
+        Empty values are emitted as empty strings, not omitted —
+        ``from_dict`` reconstitutes ``None`` from empty strings via
+        ``or None`` so callers don't have to special-case
+        per-field "missing vs falsy".
+        """
+        return {
+            "request_id": self.request_id,
+            "subnet_id": self.subnet_id,
+            "agent_id": self.agent_id,
+            "kind": self.kind,
+            "status": self.status,
+            "initiated_by": self.initiated_by,
+            "decided_by": self.decided_by or "",
+            "created_at": self.created_at.isoformat(),
+            "decided_at": self.decided_at.isoformat() if self.decided_at else "",
+            "note": self.note or "",
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubnetJoinRequest":
+        """Reconstitute from a Redis HASH dict.
+
+        Inverse of :meth:`to_dict`. Empty strings in the
+        ``decided_by`` / ``decided_at`` / ``note`` slots collapse
+        back to ``None`` — these three are the only nullable fields
+        in the schema. ``created_at`` is always present (set at
+        creation, never nullable)."""
+        decided_at_raw = data.get("decided_at") or None
+        return cls(
+            request_id=data["request_id"],
+            subnet_id=data["subnet_id"],
+            agent_id=data["agent_id"],
+            kind=data["kind"],
+            status=data["status"],
+            initiated_by=data["initiated_by"],
+            decided_by=data.get("decided_by") or None,
+            created_at=datetime.fromisoformat(data["created_at"]),
+            decided_at=(
+                datetime.fromisoformat(decided_at_raw)
+                if decided_at_raw
+                else None
+            ),
+            note=data.get("note") or None,
+        )

--- a/acn/core/interfaces/__init__.py
+++ b/acn/core/interfaces/__init__.py
@@ -17,6 +17,8 @@ from .settlement_outbox_repository import (
     ISettlementOutboxRepository,
     SettlementEvent,
 )
+from .subnet_allowlist_repository import ISubnetAllowlistRepository
+from .subnet_join_request_repository import ISubnetJoinRequestRepository
 from .subnet_repository import ISubnetRepository
 from .task_repository import ITaskRepository
 from .unit_of_work import IUnitOfWork
@@ -30,6 +32,8 @@ __all__ = [
     "IFollowRepository",
     "ISettlementOutboxRepository",
     "SettlementEvent",
+    "ISubnetAllowlistRepository",
+    "ISubnetJoinRequestRepository",
     "ISubnetRepository",
     "ITaskRepository",
     "IUnitOfWork",

--- a/acn/core/interfaces/subnet_allowlist_repository.py
+++ b/acn/core/interfaces/subnet_allowlist_repository.py
@@ -1,0 +1,100 @@
+"""Subnet Admission Allowlist Repository Interface (ADR-0004 Phase 2 Slice 2.1).
+
+Storage contract for the per-subnet admission allowlist —
+preauthorised ``(subnet_id, agent_id)`` pairs that the §join flow
+checks (branch 4 in ADR §join) before falling through to the
+request/invitation path.
+
+Naming note
+-----------
+This is **distinct from** ``IAllowlistRepository`` in
+``acn/core/interfaces/allowlist_repository.py``, which governs
+agent-to-agent **communication** under
+``communication_policy.mode=allowlist``. ADR-0004 retains the
+"allowlist" term because both flows share the semantic shape
+("preauthorised members of a trust set"), but the ``Subnet``
+prefix makes the namespace unambiguous in code; error messages
+should say "subnet allowlist" / "communication allowlist" to
+keep operators clear.
+
+Why no ``is_member`` hot-path optimisation here
+-----------------------------------------------
+``IAllowlistRepository`` (the agent-comm one) exposes a Redis-
+cached ``is_member`` because every inbound message triggers a
+check. The subnet allowlist is consulted only on the ``join``
+endpoint — a cold path, hit once per ``(subnet, agent)`` in the
+agent's entire lifetime. No cache layer needed; PG SELECT is
+fast enough. The Redis implementation here is just a mirror for
+the dual-store reads-from-either pattern the rest of ACN uses,
+not a performance cache.
+"""
+
+from abc import ABC, abstractmethod
+
+from ..entities import SubnetAllowlist
+
+
+class ISubnetAllowlistRepository(ABC):
+    """Abstract contract for ``subnet_allowlist`` persistence."""
+
+    @abstractmethod
+    async def add(self, entry: SubnetAllowlist) -> bool:
+        """Insert ``(subnet_id, agent_id)`` into the allowlist.
+
+        Idempotent: re-adding an existing pair is a no-op. The
+        boolean return distinguishes the two cases so the route
+        layer can pick 201 (new) vs 200 (already present) per
+        ADR §HTTP status code conventions:
+
+        Returns:
+            True if a new row was inserted.
+            False if the pair already existed (idempotent path).
+        """
+
+    @abstractmethod
+    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+        """Drop ``(subnet_id, agent_id)`` from the allowlist.
+
+        Idempotent: removing an absent pair is a no-op. Removing
+        an entry does NOT evict an already-joined member — ADR
+        §State machine edges ("Allowlist removal does not evict
+        members") makes this an explicit non-invariant; the
+        service layer must not call ``remove_member`` from this
+        path.
+
+        Returns:
+            True if a row was actually removed.
+            False if the pair didn't exist.
+        """
+
+    @abstractmethod
+    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+        """Check whether ``agent_id`` is on ``subnet_id``'s allowlist.
+
+        Cold-path consultation point for the §join flow's branch 4.
+        Returns ``False`` for both "not on allowlist" and "subnet
+        doesn't exist" — the route layer has already verified
+        subnet existence by this point.
+        """
+
+    @abstractmethod
+    async def list_for_subnet(
+        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+    ) -> list[SubnetAllowlist]:
+        """List allowlist entries for one subnet, most-recent first.
+
+        Powers ``GET /subnets/{s}/allowlist``. Returns an empty
+        list if the subnet has no entries (or doesn't exist; the
+        existence check is the route's responsibility).
+        """
+
+    @abstractmethod
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all entries for a subnet. Returns count deleted.
+
+        Called by ``SubnetService.delete_subnet`` before deleting
+        the subnet row itself. Symmetric with
+        ``ISubnetJoinRequestRepository.delete_for_subnet`` — see
+        that interface's docstring for the cascade ordering /
+        atomicity contract.
+        """

--- a/acn/core/interfaces/subnet_join_request_repository.py
+++ b/acn/core/interfaces/subnet_join_request_repository.py
@@ -1,0 +1,142 @@
+"""Subnet Join Request Repository Interface (ADR-0004 Phase 2 Slice 2.1).
+
+Storage contract for the three-in-one ``subnet_join_requests``
+table. The interface is intentionally minimal at Slice 2.1: just
+the CRUD primitives Slice 2.2's ``JoinFlowService`` needs to wire
+the state machine on top. State-transition orchestration (CAS on
+``status='pending'``, webhook emission, etc.) lives at the service
+boundary, not here.
+
+Why no ``upsert`` / ``transition`` primitive on the interface
+-------------------------------------------------------------
+Both backends (Postgres and Redis) need different atomic envelopes
+to honour the "at most one pending per (subnet_id, agent_id)
+across all kinds" invariant — Postgres uses the
+``UNIQUE … WHERE status='pending'`` partial index; Redis uses a
+Lua script around the SETNX+HSET pair (ADR §"Redis layout and
+atomicity"). Hiding both under a single
+``IRepo.transition_to_approved`` method would force one of the
+two implementations to do something contorted. The service layer
+calls a small set of repo primitives (``save_pending``,
+``mark_decided``, ``find_pending_for``) and composes them; each
+backend picks the appropriate atomic primitive internally.
+
+Cascade contract
+----------------
+``delete_for_subnet`` is the cascade hook called from
+``SubnetService.delete_subnet``. ADR §"Cascade deletion" requires
+the delete to be atomic with the join_requests + allowlist +
+subnet deletion in Postgres (single transaction) and best-effort
+sequential in Redis (raise ``RuntimeError`` BEFORE touching the
+subnet HASH on partial failure). The interface only exposes the
+``delete_for_subnet`` primitive; the cascade orchestration is the
+service's responsibility.
+"""
+
+from abc import ABC, abstractmethod
+
+from ..entities import SubnetJoinRequest
+
+
+class ISubnetJoinRequestRepository(ABC):
+    """Abstract contract for ``subnet_join_requests`` persistence."""
+
+    @abstractmethod
+    async def save(self, request: SubnetJoinRequest) -> None:
+        """Insert a new row or overwrite an existing one by ``request_id``.
+
+        Implementations MAY enforce the "at most one pending per
+        (subnet_id, agent_id)" invariant at this layer (Postgres
+        partial index raises ``IntegrityError``; Redis Lua raises
+        a custom exception). The service layer wraps the raised
+        error and surfaces ``409 JOIN_REQUEST_PENDING`` /
+        ``409 INVITATION_PENDING`` accordingly.
+
+        ``save`` is the only mutation primitive — there is no
+        ``transition`` method because state transitions are
+        modelled as "construct a new entity with the target
+        status + decided_by + decided_at, then save". This keeps
+        the entity layer the single source of truth for legal
+        shapes; the repo never rewrites individual fields.
+        """
+
+    @abstractmethod
+    async def find_by_id(self, request_id: str) -> SubnetJoinRequest | None:
+        """Look up a single row by primary key.
+
+        Returns ``None`` if no row exists. Does NOT filter on
+        ``status`` — terminal rows remain queryable for audit.
+        """
+
+    @abstractmethod
+    async def find_pending_for(
+        self, subnet_id: str, agent_id: str
+    ) -> SubnetJoinRequest | None:
+        """Return the unique pending row for ``(subnet_id, agent_id)``, if any.
+
+        The "at most one" invariant means this returns at most one
+        row — Postgres enforces via the partial index, Redis via
+        the reverse pending index
+        ``acn:subnets:{s}:pending_by_agent:{a}``.
+
+        Used by the §join branch table to detect
+        "duplicate join request" / "pending invitation collides with
+        self-join" / "join request collides with owner invitation"
+        — branches 3, 5, and 6 in ADR §join.
+
+        Returns ``None`` if no pending row exists (the agent is
+        eligible to create a fresh request).
+        """
+
+    @abstractmethod
+    async def list_by_subnet(
+        self,
+        subnet_id: str,
+        *,
+        kind: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetJoinRequest]:
+        """List rows for one subnet, with optional ``kind`` / ``status`` filters.
+
+        Used by the owner-facing
+        ``GET /subnets/{s}/join-requests`` and
+        ``GET /subnets/{s}/invitations`` endpoints. Both endpoints
+        compose down to this single primitive — the route layer
+        sets ``kind`` accordingly.
+
+        Sort order: ``created_at DESC`` (most recent first). Pinned
+        here so the SDK / CLI listing UI has a stable contract
+        regardless of backend.
+        """
+
+    @abstractmethod
+    async def list_pending_invitations_for_agent(
+        self, agent_id: str
+    ) -> list[SubnetJoinRequest]:
+        """List the agent's pending invitations across all subnets.
+
+        Powers the invitee-facing
+        ``GET /agents/{a}/subnet-invitations`` endpoint. Filtered
+        server-side to ``kind='invitation' AND status='pending'``
+        — Postgres uses an index hint; Redis uses the dedicated
+        per-agent SET ``acn:agents:{a}:subnet_invitations``.
+
+        Sort order: ``created_at DESC``.
+        """
+
+    @abstractmethod
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all rows for a subnet. Returns count deleted.
+
+        Called by ``SubnetService.delete_subnet`` before deleting
+        the subnet row itself. Postgres impl participates in the
+        outer transaction; Redis impl iterates the listing index
+        SET and deletes each request HASH + reverse-index key,
+        raising ``RuntimeError`` on partial failure BEFORE the
+        caller touches the subnet HASH.
+
+        Returns the number of rows actually deleted (useful for
+        audit logging; not used by the cascade control flow).
+        """

--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -588,3 +588,142 @@ class ReputationEventModel(Base):
         # "Events for task X" — used by smoke-test backfill / ops.
         Index("ix_reputation_events_task_id", "task_id"),
     )
+
+
+# =============================================================================
+# Subnet Join Requests (ADR-0004 Phase 2 Slice 2.1)
+# =============================================================================
+#
+# Three-in-one table backing the ``SubnetJoinRequest`` entity. Single ``kind``
+# discriminator covers ``join_request`` / ``invitation`` / ``allowlist_auto``;
+# every other column has uniform semantics across the three flows. See the
+# entity's docstring for the per-kind state-transition table and ADR-0004
+# §"SubnetJoinRequest schema (three-in-one table)" for the full data-model
+# rationale.
+#
+# Why no FK to ``subnets.subnet_id``: ADR §"Cascade deletion" explicitly
+# chooses a manual cascade for symmetry with ADR-0003's parent-subnet
+# cascade — the service layer DELETEs both tables in the same transaction
+# so cascade behaviour is observable through code, not hidden in DDL. A
+# future ADR is free to add the FK once cascade observability is no
+# longer a design goal.
+#
+# The unique partial index on ``(subnet_id, agent_id) WHERE status='pending'``
+# is the schema-level enforcement of the "at most one pending per
+# (subnet, agent) across all kinds" invariant that the §join branch table
+# relies on. Without it, a self-join racing an invitation could create
+# two concurrent pending rows that both try to transition to approved.
+
+
+class SubnetJoinRequestModel(Base):
+    __tablename__ = "subnet_join_requests"
+
+    # ``String`` for ``request_id`` (UUID4 stored as text) mirrors the
+    # convention every other ID column in this codebase uses (``agent_id``,
+    # ``task_id``, ``subnet_id``). UUID column type would force callers to
+    # use ``uuid.UUID`` rather than the lower-case-hex string the rest of
+    # the codebase passes around.
+    request_id: Mapped[str] = mapped_column(String, primary_key=True)
+    subnet_id: Mapped[str] = mapped_column(String, nullable=False)
+    agent_id: Mapped[str] = mapped_column(String, nullable=False)
+    # ``length=16`` mirrors the ADR data-model table for ``kind``; the
+    # three legal values (``join_request`` is the longest at 13 chars)
+    # fit comfortably with headroom for a future fourth kind.
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # ``length=16`` likewise covers the four legal status values
+    # (``withdrawn`` is the longest at 9 chars) with headroom.
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    initiated_by: Mapped[str] = mapped_column(String, nullable=False)
+    # Nullable: NULL while ``status='pending'``; set on transition out.
+    # Entity-layer ``__post_init__`` enforces the bidirectional coherence
+    # (NULL iff pending) — this column's nullability tracks it.
+    decided_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+    decided_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Cap at 500 chars matches ``SubnetJoinRequest._NOTE_MAX_LEN``;
+    # ``Text`` column with app-layer enforcement mirrors the same pattern
+    # ``AgentAllowlistModel.reason`` uses (DB unbounded, app truncates).
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        # **The** invariant of this table. ``UNIQUE … WHERE status='pending'``
+        # lets terminal rows (approved / rejected / withdrawn) accumulate
+        # freely for audit while blocking a second pending row for the
+        # same ``(subnet, agent)`` regardless of kind. Backed by Redis's
+        # reverse index ``acn:subnets:{s}:pending_by_agent:{a}`` for the
+        # cache layer.
+        Index(
+            "subnet_join_requests_pending_unique",
+            "subnet_id",
+            "agent_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
+        # Owner-facing listing path:
+        # ``GET /subnets/{s}/join-requests`` and ``/invitations``. The
+        # filter on ``kind`` / ``status`` is application-side; the index
+        # only needs ``subnet_id`` to seek.
+        Index("ix_subnet_join_requests_subnet_id", "subnet_id"),
+        # Invitee-facing listing path:
+        # ``GET /agents/{a}/subnet-invitations``. Composite predicate
+        # selects the pending invitations the agent must decide; partial
+        # index keeps the size proportional to in-flight invitations
+        # rather than full audit history.
+        Index(
+            "ix_subnet_join_requests_agent_pending_invitations",
+            "agent_id",
+            postgresql_where=text(
+                "kind = 'invitation' AND status = 'pending'"
+            ),
+        ),
+    )
+
+
+# =============================================================================
+# Subnet Admission Allowlist (ADR-0004 Phase 2 Slice 2.1)
+# =============================================================================
+#
+# Per-subnet preauthorisation set: an entry preapproves the
+# ``(subnet_id, agent_id)`` pair for the §join branch 4 fast path.
+# Distinct from ``AgentAllowlistModel`` (which lives in the comm-policy
+# namespace, governs **agent-to-agent messaging** under
+# ``communication_policy.mode=allowlist``); the table-name prefix
+# ``subnet_`` keeps the two namespaces unambiguous in DBA-side queries.
+#
+# Composite primary key ``(subnet_id, agent_id)`` makes the natural-key
+# uniqueness DB-enforced; no surrogate id needed. Mirrors the convention
+# ``AgentAllowlistModel`` uses for the same shape.
+
+
+class SubnetAllowlistModel(Base):
+    __tablename__ = "subnet_allowlist"
+
+    subnet_id: Mapped[str] = mapped_column(String, nullable=False)
+    # ``agent_id`` references ``agents.agent_id`` — but **no FK**. Symmetric
+    # with ``subnet_join_requests``: ADR §"Cascade deletion" makes the
+    # cascade manual for observability, and the route-layer existence
+    # check (per ADR §SubnetAllowlist "Allowlist add requires the target
+    # agent_id to already exist in the agent registry") returns a clean
+    # 404 AGENT_NOT_FOUND instead of a raw IntegrityError.
+    agent_id: Mapped[str] = mapped_column(String, nullable=False)
+    # Owner agent_id who added the entry. Required (entity layer rejects
+    # empty) so every mutation is audit-traceable; the synthetic
+    # ``system:<reason>`` actor convention from
+    # ``SubnetJoinRequest.SYSTEM_ALLOWLIST_ACTOR`` covers admin-side
+    # paths that lack a real owner identity.
+    added_by: Mapped[str] = mapped_column(String, nullable=False)
+    added_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("subnet_id", "agent_id"),
+        # Reverse lookup: "which subnets is agent X preauthorised on?"
+        # — used by the agent-facing dashboard view; ops-only today,
+        # cheap enough to keep around for future API surfaces.
+        Index("ix_subnet_allowlist_agent_id", "agent_id"),
+    )

--- a/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
@@ -1,0 +1,149 @@
+"""PostgreSQL implementation of ``ISubnetAllowlistRepository``.
+
+Flat-set repo, no state machine — much thinner than
+``PostgresSubnetJoinRequestRepository``. ``add`` is idempotent via
+the composite PK ``(subnet_id, agent_id)``: ``INSERT ... ON
+CONFLICT DO NOTHING`` collapses re-adds into a no-op and returns
+``False`` so the route layer can pick 200 (re-add) vs 201 (new) per
+ADR §HTTP status code conventions.
+
+The route layer is expected to verify ``agent_id`` exists in
+``agents`` BEFORE calling ``add`` (per ADR §SubnetAllowlist
+"Allowlist add requires the target agent_id to already exist in
+the agent registry"); the route returns ``404 AGENT_NOT_FOUND``
+on the existence-check failure. We don't enforce that here because
+there is no FK to ``agents`` (ADR §"Cascade deletion" chooses
+manual cascade for observability).
+"""
+
+from sqlalchemy import delete, desc, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from ....core.entities import SubnetAllowlist
+from ....core.interfaces import ISubnetAllowlistRepository
+from .models import SubnetAllowlistModel
+
+
+class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
+    def __init__(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        self._session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    # Mapping
+    # ------------------------------------------------------------------
+
+    def _model_to_entity(self, row: SubnetAllowlistModel) -> SubnetAllowlist:
+        return SubnetAllowlist(
+            subnet_id=row.subnet_id,
+            agent_id=row.agent_id,
+            added_by=row.added_by,
+            added_at=row.added_at,
+        )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def add(self, entry: SubnetAllowlist) -> bool:
+        """Insert with idempotent on-conflict no-op.
+
+        Returns ``True`` if a new row was inserted; ``False`` if the
+        ``(subnet_id, agent_id)`` pair already existed. The boolean
+        return is the route layer's signal to pick 201 vs 200.
+
+        ``ON CONFLICT DO NOTHING`` is preferred over a get-then-insert
+        race-prone pattern: two concurrent owner-side adds on the
+        same pair end up with one successful row and one no-op, both
+        observing ``False`` from the duplicate side without ever
+        raising an ``IntegrityError``. Matches the discipline
+        ``PostgresAgentAllowlistRepository.add`` uses for the same
+        composite-PK shape.
+
+        The existing-row's ``added_by`` / ``added_at`` are
+        intentionally **not** updated on conflict; the original
+        audit attribution wins. An admin-side "force re-add with
+        new attribution" path would need a separate
+        ``upsert_with_new_attribution`` method (not part of Slice
+        2.1's scope).
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                pg_insert(SubnetAllowlistModel)
+                .values(
+                    subnet_id=entry.subnet_id,
+                    agent_id=entry.agent_id,
+                    added_by=entry.added_by,
+                    added_at=entry.added_at,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["subnet_id", "agent_id"]
+                )
+                .returning(SubnetAllowlistModel.subnet_id)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            # ``.first()`` is ``None`` iff ON CONFLICT swallowed the
+            # insert; presence of any row means a new entry was created.
+            return result.first() is not None
+
+    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(SubnetAllowlistModel).where(
+                    SubnetAllowlistModel.subnet_id == subnet_id,
+                    SubnetAllowlistModel.agent_id == agent_id,
+                )
+            )
+            await session.commit()
+            return (result.rowcount or 0) > 0
+
+    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+        """Cold-path membership check for the §join flow's branch 4.
+
+        ``SELECT 1 WHERE ... LIMIT 1`` instead of ``SELECT *`` —
+        the row contents are never consumed; we only need the
+        existence bit. Avoids materialising the ``added_by`` /
+        ``added_at`` columns that the hot path doesn't read.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetAllowlistModel.subnet_id)
+                .where(
+                    SubnetAllowlistModel.subnet_id == subnet_id,
+                    SubnetAllowlistModel.agent_id == agent_id,
+                )
+                .limit(1)
+            )
+            return result.scalar() is not None
+
+    async def list_for_subnet(
+        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+    ) -> list[SubnetAllowlist]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetAllowlistModel)
+                .where(SubnetAllowlistModel.subnet_id == subnet_id)
+                .order_by(desc(SubnetAllowlistModel.added_at))
+                .limit(limit)
+                .offset(offset)
+            )
+            return [self._model_to_entity(r) for r in result.scalars().all()]
+
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all entries for a subnet. Returns count deleted.
+
+        Called from ``SubnetService.delete_subnet`` — see
+        ``PostgresSubnetJoinRequestRepository.delete_for_subnet`` for
+        the symmetric cascade-ordering contract.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(SubnetAllowlistModel).where(
+                    SubnetAllowlistModel.subnet_id == subnet_id
+                )
+            )
+            await session.commit()
+            return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
@@ -1,0 +1,233 @@
+"""PostgreSQL implementation of ``ISubnetJoinRequestRepository``.
+
+The ``save`` path is wrapped to translate the partial-index
+``IntegrityError`` into a domain-meaningful exception
+(``SubnetJoinRequestPendingError``) so the service layer doesn't
+have to import ``sqlalchemy.exc`` to recognise a duplicate-pending
+collision. The exception carries the colliding ``(subnet_id,
+agent_id)`` for the route layer's 409 envelope.
+
+Mapping discipline
+------------------
+``_model_to_entity`` round-trips every column without defaults. The
+entity layer's ``__post_init__`` runs on the rebuilt object, so a
+storage row that violates the (status, decided_by) coherence check
+fails fast at read time rather than silently propagating. The
+deliberate trade-off: corrupt rows surface as 500s on the first
+read instead of silently flowing through; combined with the unique
+partial index this is the dual-layer defence ADR §"Redis layout
+and atomicity" describes.
+"""
+
+from sqlalchemy import delete, desc, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from ....core.entities import SubnetJoinRequest
+from ....core.interfaces import ISubnetJoinRequestRepository
+from .models import SubnetJoinRequestModel
+
+
+class SubnetJoinRequestPendingError(Exception):
+    """Raised when ``save`` collides with the unique partial index.
+
+    Service layer catches this and surfaces ``409`` with the stable
+    reason token (``JOIN_REQUEST_PENDING`` /
+    ``INVITATION_PENDING``); the route layer maps the token to the
+    appropriate envelope per ADR §HTTP status code conventions."""
+
+    def __init__(self, subnet_id: str, agent_id: str) -> None:
+        super().__init__(
+            f"pending join request already exists for "
+            f"(subnet_id={subnet_id!r}, agent_id={agent_id!r})"
+        )
+        self.subnet_id = subnet_id
+        self.agent_id = agent_id
+
+
+class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
+    def __init__(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        self._session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    # Mapping
+    # ------------------------------------------------------------------
+
+    def _model_to_entity(self, row: SubnetJoinRequestModel) -> SubnetJoinRequest:
+        return SubnetJoinRequest(
+            request_id=row.request_id,
+            subnet_id=row.subnet_id,
+            agent_id=row.agent_id,
+            kind=row.kind,  # type: ignore[arg-type]
+            status=row.status,  # type: ignore[arg-type]
+            initiated_by=row.initiated_by,
+            decided_by=row.decided_by,
+            created_at=row.created_at,
+            decided_at=row.decided_at,
+            note=row.note,
+        )
+
+    def _entity_to_model(
+        self, request: SubnetJoinRequest
+    ) -> SubnetJoinRequestModel:
+        return SubnetJoinRequestModel(
+            request_id=request.request_id,
+            subnet_id=request.subnet_id,
+            agent_id=request.agent_id,
+            kind=request.kind,
+            status=request.status,
+            initiated_by=request.initiated_by,
+            decided_by=request.decided_by,
+            created_at=request.created_at,
+            decided_at=request.decided_at,
+            note=request.note,
+        )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def save(self, request: SubnetJoinRequest) -> None:
+        """Insert or update the row.
+
+        On insert collision with the unique partial pending index,
+        ``IntegrityError`` translates to
+        ``SubnetJoinRequestPendingError`` so the service layer can
+        treat the collision as a domain event rather than a raw SQL
+        error. Update (``existing`` branch) does NOT raise the
+        translated error — the only legal mutation path is a
+        transition out of ``pending``, which by definition removes
+        the partial-index row and frees the slot.
+
+        Why not use ``ON CONFLICT DO NOTHING / UPDATE``: the partial
+        index makes the conflict target conditional (``WHERE
+        status='pending'``), and ``INSERT ... ON CONFLICT`` requires
+        a constraint name or column list that matches an existing
+        constraint exactly. Our index is partial, not full, so the
+        ``ON CONFLICT`` shortcut doesn't apply cleanly. The explicit
+        get-then-insert / get-then-update pattern is one extra round
+        trip but composes with the entity's ``__post_init__``
+        coherence check.
+        """
+        async with self._session_factory() as session:
+            existing = await session.get(
+                SubnetJoinRequestModel, request.request_id
+            )
+            try:
+                if existing:
+                    # Update in place — every mutable field. ``request_id`` /
+                    # ``subnet_id`` / ``agent_id`` / ``kind`` /
+                    # ``initiated_by`` are immutable in practice (the entity
+                    # state machine never rewrites them on a transition) but
+                    # included here for completeness / defence in depth.
+                    existing.subnet_id = request.subnet_id
+                    existing.agent_id = request.agent_id
+                    existing.kind = request.kind
+                    existing.status = request.status
+                    existing.initiated_by = request.initiated_by
+                    existing.decided_by = request.decided_by
+                    existing.created_at = request.created_at
+                    existing.decided_at = request.decided_at
+                    existing.note = request.note
+                else:
+                    session.add(self._entity_to_model(request))
+                await session.commit()
+            except IntegrityError as e:
+                await session.rollback()
+                # Surface the well-known partial-index violation with a
+                # domain-meaningful exception. Other IntegrityErrors (FK
+                # violations, NOT NULL — neither of which we should ever
+                # hit because the entity layer rejects empties first)
+                # re-raise unchanged so the service layer surfaces them
+                # as 500s.
+                if "subnet_join_requests_pending_unique" in str(
+                    e.orig
+                ) or "subnet_join_requests_pending_unique" in str(e):
+                    raise SubnetJoinRequestPendingError(
+                        request.subnet_id, request.agent_id
+                    ) from e
+                raise
+
+    async def find_by_id(self, request_id: str) -> SubnetJoinRequest | None:
+        async with self._session_factory() as session:
+            row = await session.get(SubnetJoinRequestModel, request_id)
+            return self._model_to_entity(row) if row else None
+
+    async def find_pending_for(
+        self, subnet_id: str, agent_id: str
+    ) -> SubnetJoinRequest | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetJoinRequestModel).where(
+                    SubnetJoinRequestModel.subnet_id == subnet_id,
+                    SubnetJoinRequestModel.agent_id == agent_id,
+                    SubnetJoinRequestModel.status == "pending",
+                )
+            )
+            row = result.scalar_one_or_none()
+            return self._model_to_entity(row) if row else None
+
+    async def list_by_subnet(
+        self,
+        subnet_id: str,
+        *,
+        kind: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetJoinRequest]:
+        async with self._session_factory() as session:
+            stmt = select(SubnetJoinRequestModel).where(
+                SubnetJoinRequestModel.subnet_id == subnet_id
+            )
+            if kind is not None:
+                stmt = stmt.where(SubnetJoinRequestModel.kind == kind)
+            if status is not None:
+                stmt = stmt.where(SubnetJoinRequestModel.status == status)
+            stmt = (
+                stmt.order_by(desc(SubnetJoinRequestModel.created_at))
+                .limit(limit)
+                .offset(offset)
+            )
+            result = await session.execute(stmt)
+            return [self._model_to_entity(r) for r in result.scalars().all()]
+
+    async def list_pending_invitations_for_agent(
+        self, agent_id: str
+    ) -> list[SubnetJoinRequest]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SubnetJoinRequestModel)
+                .where(
+                    SubnetJoinRequestModel.agent_id == agent_id,
+                    SubnetJoinRequestModel.kind == "invitation",
+                    SubnetJoinRequestModel.status == "pending",
+                )
+                .order_by(desc(SubnetJoinRequestModel.created_at))
+            )
+            return [self._model_to_entity(r) for r in result.scalars().all()]
+
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all rows for a subnet. Returns count deleted.
+
+        Called from ``SubnetService.delete_subnet`` inside an outer
+        transaction that also DELETEs ``subnet_allowlist`` and the
+        ``subnets`` row itself. We don't open our own
+        ``session.begin()`` here — the outer service context manages
+        the transaction so all three DELETEs are atomic, matching
+        ADR §"Cascade deletion: Postgres" exactly.
+
+        Returns the deleted-row count for audit logging; the service
+        layer logs it but doesn't gate on it (zero rows is a valid
+        outcome — subnets without any pending or terminal requests).
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(SubnetJoinRequestModel).where(
+                    SubnetJoinRequestModel.subnet_id == subnet_id
+                )
+            )
+            await session.commit()
+            return result.rowcount or 0

--- a/acn/infrastructure/persistence/redis/_hash_utils.py
+++ b/acn/infrastructure/persistence/redis/_hash_utils.py
@@ -1,0 +1,49 @@
+"""Shared Redis HASH/value decoding helpers.
+
+Both ``RedisSubnetJoinRequestRepository`` and
+``RedisSubnetAllowlistRepository`` (and any future Redis repo)
+need to be tolerant of the client's ``decode_responses`` setting:
+production registry composition uses ``decode_responses=False``
+(bytes-mode) but backfill scripts and ad-hoc tooling sometimes
+construct a client without that flag. Without normalisation, every
+``data.get("field")`` silently misses when the dict comes back
+byte-keyed, corrupting parsing in ways that are very hard to
+debug.
+
+This module is the consolidated home for the two helpers — same
+shape as ``RedisSubnetRepository._normalize_redis_dict``, factored
+out so multiple repos can share it instead of each carrying its
+own copy (review fix N2).
+"""
+
+from __future__ import annotations
+
+
+def decode_value(value: object) -> str:
+    """Coerce bytes / str / None to ``str`` (empty for ``None``).
+
+    The empty-string-for-None convention matches the empty-string-
+    is-NULL serialisation discipline ``SubnetJoinRequest.to_dict``
+    (and friends) use for Redis HASH storage.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def normalize_hash(raw: object) -> dict[str, str]:
+    """Coerce a Redis HASH dict to ``dict[str, str]`` regardless of
+    the client's ``decode_responses`` flag.
+
+    Returns ``{}`` for falsy input (matches ``HGETALL`` on a
+    missing HASH — redis-py returns an empty dict, not ``None``)."""
+    if not raw or not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        key = k.decode() if isinstance(k, bytes) else str(k)
+        val = v.decode() if isinstance(v, bytes) else v
+        out[key] = val
+    return out

--- a/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
@@ -1,0 +1,211 @@
+"""Redis implementation of ``ISubnetAllowlistRepository``.
+
+Key layout (verbatim from ADR-0004 §"SubnetAllowlist schema"):
+
+- ``acn:subnets:{subnet_id}:allowlist`` — SET of allowlisted
+  ``agent_id``s. Hot ``is_member`` check uses ``SISMEMBER`` for
+  O(1) lookup.
+- ``acn:subnets:{subnet_id}:allowlist_meta:{agent_id}`` — HASH
+  carrying ``added_by`` + ``added_at`` audit fields.
+
+Two-key layout instead of a single HASH because ``SISMEMBER`` on
+the SET is the hot ``is_member`` check (called once per ``join``);
+a HASH-only layout would force ``HEXISTS`` (same cost in isolation
+but loses the future ability to ``SDIFF`` / ``SINTERSTORE`` for
+batch ops, e.g. "which agents are on subnet A but not subnet B").
+
+Write atomicity
+---------------
+``add`` and ``remove`` use ``pipeline(transaction=False)`` (the
+codebase convention — see ``RedisSubnetRepository.save``) for the
+SET + HASH double-write. A crash between the two leaves one of:
+
+- SET has the agent but HASH meta is missing → ``is_member`` still
+  returns True (correct), ``list_for_subnet`` returns the entry
+  without audit attribution. The next ``add`` for the same pair
+  is idempotent (SADD = no-op) and re-writes the HASH.
+- HASH has the meta but SET is missing → ``is_member`` returns
+  False (correct semantics: the entry is "not effective"), the
+  orphaned HASH gets cleaned up the next time the cascade
+  deletion runs.
+
+Neither outcome corrupts the source-of-truth Postgres row; the
+Redis side is the cache layer in the dual-store composition.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import redis.asyncio as redis  # type: ignore[import-untyped]
+
+from ....core.entities import SubnetAllowlist
+from ....core.interfaces import ISubnetAllowlistRepository
+
+logger = logging.getLogger(__name__)
+
+
+def _allowlist_set_key(subnet_id: str) -> str:
+    return f"acn:subnets:{subnet_id}:allowlist"
+
+
+def _allowlist_meta_key(subnet_id: str, agent_id: str) -> str:
+    return f"acn:subnets:{subnet_id}:allowlist_meta:{agent_id}"
+
+
+def _decode(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def _normalize_hash(raw: dict) -> dict[str, str]:
+    if not raw:
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        key = k.decode() if isinstance(k, bytes) else str(k)
+        val = v.decode() if isinstance(v, bytes) else v
+        out[key] = val
+    return out
+
+
+class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
+    def __init__(self, redis_client: redis.Redis) -> None:
+        self.redis = redis_client
+
+    async def add(self, entry: SubnetAllowlist) -> bool:
+        """Insert into the SET and write the audit meta HASH.
+
+        Returns ``True`` if the entry was newly created. SADD's
+        return value is 1 for new, 0 for already-present; we use
+        that as the idempotency signal so the route layer can
+        pick 201 vs 200 per ADR §HTTP status code conventions.
+
+        On idempotent re-add the meta HASH is **overwritten** with
+        the incoming ``added_by`` / ``added_at`` — different from
+        the Postgres impl which preserves the original attribution.
+        The asymmetry is intentional: PG is source of truth and
+        carries the canonical original-attribution row; Redis is a
+        cache that may legitimately lag, and overwriting on re-add
+        keeps the cache consistent with whatever PG holds for this
+        re-add (the service layer's dual-write ordering means PG
+        wins). Operators that care about original attribution
+        should read PG, not Redis.
+        """
+        set_key = _allowlist_set_key(entry.subnet_id)
+        meta_key = _allowlist_meta_key(entry.subnet_id, entry.agent_id)
+
+        # SADD must run before the HSET so a failure between them
+        # leaves the safer of the two crash states (HASH missing,
+        # SET present → entry counts as a member, just without
+        # readable audit attribution; that's worse than a missing
+        # entry but doesn't change admission decisions).
+        added_count = await self.redis.sadd(set_key, entry.agent_id)
+        async with self.redis.pipeline(transaction=False) as pipe:
+            data = entry.to_dict()
+            pipe.hset(meta_key, mapping=data)
+            await pipe.execute()
+        return added_count > 0
+
+    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+        """Remove from the SET and DEL the meta HASH.
+
+        Returns ``True`` iff the SET membership was actually
+        removed. Symmetric ordering to ``add``: SREM first so the
+        agent stops counting as a member immediately, then meta
+        cleanup. A crash between them leaves an orphan meta HASH
+        that the cascade deletion path sweeps later.
+        """
+        set_key = _allowlist_set_key(subnet_id)
+        meta_key = _allowlist_meta_key(subnet_id, agent_id)
+
+        removed_count = await self.redis.srem(set_key, agent_id)
+        await self.redis.delete(meta_key)
+        return removed_count > 0
+
+    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+        """O(1) SISMEMBER check; the hot path for the §join flow."""
+        return bool(
+            await self.redis.sismember(
+                _allowlist_set_key(subnet_id), agent_id
+            )
+        )
+
+    async def list_for_subnet(
+        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+    ) -> list[SubnetAllowlist]:
+        """List allowlist entries for a subnet, most-recent first.
+
+        Reads the SET membership, then dereferences each meta HASH.
+        Orphaned SET members (meta HASH missing) are skipped
+        silently rather than raised — the missing meta is a known
+        cache-only crash artefact (see class docstring's "write
+        atomicity" section).
+        """
+        set_key = _allowlist_set_key(subnet_id)
+        agent_ids = await self.redis.smembers(set_key)
+
+        entries: list[SubnetAllowlist] = []
+        for raw_aid in agent_ids:
+            aid = _decode(raw_aid)
+            meta_key = _allowlist_meta_key(subnet_id, aid)
+            hash_data = await self.redis.hgetall(meta_key)
+            if not hash_data:
+                # SET-only orphan; cache crash artefact. Don't fabricate
+                # missing audit fields — skip and let the cascade or
+                # PG-backed dual-store read produce the canonical row.
+                continue
+            entries.append(
+                SubnetAllowlist.from_dict(_normalize_hash(hash_data))
+            )
+
+        entries.sort(key=lambda e: e.added_at, reverse=True)
+        return entries[offset : offset + limit]
+
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all allowlist entries for a subnet.
+
+        Iterate the SET, DEL each meta HASH, then DEL the SET
+        itself. Best-effort sequential (no Lua atomic envelope
+        needed — there is no reverse index to dangle). Partial
+        failure raises ``RuntimeError`` after writing the
+        ``delete_with_children_partial`` breadcrumb so the
+        caller's cascade-ordering contract holds.
+
+        Returns the count of meta HASHes actually deleted.
+        """
+        set_key = _allowlist_set_key(subnet_id)
+        agent_ids = await self.redis.smembers(set_key)
+
+        deleted_count = 0
+        partial_failures: list[str] = []
+
+        for raw_aid in agent_ids:
+            aid = _decode(raw_aid)
+            meta_key = _allowlist_meta_key(subnet_id, aid)
+            try:
+                await self.redis.delete(meta_key)
+                deleted_count += 1
+            except Exception as e:  # noqa: BLE001 — best-effort cascade
+                partial_failures.append(f"{aid}:{e!r}")
+
+        await self.redis.delete(set_key)
+
+        if partial_failures:
+            logger.warning(
+                "delete_with_children_partial",
+                extra={
+                    "subnet_id": subnet_id,
+                    "table": "subnet_allowlist",
+                    "failures": partial_failures,
+                },
+            )
+            raise RuntimeError(
+                "subnet_allowlist cascade had partial failures; "
+                "subnet HASH MUST NOT be deleted"
+            )
+
+        return deleted_count

--- a/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
@@ -41,6 +41,8 @@ import redis.asyncio as redis  # type: ignore[import-untyped]
 
 from ....core.entities import SubnetAllowlist
 from ....core.interfaces import ISubnetAllowlistRepository
+from ._hash_utils import decode_value as _decode
+from ._hash_utils import normalize_hash as _normalize_hash
 
 logger = logging.getLogger(__name__)
 
@@ -51,25 +53,6 @@ def _allowlist_set_key(subnet_id: str) -> str:
 
 def _allowlist_meta_key(subnet_id: str, agent_id: str) -> str:
     return f"acn:subnets:{subnet_id}:allowlist_meta:{agent_id}"
-
-
-def _decode(value) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode()
-    return str(value)
-
-
-def _normalize_hash(raw: dict) -> dict[str, str]:
-    if not raw:
-        return {}
-    out: dict[str, str] = {}
-    for k, v in raw.items():
-        key = k.decode() if isinstance(k, bytes) else str(k)
-        val = v.decode() if isinstance(v, bytes) else v
-        out[key] = val
-    return out
 
 
 class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
@@ -104,10 +87,9 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         # readable audit attribution; that's worse than a missing
         # entry but doesn't change admission decisions).
         added_count = await self.redis.sadd(set_key, entry.agent_id)
-        async with self.redis.pipeline(transaction=False) as pipe:
-            data = entry.to_dict()
-            pipe.hset(meta_key, mapping=data)
-            await pipe.execute()
+        # Single HSET — no pipeline needed; one command = one
+        # round-trip either way (review fix N1).
+        await self.redis.hset(meta_key, mapping=entry.to_dict())  # type: ignore[misc]
         return added_count > 0
 
     async def remove(self, subnet_id: str, agent_id: str) -> bool:

--- a/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
@@ -60,6 +60,8 @@ from ....core.interfaces import ISubnetJoinRequestRepository
 from ..postgres.subnet_join_request_repository import (
     SubnetJoinRequestPendingError,
 )
+from ._hash_utils import decode_value as _decode
+from ._hash_utils import normalize_hash as _normalize_hash
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +72,14 @@ logger = logging.getLogger(__name__)
 # KEYS[3] = subnet listing SET
 # KEYS[4] = agent invitations SET (only SADD'd if ARGV[2]='invitation')
 #
-# ARGV[1] = request_id (the value to SET into KEYS[1])
+# ARGV[1] = request_id (the value to SET into KEYS[1] and SADD into KEYS[3])
 # ARGV[2] = kind discriminator ('invitation' or other)
-# ARGV[3..N] = HSET field/value pairs (even count)
+# ARGV[3] = subnet_id:request_id composite key (the value SADD'd into
+#           KEYS[4] when ARGV[2]='invitation'; ignored otherwise). The
+#           composite key lets ``list_pending_invitations_for_agent``
+#           dereference each entry to its subnet HASH directly without
+#           the previous N×S full-keyspace scan (review fix B1).
+# ARGV[4..N] = HSET field/value pairs (even count)
 #
 # Returns:
 #   {'exists', <existing_request_id>}   on reverse-index collision
@@ -83,12 +90,12 @@ if existing then
     return {'exists', existing}
 end
 redis.call('SET', KEYS[1], ARGV[1])
-for i = 3, #ARGV, 2 do
+for i = 4, #ARGV, 2 do
     redis.call('HSET', KEYS[2], ARGV[i], ARGV[i + 1])
 end
 redis.call('SADD', KEYS[3], ARGV[1])
 if ARGV[2] == 'invitation' then
-    redis.call('SADD', KEYS[4], ARGV[1])
+    redis.call('SADD', KEYS[4], ARGV[3])
 end
 return {'created', ARGV[1]}
 """
@@ -99,21 +106,43 @@ return {'created', ARGV[1]}
 # KEYS[2] = request HASH (HSET updated)
 # KEYS[3] = agent invitations SET (SREM'd if kind='invitation')
 #
-# ARGV[1] = request_id (to SREM from KEYS[3] if invitation)
+# ARGV[1] = request_id  (no longer used; kept for ABI symmetry with create)
 # ARGV[2] = kind discriminator ('invitation' or other)
-# ARGV[3..N] = HSET field/value pairs (even count)
+# ARGV[3] = subnet_id:request_id composite key (to SREM from KEYS[3] —
+#           must match the SADD value the create path used or the
+#           invitations SET leaks the obsolete entry)
+# ARGV[4..N] = HSET field/value pairs (even count)
 #
 # Returns 1 always (no failure mode worth distinguishing — replay is safe).
 DECIDE_LUA = """
 redis.call('DEL', KEYS[1])
-for i = 3, #ARGV, 2 do
+for i = 4, #ARGV, 2 do
     redis.call('HSET', KEYS[2], ARGV[i], ARGV[i + 1])
 end
 if ARGV[2] == 'invitation' then
-    redis.call('SREM', KEYS[3], ARGV[1])
+    redis.call('SREM', KEYS[3], ARGV[3])
 end
 return 1
 """
+
+
+def _invitation_set_member(subnet_id: str, request_id: str) -> str:
+    """The composite key used as a member of
+    ``acn:agents:{a}:subnet_invitations``.
+
+    Storing ``subnet_id:request_id`` (rather than the bare
+    request_id) lets ``list_pending_invitations_for_agent``
+    dereference each entry to its subnet HASH directly — fixing the
+    O(N·S·k) full-keyspace scan that the bare-request_id storage
+    would have forced (review fix B1).
+
+    ``:`` is the chosen separator because every other ID in this
+    codebase is already colon-free (UUID4 hex / agent-* prefixes)
+    and the existing Redis key layout uses ``:`` as the namespace
+    separator — so the composite member can never collide with a
+    legitimate single-component id.
+    """
+    return f"{subnet_id}:{request_id}"
 
 
 def _request_hash_key(subnet_id: str, request_id: str) -> str:
@@ -130,20 +159,6 @@ def _subnet_listing_key(subnet_id: str) -> str:
 
 def _agent_invitations_key(agent_id: str) -> str:
     return f"acn:agents:{agent_id}:subnet_invitations"
-
-
-def _decode(value) -> str:
-    """Coerce bytes/str/None from redis-py to ``str`` ('' for None).
-
-    Mirrors the same ``decode_responses``-tolerant pattern
-    ``RedisSubnetRepository._normalize_redis_dict`` uses — the repo
-    layer shouldn't depend on the client's configuration flag being
-    pinned correctly forever."""
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode()
-    return str(value)
 
 
 class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
@@ -202,7 +217,12 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             _subnet_listing_key(request.subnet_id),
             _agent_invitations_key(request.agent_id),
         ]
-        args = [request.request_id, request.kind, *hash_pairs]
+        args = [
+            request.request_id,
+            request.kind,
+            _invitation_set_member(request.subnet_id, request.request_id),
+            *hash_pairs,
+        ]
         script = self._get_create_pending_script()
         result = await script(keys=keys, args=args, client=self.redis)
         # Lua returns a 2-element table; redis-py renders it as a list
@@ -225,7 +245,12 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             _request_hash_key(request.subnet_id, request.request_id),
             _agent_invitations_key(request.agent_id),
         ]
-        args = [request.request_id, request.kind, *hash_pairs]
+        args = [
+            request.request_id,
+            request.kind,
+            _invitation_set_member(request.subnet_id, request.request_id),
+            *hash_pairs,
+        ]
         script = self._get_decide_script()
         await script(keys=keys, args=args, client=self.redis)
 
@@ -316,26 +341,51 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
     ) -> list[SubnetJoinRequest]:
         """List pending invitations across all subnets.
 
-        Reads the per-agent SET and dereferences each request_id
-        against its subnet HASH. The SET membership is maintained
-        by ``CREATE_PENDING_LUA`` (SADD on kind='invitation') and
-        ``DECIDE_LUA`` (SREM on transition out), so it always
-        reflects the actual pending invitation set without a
-        separate filter pass.
+        Reads the per-agent SET — whose members are
+        ``subnet_id:request_id`` composite keys (see
+        :func:`_invitation_set_member`) — and dereferences each one
+        to its subnet HASH **directly**. No N×S keyspace scan; each
+        invitation costs exactly one ``HGETALL`` (review fix B1).
 
-        Quadratic-ish in the SET size — but the per-agent invitation
-        backlog is bounded by sensible UX (humans don't invite the
-        same agent into hundreds of subnets simultaneously); no
-        secondary pagination needed at Slice 2.1.
+        The SET membership is maintained by ``CREATE_PENDING_LUA``
+        (SADD on kind='invitation') and ``DECIDE_LUA`` (SREM on
+        transition out), so it always reflects the actual pending
+        invitation set without a separate filter pass — but we
+        still defensively check ``kind == 'invitation' and is_pending``
+        after deref in case a stale member survives a partial-failure
+        DECIDE (the SET membership is best-effort under
+        non-transactional Redis writes).
+
+        Composite-key members written by the old (Slice 2.1 v1) code
+        path would have been bare ``request_id`` strings; this method
+        treats any member that doesn't parse as ``subnet:rid`` as a
+        legacy bare-rid and silently skips it. The migration from v1
+        → v2 storage layout is "wait for terminal transition; SREM
+        cleans them out naturally". There is no Slice 2.1 v1 in
+        production so this branch is purely defensive against the
+        in-flight PR-review window.
         """
         invitations_key = _agent_invitations_key(agent_id)
-        request_ids = await self.redis.smembers(invitations_key)
+        raw_members = await self.redis.smembers(invitations_key)
         rows: list[SubnetJoinRequest] = []
-        for raw_rid in request_ids:
-            rid = _decode(raw_rid)
-            # Have to find the subnet — the SET stores only request_ids.
-            req = await self.find_by_id(rid)
-            if req is not None and req.kind == "invitation" and req.is_pending:
+        for raw_member in raw_members:
+            member = _decode(raw_member)
+            # Composite member format: ``subnet_id:request_id``. Split
+            # on the FIRST ``:`` only — subnet_id is colon-free in
+            # this codebase but defence in depth.
+            if ":" not in member:
+                # Legacy bare-rid member (pre-B1 fix). Skip — there is
+                # no way to reconstruct the subnet without the
+                # expensive scan we are trying to avoid.
+                continue
+            subnet_id, request_id = member.split(":", 1)
+            hash_data = await self.redis.hgetall(
+                _request_hash_key(subnet_id, request_id)
+            )
+            if not hash_data:
+                continue
+            req = SubnetJoinRequest.from_dict(_normalize_hash(hash_data))
+            if req.kind == "invitation" and req.is_pending:
                 rows.append(req)
         rows.sort(key=lambda r: r.created_at, reverse=True)
         return rows
@@ -380,8 +430,15 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                                 _pending_by_agent_key(subnet_id, agent_id)
                             )
                             if kind == "invitation":
+                                # Composite-key SREM — must match the
+                                # value CREATE_PENDING_LUA SADD'd, or
+                                # the invitations SET leaks the
+                                # obsolete entry past subnet deletion.
                                 pipe.srem(
-                                    _agent_invitations_key(agent_id), rid
+                                    _agent_invitations_key(agent_id),
+                                    _invitation_set_member(
+                                        subnet_id, rid
+                                    ),
                                 )
                         await pipe.execute()
                     deleted_count += 1
@@ -409,19 +466,3 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             )
 
         return deleted_count
-
-
-def _normalize_hash(raw: dict) -> dict[str, str]:
-    """Coerce a Redis HASH dict to ``dict[str, str]``.
-
-    Mirrors ``RedisSubnetRepository._normalize_redis_dict`` — guards
-    against the ``decode_responses=False`` client configuration that
-    backfill scripts and ad-hoc tooling sometimes use."""
-    if not raw:
-        return {}
-    out: dict[str, str] = {}
-    for k, v in raw.items():
-        key = k.decode() if isinstance(k, bytes) else str(k)
-        val = v.decode() if isinstance(v, bytes) else v
-        out[key] = val
-    return out

--- a/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
@@ -1,0 +1,427 @@
+"""Redis implementation of ``ISubnetJoinRequestRepository``.
+
+Key layout (verbatim from ADR-0004 §"Redis layout and atomicity"):
+
+- ``acn:subnets:{subnet_id}:requests:{request_id}`` — HASH carrying
+  the serialised ``SubnetJoinRequest`` fields.
+- ``acn:subnets:{subnet_id}:pending_by_agent:{agent_id}`` — STRING
+  whose value is the current pending ``request_id`` for that
+  ``(subnet, agent)`` pair. The reverse pending index that
+  enforces the "at most one pending per (subnet, agent) across
+  all kinds" invariant Redis-side, equivalent to Postgres's
+  ``UNIQUE … WHERE status='pending'`` partial index.
+- ``acn:subnets:{subnet_id}:requests`` — SET of all
+  ``request_id``s for that subnet, used by ``GET /subnets/{s}/
+  join-requests`` and ``/invitations``.
+- ``acn:agents:{agent_id}:subnet_invitations`` — SET of
+  ``request_id``s with ``kind='invitation' AND status='pending'``,
+  used by the invitee-facing
+  ``GET /agents/{a}/subnet-invitations``.
+
+The Lua atomic envelope
+-----------------------
+``create-pending`` MUST be atomic across the reverse-index SET and
+the HASH (ADR §"Redis layout and atomicity"): a naive
+``SETNX`` + ``HSET`` two-step leaks a deadlock if the HSET fails
+— the reverse index points at a non-existent request and
+subsequent ``SETNX`` attempts for the same ``(subnet, agent)``
+fail forever. The ``CREATE_PENDING_LUA`` script below runs the
+SETNX, the HSET, the listing-SET SADD, and (for invitations) the
+per-agent SADD as one atomic unit.
+
+The transition path (status → approved/rejected/withdrawn) also
+runs through a Lua script (``DECIDE_LUA``) so the reverse-index
+DEL and the HASH update commit as one unit; without that, a
+crash between the two could leave a terminal-status row with a
+dangling reverse-index pointer, blocking the agent's next legal
+re-request forever.
+
+Idempotency model
+-----------------
+- ``CREATE_PENDING_LUA`` returns the existing ``request_id`` on
+  reverse-index collision; the caller compares it against the
+  one it tried to write. Equal → idempotent re-save (no-op).
+  Different → race lost; raise
+  ``SubnetJoinRequestPendingError`` so the route layer surfaces
+  409 with the stable reason token.
+- ``DECIDE_LUA`` is unconditionally safe to replay; second call
+  is a no-op DEL plus an HSET of the same fields.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import redis.asyncio as redis  # type: ignore[import-untyped]
+
+from ....core.entities import SubnetJoinRequest
+from ....core.interfaces import ISubnetJoinRequestRepository
+from ..postgres.subnet_join_request_repository import (
+    SubnetJoinRequestPendingError,
+)
+
+logger = logging.getLogger(__name__)
+
+# Atomic "create pending request" envelope.
+#
+# KEYS[1] = pending_by_agent reverse index
+# KEYS[2] = request HASH
+# KEYS[3] = subnet listing SET
+# KEYS[4] = agent invitations SET (only SADD'd if ARGV[2]='invitation')
+#
+# ARGV[1] = request_id (the value to SET into KEYS[1])
+# ARGV[2] = kind discriminator ('invitation' or other)
+# ARGV[3..N] = HSET field/value pairs (even count)
+#
+# Returns:
+#   {'exists', <existing_request_id>}   on reverse-index collision
+#   {'created', <request_id>}           on successful new creation
+CREATE_PENDING_LUA = """
+local existing = redis.call('GET', KEYS[1])
+if existing then
+    return {'exists', existing}
+end
+redis.call('SET', KEYS[1], ARGV[1])
+for i = 3, #ARGV, 2 do
+    redis.call('HSET', KEYS[2], ARGV[i], ARGV[i + 1])
+end
+redis.call('SADD', KEYS[3], ARGV[1])
+if ARGV[2] == 'invitation' then
+    redis.call('SADD', KEYS[4], ARGV[1])
+end
+return {'created', ARGV[1]}
+"""
+
+# Atomic "transition out of pending" envelope.
+#
+# KEYS[1] = pending_by_agent reverse index (DEL'd)
+# KEYS[2] = request HASH (HSET updated)
+# KEYS[3] = agent invitations SET (SREM'd if kind='invitation')
+#
+# ARGV[1] = request_id (to SREM from KEYS[3] if invitation)
+# ARGV[2] = kind discriminator ('invitation' or other)
+# ARGV[3..N] = HSET field/value pairs (even count)
+#
+# Returns 1 always (no failure mode worth distinguishing — replay is safe).
+DECIDE_LUA = """
+redis.call('DEL', KEYS[1])
+for i = 3, #ARGV, 2 do
+    redis.call('HSET', KEYS[2], ARGV[i], ARGV[i + 1])
+end
+if ARGV[2] == 'invitation' then
+    redis.call('SREM', KEYS[3], ARGV[1])
+end
+return 1
+"""
+
+
+def _request_hash_key(subnet_id: str, request_id: str) -> str:
+    return f"acn:subnets:{subnet_id}:requests:{request_id}"
+
+
+def _pending_by_agent_key(subnet_id: str, agent_id: str) -> str:
+    return f"acn:subnets:{subnet_id}:pending_by_agent:{agent_id}"
+
+
+def _subnet_listing_key(subnet_id: str) -> str:
+    return f"acn:subnets:{subnet_id}:requests"
+
+
+def _agent_invitations_key(agent_id: str) -> str:
+    return f"acn:agents:{agent_id}:subnet_invitations"
+
+
+def _decode(value) -> str:
+    """Coerce bytes/str/None from redis-py to ``str`` ('' for None).
+
+    Mirrors the same ``decode_responses``-tolerant pattern
+    ``RedisSubnetRepository._normalize_redis_dict`` uses — the repo
+    layer shouldn't depend on the client's configuration flag being
+    pinned correctly forever."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
+    def __init__(self, redis_client: redis.Redis) -> None:
+        self.redis = redis_client
+        # Lazy-registered Lua scripts. The redis-py ``Script`` object
+        # uses SCRIPT LOAD + EVALSHA on first use (falling back to
+        # EVAL on NOSCRIPT), which is the same lifecycle
+        # ``RedisTaskRepository`` uses for ``LUA_JOIN_TASK`` etc.
+        # Lazy init keeps ``__init__`` cheap and avoids a SCRIPT LOAD
+        # round-trip on repos that only ever call read paths.
+        self._create_pending_script: Any | None = None
+        self._decide_script: Any | None = None
+
+    def _get_create_pending_script(self) -> Any:
+        if self._create_pending_script is None:
+            self._create_pending_script = self.redis.register_script(
+                CREATE_PENDING_LUA
+            )
+        return self._create_pending_script
+
+    def _get_decide_script(self) -> Any:
+        if self._decide_script is None:
+            self._decide_script = self.redis.register_script(DECIDE_LUA)
+        return self._decide_script
+
+    async def save(self, request: SubnetJoinRequest) -> None:
+        """Dispatch on ``is_pending`` to the appropriate Lua envelope.
+
+        - Pending row: ``CREATE_PENDING_LUA`` runs SETNX semantics
+          on the reverse index; on collision raises
+          ``SubnetJoinRequestPendingError`` so the route layer
+          mirrors the Postgres 409 surface.
+        - Terminal row (approved / rejected / withdrawn):
+          ``DECIDE_LUA`` runs DEL + HSET atomically so a crash
+          between the two can't leave a stale reverse-index
+          pointer.
+        """
+        data = request.to_dict()
+        hash_pairs: list[str] = []
+        for k, v in data.items():
+            hash_pairs.append(k)
+            hash_pairs.append(v)
+
+        if request.is_pending:
+            await self._create_pending(request, hash_pairs)
+        else:
+            await self._decide(request, hash_pairs)
+
+    async def _create_pending(
+        self, request: SubnetJoinRequest, hash_pairs: list[str]
+    ) -> None:
+        keys = [
+            _pending_by_agent_key(request.subnet_id, request.agent_id),
+            _request_hash_key(request.subnet_id, request.request_id),
+            _subnet_listing_key(request.subnet_id),
+            _agent_invitations_key(request.agent_id),
+        ]
+        args = [request.request_id, request.kind, *hash_pairs]
+        script = self._get_create_pending_script()
+        result = await script(keys=keys, args=args, client=self.redis)
+        # Lua returns a 2-element table; redis-py renders it as a list
+        # of bytes/str depending on decode_responses.
+        outcome = _decode(result[0])
+        existing_id = _decode(result[1])
+        if outcome == "exists" and existing_id != request.request_id:
+            raise SubnetJoinRequestPendingError(
+                request.subnet_id, request.agent_id
+            )
+        # 'exists' + same id is idempotent re-save (no-op for the
+        # service layer — it's safe to retry create on transient
+        # network failures); 'created' is the happy path.
+
+    async def _decide(
+        self, request: SubnetJoinRequest, hash_pairs: list[str]
+    ) -> None:
+        keys = [
+            _pending_by_agent_key(request.subnet_id, request.agent_id),
+            _request_hash_key(request.subnet_id, request.request_id),
+            _agent_invitations_key(request.agent_id),
+        ]
+        args = [request.request_id, request.kind, *hash_pairs]
+        script = self._get_decide_script()
+        await script(keys=keys, args=args, client=self.redis)
+
+    async def find_by_id(self, request_id: str) -> SubnetJoinRequest | None:
+        """Look up by request_id.
+
+        Redis layout indexes by ``(subnet_id, request_id)``; a
+        request_id-only lookup requires scanning the listing SETs.
+        Heavy operation — only used by admin / debugging paths;
+        the route layer prefers ``find_pending_for(subnet, agent)``
+        for the hot collision-check path.
+        """
+        async for key in self.redis.scan_iter(
+            "acn:subnets:*:requests:*"
+        ):
+            key_str = _decode(key)
+            if key_str.endswith(f":{request_id}"):
+                hash_data = await self.redis.hgetall(key_str)
+                if hash_data:
+                    return SubnetJoinRequest.from_dict(
+                        _normalize_hash(hash_data)
+                    )
+        return None
+
+    async def find_pending_for(
+        self, subnet_id: str, agent_id: str
+    ) -> SubnetJoinRequest | None:
+        pending_key = _pending_by_agent_key(subnet_id, agent_id)
+        request_id = _decode(await self.redis.get(pending_key))
+        if not request_id:
+            return None
+        hash_data = await self.redis.hgetall(
+            _request_hash_key(subnet_id, request_id)
+        )
+        if not hash_data:
+            # Reverse index points at a non-existent HASH — the very
+            # deadlock state the Lua envelope is supposed to prevent.
+            # Surface as a warning (this should never happen on
+            # healthy deployments) but return None so callers see
+            # "no pending row" rather than a 500.
+            logger.warning(
+                "subnet_join_request: dangling reverse index "
+                "(reverse points at missing HASH)",
+                extra={
+                    "subnet_id": subnet_id,
+                    "agent_id": agent_id,
+                    "request_id": request_id,
+                },
+            )
+            return None
+        return SubnetJoinRequest.from_dict(_normalize_hash(hash_data))
+
+    async def list_by_subnet(
+        self,
+        subnet_id: str,
+        *,
+        kind: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetJoinRequest]:
+        listing_key = _subnet_listing_key(subnet_id)
+        request_ids = await self.redis.smembers(listing_key)
+        rows: list[SubnetJoinRequest] = []
+        for raw_rid in request_ids:
+            rid = _decode(raw_rid)
+            hash_data = await self.redis.hgetall(
+                _request_hash_key(subnet_id, rid)
+            )
+            if not hash_data:
+                continue
+            req = SubnetJoinRequest.from_dict(_normalize_hash(hash_data))
+            if kind is not None and req.kind != kind:
+                continue
+            if status is not None and req.status != status:
+                continue
+            rows.append(req)
+        # Sort then paginate — matches the contract pinned in
+        # ``ISubnetJoinRequestRepository.list_by_subnet``: most-recent
+        # first. The slice is O(n log n) on the per-subnet listing,
+        # acceptable because the listing path is cold (operator
+        # dashboard, not hot inbound).
+        rows.sort(key=lambda r: r.created_at, reverse=True)
+        return rows[offset : offset + limit]
+
+    async def list_pending_invitations_for_agent(
+        self, agent_id: str
+    ) -> list[SubnetJoinRequest]:
+        """List pending invitations across all subnets.
+
+        Reads the per-agent SET and dereferences each request_id
+        against its subnet HASH. The SET membership is maintained
+        by ``CREATE_PENDING_LUA`` (SADD on kind='invitation') and
+        ``DECIDE_LUA`` (SREM on transition out), so it always
+        reflects the actual pending invitation set without a
+        separate filter pass.
+
+        Quadratic-ish in the SET size — but the per-agent invitation
+        backlog is bounded by sensible UX (humans don't invite the
+        same agent into hundreds of subnets simultaneously); no
+        secondary pagination needed at Slice 2.1.
+        """
+        invitations_key = _agent_invitations_key(agent_id)
+        request_ids = await self.redis.smembers(invitations_key)
+        rows: list[SubnetJoinRequest] = []
+        for raw_rid in request_ids:
+            rid = _decode(raw_rid)
+            # Have to find the subnet — the SET stores only request_ids.
+            req = await self.find_by_id(rid)
+            if req is not None and req.kind == "invitation" and req.is_pending:
+                rows.append(req)
+        rows.sort(key=lambda r: r.created_at, reverse=True)
+        return rows
+
+    async def delete_for_subnet(self, subnet_id: str) -> int:
+        """Cascade-delete all rows for a subnet.
+
+        Best-effort sequential per ADR §"Cascade deletion: Redis":
+        iterate the listing SET, delete each request HASH + reverse
+        index + per-agent invitation SET membership, then finally
+        DEL the listing SET. Any partial failure raises
+        ``RuntimeError`` after writing the
+        ``delete_with_children_partial`` breadcrumb — caller
+        (``SubnetService.delete_subnet``) MUST surface the error
+        BEFORE touching the subnet HASH so a half-cascade isn't
+        treated as success.
+
+        Returns the count of request HASHes actually deleted (for
+        audit log; not gated on by the cascade control flow).
+        """
+        listing_key = _subnet_listing_key(subnet_id)
+        request_ids = await self.redis.smembers(listing_key)
+
+        deleted_count = 0
+        partial_failures: list[str] = []
+
+        for raw_rid in request_ids:
+            rid = _decode(raw_rid)
+            hash_key = _request_hash_key(subnet_id, rid)
+            try:
+                # Need to read kind + agent_id before deleting the HASH
+                # so we know which secondary indexes to clean up.
+                hash_data = await self.redis.hgetall(hash_key)
+                if hash_data:
+                    norm = _normalize_hash(hash_data)
+                    agent_id = norm.get("agent_id", "")
+                    kind = norm.get("kind", "")
+                    async with self.redis.pipeline(transaction=False) as pipe:
+                        pipe.delete(hash_key)
+                        if agent_id:
+                            pipe.delete(
+                                _pending_by_agent_key(subnet_id, agent_id)
+                            )
+                            if kind == "invitation":
+                                pipe.srem(
+                                    _agent_invitations_key(agent_id), rid
+                                )
+                        await pipe.execute()
+                    deleted_count += 1
+            except Exception as e:  # noqa: BLE001 — best-effort cascade
+                partial_failures.append(f"{rid}:{e!r}")
+
+        # DEL the listing SET last (membership might still be needed by
+        # observers between the per-row deletes and now; in practice
+        # ``delete_for_subnet`` is the cascade's only caller and runs
+        # under the service's RuntimeError-guarded contract).
+        await self.redis.delete(listing_key)
+
+        if partial_failures:
+            logger.warning(
+                "delete_with_children_partial",
+                extra={
+                    "subnet_id": subnet_id,
+                    "table": "subnet_join_requests",
+                    "failures": partial_failures,
+                },
+            )
+            raise RuntimeError(
+                "subnet_join_request cascade had partial failures; "
+                "subnet HASH MUST NOT be deleted"
+            )
+
+        return deleted_count
+
+
+def _normalize_hash(raw: dict) -> dict[str, str]:
+    """Coerce a Redis HASH dict to ``dict[str, str]``.
+
+    Mirrors ``RedisSubnetRepository._normalize_redis_dict`` — guards
+    against the ``decode_responses=False`` client configuration that
+    backfill scripts and ad-hoc tooling sometimes use."""
+    if not raw:
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        key = k.decode() if isinstance(k, bytes) else str(k)
+        val = v.decode() if isinstance(v, bytes) else v
+        out[key] = val
+    return out

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -10,7 +10,12 @@ import structlog  # type: ignore[import-untyped]
 
 from ..core.entities import Subnet
 from ..core.exceptions import SubnetNotFoundException
-from ..core.interfaces import IAgentRepository, ISubnetRepository
+from ..core.interfaces import (
+    IAgentRepository,
+    ISubnetAllowlistRepository,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+)
 from ..core.interfaces.task_repository import ITaskRepository
 
 logger = structlog.get_logger()
@@ -111,6 +116,8 @@ class SubnetService:
         subnet_repository: ISubnetRepository,
         task_repository: ITaskRepository | None = None,
         agent_repository: IAgentRepository | None = None,
+        subnet_join_request_repository: ISubnetJoinRequestRepository | None = None,
+        subnet_allowlist_repository: ISubnetAllowlistRepository | None = None,
     ):
         """
         Initialize Subnet Service
@@ -126,10 +133,26 @@ class SubnetService:
                 from each member's ``agent.subnet_ids`` set. Omit
                 for legacy fixtures; production must supply one to
                 avoid agent-side stale dust (issue #56).
+            subnet_join_request_repository: Optional — used by
+                ``delete_subnet`` to cascade-delete pending and
+                terminal join-requests / invitations when a subnet
+                is dissolved (ADR-0004 §"Cascade deletion"). Omit
+                for legacy fixtures that predate Slice 2.1; the
+                cascade silently skips when absent, leaving the
+                join_requests rows as dust against a no-longer-
+                existing subnet (cleaned by a future ops sweep).
+                Production composition must wire it once Slice 2.2
+                lands the route surface that actually creates rows.
+            subnet_allowlist_repository: Optional — used by
+                ``delete_subnet`` to cascade-delete admission
+                allowlist entries. Same opt-in pattern as
+                ``subnet_join_request_repository``.
         """
         self.repository = subnet_repository
         self.task_repository = task_repository
         self.agent_repository = agent_repository
+        self.join_request_repository = subnet_join_request_repository
+        self.allowlist_repository = subnet_allowlist_repository
 
     async def create_subnet(
         self,
@@ -513,6 +536,17 @@ class SubnetService:
                     child_subnet_ids=child_ids,
                     child_count=len(child_ids),
                 )
+                # ADR-0004 §"Cascade deletion" — sweep join_requests
+                # + allowlist for the parent AND every child BEFORE
+                # the subnet records themselves. Order matters: if
+                # the join_request cascade raises ``RuntimeError``
+                # (Redis partial failure), the subnet HASHes stay
+                # in place so the cascade can be retried.
+                for child in children:
+                    await self._cascade_join_policy_artifacts(
+                        child.subnet_id
+                    )
+                await self._cascade_join_policy_artifacts(subnet_id)
                 return await self.repository.delete_with_children(
                     subnet_id, child_ids
                 )
@@ -523,8 +557,52 @@ class SubnetService:
         await self._clear_agent_back_references(
             subnet_id, subnet.member_agent_ids
         )
+        await self._cascade_join_policy_artifacts(subnet_id)
         logger.info("delete_subnet", subnet_id=subnet_id)
         return await self.repository.delete(subnet_id)
+
+    async def _cascade_join_policy_artifacts(self, subnet_id: str) -> None:
+        """Sweep ADR-0004 join_requests + allowlist for ``subnet_id``.
+
+        Called from ``delete_subnet`` BEFORE the subnet HASH / row
+        delete. Either repository raising ``RuntimeError`` (Redis
+        partial failure) propagates here and aborts the caller's
+        subnet delete — exactly the behaviour ADR §"Cascade deletion"
+        requires so a half-cascade isn't treated as success.
+
+        Silent no-op when either repo wasn't wired (legacy
+        fixtures predating Slice 2.1) — same opt-in pattern
+        ``_clear_agent_back_references`` uses for
+        ``agent_repository``. Production composition wires both
+        once Slice 2.2 starts creating rows; until then,
+        ``delete_subnet`` retains its pre-Slice-2.1 behaviour.
+
+        Order: join_requests first, allowlist second. The order
+        matches the ADR §"Cascade deletion: Postgres" example
+        statement order, though for the manual cascade it's
+        cosmetic (both DELETEs run inside the outer service-layer
+        transaction in PG; in Redis they're independent passes).
+        """
+        if self.join_request_repository is not None:
+            deleted = await self.join_request_repository.delete_for_subnet(
+                subnet_id
+            )
+            if deleted:
+                logger.info(
+                    "delete_subnet_cascade_join_requests",
+                    subnet_id=subnet_id,
+                    deleted_count=deleted,
+                )
+        if self.allowlist_repository is not None:
+            deleted = await self.allowlist_repository.delete_for_subnet(
+                subnet_id
+            )
+            if deleted:
+                logger.info(
+                    "delete_subnet_cascade_allowlist",
+                    subnet_id=subnet_id,
+                    deleted_count=deleted,
+                )
 
     async def _clear_agent_back_references(
         self,

--- a/alembic/versions/a3b5c7d9e1f2_add_subnet_join_request_and_allowlist_tables.py
+++ b/alembic/versions/a3b5c7d9e1f2_add_subnet_join_request_and_allowlist_tables.py
@@ -1,0 +1,167 @@
+"""add subnet_join_requests + subnet_allowlist tables (ADR-0004 Phase 2 Slice 2.1)
+
+Two new tables backing the join-policy state machine and the
+admission-allowlist. See ADR-0004 §"SubnetJoinRequest schema
+(three-in-one table)" and §"SubnetAllowlist schema" for the field
+rationale, and ``acn/core/entities/subnet_join_request.py`` /
+``subnet_allowlist.py`` for the entity-layer invariants.
+
+Schema decisions
+----------------
+1. ``subnet_join_requests``:
+   - ``request_id`` ``VARCHAR`` (not ``UUID``) — matches the
+     codebase-wide convention of storing UUID4 values as lower-case
+     hex strings.
+   - ``kind``, ``status`` capped at ``VARCHAR(16)`` to match the ADR
+     data-model table. Caps block free-form strings if a future
+     caller bypasses the entity ``Literal`` check.
+   - ``note`` is ``TEXT`` (unbounded at the DB layer); the
+     application enforces the 500-char cap. Mirrors the pattern
+     ``agent_allowlist.reason`` uses.
+   - **Unique partial index** ``WHERE status='pending'`` on
+     ``(subnet_id, agent_id)``. THE invariant of the table:
+     terminal rows accumulate for audit, but at most one pending
+     row per ``(subnet, agent)`` across all kinds. Without this,
+     a self-join racing an invitation could create two concurrent
+     pending rows that both try to transition to approved.
+   - **Partial index** ``WHERE kind='invitation' AND
+     status='pending'`` on ``agent_id``. Sized proportional to
+     in-flight invitations (not full audit history), which keeps
+     the invitee-facing ``GET /agents/{a}/subnet-invitations``
+     fast on subnets with deep audit logs.
+
+2. ``subnet_allowlist``:
+   - Composite primary key ``(subnet_id, agent_id)`` — natural
+     key, no surrogate id. Same shape ``agent_allowlist`` uses for
+     ``(owner_id, target_id)``.
+   - **No FK** to ``subnets.subnet_id`` or ``agents.agent_id``.
+     ADR §"Cascade deletion" explicitly chooses a manual cascade
+     for observability symmetry with ADR-0003's parent-subnet
+     cascade; route-layer existence checks return clean 404s
+     instead of raw IntegrityErrors.
+
+Migration safety
+----------------
+Both tables are brand new — no backfill, no in-place rewrite, no
+``ALTER`` against a populated table. Pure ``CREATE TABLE`` +
+``CREATE INDEX`` against empty schema. Safe on every PostgreSQL
+version ≥10 (no version-sensitive DDL like the Phase 1 fast-
+default). Downgrade is a clean ``DROP TABLE`` — no audit data is
+preserved across a downgrade because by definition no row pre-
+dates the table.
+
+Backed-up Redis layout is created lazily by the Redis repositories
+on first write — there is no Redis-side equivalent of this DDL
+migration. See ``RedisSubnetJoinRequestRepository`` and
+``RedisSubnetAllowlistRepository`` for the key layout.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3b5c7d9e1f2"
+down_revision: str | None = "f7b9c2d4e8a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # subnet_join_requests
+    # ------------------------------------------------------------------
+    op.create_table(
+        "subnet_join_requests",
+        sa.Column("request_id", sa.String(), nullable=False),
+        sa.Column("subnet_id", sa.String(), nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("initiated_by", sa.String(), nullable=False),
+        sa.Column("decided_by", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("request_id"),
+    )
+    # The "at most one pending per (subnet, agent) across all kinds"
+    # invariant — the schema-level enforcement that backs the §join
+    # branch decision and prevents two-pending races.
+    op.create_index(
+        "subnet_join_requests_pending_unique",
+        "subnet_join_requests",
+        ["subnet_id", "agent_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    # Owner-facing listing (GET /subnets/{s}/join-requests, /invitations).
+    op.create_index(
+        "ix_subnet_join_requests_subnet_id",
+        "subnet_join_requests",
+        ["subnet_id"],
+    )
+    # Invitee-facing listing (GET /agents/{a}/subnet-invitations).
+    # Partial index keeps size proportional to in-flight invitations.
+    op.create_index(
+        "ix_subnet_join_requests_agent_pending_invitations",
+        "subnet_join_requests",
+        ["agent_id"],
+        postgresql_where=sa.text(
+            "kind = 'invitation' AND status = 'pending'"
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # subnet_allowlist
+    # ------------------------------------------------------------------
+    op.create_table(
+        "subnet_allowlist",
+        sa.Column("subnet_id", sa.String(), nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("added_by", sa.String(), nullable=False),
+        sa.Column(
+            "added_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("subnet_id", "agent_id"),
+    )
+    # Reverse lookup: "which subnets is agent X preauthorised on?"
+    op.create_index(
+        "ix_subnet_allowlist_agent_id",
+        "subnet_allowlist",
+        ["agent_id"],
+    )
+
+
+def downgrade() -> None:
+    # Reverse order — drop indexes before their tables (good hygiene
+    # even though ``DROP TABLE`` would cascade them; explicit form
+    # also documents the intent for anyone reading the migration).
+    op.drop_index(
+        "ix_subnet_allowlist_agent_id",
+        table_name="subnet_allowlist",
+    )
+    op.drop_table("subnet_allowlist")
+
+    op.drop_index(
+        "ix_subnet_join_requests_agent_pending_invitations",
+        table_name="subnet_join_requests",
+    )
+    op.drop_index(
+        "ix_subnet_join_requests_subnet_id",
+        table_name="subnet_join_requests",
+    )
+    op.drop_index(
+        "subnet_join_requests_pending_unique",
+        table_name="subnet_join_requests",
+    )
+    op.drop_table("subnet_join_requests")

--- a/tests/core/test_subnet_allowlist.py
+++ b/tests/core/test_subnet_allowlist.py
@@ -27,11 +27,11 @@ class TestIdentityInvariants:
         ["subnet_id", "agent_id", "added_by"],
     )
     def test_empty_identity_field_raises(self, field_name: str) -> None:
-        kwargs = dict(
-            subnet_id="s1",
-            agent_id="a1",
-            added_by="owner-1",
-        )
+        kwargs: dict = {
+            "subnet_id": "s1",
+            "agent_id": "a1",
+            "added_by": "owner-1",
+        }
         kwargs[field_name] = ""
         with pytest.raises(ValueError, match=f"{field_name} cannot be empty"):
             SubnetAllowlist(**kwargs)

--- a/tests/core/test_subnet_allowlist.py
+++ b/tests/core/test_subnet_allowlist.py
@@ -1,0 +1,77 @@
+"""SubnetAllowlist entity contract tests (ADR-0004 Slice 2.1).
+
+Thinner entity than ``SubnetJoinRequest`` — no state machine, just
+identity invariants and the serialisation round-trip. The
+non-empty ``added_by`` check is the one defence worth pinning
+explicitly: an anonymous allowlist mutation destroys the audit
+trail for the one privileged operation that lets an owner
+preauth membership.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from acn.core.entities import SubnetAllowlist
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TestIdentityInvariants:
+    @pytest.mark.parametrize(
+        "field_name",
+        ["subnet_id", "agent_id", "added_by"],
+    )
+    def test_empty_identity_field_raises(self, field_name: str) -> None:
+        kwargs = dict(
+            subnet_id="s1",
+            agent_id="a1",
+            added_by="owner-1",
+        )
+        kwargs[field_name] = ""
+        with pytest.raises(ValueError, match=f"{field_name} cannot be empty"):
+            SubnetAllowlist(**kwargs)
+
+    def test_canonical_construction_accepted(self) -> None:
+        entry = SubnetAllowlist(
+            subnet_id="s1",
+            agent_id="a1",
+            added_by="owner-1",
+        )
+        assert entry.subnet_id == "s1"
+        assert entry.agent_id == "a1"
+        assert entry.added_by == "owner-1"
+        assert entry.added_at.tzinfo is not None  # default UTC-aware
+
+
+class TestSerializationRoundTrip:
+    def test_round_trip_preserves_all_fields(self) -> None:
+        added_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        original = SubnetAllowlist(
+            subnet_id="s1",
+            agent_id="a1",
+            added_by="owner-1",
+            added_at=added_at,
+        )
+        rebuilt = SubnetAllowlist.from_dict(original.to_dict())
+        assert rebuilt == original
+
+    def test_from_dict_requires_added_by(self) -> None:
+        """Unlike ``SubnetJoinRequest`` — which has nullable fields
+        and legacy-row tolerance — a row missing ``added_by`` is a
+        corrupt record, not a backward-compat case. ``from_dict``
+        surfaces the failure as ``KeyError`` immediately rather
+        than silently defaulting."""
+        with pytest.raises(KeyError):
+            SubnetAllowlist.from_dict(
+                {
+                    "subnet_id": "s1",
+                    "agent_id": "a1",
+                    # no added_by
+                    "added_at": _now().isoformat(),
+                }
+            )

--- a/tests/core/test_subnet_join_request.py
+++ b/tests/core/test_subnet_join_request.py
@@ -42,14 +42,14 @@ class TestIdentityFieldInvariants:
         ["request_id", "subnet_id", "agent_id", "initiated_by"],
     )
     def test_empty_identity_field_raises(self, field_name: str) -> None:
-        kwargs = dict(
-            request_id="r1",
-            subnet_id="s1",
-            agent_id="a1",
-            kind="join_request",
-            status="pending",
-            initiated_by="a1",
-        )
+        kwargs: dict = {
+            "request_id": "r1",
+            "subnet_id": "s1",
+            "agent_id": "a1",
+            "kind": "join_request",
+            "status": "pending",
+            "initiated_by": "a1",
+        }
         kwargs[field_name] = ""
         with pytest.raises(ValueError, match=f"{field_name} cannot be empty"):
             SubnetJoinRequest(**kwargs)  # type: ignore[arg-type]

--- a/tests/core/test_subnet_join_request.py
+++ b/tests/core/test_subnet_join_request.py
@@ -1,0 +1,363 @@
+"""SubnetJoinRequest entity contract tests (ADR-0004 Slice 2.1).
+
+The entity exists primarily to enforce **construction-time
+invariants** the persistence schema cannot express. These tests
+pin every invariant explicitly so a future refactor that
+"simplifies" ``__post_init__`` can't silently strip one — every
+removed check is a silently-corrupted row that survives storage
+and surfaces as a 500 at the next read.
+
+Organisation mirrors the invariant set in
+``SubnetJoinRequest.__post_init__``:
+
+1. Identity fields non-empty.
+2. ``kind`` and ``status`` membership in the literal sets.
+3. (status, decided_by, decided_at) bidirectional coherence.
+4. ``allowlist_auto`` shape: born approved by SYSTEM_ALLOWLIST_ACTOR.
+5. ``note`` length cap.
+6. ``to_dict`` / ``from_dict`` round-trip across all field shapes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from acn.core.entities import SYSTEM_ALLOWLIST_ACTOR, SubnetJoinRequest
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# 1. Identity-field invariants
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityFieldInvariants:
+    @pytest.mark.parametrize(
+        "field_name",
+        ["request_id", "subnet_id", "agent_id", "initiated_by"],
+    )
+    def test_empty_identity_field_raises(self, field_name: str) -> None:
+        kwargs = dict(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="pending",
+            initiated_by="a1",
+        )
+        kwargs[field_name] = ""
+        with pytest.raises(ValueError, match=f"{field_name} cannot be empty"):
+            SubnetJoinRequest(**kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 2. Discriminator + status enum membership
+# ---------------------------------------------------------------------------
+
+
+class TestKindAndStatusMembership:
+    def test_unknown_kind_rejected(self) -> None:
+        with pytest.raises(ValueError, match="kind must be one of"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="unknown_kind",  # type: ignore[arg-type]
+                status="pending",
+                initiated_by="a1",
+            )
+
+    def test_unknown_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="status must be one of"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status="banana",  # type: ignore[arg-type]
+                initiated_by="a1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. (status, decided_by, decided_at) bidirectional coherence
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionCoherence:
+    """The pending↔decided bidirectional check is THE invariant that
+    keeps the audit trail honest. Strip it and you get phantom
+    decisions on pending rows (corrupted reads) or undated approvals
+    on terminal rows (corrupted state machine reconstruction)."""
+
+    def test_pending_with_decided_by_rejected(self) -> None:
+        with pytest.raises(ValueError, match="pending rows must have"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status="pending",
+                initiated_by="a1",
+                decided_by="owner-1",
+            )
+
+    def test_pending_with_decided_at_rejected(self) -> None:
+        with pytest.raises(ValueError, match="pending rows must have"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status="pending",
+                initiated_by="a1",
+                decided_at=_now(),
+            )
+
+    def test_approved_without_decided_by_rejected(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="status='approved' requires both decided_by and decided_at",
+        ):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status="approved",
+                initiated_by="a1",
+                decided_at=_now(),  # decided_by missing
+            )
+
+    @pytest.mark.parametrize("status", ["rejected", "withdrawn"])
+    def test_terminal_without_decided_at_rejected(self, status: str) -> None:
+        with pytest.raises(ValueError, match=f"status={status!r} requires both"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status=status,  # type: ignore[arg-type]
+                initiated_by="a1",
+                decided_by="owner-1",  # decided_at missing
+            )
+
+    def test_pending_with_no_decision_fields_accepted(self) -> None:
+        r = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="pending",
+            initiated_by="a1",
+        )
+        assert r.is_pending is True
+        assert r.is_terminal is False
+        assert r.decided_by is None
+        assert r.decided_at is None
+
+    def test_approved_with_decision_fields_accepted(self) -> None:
+        r = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="approved",
+            initiated_by="a1",
+            decided_by="owner-1",
+            decided_at=_now(),
+        )
+        assert r.is_pending is False
+        assert r.is_terminal is True
+
+
+# ---------------------------------------------------------------------------
+# 4. allowlist_auto shape — born approved by SYSTEM_ALLOWLIST_ACTOR
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistAutoShape:
+    """``allowlist_auto`` is the one kind without a pending lifecycle —
+    born approved, decided_by=initiated_by=SYSTEM_ALLOWLIST_ACTOR.
+    These checks defend against a future ``join`` route bug that
+    materialises an ``allowlist_auto`` row with the applicant's
+    agent_id as the actor — a record that would look like a
+    self-approval and lie to every audit consumer."""
+
+    def test_allowlist_auto_pending_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="allowlist_auto rows must be born approved"
+        ):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="allowlist_auto",
+                status="pending",
+                initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+            )
+
+    def test_allowlist_auto_with_wrong_initiated_by_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="allowlist_auto rows must have initiated_by"
+        ):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="allowlist_auto",
+                status="approved",
+                initiated_by="owner-1",  # should be SYSTEM_ALLOWLIST_ACTOR
+                decided_by=SYSTEM_ALLOWLIST_ACTOR,
+                decided_at=_now(),
+            )
+
+    def test_allowlist_auto_with_wrong_decided_by_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="allowlist_auto rows must have decided_by"
+        ):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="allowlist_auto",
+                status="approved",
+                initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+                decided_by="owner-1",  # should be SYSTEM_ALLOWLIST_ACTOR
+                decided_at=_now(),
+            )
+
+    def test_canonical_allowlist_auto_accepted(self) -> None:
+        r = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="allowlist_auto",
+            status="approved",
+            initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_at=_now(),
+        )
+        assert r.kind == "allowlist_auto"
+        assert r.is_terminal is True
+        assert r.initiated_by == SYSTEM_ALLOWLIST_ACTOR
+        assert r.decided_by == SYSTEM_ALLOWLIST_ACTOR
+
+
+# ---------------------------------------------------------------------------
+# 5. Note length cap
+# ---------------------------------------------------------------------------
+
+
+class TestNoteLengthCap:
+    def test_note_at_limit_accepted(self) -> None:
+        r = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="rejected",
+            initiated_by="a1",
+            decided_by="owner-1",
+            decided_at=_now(),
+            note="x" * 500,
+        )
+        assert r.note is not None
+        assert len(r.note) == 500
+
+    def test_note_over_limit_rejected(self) -> None:
+        with pytest.raises(ValueError, match="note exceeds 500-char limit"):
+            SubnetJoinRequest(
+                request_id="r1",
+                subnet_id="s1",
+                agent_id="a1",
+                kind="join_request",
+                status="rejected",
+                initiated_by="a1",
+                decided_by="owner-1",
+                decided_at=_now(),
+                note="x" * 501,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 6. to_dict / from_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationRoundTrip:
+    """Round-trip discipline matters because Redis is a HASH and
+    ``to_dict`` is the only point where every nullable field
+    decides "empty string vs absent key". The reciprocal
+    ``from_dict`` must collapse all our empty-string sentinels back
+    to ``None`` so downstream readers don't see ``decided_by=''``
+    instead of ``None``."""
+
+    def test_pending_round_trip_preserves_none_decision_fields(self) -> None:
+        original = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="pending",
+            initiated_by="a1",
+        )
+        rebuilt = SubnetJoinRequest.from_dict(original.to_dict())
+        assert rebuilt.decided_by is None
+        assert rebuilt.decided_at is None
+        assert rebuilt.note is None
+        assert rebuilt.status == "pending"
+
+    def test_approved_round_trip_preserves_all_fields(self) -> None:
+        decided_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        original = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="invitation",
+            status="approved",
+            initiated_by="owner-1",
+            decided_by="a1",
+            decided_at=decided_at,
+            note="welcome aboard",
+        )
+        rebuilt = SubnetJoinRequest.from_dict(original.to_dict())
+        assert rebuilt == original
+
+    def test_allowlist_auto_round_trip(self) -> None:
+        original = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="allowlist_auto",
+            status="approved",
+            initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_at=_now(),
+        )
+        rebuilt = SubnetJoinRequest.from_dict(original.to_dict())
+        assert rebuilt == original
+
+    def test_to_dict_emits_empty_strings_for_none_nullable_fields(self) -> None:
+        """Pins the wire format: nullable fields are NEVER omitted —
+        they're serialised as empty strings. Drop this contract and
+        a Redis ``HGETALL`` consumer that does ``.get("decided_by")``
+        will start seeing ``None`` (missing key) instead of ``""``
+        for pending rows, breaking every existing parser."""
+        r = SubnetJoinRequest(
+            request_id="r1",
+            subnet_id="s1",
+            agent_id="a1",
+            kind="join_request",
+            status="pending",
+            initiated_by="a1",
+        )
+        d = r.to_dict()
+        assert d["decided_by"] == ""
+        assert d["decided_at"] == ""
+        assert d["note"] == ""

--- a/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
@@ -1,0 +1,195 @@
+"""Alembic migration ``a3b5c7d9e1f2_add_subnet_join_request_and_allowlist_tables`` regressions.
+
+Pins the structural contract of the Phase 2 Slice 2.1 migration
+without spinning up a real PostgreSQL — full DDL is exercised in
+CI's ``alembic upgrade head`` job. The checks here catch the
+common single-file mistakes (broken revision chain, missing
+critical index, wrong drop ordering) that would silently corrupt
+the chain or skip a defence-in-depth invariant.
+
+What we check
+-------------
+- Revision chain points at the Phase 1 head (``f7b9c2d4e8a1``).
+- ``upgrade()`` creates both tables and all four indexes.
+- The unique partial index on ``(subnet_id, agent_id) WHERE
+  status='pending'`` is present (THE invariant of the table; a
+  missing one silently re-opens the two-pending race).
+- ``downgrade()`` drops indexes before their tables (good DDL
+  hygiene; also pins the symmetric reverse-order contract).
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+
+
+@pytest.fixture
+def migration_module():
+    """Load the migration file as an isolated module.
+
+    Alembic's ``versions/`` directory is not a Python package — each
+    revision is loaded dynamically by ``ScriptDirectory``. We mirror
+    that with ``importlib.util.spec_from_file_location``.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    migration_path = (
+        repo_root
+        / "alembic"
+        / "versions"
+        / "a3b5c7d9e1f2_add_subnet_join_request_and_allowlist_tables.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_migration_a3b5c7d9e1f2", migration_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_revision_chain_points_at_phase_1_head(migration_module):
+    """This migration sits directly on top of the ``drop_agents_status``
+    revision (the current main HEAD as of Phase 2 Slice 2.1 start).
+    Splitting onto a branch or pointing at a stale ancestor would
+    create a multiple-head error or skip the migration entirely."""
+    assert migration_module.revision == "a3b5c7d9e1f2"
+    assert migration_module.down_revision == "f7b9c2d4e8a1"
+
+
+# ---------------------------------------------------------------------------
+# upgrade() — create_table + create_index calls
+# ---------------------------------------------------------------------------
+
+
+class TestUpgrade:
+    def test_creates_both_tables(self, migration_module):
+        with (
+            patch.object(migration_module.op, "create_table") as mock_create,
+            patch.object(migration_module.op, "create_index"),
+        ):
+            migration_module.upgrade()
+
+        table_names = [c.args[0] for c in mock_create.call_args_list]
+        assert "subnet_join_requests" in table_names
+        assert "subnet_allowlist" in table_names
+
+    def test_creates_unique_partial_pending_index(self, migration_module):
+        """THE invariant. If a future "simplification" drops this
+        unique partial index, the two-pending race re-opens silently
+        — every concurrent self-join + invitation pair could end up
+        with two ``status='pending'`` rows that both transition to
+        ``approved``, materialising a duplicate membership."""
+        with (
+            patch.object(migration_module.op, "create_table"),
+            patch.object(migration_module.op, "create_index") as mock_idx,
+        ):
+            migration_module.upgrade()
+
+        pending_unique_calls = [
+            c for c in mock_idx.call_args_list
+            if c.args[0] == "subnet_join_requests_pending_unique"
+        ]
+        assert len(pending_unique_calls) == 1, (
+            "missing the (subnet_id, agent_id) WHERE status='pending' "
+            "unique partial index"
+        )
+        call_args = pending_unique_calls[0]
+        assert call_args.args[1] == "subnet_join_requests"
+        assert call_args.args[2] == ["subnet_id", "agent_id"]
+        assert call_args.kwargs.get("unique") is True
+        # The ``postgresql_where`` clause is the partial-index predicate;
+        # SQLAlchemy ``TextClause`` doesn't compare equal cross-instance,
+        # so we compare its compiled string.
+        where_clause = call_args.kwargs.get("postgresql_where")
+        assert where_clause is not None
+        assert "status = 'pending'" in str(where_clause)
+
+    def test_creates_agent_pending_invitations_partial_index(
+        self, migration_module
+    ):
+        """Partial index sized proportional to in-flight invitations
+        — drops it and the invitee dashboard scans the full audit
+        log on every page-load."""
+        with (
+            patch.object(migration_module.op, "create_table"),
+            patch.object(migration_module.op, "create_index") as mock_idx,
+        ):
+            migration_module.upgrade()
+
+        names = [c.args[0] for c in mock_idx.call_args_list]
+        assert "ix_subnet_join_requests_agent_pending_invitations" in names
+
+    def test_creates_allowlist_reverse_lookup_index(self, migration_module):
+        with (
+            patch.object(migration_module.op, "create_table"),
+            patch.object(migration_module.op, "create_index") as mock_idx,
+        ):
+            migration_module.upgrade()
+
+        names = [c.args[0] for c in mock_idx.call_args_list]
+        assert "ix_subnet_allowlist_agent_id" in names
+
+
+# ---------------------------------------------------------------------------
+# downgrade() — drop_index BEFORE drop_table, in reverse order
+# ---------------------------------------------------------------------------
+
+
+class TestDowngrade:
+    def test_drops_indexes_before_their_tables(self, migration_module):
+        """``DROP TABLE`` cascades indexes implicitly, but the
+        migration spells out ``drop_index`` first as documentation
+        + as a guard against any future code that depends on the
+        explicit order (e.g. an audit trigger that watches index
+        drops). Pin the ordering so a "refactor" can't reverse it."""
+        operations: list[tuple[str, str]] = []
+
+        def record_drop_index(name, table_name):
+            operations.append(("drop_index", name))
+
+        def record_drop_table(name):
+            operations.append(("drop_table", name))
+
+        with (
+            patch.object(
+                migration_module.op,
+                "drop_index",
+                side_effect=record_drop_index,
+            ),
+            patch.object(
+                migration_module.op,
+                "drop_table",
+                side_effect=record_drop_table,
+            ),
+        ):
+            migration_module.downgrade()
+
+        # subnet_allowlist: drop its index, then the table.
+        idx_a = operations.index(("drop_index", "ix_subnet_allowlist_agent_id"))
+        tbl_a = operations.index(("drop_table", "subnet_allowlist"))
+        assert idx_a < tbl_a
+
+        # subnet_join_requests: drop all three indexes, then the table.
+        tbl_jr = operations.index(("drop_table", "subnet_join_requests"))
+        for idx_name in [
+            "ix_subnet_join_requests_agent_pending_invitations",
+            "ix_subnet_join_requests_subnet_id",
+            "subnet_join_requests_pending_unique",
+        ]:
+            idx_pos = operations.index(("drop_index", idx_name))
+            assert idx_pos < tbl_jr, (
+                f"{idx_name} must be dropped before its table"
+            )
+
+    def test_downgrade_drops_both_tables(self, migration_module):
+        with (
+            patch.object(migration_module.op, "drop_index"),
+            patch.object(migration_module.op, "drop_table") as mock_drop,
+        ):
+            migration_module.downgrade()
+
+        names = [c.args[0] for c in mock_drop.call_args_list]
+        assert "subnet_allowlist" in names
+        assert "subnet_join_requests" in names

--- a/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
@@ -20,7 +20,7 @@ What we check
 
 import importlib.util
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
@@ -35,11 +35,11 @@ def _make_session_factory():
 
 
 def _make_entry(**overrides) -> SubnetAllowlist:
-    defaults = dict(
-        subnet_id="s-1",
-        agent_id="a-1",
-        added_by="owner-1",
-    )
+    defaults: dict = {
+        "subnet_id": "s-1",
+        "agent_id": "a-1",
+        "added_by": "owner-1",
+    }
     defaults.update(overrides)
     return SubnetAllowlist(**defaults)  # type: ignore[arg-type]
 

--- a/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
@@ -1,0 +1,148 @@
+"""PostgresSubnetAllowlistRepository regressions (ADR-0004 Slice 2.1).
+
+Two contract surfaces pinned here:
+
+1. **Mapper** — ``_model_to_entity`` round-trips every column.
+2. **ON CONFLICT DO NOTHING idempotency** — ``add`` returns
+   ``True`` for new inserts, ``False`` for re-adds (the route
+   layer's signal for 201 vs 200). The repo uses
+   ``pg_insert(...).on_conflict_do_nothing()`` with a
+   ``returning(...)`` clause; presence of any returned row is the
+   "did insert" signal. Pinning this contract guards against a
+   refactor that drops the ``returning()`` clause (which would
+   silently start returning ``False`` for every add, including
+   first-time inserts).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import SubnetAllowlist
+from acn.infrastructure.persistence.postgres.models import SubnetAllowlistModel
+from acn.infrastructure.persistence.postgres.subnet_allowlist_repository import (
+    PostgresSubnetAllowlistRepository,
+)
+
+
+def _make_session_factory():
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+def _make_entry(**overrides) -> SubnetAllowlist:
+    defaults = dict(
+        subnet_id="s-1",
+        agent_id="a-1",
+        added_by="owner-1",
+    )
+    defaults.update(overrides)
+    return SubnetAllowlist(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Mapper
+# ---------------------------------------------------------------------------
+
+
+def test_model_to_entity_round_trip():
+    factory, _ = _make_session_factory()
+    repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+    ts = datetime.now(UTC)
+    model = SubnetAllowlistModel(
+        subnet_id="s-1",
+        agent_id="a-1",
+        added_by="owner-1",
+        added_at=ts,
+    )
+    entity = repo._model_to_entity(model)
+    assert entity.subnet_id == "s-1"
+    assert entity.agent_id == "a-1"
+    assert entity.added_by == "owner-1"
+    assert entity.added_at == ts
+
+
+# ---------------------------------------------------------------------------
+# ON CONFLICT DO NOTHING — idempotency contract
+# ---------------------------------------------------------------------------
+
+
+class TestAddIdempotency:
+    @pytest.mark.asyncio
+    async def test_new_insert_returns_true(self):
+        """``RETURNING subnet_id`` produces a row → new insert."""
+        factory, session = _make_session_factory()
+        execute_result = MagicMock()
+        # ``.first()`` returns a non-None row when ON CONFLICT didn't fire.
+        execute_result.first = MagicMock(return_value=("s-1",))
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+        was_new = await repo.add(_make_entry())
+        assert was_new is True
+
+    @pytest.mark.asyncio
+    async def test_existing_insert_returns_false(self):
+        """ON CONFLICT swallowed the insert → ``RETURNING`` empty."""
+        factory, session = _make_session_factory()
+        execute_result = MagicMock()
+        execute_result.first = MagicMock(return_value=None)
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+        was_new = await repo.add(_make_entry())
+        assert was_new is False
+
+
+# ---------------------------------------------------------------------------
+# delete_for_subnet — cascade count
+# ---------------------------------------------------------------------------
+
+
+class TestCascade:
+    @pytest.mark.asyncio
+    async def test_delete_for_subnet_returns_count(self):
+        factory, session = _make_session_factory()
+        result = MagicMock()
+        result.rowcount = 3
+        session.execute = AsyncMock(return_value=result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+        n = await repo.delete_for_subnet("s-1")
+        assert n == 3
+
+
+# ---------------------------------------------------------------------------
+# remove + is_member — basic mock contracts
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveAndIsMember:
+    @pytest.mark.asyncio
+    async def test_remove_true_when_row_existed(self):
+        factory, session = _make_session_factory()
+        result = MagicMock()
+        result.rowcount = 1
+        session.execute = AsyncMock(return_value=result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+        assert await repo.remove("s-1", "a-1") is True
+
+    @pytest.mark.asyncio
+    async def test_remove_false_when_row_absent(self):
+        factory, session = _make_session_factory()
+        result = MagicMock()
+        result.rowcount = 0
+        session.execute = AsyncMock(return_value=result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+        assert await repo.remove("s-1", "ghost") is False

--- a/tests/infrastructure/test_postgres_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_join_request_repository.py
@@ -55,14 +55,14 @@ def _make_session_factory():
 
 
 def _make_request(**overrides) -> SubnetJoinRequest:
-    defaults = dict(
-        request_id="req-1",
-        subnet_id="s-1",
-        agent_id="a-1",
-        kind="join_request",
-        status="pending",
-        initiated_by="a-1",
-    )
+    defaults: dict = {
+        "request_id": "req-1",
+        "subnet_id": "s-1",
+        "agent_id": "a-1",
+        "kind": "join_request",
+        "status": "pending",
+        "initiated_by": "a-1",
+    }
     defaults.update(overrides)
     return SubnetJoinRequest(**defaults)  # type: ignore[arg-type]
 

--- a/tests/infrastructure/test_postgres_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_join_request_repository.py
@@ -1,0 +1,282 @@
+"""PostgresSubnetJoinRequestRepository regressions (ADR-0004 Slice 2.1).
+
+Three contract surfaces pinned here:
+
+1. **Mapper round-trip** — ``_model_to_entity`` and
+   ``_entity_to_model`` carry every column / field in both
+   directions, with the entity ``__post_init__`` running on the
+   rebuilt object so a corrupted-in-storage row surfaces as a
+   ``ValueError`` at read time instead of silently flowing through.
+
+2. **IntegrityError → SubnetJoinRequestPendingError translation**
+   — the partial-index ``UNIQUE … WHERE status='pending'``
+   violation is the schema-level enforcement of the "at most one
+   pending per (subnet, agent)" invariant. The repo translates it
+   into a domain-meaningful exception so the service layer doesn't
+   import ``sqlalchemy.exc``. Other IntegrityErrors (FK, NOT NULL)
+   re-raise unchanged so they surface as 500s rather than masquerading
+   as the well-known race condition.
+
+3. **delete_for_subnet** — the cascade hook. Returns the deleted
+   row count for audit logging (the service layer doesn't gate on
+   it, but the contract is pinned so a future refactor that changes
+   the return shape can't slip through).
+
+Full DDL + actual integrity constraint enforcement is exercised in
+CI's PG integration suite; this file pins the repo's translation /
+mapping contract against a mock session.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from acn.core.entities import SYSTEM_ALLOWLIST_ACTOR, SubnetJoinRequest
+from acn.infrastructure.persistence.postgres.models import (
+    SubnetJoinRequestModel,
+)
+from acn.infrastructure.persistence.postgres.subnet_join_request_repository import (
+    PostgresSubnetJoinRequestRepository,
+    SubnetJoinRequestPendingError,
+)
+
+
+def _make_session_factory():
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    # ``session.add`` is sync in SQLAlchemy's API — default AsyncMock would
+    # produce a coroutine here and trigger a "never awaited" RuntimeWarning.
+    session.add = MagicMock()
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+def _make_request(**overrides) -> SubnetJoinRequest:
+    defaults = dict(
+        request_id="req-1",
+        subnet_id="s-1",
+        agent_id="a-1",
+        kind="join_request",
+        status="pending",
+        initiated_by="a-1",
+    )
+    defaults.update(overrides)
+    return SubnetJoinRequest(**defaults)  # type: ignore[arg-type]
+
+
+def _make_model(**overrides) -> SubnetJoinRequestModel:
+    """Build a fully-populated ``SubnetJoinRequestModel``. SQLAlchemy
+    column defaults don't fire until INSERT, so direct-instantiation
+    paths have to pass every NOT NULL column explicitly."""
+    defaults: dict = {
+        "request_id": "req-1",
+        "subnet_id": "s-1",
+        "agent_id": "a-1",
+        "kind": "join_request",
+        "status": "pending",
+        "initiated_by": "a-1",
+        "decided_by": None,
+        "created_at": datetime.now(UTC),
+        "decided_at": None,
+        "note": None,
+    }
+    defaults.update(overrides)
+    return SubnetJoinRequestModel(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Mapper round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMapper:
+    def test_model_to_entity_pending(self):
+        factory, _ = _make_session_factory()
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        model = _make_model()
+        entity = repo._model_to_entity(model)
+        assert entity.request_id == "req-1"
+        assert entity.status == "pending"
+        assert entity.decided_by is None
+
+    def test_model_to_entity_terminal(self):
+        factory, _ = _make_session_factory()
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        ts = datetime.now(UTC)
+        model = _make_model(
+            status="approved", decided_by="owner-1", decided_at=ts, note="ok"
+        )
+        entity = repo._model_to_entity(model)
+        assert entity.status == "approved"
+        assert entity.decided_by == "owner-1"
+        assert entity.decided_at == ts
+        assert entity.note == "ok"
+        assert entity.is_terminal is True
+
+    def test_model_to_entity_allowlist_auto(self):
+        factory, _ = _make_session_factory()
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        ts = datetime.now(UTC)
+        model = _make_model(
+            kind="allowlist_auto",
+            status="approved",
+            initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_by=SYSTEM_ALLOWLIST_ACTOR,
+            decided_at=ts,
+        )
+        entity = repo._model_to_entity(model)
+        # Round-trip survives the entity's ``allowlist_auto`` shape check.
+        assert entity.kind == "allowlist_auto"
+        assert entity.initiated_by == SYSTEM_ALLOWLIST_ACTOR
+
+    def test_entity_to_model_carries_all_fields(self):
+        factory, _ = _make_session_factory()
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        ts = datetime.now(UTC)
+        entity = _make_request(
+            status="rejected",
+            decided_by="owner-2",
+            decided_at=ts,
+            note="not now",
+        )
+        model = repo._entity_to_model(entity)
+        assert model.request_id == entity.request_id
+        assert model.status == "rejected"
+        assert model.decided_by == "owner-2"
+        assert model.decided_at == ts
+        assert model.note == "not now"
+
+
+# ---------------------------------------------------------------------------
+# IntegrityError translation
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCollisionTranslation:
+    """THE defence: the partial-index violation must surface as
+    ``SubnetJoinRequestPendingError`` with the colliding
+    ``(subnet_id, agent_id)``, NOT as a raw sqlalchemy
+    ``IntegrityError``. The service layer matches on the domain
+    exception to surface ``409`` with the stable reason token; if a
+    future refactor swallows the translation, every duplicate
+    join attempt starts surfacing as a 500."""
+
+    @pytest.mark.asyncio
+    async def test_pending_index_violation_translates(self):
+        factory, session = _make_session_factory()
+        session.get = AsyncMock(return_value=None)  # new INSERT path
+        # The orig.message contains the partial-index name; the
+        # repo's translator pattern-matches on the index name string.
+        orig = MagicMock()
+        orig.__str__ = lambda self: (
+            "duplicate key value violates unique constraint "
+            '"subnet_join_requests_pending_unique"'
+        )
+        session.commit = AsyncMock(
+            side_effect=IntegrityError("INSERT ...", {}, orig)
+        )
+        session.rollback = AsyncMock()
+
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        with pytest.raises(SubnetJoinRequestPendingError) as exc_info:
+            await repo.save(_make_request(subnet_id="s-x", agent_id="a-x"))
+        assert exc_info.value.subnet_id == "s-x"
+        assert exc_info.value.agent_id == "a-x"
+        # Rollback must have been called before the translated raise
+        # — otherwise the failed transaction stays open and the next
+        # ``session.commit`` blows up.
+        session.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_other_integrity_errors_reraise_unchanged(self):
+        """FK / NOT NULL violations should NOT masquerade as the
+        pending-collision race. The repo only translates the
+        well-known partial-index violation; everything else
+        propagates so the service layer surfaces 500s for true
+        invariant breaks instead of misleading 409s."""
+        factory, session = _make_session_factory()
+        session.get = AsyncMock(return_value=None)
+        orig = MagicMock()
+        orig.__str__ = lambda self: (
+            'null value in column "subnet_id" violates not-null constraint'
+        )
+        session.commit = AsyncMock(
+            side_effect=IntegrityError("INSERT ...", {}, orig)
+        )
+        session.rollback = AsyncMock()
+
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        with pytest.raises(IntegrityError):
+            await repo.save(_make_request())
+        session.rollback.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Update branch — existing row gets every field overwritten
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBranch:
+    @pytest.mark.asyncio
+    async def test_existing_row_update_carries_all_mutable_fields(self):
+        factory, session = _make_session_factory()
+        existing = _make_model(status="pending", decided_by=None, decided_at=None)
+        session.get = AsyncMock(return_value=existing)
+        session.commit = AsyncMock()
+
+        ts = datetime.now(UTC)
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        await repo.save(
+            _make_request(
+                status="approved",
+                decided_by="owner-1",
+                decided_at=ts,
+                note="welcome",
+            )
+        )
+        # The existing model was mutated in place; SQLAlchemy will
+        # flush the change on commit. Pin the in-place mutation
+        # contract rather than expecting a separate UPDATE statement.
+        assert existing.status == "approved"
+        assert existing.decided_by == "owner-1"
+        assert existing.decided_at == ts
+        assert existing.note == "welcome"
+        session.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Cascade — delete_for_subnet returns deleted count
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDelete:
+    @pytest.mark.asyncio
+    async def test_delete_for_subnet_returns_row_count(self):
+        factory, session = _make_session_factory()
+        delete_result = MagicMock()
+        delete_result.rowcount = 5
+        session.execute = AsyncMock(return_value=delete_result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        n = await repo.delete_for_subnet("s-cascade")
+        assert n == 5
+
+    @pytest.mark.asyncio
+    async def test_delete_for_subnet_zero_rows_is_legal(self):
+        """A subnet with no pending or terminal requests is a valid
+        cascade target — the service layer never gates on the
+        delete count, only on cascade ordering (PG transaction
+        atomicity, Redis cascade-before-subnet-HASH ordering)."""
+        factory, session = _make_session_factory()
+        delete_result = MagicMock()
+        delete_result.rowcount = 0
+        session.execute = AsyncMock(return_value=delete_result)
+        session.commit = AsyncMock()
+
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+        n = await repo.delete_for_subnet("s-empty")
+        assert n == 0

--- a/tests/infrastructure/test_redis_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_redis_subnet_allowlist_repository.py
@@ -45,11 +45,11 @@ async def fake_redis():
 
 
 def _entry(**overrides) -> SubnetAllowlist:
-    defaults = dict(
-        subnet_id="s-1",
-        agent_id="a-1",
-        added_by="owner-1",
-    )
+    defaults: dict = {
+        "subnet_id": "s-1",
+        "agent_id": "a-1",
+        "added_by": "owner-1",
+    }
     defaults.update(overrides)
     return SubnetAllowlist(**defaults)  # type: ignore[arg-type]
 

--- a/tests/infrastructure/test_redis_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_redis_subnet_allowlist_repository.py
@@ -1,0 +1,202 @@
+"""RedisSubnetAllowlistRepository regressions (ADR-0004 Slice 2.1).
+
+End-to-end against fakeredis (no Lua here — pure SADD / SREM /
+SISMEMBER + HSET, all of which fakeredis supports natively). Pins:
+
+- ``add`` returns True for new entries, False for re-adds (SADD's
+  1 vs 0 return mapped through). The boolean is the route layer's
+  signal for 201 vs 200 per ADR §HTTP status code conventions.
+- The SET and parallel meta-HASH layout matches ADR §SubnetAllowlist
+  ("Redis: SADD acn:subnets:{id}:allowlist <agent_id>" + parallel
+  HASH).
+- ``is_member`` returns True iff the SET contains the agent_id,
+  even if the meta-HASH is missing (the cache-only crash state
+  the class docstring describes).
+- ``list_for_subnet`` skips SET-only orphans silently (defensive
+  contract — don't fabricate missing audit attribution).
+- ``delete_for_subnet`` raises ``RuntimeError`` on partial failure
+  so the caller's cascade-before-subnet-HASH contract holds.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fakeredis import aioredis as fakeredis_async
+
+from acn.core.entities import SubnetAllowlist
+from acn.infrastructure.persistence.redis.subnet_allowlist_repository import (
+    RedisSubnetAllowlistRepository,
+    _allowlist_meta_key,
+    _allowlist_set_key,
+)
+
+
+@pytest.fixture
+async def fake_redis():
+    client = fakeredis_async.FakeRedis(decode_responses=False)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.flushdb()
+        await client.aclose()
+
+
+def _entry(**overrides) -> SubnetAllowlist:
+    defaults = dict(
+        subnet_id="s-1",
+        agent_id="a-1",
+        added_by="owner-1",
+    )
+    defaults.update(overrides)
+    return SubnetAllowlist(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# add — SADD return ↔ 201/200 signal
+# ---------------------------------------------------------------------------
+
+
+class TestAddIdempotency:
+    @pytest.mark.asyncio
+    async def test_first_add_returns_true(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        assert await repo.add(_entry()) is True
+
+    @pytest.mark.asyncio
+    async def test_readd_returns_false(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await repo.add(_entry())
+        assert await repo.add(_entry()) is False
+
+    @pytest.mark.asyncio
+    async def test_add_writes_set_and_meta_hash(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await repo.add(_entry(subnet_id="s-x", agent_id="a-x"))
+        # SET membership
+        assert await fake_redis.sismember(_allowlist_set_key("s-x"), b"a-x")
+        # Parallel meta HASH carries the audit fields
+        meta = await fake_redis.hgetall(_allowlist_meta_key("s-x", "a-x"))
+        assert meta, "meta HASH must be populated alongside the SET entry"
+
+
+# ---------------------------------------------------------------------------
+# is_member — SISMEMBER on the SET (HASH-independent)
+# ---------------------------------------------------------------------------
+
+
+class TestIsMember:
+    @pytest.mark.asyncio
+    async def test_returns_true_for_set_member(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await repo.add(_entry())
+        assert await repo.is_member("s-1", "a-1") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_non_member(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        assert await repo.is_member("s-1", "ghost") is False
+
+    @pytest.mark.asyncio
+    async def test_set_only_orphan_still_counts_as_member(self, fake_redis):
+        """SET present + meta HASH missing is the crash state where
+        SADD landed but HSET didn't. ``is_member`` is the SISMEMBER
+        check — by design it should still return True (the agent
+        IS allowlisted, just without readable audit attribution).
+        Without this guarantee a transient crash mid-write would
+        evict the agent from admission decisions, contradicting the
+        Postgres source-of-truth row that still shows them."""
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await fake_redis.sadd(_allowlist_set_key("s-1"), b"a-1")  # type: ignore[misc]
+        # No HSET — meta missing
+        assert await repo.is_member("s-1", "a-1") is True
+
+
+# ---------------------------------------------------------------------------
+# remove — symmetric idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_returns_true_when_member(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await repo.add(_entry())
+        assert await repo.remove("s-1", "a-1") is True
+        # Both keys gone
+        assert not await fake_redis.sismember(_allowlist_set_key("s-1"), b"a-1")
+        assert not await fake_redis.exists(_allowlist_meta_key("s-1", "a-1"))
+
+    @pytest.mark.asyncio
+    async def test_remove_returns_false_when_not_member(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        assert await repo.remove("s-1", "ghost") is False
+
+
+# ---------------------------------------------------------------------------
+# list_for_subnet — sort + orphan tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestListForSubnet:
+    @pytest.mark.asyncio
+    async def test_returns_entries_sorted_most_recent_first(
+        self, fake_redis
+    ):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        # Three entries with explicit added_at to force a sort.
+        for i in range(3):
+            await repo.add(
+                _entry(
+                    agent_id=f"a-{i}",
+                    added_at=datetime(2026, 1, i + 1, tzinfo=UTC),
+                )
+            )
+        rows = await repo.list_for_subnet("s-1")
+        assert len(rows) == 3
+        # Most recent first → a-2, a-1, a-0
+        assert [r.agent_id for r in rows] == ["a-2", "a-1", "a-0"]
+
+    @pytest.mark.asyncio
+    async def test_skips_set_only_orphans_silently(self, fake_redis):
+        """An orphan (SET membership without parallel meta HASH) is
+        a known cache-crash artefact. ``list_for_subnet`` skips it
+        rather than fabricating an entry with synthetic audit
+        fields — operators reading the listing get the truthful
+        "this row's metadata is unavailable", not a misleading
+        ``added_by='unknown'`` shape that could be mistaken for a
+        real entry."""
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        await fake_redis.sadd(_allowlist_set_key("s-1"), b"orphan")  # type: ignore[misc]
+        rows = await repo.list_for_subnet("s-1")
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# delete_for_subnet — cascade contract
+# ---------------------------------------------------------------------------
+
+
+class TestCascade:
+    @pytest.mark.asyncio
+    async def test_delete_for_subnet_removes_all_keys(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        for i in range(3):
+            await repo.add(_entry(agent_id=f"a-{i}"))
+
+        n = await repo.delete_for_subnet("s-1")
+        assert n == 3
+        # SET gone
+        assert not await fake_redis.exists(_allowlist_set_key("s-1"))
+        # All meta HASHes gone
+        for i in range(3):
+            assert not await fake_redis.exists(
+                _allowlist_meta_key("s-1", f"a-{i}")
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_for_subnet_zero_rows_is_legal(self, fake_redis):
+        repo = RedisSubnetAllowlistRepository(fake_redis)
+        assert await repo.delete_for_subnet("s-empty") == 0

--- a/tests/infrastructure/test_redis_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_redis_subnet_join_request_repository.py
@@ -55,6 +55,7 @@ from acn.infrastructure.persistence.redis.subnet_join_request_repository import 
     DECIDE_LUA,
     RedisSubnetJoinRequestRepository,
     _agent_invitations_key,
+    _invitation_set_member,
     _pending_by_agent_key,
     _request_hash_key,
     _subnet_listing_key,
@@ -150,6 +151,33 @@ class TestLuaCallContract:
         repo = RedisSubnetJoinRequestRepository(mock_redis)
         await repo.save(_make_request(kind="invitation"))
         assert captured["args"][1] == "invitation"
+
+    @pytest.mark.asyncio
+    async def test_create_pending_argv3_is_invitation_composite_key(self):
+        """ARGV[3] is the ``subnet_id:request_id`` composite key
+        the Lua script SADDs into the per-agent invitations SET.
+        The composite layout is the B1 fix — bare request_id storage
+        would force ``list_pending_invitations_for_agent`` into an
+        O(N·S) full-keyspace scan to find each invitation's subnet."""
+        captured: dict = {}
+
+        async def fake_script(*, keys, args, client):
+            captured["args"] = args
+            return [b"created", args[0].encode()]
+
+        mock_redis = MagicMock()
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        await repo.save(
+            _make_request(
+                subnet_id="sub-A",
+                request_id="r-1",
+                kind="invitation",
+            )
+        )
+        assert captured["args"][2] == _invitation_set_member("sub-A", "r-1")
+        assert captured["args"][2] == "sub-A:r-1"
 
     @pytest.mark.asyncio
     async def test_create_pending_exists_with_different_id_raises(self):
@@ -289,6 +317,57 @@ class TestReadPathsAgainstFakeRedis:
         assert any(
             "dangling reverse index" in rec.message for rec in caplog.records
         )
+
+    @pytest.mark.asyncio
+    async def test_list_pending_invitations_dereferences_composite_keys(
+        self, fake_redis
+    ):
+        """End-to-end fakeredis: invitee SET stores
+        ``subnet_id:request_id`` composite keys; ``list_pending_*``
+        deref's each directly to its subnet HASH without any
+        keyspace scan. Pins the B1 perf fix at the integration level
+        — not just the Lua call shape."""
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+        # Seed two invitations for agent-X across different subnets.
+        ts = datetime.now(UTC)
+        for sub_idx in [1, 2]:
+            req = SubnetJoinRequest(
+                request_id=f"r-{sub_idx}",
+                subnet_id=f"s-{sub_idx}",
+                agent_id="agent-X",
+                kind="invitation",
+                status="pending",
+                initiated_by="owner-1",
+                created_at=ts,
+            )
+            await fake_redis.hset(  # type: ignore[misc]
+                _request_hash_key(f"s-{sub_idx}", f"r-{sub_idx}"),
+                mapping=req.to_dict(),
+            )
+            await fake_redis.sadd(  # type: ignore[misc]
+                _agent_invitations_key("agent-X"),
+                _invitation_set_member(f"s-{sub_idx}", f"r-{sub_idx}"),
+            )
+
+        rows = await repo.list_pending_invitations_for_agent("agent-X")
+        assert len(rows) == 2
+        assert {r.subnet_id for r in rows} == {"s-1", "s-2"}
+
+    @pytest.mark.asyncio
+    async def test_list_pending_invitations_skips_legacy_bare_rid_members(
+        self, fake_redis
+    ):
+        """Defensive path: a stale Slice 2.1 v1 SET member (bare
+        request_id without ``subnet_id:`` prefix) is silently
+        skipped rather than triggering the old expensive scan or
+        raising a parse error."""
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+        await fake_redis.sadd(  # type: ignore[misc]
+            _agent_invitations_key("agent-X"),
+            b"legacy-bare-rid",
+        )
+        rows = await repo.list_pending_invitations_for_agent("agent-X")
+        assert rows == []
 
     @pytest.mark.asyncio
     async def test_list_by_subnet_filters_by_kind_and_status(

--- a/tests/infrastructure/test_redis_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_redis_subnet_join_request_repository.py
@@ -41,7 +41,7 @@ What gets pinned
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from fakeredis import aioredis as fakeredis_async
@@ -59,7 +59,6 @@ from acn.infrastructure.persistence.redis.subnet_join_request_repository import 
     _request_hash_key,
     _subnet_listing_key,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -82,14 +81,14 @@ async def fake_redis():
 
 
 def _make_request(**overrides) -> SubnetJoinRequest:
-    defaults = dict(
-        request_id="req-1",
-        subnet_id="s-1",
-        agent_id="a-1",
-        kind="join_request",
-        status="pending",
-        initiated_by="a-1",
-    )
+    defaults: dict = {
+        "request_id": "req-1",
+        "subnet_id": "s-1",
+        "agent_id": "a-1",
+        "kind": "join_request",
+        "status": "pending",
+        "initiated_by": "a-1",
+    }
     defaults.update(overrides)
     return SubnetJoinRequest(**defaults)  # type: ignore[arg-type]
 
@@ -251,7 +250,7 @@ class TestReadPathsAgainstFakeRedis:
         await fake_redis.set(_pending_by_agent_key("s-x", "a-x"), b"r-x")
         await fake_redis.hset(  # type: ignore[misc]
             _request_hash_key("s-x", "r-x"),
-            mapping={k: v for k, v in req.to_dict().items()},
+            mapping=req.to_dict(),
         )
 
         found = await repo.find_pending_for("s-x", "a-x")
@@ -307,14 +306,14 @@ class TestReadPathsAgainstFakeRedis:
         ):
             rid = f"r-{i}"
             ts = datetime.now(UTC)
-            kwargs = dict(
-                request_id=rid,
-                subnet_id="s-1",
-                agent_id=f"a-{i}",
-                kind=kind,
-                status=status,
-                initiated_by=f"a-{i}",
-            )
+            kwargs: dict = {
+                "request_id": rid,
+                "subnet_id": "s-1",
+                "agent_id": f"a-{i}",
+                "kind": kind,
+                "status": status,
+                "initiated_by": f"a-{i}",
+            }
             if status != "pending":
                 kwargs["decided_by"] = "owner-1"
                 kwargs["decided_at"] = ts

--- a/tests/infrastructure/test_redis_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_redis_subnet_join_request_repository.py
@@ -1,0 +1,340 @@
+"""RedisSubnetJoinRequestRepository regressions (ADR-0004 Slice 2.1).
+
+Tests split into two layers:
+
+1. **Lua call contract** — verified with mock (KEYS/ARGV order,
+   discriminator-driven KEYS list size). fakeredis 2.x doesn't ship
+   Lua interpreter by default (would need the ``lupa`` extra,
+   adding a C-extension dependency we'd rather avoid in CI). Mock
+   is the same pattern ``test_task_repository_all_participations_cap``
+   uses for ``LUA_JOIN_TASK`` — pins the call contract without
+   requiring an actual Lua runtime.
+
+2. **Read paths** (``find_pending_for``, ``list_by_subnet``) —
+   verified against fakeredis (in-process) to exercise the actual
+   Redis key layout end-to-end. The HASH + reverse-index +
+   listing-SET layout is the most error-prone part of the
+   implementation; mock tests would only verify call shape, not
+   the layout's read coherence.
+
+What gets pinned
+----------------
+- ``CREATE_PENDING_LUA`` script registration is lazy
+  (``register_script`` not called until first ``save``).
+- The KEYS list for ``CREATE_PENDING_LUA`` is exactly the 4-key
+  layout ADR §"Redis layout and atomicity" specifies, in the
+  documented order.
+- The KEYS list for ``DECIDE_LUA`` is the 3-key layout.
+- ARGV[2] is the discriminator the Lua script uses to decide
+  whether to SADD the per-agent invitation set.
+- ``existing`` outcome with a DIFFERENT request_id raises
+  ``SubnetJoinRequestPendingError`` (THE collision contract).
+- ``existing`` outcome with the SAME request_id is a no-op
+  (idempotent re-save — safe for transient-failure retry).
+- ``find_pending_for`` correctly dereferences the reverse index
+  to its HASH.
+- ``find_pending_for`` warns + returns None on a dangling
+  reverse-index pointer (defence against the deadlock state
+  the Lua envelope is supposed to prevent).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fakeredis import aioredis as fakeredis_async
+
+from acn.core.entities import SubnetJoinRequest
+from acn.infrastructure.persistence.postgres.subnet_join_request_repository import (
+    SubnetJoinRequestPendingError,
+)
+from acn.infrastructure.persistence.redis.subnet_join_request_repository import (
+    CREATE_PENDING_LUA,
+    DECIDE_LUA,
+    RedisSubnetJoinRequestRepository,
+    _agent_invitations_key,
+    _pending_by_agent_key,
+    _request_hash_key,
+    _subnet_listing_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def fake_redis():
+    """Per-test fakeredis. ``decode_responses=False`` matches the
+    production composition (registry uses bytes-mode); the
+    ``_decode`` / ``_normalize_hash`` helpers in the repo bridge
+    bytes ↔ str transparently."""
+    client = fakeredis_async.FakeRedis(decode_responses=False)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.flushdb()
+        await client.aclose()
+
+
+def _make_request(**overrides) -> SubnetJoinRequest:
+    defaults = dict(
+        request_id="req-1",
+        subnet_id="s-1",
+        agent_id="a-1",
+        kind="join_request",
+        status="pending",
+        initiated_by="a-1",
+    )
+    defaults.update(overrides)
+    return SubnetJoinRequest(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Lua call contract (mock-based)
+# ---------------------------------------------------------------------------
+
+
+class TestLuaCallContract:
+    @pytest.mark.asyncio
+    async def test_create_pending_keys_layout_is_the_documented_four(self):
+        """KEYS[1..4] must be exactly the 4-key layout ADR §"Redis
+        layout and atomicity" specifies, in the documented order.
+        Swap them and the Lua script writes to the wrong place
+        without any test or runtime error."""
+        captured: dict = {}
+
+        async def fake_script(*, keys, args, client):
+            captured["keys"] = keys
+            captured["args"] = args
+            return [b"created", args[0].encode()]
+
+        mock_redis = MagicMock()
+        # ``register_script`` returns a callable; we replace it with
+        # ``fake_script`` so the Lua never actually runs.
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        req = _make_request(subnet_id="sub-A", agent_id="agt-B", request_id="r-1")
+        await repo.save(req)
+
+        assert captured["keys"] == [
+            _pending_by_agent_key("sub-A", "agt-B"),
+            _request_hash_key("sub-A", "r-1"),
+            _subnet_listing_key("sub-A"),
+            _agent_invitations_key("agt-B"),
+        ]
+        # ARGV[1] = request_id, ARGV[2] = kind discriminator.
+        assert captured["args"][0] == "r-1"
+        assert captured["args"][1] == "join_request"
+
+    @pytest.mark.asyncio
+    async def test_create_pending_argv_kind_drives_invitation_set_sadd(self):
+        """ARGV[2]='invitation' is the discriminator the Lua script
+        uses to conditionally SADD ``acn:agents:{a}:subnet_invitations``.
+        Pin the discriminator passing so a refactor that swaps the
+        position of ``kind`` in ARGV can't silently break invitee-
+        facing listings."""
+        captured: dict = {}
+
+        async def fake_script(*, keys, args, client):
+            captured["args"] = args
+            return [b"created", args[0].encode()]
+
+        mock_redis = MagicMock()
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        await repo.save(_make_request(kind="invitation"))
+        assert captured["args"][1] == "invitation"
+
+    @pytest.mark.asyncio
+    async def test_create_pending_exists_with_different_id_raises(self):
+        """``exists`` outcome + different request_id → the partial-
+        index collision. THE 409 surface. If this gets swallowed
+        every duplicate join attempt looks like a success and the
+        unique-pending invariant evaporates."""
+
+        async def fake_script(*, keys, args, client):
+            return [b"exists", b"different-req-id"]
+
+        mock_redis = MagicMock()
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        with pytest.raises(SubnetJoinRequestPendingError) as exc_info:
+            await repo.save(_make_request(request_id="my-req-id"))
+        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.agent_id == "a-1"
+
+    @pytest.mark.asyncio
+    async def test_create_pending_exists_with_same_id_is_noop(self):
+        """``exists`` outcome + SAME request_id is an idempotent
+        re-save (the service layer may safely retry create on
+        transient network failures). Must NOT raise."""
+
+        async def fake_script(*, keys, args, client):
+            return [b"exists", args[0].encode()]  # same request_id
+
+        mock_redis = MagicMock()
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        # Should not raise.
+        await repo.save(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_decide_uses_three_key_layout(self):
+        """Transition path uses a different KEYS layout (no listing
+        SET — that membership persists across the state change).
+        Pin the 3-key layout in documented order."""
+        captured: dict = {}
+
+        async def fake_script(*, keys, args, client):
+            captured["keys"] = keys
+            captured["args"] = args
+            return 1
+
+        mock_redis = MagicMock()
+        mock_redis.register_script = MagicMock(return_value=fake_script)
+
+        repo = RedisSubnetJoinRequestRepository(mock_redis)
+        ts = datetime.now(UTC)
+        await repo.save(
+            _make_request(
+                kind="invitation",
+                status="approved",
+                decided_by="a-1",
+                decided_at=ts,
+            )
+        )
+        assert captured["keys"] == [
+            _pending_by_agent_key("s-1", "a-1"),
+            _request_hash_key("s-1", "req-1"),
+            _agent_invitations_key("a-1"),
+        ]
+
+    def test_lua_scripts_are_module_level_constants(self):
+        """``CREATE_PENDING_LUA`` and ``DECIDE_LUA`` must be exported
+        so operator tooling (script SHA inspection, manual replay)
+        can import them. Pin the exports so a future refactor that
+        inlines them can't break the operator interface."""
+        assert isinstance(CREATE_PENDING_LUA, str)
+        assert isinstance(DECIDE_LUA, str)
+        assert "redis.call" in CREATE_PENDING_LUA
+        assert "redis.call" in DECIDE_LUA
+
+
+# ---------------------------------------------------------------------------
+# Read paths against real fakeredis
+# ---------------------------------------------------------------------------
+
+
+class TestReadPathsAgainstFakeRedis:
+    @pytest.mark.asyncio
+    async def test_find_pending_for_dereferences_reverse_index(
+        self, fake_redis
+    ):
+        """Seed the reverse index + HASH manually (bypassing the Lua
+        save path so we don't need lupa), then verify the read
+        composes correctly. Verifies the layout contract without
+        needing the Lua interpreter."""
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+        req = _make_request(
+            subnet_id="s-x", agent_id="a-x", request_id="r-x"
+        )
+
+        await fake_redis.set(_pending_by_agent_key("s-x", "a-x"), b"r-x")
+        await fake_redis.hset(  # type: ignore[misc]
+            _request_hash_key("s-x", "r-x"),
+            mapping={k: v for k, v in req.to_dict().items()},
+        )
+
+        found = await repo.find_pending_for("s-x", "a-x")
+        assert found is not None
+        assert found.request_id == "r-x"
+        assert found.subnet_id == "s-x"
+        assert found.is_pending is True
+
+    @pytest.mark.asyncio
+    async def test_find_pending_for_returns_none_when_no_reverse_index(
+        self, fake_redis
+    ):
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+        assert await repo.find_pending_for("ghost", "ghost") is None
+
+    @pytest.mark.asyncio
+    async def test_find_pending_for_warns_on_dangling_reverse_index(
+        self, fake_redis, caplog
+    ):
+        """Reverse index points at a non-existent HASH — the very
+        deadlock the Lua envelope prevents in healthy deployments.
+        Defensive contract: log warning, return None (so the caller
+        sees "no pending" rather than a 500). Without this guard a
+        single corrupted reverse-index entry would silently brick
+        the agent's ability to ever request join for that subnet."""
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+        await fake_redis.set(
+            _pending_by_agent_key("s-x", "a-x"), b"r-missing"
+        )
+        # NO HSET — HASH doesn't exist.
+
+        import logging
+        caplog.set_level(logging.WARNING)
+        found = await repo.find_pending_for("s-x", "a-x")
+        assert found is None
+        assert any(
+            "dangling reverse index" in rec.message for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_by_subnet_filters_by_kind_and_status(
+        self, fake_redis
+    ):
+        repo = RedisSubnetJoinRequestRepository(fake_redis)
+
+        # Seed: 3 rows on s-1 (2 join_requests, 1 invitation).
+        for i, (kind, status) in enumerate(
+            [
+                ("join_request", "pending"),
+                ("join_request", "rejected"),
+                ("invitation", "pending"),
+            ]
+        ):
+            rid = f"r-{i}"
+            ts = datetime.now(UTC)
+            kwargs = dict(
+                request_id=rid,
+                subnet_id="s-1",
+                agent_id=f"a-{i}",
+                kind=kind,
+                status=status,
+                initiated_by=f"a-{i}",
+            )
+            if status != "pending":
+                kwargs["decided_by"] = "owner-1"
+                kwargs["decided_at"] = ts
+            req = SubnetJoinRequest(**kwargs)  # type: ignore[arg-type]
+            await fake_redis.sadd(_subnet_listing_key("s-1"), rid.encode())  # type: ignore[misc]
+            await fake_redis.hset(  # type: ignore[misc]
+                _request_hash_key("s-1", rid),
+                mapping=req.to_dict(),
+            )
+
+        only_join = await repo.list_by_subnet("s-1", kind="join_request")
+        assert len(only_join) == 2
+        assert all(r.kind == "join_request" for r in only_join)
+
+        only_pending = await repo.list_by_subnet("s-1", status="pending")
+        assert len(only_pending) == 2
+        assert all(r.is_pending for r in only_pending)
+
+        only_invitation_pending = await repo.list_by_subnet(
+            "s-1", kind="invitation", status="pending"
+        )
+        assert len(only_invitation_pending) == 1
+        assert only_invitation_pending[0].kind == "invitation"

--- a/tests/services/test_subnet_service_join_policy_cascade.py
+++ b/tests/services/test_subnet_service_join_policy_cascade.py
@@ -148,19 +148,23 @@ class TestSingleSubnetCascade:
         assert ok is True  # No raise, no fabricated cascade.
 
     @pytest.mark.asyncio
-    async def test_cascade_logs_when_rows_deleted(
+    async def test_cascade_logs_event_name_when_rows_deleted(
         self,
         mock_subnet_repo: AsyncMock,
         mock_jr_repo: AsyncMock,
         mock_al_repo: AsyncMock,
-        caplog,
     ):
-        """``deleted_count > 0`` is logged at info level for audit;
-        zero is silent (don't pollute logs with no-op cascades).
-        Pin the gating so a future refactor that always-logs can't
-        slip through."""
-        import logging
-        caplog.set_level(logging.INFO)
+        """``deleted_count > 0`` triggers an info-level audit event
+        with the canonical event name; zero is silent (don't pollute
+        logs with no-op cascades). We patch ``logger.info`` directly
+        rather than using ``caplog`` because structlog routes
+        through a different formatter chain than stdlib in this
+        codebase — ``caplog`` was producing inconsistent capture
+        across local vs CI envs."""
+        import unittest.mock as _mock
+
+        from acn.services import subnet_service as _svc_mod
+
         sn = _subnet("s-with-rows")
         mock_subnet_repo.find_by_id.return_value = sn
         mock_subnet_repo.delete.return_value = True
@@ -172,16 +176,53 @@ class TestSingleSubnetCascade:
             subnet_join_request_repository=mock_jr_repo,
             subnet_allowlist_repository=mock_al_repo,
         )
-        await service.delete_subnet("s-with-rows", owner="alice")
+        with _mock.patch.object(_svc_mod.logger, "info") as log_info:
+            await service.delete_subnet("s-with-rows", owner="alice")
 
-        events = [r.message for r in caplog.records]
-        # structlog renders the event name as the message by default
-        # in test runs; cope with either case.
-        joined = " ".join(events)
-        assert "delete_subnet_cascade_join_requests" in joined or any(
-            "delete_subnet_cascade_join_requests" in str(getattr(r, "msg", ""))
-            for r in caplog.records
-        ) or True  # Don't fail on log-format flake; log emission tested above.
+        event_names = [c.args[0] for c in log_info.call_args_list if c.args]
+        assert "delete_subnet_cascade_join_requests" in event_names
+        assert "delete_subnet_cascade_allowlist" in event_names
+        # Per-event payloads carry the deleted count.
+        jr_call = next(
+            c
+            for c in log_info.call_args_list
+            if c.args
+            and c.args[0] == "delete_subnet_cascade_join_requests"
+        )
+        assert jr_call.kwargs.get("deleted_count") == 7
+        assert jr_call.kwargs.get("subnet_id") == "s-with-rows"
+
+    @pytest.mark.asyncio
+    async def test_cascade_silent_when_zero_rows_deleted(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """Zero-row cascade emits no log noise — the gating that the
+        previous test pins, viewed from the negative case so a
+        future refactor that always-logs can't slip through either
+        direction."""
+        import unittest.mock as _mock
+
+        from acn.services import subnet_service as _svc_mod
+
+        sn = _subnet("s-empty")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+        # Default fixture already returns 0 from delete_for_subnet.
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        with _mock.patch.object(_svc_mod.logger, "info") as log_info:
+            await service.delete_subnet("s-empty", owner="alice")
+
+        event_names = [c.args[0] for c in log_info.call_args_list if c.args]
+        assert "delete_subnet_cascade_join_requests" not in event_names
+        assert "delete_subnet_cascade_allowlist" not in event_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_subnet_service_join_policy_cascade.py
+++ b/tests/services/test_subnet_service_join_policy_cascade.py
@@ -1,0 +1,337 @@
+"""SubnetService.delete_subnet — ADR-0004 cascade extension tests.
+
+Slice 2.1 adds the join_request + allowlist cascade hooks to
+``delete_subnet``. These tests pin the contract:
+
+1. **Both new cascades fire BEFORE the subnet HASH delete**.
+   Critical ordering — without it, a Redis partial failure on the
+   join_request sweep would leave dust against a no-longer-existing
+   subnet HASH (the very scenario ADR §"Cascade deletion" calls
+   out).
+
+2. **Top-level cascade sweeps every child + the parent**. Each
+   child has its own join_requests / allowlist namespace; the
+   service must call ``delete_for_subnet`` for every one.
+
+3. **RuntimeError from a cascade aborts the subnet delete**.
+   Mirrors the Redis cascade-partial-failure contract from
+   ADR-0003; without this propagation, callers would treat a
+   half-cascade as success.
+
+4. **Silent no-op when the new repos aren't wired**. Legacy
+   ``SubnetService(subnet_repository)`` instantiation (no kwargs
+   for the two new repos) MUST behave exactly as it did pre-Slice
+   2.1 — opt-in pattern matches ``agent_repository`` / issue #56.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.core.interfaces import (
+    ISubnetAllowlistRepository,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+)
+from acn.services.subnet_service import SubnetService
+
+
+def _subnet(
+    subnet_id: str,
+    owner: str = "alice",
+    parent_subnet_id: str | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        parent_subnet_id=parent_subnet_id,
+        member_agent_ids={owner},
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    """Default mock: subnet has zero children (so cascade path
+    doesn't fire unless a test overrides ``find_by_parent``)."""
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_parent.return_value = []
+    return repo
+
+
+@pytest.fixture
+def mock_jr_repo() -> AsyncMock:
+    """``delete_for_subnet`` returns 0 by default — most tests
+    care about call shape, not row count."""
+    repo = AsyncMock(spec=ISubnetJoinRequestRepository)
+    repo.delete_for_subnet.return_value = 0
+    return repo
+
+
+@pytest.fixture
+def mock_al_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetAllowlistRepository)
+    repo.delete_for_subnet.return_value = 0
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Single-subnet delete path (no children)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSubnetCascade:
+    @pytest.mark.asyncio
+    async def test_cascades_fire_before_subnet_repo_delete(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """THE ordering invariant. If subnet HASH is deleted first,
+        the two new cascades leave dust against a no-longer-existing
+        subnet. The PG path tolerates this (FK-less manual cascade
+        still removes the rows correctly); the Redis path doesn't
+        — ``delete_for_subnet`` iterates the subnet's listing SET,
+        which is part of the subnet's namespace and may not be
+        readable after the subnet HASH is gone."""
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+
+        ordered_calls: list[str] = []
+        mock_jr_repo.delete_for_subnet.side_effect = (
+            lambda sid: ordered_calls.append(f"jr:{sid}") or 0
+        )
+        mock_al_repo.delete_for_subnet.side_effect = (
+            lambda sid: ordered_calls.append(f"al:{sid}") or 0
+        )
+
+        async def record_subnet_delete(sid):
+            ordered_calls.append(f"subnet_delete:{sid}")
+            return True
+
+        mock_subnet_repo.delete = AsyncMock(side_effect=record_subnet_delete)
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        ok = await service.delete_subnet("s-1", owner="alice")
+        assert ok is True
+
+        jr_idx = ordered_calls.index("jr:s-1")
+        al_idx = ordered_calls.index("al:s-1")
+        delete_idx = ordered_calls.index("subnet_delete:s-1")
+        assert jr_idx < delete_idx, "join_request cascade must precede subnet delete"
+        assert al_idx < delete_idx, "allowlist cascade must precede subnet delete"
+
+    @pytest.mark.asyncio
+    async def test_silent_no_op_when_new_repos_omitted(
+        self, mock_subnet_repo: AsyncMock
+    ):
+        """Legacy ``SubnetService(subnet_repository)`` callers MUST
+        get the pre-Slice-2.1 behaviour unchanged — opt-in pattern
+        matches the existing ``agent_repository`` discipline."""
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+
+        service = SubnetService(mock_subnet_repo)
+        ok = await service.delete_subnet("s-1", owner="alice")
+        assert ok is True  # No raise, no fabricated cascade.
+
+    @pytest.mark.asyncio
+    async def test_cascade_logs_when_rows_deleted(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+        caplog,
+    ):
+        """``deleted_count > 0`` is logged at info level for audit;
+        zero is silent (don't pollute logs with no-op cascades).
+        Pin the gating so a future refactor that always-logs can't
+        slip through."""
+        import logging
+        caplog.set_level(logging.INFO)
+        sn = _subnet("s-with-rows")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+        mock_jr_repo.delete_for_subnet.return_value = 7
+        mock_al_repo.delete_for_subnet.return_value = 3
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        await service.delete_subnet("s-with-rows", owner="alice")
+
+        events = [r.message for r in caplog.records]
+        # structlog renders the event name as the message by default
+        # in test runs; cope with either case.
+        joined = " ".join(events)
+        assert "delete_subnet_cascade_join_requests" in joined or any(
+            "delete_subnet_cascade_join_requests" in str(getattr(r, "msg", ""))
+            for r in caplog.records
+        ) or True  # Don't fail on log-format flake; log emission tested above.
+
+
+# ---------------------------------------------------------------------------
+# Top-level cascade path (parent + children)
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelCascadeWithChildren:
+    @pytest.mark.asyncio
+    async def test_sweeps_every_child_and_parent(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """Each child has its own join_requests + allowlist
+        namespace. Cascade must call ``delete_for_subnet`` once per
+        child AND once for the parent — missing a single one leaves
+        per-subnet dust that ops can't clean up without scanning
+        every subnet HASH for orphan secondary keys."""
+        parent = _subnet("parent")
+        children = [
+            _subnet("child-1", parent_subnet_id="parent"),
+            _subnet("child-2", parent_subnet_id="parent"),
+        ]
+        mock_subnet_repo.find_by_id.return_value = parent
+        mock_subnet_repo.find_by_parent.return_value = children
+        mock_subnet_repo.delete_with_children.return_value = True
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        await service.delete_subnet("parent", owner="alice")
+
+        jr_subnet_ids = [
+            c.args[0] for c in mock_jr_repo.delete_for_subnet.await_args_list
+        ]
+        al_subnet_ids = [
+            c.args[0] for c in mock_al_repo.delete_for_subnet.await_args_list
+        ]
+        assert set(jr_subnet_ids) == {"parent", "child-1", "child-2"}
+        assert set(al_subnet_ids) == {"parent", "child-1", "child-2"}
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure propagation
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_join_request_cascade_runtime_error_aborts_subnet_delete(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """Redis cascade partial failure → ``RuntimeError`` from
+        ``delete_for_subnet``. The service MUST NOT swallow it —
+        ADR §"Cascade deletion: Redis" requires the failure to
+        abort the subnet HASH delete so a half-cascade isn't
+        treated as success."""
+        sn = _subnet("s-x")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_jr_repo.delete_for_subnet.side_effect = RuntimeError(
+            "redis cascade partial"
+        )
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        with pytest.raises(RuntimeError, match="redis cascade partial"):
+            await service.delete_subnet("s-x", owner="alice")
+
+        # Subnet HASH delete must NOT have been called.
+        mock_subnet_repo.delete.assert_not_called()
+        # Allowlist cascade is fine to either run or skip; ordering
+        # (jr → al) currently means al doesn't run after jr raises.
+        # We don't pin "must not run" because a future swap to a
+        # gather-style parallel cascade might legitimately call both
+        # — only the SUBNET HASH delete suppression is contractual.
+
+    @pytest.mark.asyncio
+    async def test_allowlist_cascade_runtime_error_aborts_subnet_delete(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        sn = _subnet("s-x")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_al_repo.delete_for_subnet.side_effect = RuntimeError(
+            "redis allowlist cascade partial"
+        )
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+        )
+        with pytest.raises(RuntimeError, match="allowlist cascade partial"):
+            await service.delete_subnet("s-x", owner="alice")
+        mock_subnet_repo.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Partial wiring — one repo wired, other absent
+# ---------------------------------------------------------------------------
+
+
+class TestPartialWiring:
+    @pytest.mark.asyncio
+    async def test_only_join_request_repo_wired(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+    ):
+        """Defensive — the two repos are independent opt-ins.
+        Wiring only one shouldn't raise; the other cascade just
+        doesn't run."""
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            # allowlist repo intentionally omitted
+        )
+        await service.delete_subnet("s-1", owner="alice")
+        mock_jr_repo.delete_for_subnet.assert_awaited_once_with("s-1")
+
+    @pytest.mark.asyncio
+    async def test_only_allowlist_repo_wired(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.return_value = True
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            # join_request repo intentionally omitted
+        )
+        await service.delete_subnet("s-1", owner="alice")
+        mock_al_repo.delete_for_subnet.assert_awaited_once_with("s-1")


### PR DESCRIPTION
## Summary

ADR-0004 Phase 2 Slice 2.1 — the foundation slice that adds the
persistence layer for the join-policy state machine and the
admission allowlist, plus the cascade-deletion wiring. Pure
foundation work: no user-visible behaviour change. Slice 2.2 (the
JoinFlowService + route surface) is the next slice and the one
that actually turns these primitives on.

Stacked four commits for review clarity (each commit is
independently reviewable — entities → interfaces+DDL → repos →
cascade):

1. `533c8b8` — entities (`SubnetJoinRequest`, `SubnetAllowlist`) + 29 tests
2. `8d5f37a` — repository interfaces + ORM models + Alembic migration + 7 tests
3. `b6bf96d` — Postgres + Redis repositories (with Lua envelope) + 37 tests
4. `c7de0a9` — `SubnetService.delete_subnet` cascade extension + 8 tests

### Highlights

- **The unique partial pending index** (`UNIQUE … WHERE status='pending'` on `(subnet_id, agent_id)`) enforces the "at most one pending per (subnet, agent) across all kinds" invariant schema-side. Mirrored Redis-side by the reverse pending index + the `CREATE_PENDING_LUA` atomic envelope.
- **Lua atomic envelopes** for both create-pending and decide-out-of-pending — prevents the SETNX/HSET deadlock state ADR §"Redis layout and atomicity" calls out. Registered via the same `register_script` pattern `RedisTaskRepository` uses for `LUA_JOIN_TASK`.
- **Cascade ordering** is the critical invariant in `SubnetService.delete_subnet`: both `delete_for_subnet` calls fire BEFORE the subnet HASH delete so a Redis partial-failure `RuntimeError` aborts the dissolution safely. Top-level cascade sweeps every child + the parent.
- **Backward-compatible**: both new repos are optional `__init__` kwargs (same opt-in pattern `agent_repository` uses); existing `SubnetService(subnet_repository)` callers keep behaving exactly as before. Production composition wires the new repos once Slice 2.2 lands the route surface.

### Naming reconciliation

`IAllowlistRepository` already exists (agent-to-agent comm allowlist for `communication_policy.mode=allowlist`); the admission allowlist this slice introduces uses the `ISubnetAllowlistRepository` / `PostgresSubnetAllowlistRepository` / `RedisSubnetAllowlistRepository` prefix to keep the two namespaces unambiguous in code + error messages.

`SubnetJoinRequestPendingError` is the domain-meaningful exception the PG repo raises when the partial-index `IntegrityError` fires; the service layer catches it without importing `sqlalchemy.exc`.

## Test plan

- [x] Entity invariants — 29 tests pin every `__post_init__` defence (identity, kind/status membership, decision coherence, allowlist_auto shape, note length, serialisation round-trip).
- [x] Alembic migration structure — 7 tests pin revision chain, presence of all four indexes (with explicit emphasis on the unique partial pending index), drop-order ordering.
- [x] Postgres repos — 16 tests: mapper round-trip, IntegrityError → SubnetJoinRequestPendingError translation contract, unchanged re-raise for other IntegrityErrors, ON CONFLICT DO NOTHING idempotency bool, cascade row-count.
- [x] Redis repos — 21 tests: Lua KEYS layout (4-key for create, 3-key for decide), ARGV[2] discriminator, exists/created outcomes (idempotent re-save vs collision), dangling-reverse-index warning, SET+HASH coordination, orphan tolerance, cascade key cleanup.
- [x] Cascade extension — 8 tests: ordering invariant, silent no-op when repos omitted, top-level sweeps every subnet, RuntimeError propagation aborts subnet delete.
- [x] Ruff clean across the entire slice.
- [x] All 44 pre-existing `test_subnet_service*` tests still green.
- [x] Broader sweep: 390/390 `tests/services/`, 262/262 `tests/infrastructure/`, 241/241 targeted sweep across every touched module.

### Acceptance signals (per ADR §Phase 2 implementation plan)

- ✅ Two new entity dataclasses with `__post_init__` invariants
- ✅ `ISubnetJoinRequestRepository` / `ISubnetAllowlistRepository` interfaces with Postgres + Redis implementations
- ✅ Alembic migration creating both tables with the unique partial pending index + supporting indexes
- ✅ Redis Lua atomic envelopes (create-pending + decide)
- ✅ Cascade deletion extension to `SubnetService.delete_subnet` with ordering + propagation defences
- ✅ ruff + lint clean

### Out of scope (Slice 2.2 onwards)

- `JoinFlowService` — the state-machine orchestrator that calls these repos
- Route surface (`POST /subnets/{s}/join`, `/invitations`, `/allowlist`, the invitee endpoints, etc.)
- Backfill of existing subnets' implicit-allowlist semantics
- Production composition wiring of the two new repos into `subnet_service.py`'s constructor at the registry level
