### PR TITLE
fix(adr-0004): atomic cascade deletion via IUnitOfWork (closes #75)

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -317,11 +317,12 @@ async def lifespan(app: FastAPI):
     # ``subnet_allowlist_repository`` themselves are deliberately
     # NOT wired here yet — Slice 2.2 will land them together with
     # the route handlers that actually create rows. Until then the
-    # cascade body short-circuits over those repos (Slice 2.1
-    # behaviour preserved) and the UoW transaction simply commits
-    # the subnet DELETE on its own — a no-op fast-path that costs
-    # nothing and lets the atomicity machinery be exercised end-to-end
-    # by the test suite before Slice 2.2 hooks up production rows.
+    # join-policy cascade sweeps short-circuit over those absent
+    # repos (Slice 2.1 behaviour preserved); the subnet DELETE
+    # still runs inside the UoW transaction, which is a one-statement
+    # batch but exercises the IUnitOfWork wiring path end-to-end so
+    # Slice 2.2 can plug cascade repos in without re-touching this
+    # composition.
     subnet_service_instance = SubnetService(
         subnet_repository,
         task_repository=task_repository,

--- a/acn/api.py
+++ b/acn/api.py
@@ -307,10 +307,26 @@ async def lifespan(app: FastAPI):
     # before the subnet record is removed (issue #56). Without this
     # wiring, agent-side dust accumulates and gets amplified by every
     # parent-delete cascade.
+    # ``unit_of_work`` (ADR-0004 Slice 2.1.1 / issue #75) is wired
+    # whenever PG mode is on so ``delete_subnet`` can run the
+    # three-table cascade (subnet_join_requests + subnet_allowlist +
+    # subnets) inside one transaction. In Redis-only mode
+    # ``_unit_of_work`` is None and the service falls back to the
+    # sequential-commit path, matching ADR §"Cascade deletion: Redis".
+    # The cascade ``subnet_join_request_repository`` and
+    # ``subnet_allowlist_repository`` themselves are deliberately
+    # NOT wired here yet — Slice 2.2 will land them together with
+    # the route handlers that actually create rows. Until then the
+    # cascade body short-circuits over those repos (Slice 2.1
+    # behaviour preserved) and the UoW transaction simply commits
+    # the subnet DELETE on its own — a no-op fast-path that costs
+    # nothing and lets the atomicity machinery be exercised end-to-end
+    # by the test suite before Slice 2.2 hooks up production rows.
     subnet_service_instance = SubnetService(
         subnet_repository,
         task_repository=task_repository,
         agent_repository=agent_repository,
+        unit_of_work=_unit_of_work,
     )
 
     # Phase 1 communication_policy gateway: a single PolicyCheckService

--- a/acn/core/interfaces/subnet_allowlist_repository.py
+++ b/acn/core/interfaces/subnet_allowlist_repository.py
@@ -30,6 +30,7 @@ not a performance cache.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from ..entities import SubnetAllowlist
 
@@ -89,7 +90,9 @@ class ISubnetAllowlistRepository(ABC):
         """
 
     @abstractmethod
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: Any | None = None
+    ) -> int:
         """Cascade-delete all entries for a subnet. Returns count deleted.
 
         Called by ``SubnetService.delete_subnet`` before deleting
@@ -97,4 +100,12 @@ class ISubnetAllowlistRepository(ABC):
         ``ISubnetJoinRequestRepository.delete_for_subnet`` — see
         that interface's docstring for the cascade ordering /
         atomicity contract.
+
+        Transaction participation
+        -------------------------
+        ``session`` is the opaque :class:`IUnitOfWork` token. Same
+        contract as :meth:`ISubnetJoinRequestRepository.delete_for_subnet`:
+        Postgres impl binds to it (no internal commit / close);
+        Redis impl ignores it; ``None`` (default) is the legacy
+        path with self-managed session + commit.
         """

--- a/acn/core/interfaces/subnet_join_request_repository.py
+++ b/acn/core/interfaces/subnet_join_request_repository.py
@@ -34,6 +34,7 @@ service's responsibility.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from ..entities import SubnetJoinRequest
 
@@ -127,7 +128,9 @@ class ISubnetJoinRequestRepository(ABC):
         """
 
     @abstractmethod
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: Any | None = None
+    ) -> int:
         """Cascade-delete all rows for a subnet. Returns count deleted.
 
         Called by ``SubnetService.delete_subnet`` before deleting
@@ -139,4 +142,19 @@ class ISubnetJoinRequestRepository(ABC):
 
         Returns the number of rows actually deleted (useful for
         audit logging; not used by the cascade control flow).
+
+        Transaction participation
+        -------------------------
+        ``session`` is the opaque token yielded by
+        :class:`IUnitOfWork`'s ``transaction()`` context manager
+        (see ``acn/core/interfaces/unit_of_work.py``). Implementations
+        that understand the token's runtime type MUST bind to it for
+        the duration of the call (no internal commit, no internal
+        close) so the outer Unit-of-Work owns the transaction
+        boundary; implementations that don't understand the token
+        (e.g. the Redis impl, which has no transaction model that
+        composes with PG's ``AsyncSession``) MUST ignore it and
+        keep their best-effort behaviour. Passing ``session=None``
+        (the default) is the legacy path: the implementation opens
+        and commits its own connection.
         """

--- a/acn/core/interfaces/subnet_repository.py
+++ b/acn/core/interfaces/subnet_repository.py
@@ -4,6 +4,7 @@ Defines contract for subnet persistence operations.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from ..entities import Subnet
 
@@ -72,12 +73,21 @@ class ISubnetRepository(ABC):
         pass
 
     @abstractmethod
-    async def delete(self, subnet_id: str) -> bool:
+    async def delete(
+        self, subnet_id: str, *, session: Any | None = None
+    ) -> bool:
         """
         Delete a subnet
 
         Args:
             subnet_id: Subnet identifier
+            session: Optional :class:`IUnitOfWork` token. When passed,
+                Postgres impl binds to it (no internal commit / close)
+                so the call participates in the outer transaction; the
+                Redis impl ignores it. Default ``None`` is the legacy
+                path with self-managed session + commit. See
+                ``acn/core/interfaces/unit_of_work.py`` for the
+                cross-cutting contract.
 
         Returns:
             True if deleted, False if not found
@@ -86,7 +96,11 @@ class ISubnetRepository(ABC):
 
     @abstractmethod
     async def delete_with_children(
-        self, parent_id: str, child_ids: list[str]
+        self,
+        parent_id: str,
+        child_ids: list[str],
+        *,
+        session: Any | None = None,
     ) -> bool:
         """
         Atomic-where-supported parent + children delete (ADR-0003 §A.4).
@@ -122,6 +136,16 @@ class ISubnetRepository(ABC):
             child_ids: Child subnet identifiers to delete first. May be
                 empty — in that case behaves identically to
                 ``delete(parent_id)``.
+            session: Optional :class:`IUnitOfWork` token. When passed,
+                Postgres impl binds to it and skips its own
+                ``session.begin()`` (the outer Unit-of-Work already
+                owns the transaction boundary, so a nested
+                ``session.begin()`` would only create a SAVEPOINT and
+                couple the cascade to PG-specific nesting semantics —
+                avoided by design). Redis impl ignores it. Default
+                ``None`` is the legacy self-managed path that still
+                uses ``async with session.begin()`` internally for
+                PG (single transaction across all child DELETEs).
 
         Returns:
             True on full cascade success, False when parent did not exist.

--- a/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
@@ -16,6 +16,8 @@ there is no FK to ``agents`` (ADR §"Cascade deletion" chooses
 manual cascade for observability).
 """
 
+from contextlib import asynccontextmanager
+
 from sqlalchemy import delete, desc, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -30,6 +32,28 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         self._session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @asynccontextmanager
+    async def _session_scope(self, session: AsyncSession | None):
+        """Yield ``session`` if passed (no commit / no close) — caller
+        owns the transaction. Otherwise open + commit + close ourselves.
+
+        Mirrors
+        :meth:`PostgresSubnetJoinRequestRepository._session_scope` so
+        both halves of the ADR-0004 cascade compose under the same
+        outer ``IUnitOfWork`` transaction without either repo
+        committing early.
+        """
+        if session is not None:
+            yield session
+            return
+        async with self._session_factory() as own_session:
+            yield own_session
+            await own_session.commit()
 
     # ------------------------------------------------------------------
     # Mapping
@@ -132,18 +156,22 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             )
             return [self._model_to_entity(r) for r in result.scalars().all()]
 
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: AsyncSession | None = None
+    ) -> int:
         """Cascade-delete all entries for a subnet. Returns count deleted.
 
         Called from ``SubnetService.delete_subnet`` — see
-        ``PostgresSubnetJoinRequestRepository.delete_for_subnet`` for
-        the symmetric cascade-ordering contract.
+        :meth:`PostgresSubnetJoinRequestRepository.delete_for_subnet`
+        for the symmetric outer-session contract (passing ``session``
+        binds this DELETE to the caller's :class:`IUnitOfWork`
+        transaction; ``None`` is the legacy self-managed path that
+        commits independently).
         """
-        async with self._session_factory() as session:
-            result = await session.execute(
+        async with self._session_scope(session) as sess:
+            result = await sess.execute(
                 delete(SubnetAllowlistModel).where(
                     SubnetAllowlistModel.subnet_id == subnet_id
                 )
             )
-            await session.commit()
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
@@ -19,6 +19,8 @@ partial index this is the dual-layer defence ADR §"Redis layout
 and atomicity" describes.
 """
 
+from contextlib import asynccontextmanager
+
 from sqlalchemy import delete, desc, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -50,6 +52,30 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         self._session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @asynccontextmanager
+    async def _session_scope(self, session: AsyncSession | None):
+        """Yield ``session`` if passed (no commit / no close) — caller
+        owns the transaction. Otherwise open + commit + close ourselves.
+
+        Identical shape to
+        ``PostgresSettlementOutboxRepository._session_scope`` — picked
+        deliberately so the saga and the ADR-0004 cascade share one
+        outer-session contract: passing a session means "this call is
+        a brick in someone else's transaction; do not commit". The
+        outer Unit-of-Work owns commit-on-clean-exit and
+        rollback-on-exception; we just stay out of its way.
+        """
+        if session is not None:
+            yield session
+            return
+        async with self._session_factory() as own_session:
+            yield own_session
+            await own_session.commit()
 
     # ------------------------------------------------------------------
     # Mapping
@@ -209,25 +235,39 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             )
             return [self._model_to_entity(r) for r in result.scalars().all()]
 
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: AsyncSession | None = None
+    ) -> int:
         """Cascade-delete all rows for a subnet. Returns count deleted.
 
-        Called from ``SubnetService.delete_subnet`` inside an outer
-        transaction that also DELETEs ``subnet_allowlist`` and the
-        ``subnets`` row itself. We don't open our own
-        ``session.begin()`` here — the outer service context manages
-        the transaction so all three DELETEs are atomic, matching
-        ADR §"Cascade deletion: Postgres" exactly.
+        When ``session`` is passed (the production cascade path —
+        ``SubnetService.delete_subnet`` opens a single
+        ``uow.transaction()`` and threads it through here, the
+        allowlist repo, and the ``subnets`` DELETE), this call
+        participates in that outer transaction: no internal commit,
+        no internal close, so a failure on any of the sibling DELETEs
+        rolls the whole batch back. This is what ADR §"Cascade
+        deletion: Postgres" actually promises ("any failure rolls back
+        the whole batch") — Slice 2.1 shipped this without the outer
+        session and issue #75 tracked the gap until Slice 2.1.1 (this
+        change) closed it.
+
+        When ``session`` is ``None`` (legacy fixtures, ad-hoc tools)
+        the call falls back to the original self-managed
+        ``self._session_factory() → execute → commit`` shape — the
+        cascade still works, just at lower atomicity. The behaviour
+        is byte-for-byte the same as the pre-Slice-2.1.1 code so
+        out-of-tree callers that constructed the repo bare keep
+        working unchanged.
 
         Returns the deleted-row count for audit logging; the service
         layer logs it but doesn't gate on it (zero rows is a valid
         outcome — subnets without any pending or terminal requests).
         """
-        async with self._session_factory() as session:
-            result = await session.execute(
+        async with self._session_scope(session) as sess:
+            result = await sess.execute(
                 delete(SubnetJoinRequestModel).where(
                     SubnetJoinRequestModel.subnet_id == subnet_id
                 )
             )
-            await session.commit()
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_repository.py
@@ -1,5 +1,7 @@
 """PostgreSQL Implementation of ISubnetRepository"""
 
+from contextlib import asynccontextmanager
+
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -11,6 +13,34 @@ from .models import SubnetModel
 class PostgresSubnetRepository(ISubnetRepository):
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    @asynccontextmanager
+    async def _session_scope(self, session: AsyncSession | None):
+        """Yield ``session`` if passed (no commit / no close) — caller
+        owns the transaction. Otherwise open + commit + close ourselves.
+
+        Used by ``delete`` and ``delete_with_children`` to participate
+        in :class:`SubnetService.delete_subnet`'s outer
+        :class:`IUnitOfWork` transaction (ADR-0004 §"Cascade deletion:
+        Postgres"). Same shape as the other ``Postgres*`` subnet repos
+        so the three cascade DELETEs (join_requests, allowlist, subnet)
+        plug into one transaction without anyone committing early.
+
+        Only ``delete`` / ``delete_with_children`` use this scope —
+        the read-side methods (``find_by_id`` / ``find_all`` / …) and
+        ``save`` keep their original self-managed shape because the
+        cascade orchestration never threads a session through them.
+        """
+        if session is not None:
+            yield session
+            return
+        async with self._session_factory() as own_session:
+            yield own_session
+            await own_session.commit()
 
     # =========================================================================
     # Mapping
@@ -132,16 +162,21 @@ class PostgresSubnetRepository(ISubnetRepository):
             )
             return [self._model_to_subnet(r) for r in result.scalars().all()]
 
-    async def delete(self, subnet_id: str) -> bool:
-        async with self._session_factory() as session:
-            result = await session.execute(
+    async def delete(
+        self, subnet_id: str, *, session: AsyncSession | None = None
+    ) -> bool:
+        async with self._session_scope(session) as sess:
+            result = await sess.execute(
                 delete(SubnetModel).where(SubnetModel.subnet_id == subnet_id)
             )
-            await session.commit()
             return result.rowcount > 0
 
     async def delete_with_children(
-        self, parent_id: str, child_ids: list[str]
+        self,
+        parent_id: str,
+        child_ids: list[str],
+        *,
+        session: AsyncSession | None = None,
     ) -> bool:
         """Delete parent + children atomically in one PG transaction.
 
@@ -150,14 +185,33 @@ class PostgresSubnetRepository(ISubnetRepository):
         uncommitted state — there shouldn't be one, but defence in
         depth) never observe a deleted parent with surviving children.
 
-        ``async with session.begin()`` is the SQLAlchemy idiom for
-        "transaction with auto rollback on exception": the context
-        manager calls ``commit()`` on a clean exit and ``rollback()`` on
-        any in-block raise, then re-raises. That means a failing child
-        DELETE leaves nothing committed — exactly what ADR-0003 §A.4
-        promises for the PG branch.
+        Transaction shape splits on ``session``:
+
+        - ``session=None`` (legacy + ADR-0003 contract): opens a fresh
+          session and uses ``async with session.begin():`` — the
+          SQLAlchemy idiom for "transaction with auto rollback on
+          exception". The ctx manager calls ``commit()`` on a clean
+          exit and ``rollback()`` on any in-block raise, then
+          re-raises. That means a failing child DELETE leaves nothing
+          committed — exactly what ADR-0003 §A.4 promises for the PG
+          branch. Pinned by
+          ``tests/infrastructure/test_postgres_subnet_repository_cascade.py``.
+        - ``session=<outer>`` (ADR-0004 cascade UoW path,
+          Slice 2.1.1 / issue #75): the caller
+          (``SubnetService.delete_subnet`` via
+          :meth:`IUnitOfWork.transaction`) already owns the outer
+          transaction. We just thread the cascade DELETEs into it.
+          We deliberately do NOT call ``session.begin()`` here in
+          this branch — a nested ``begin()`` would only create a
+          SAVEPOINT and conflate the cross-table cascade with
+          PG-specific nesting semantics, and SQLAlchemy 2.x's
+          autobegin model means the second ``begin()`` actually
+          raises ``InvalidRequestError`` outside savepoint mode.
+          The caller's outer ``commit``/``rollback`` decides the
+          batch's fate together with the sibling join_requests +
+          allowlist DELETEs (ADR-0004 §"Cascade deletion: Postgres").
         """
-        async with self._session_factory() as session, session.begin():
+        if session is not None:
             for child_id in child_ids:
                 await session.execute(
                     delete(SubnetModel).where(
@@ -165,6 +219,17 @@ class PostgresSubnetRepository(ISubnetRepository):
                     )
                 )
             result = await session.execute(
+                delete(SubnetModel).where(SubnetModel.subnet_id == parent_id)
+            )
+            return result.rowcount > 0
+        async with self._session_factory() as own_session, own_session.begin():
+            for child_id in child_ids:
+                await own_session.execute(
+                    delete(SubnetModel).where(
+                        SubnetModel.subnet_id == child_id
+                    )
+                )
+            result = await own_session.execute(
                 delete(SubnetModel).where(SubnetModel.subnet_id == parent_id)
             )
             return result.rowcount > 0

--- a/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
@@ -147,7 +147,9 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         entries.sort(key=lambda e: e.added_at, reverse=True)
         return entries[offset : offset + limit]
 
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: object | None = None
+    ) -> int:
         """Cascade-delete all allowlist entries for a subnet.
 
         Iterate the SET, DEL each meta HASH, then DEL the SET
@@ -157,8 +159,15 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         ``delete_with_children_partial`` breadcrumb so the
         caller's cascade-ordering contract holds.
 
+        The ``session`` kwarg is part of the
+        :class:`ISubnetAllowlistRepository` contract (an
+        :class:`IUnitOfWork` token) — Redis ignores it for the same
+        reason :meth:`RedisSubnetJoinRequestRepository.delete_for_subnet`
+        does. See that method's docstring for the rationale.
+
         Returns the count of meta HASHes actually deleted.
         """
+        del session  # explicit ignore — see docstring
         set_key = _allowlist_set_key(subnet_id)
         agent_ids = await self.redis.smembers(set_key)
 

--- a/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
@@ -390,7 +390,9 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         rows.sort(key=lambda r: r.created_at, reverse=True)
         return rows
 
-    async def delete_for_subnet(self, subnet_id: str) -> int:
+    async def delete_for_subnet(
+        self, subnet_id: str, *, session: object | None = None
+    ) -> int:
         """Cascade-delete all rows for a subnet.
 
         Best-effort sequential per ADR §"Cascade deletion: Redis":
@@ -403,9 +405,19 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         BEFORE touching the subnet HASH so a half-cascade isn't
         treated as success.
 
+        The ``session`` kwarg is part of the
+        :class:`ISubnetJoinRequestRepository` contract (an
+        :class:`IUnitOfWork` token) but Redis has no PG-style
+        transactional composition primitive — we ignore it and keep
+        the existing best-effort sequential behaviour. ADR-0004
+        §"Cascade deletion: Redis" makes the asymmetry explicit;
+        accepting + ignoring is the cleanest way to satisfy the
+        Liskov contract without pretending Redis is transactional.
+
         Returns the count of request HASHes actually deleted (for
         audit log; not gated on by the cascade control flow).
         """
+        del session  # explicit ignore — see docstring
         listing_key = _subnet_listing_key(subnet_id)
         request_ids = await self.redis.smembers(listing_key)
 

--- a/acn/infrastructure/persistence/redis/subnet_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_repository.py
@@ -150,13 +150,25 @@ class RedisSubnetRepository(ISubnetRepository):
         all_subnets = await self.find_all()
         return [s for s in all_subnets if s.is_public()]
 
-    async def delete(self, subnet_id: str) -> bool:
+    async def delete(
+        self, subnet_id: str, *, session: object | None = None
+    ) -> bool:
         """Delete a subnet and all its secondary index entries.
 
         Reads the subnet first to know which index sets to clean up
         (owner, parent, linked-task). All deletions are then batched
         in a single pipeline.
+
+        The ``session`` kwarg is part of the :class:`ISubnetRepository`
+        contract (an :class:`IUnitOfWork` token used by the Postgres
+        impl to participate in the outer cascade transaction). Redis
+        ignores it — the per-call pipeline is the strongest atomicity
+        primitive available here and it doesn't compose across method
+        calls. See ADR-0004 §"Cascade deletion: Redis" for the
+        asymmetric ordering contract the service layer relies on
+        instead.
         """
+        del session  # explicit ignore — see docstring
         subnet = await self.find_by_id(subnet_id)
         if not subnet:
             return False
@@ -178,7 +190,11 @@ class RedisSubnetRepository(ISubnetRepository):
         return True
 
     async def delete_with_children(
-        self, parent_id: str, child_ids: list[str]
+        self,
+        parent_id: str,
+        child_ids: list[str],
+        *,
+        session: object | None = None,
     ) -> bool:
         """Sequential cascade delete with audit-log breadcrumb on
         partial failure (ADR-0003 §A.4 Redis branch).
@@ -197,7 +213,12 @@ class RedisSubnetRepository(ISubnetRepository):
         - On a fully successful child sweep, the parent delete is
           attempted last. Its return value propagates (False = parent
           already gone, but children were still cleaned).
+
+        The ``session`` kwarg is part of the :class:`ISubnetRepository`
+        contract — Redis ignores it for the same reason
+        :meth:`delete` does (no transactional composition primitive).
         """
+        del session  # explicit ignore — see docstring
         for child_id in child_ids:
             deleted = await self.delete(child_id)
             if not deleted:

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -115,14 +115,19 @@ class SubnetService:
     can run its three-table cascade (``subnet_join_requests``,
     ``subnet_allowlist``, ``subnets``) inside one Postgres
     transaction (issue #75 / ADR-0004 §"Cascade deletion: Postgres").
-    When wired together with both
+    Slice 2.1.1 (this) wires the UoW machinery so the cascade is
+    genuinely atomic the moment both
     ``subnet_join_request_repository`` and
-    ``subnet_allowlist_repository`` (the Slice 2.1.1+ production
-    composition), the cascade is genuinely atomic — a failure on
-    any of the three DELETEs rolls all three back. When omitted
-    (Redis-only deployments, legacy fixtures), the cascade falls
-    back to the Slice-2.1 sequential-commit shape: each repo
-    commits independently. ADR-0004 explicitly accepts the Redis
+    ``subnet_allowlist_repository`` are also wired — currently the
+    cascade repos themselves stay unwired in production until
+    Slice 2.2 lands the route surface that creates rows. Until
+    then the UoW is opened around just the subnet DELETE itself
+    (the cascade sweeps short-circuit when their repos are
+    absent), exercising the atomicity machinery end-to-end before
+    real rows show up. When the UoW is omitted (Redis-only
+    deployments, legacy fixtures), the cascade falls back to the
+    Slice-2.1 sequential-commit shape: each repo commits
+    independently. ADR-0004 explicitly accepts the Redis
     asymmetry; the legacy fallback exists only so out-of-tree
     code that builds a bare ``SubnetService`` keeps working.
     """

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -15,6 +15,7 @@ from ..core.interfaces import (
     ISubnetAllowlistRepository,
     ISubnetJoinRequestRepository,
     ISubnetRepository,
+    IUnitOfWork,
 )
 from ..core.interfaces.task_repository import ITaskRepository
 
@@ -109,6 +110,21 @@ class SubnetService:
     #56). Production wiring supplies one; legacy fixtures that omit
     it get the pre-#56 behaviour (stale agent-side dust survives
     the delete) — best-effort and backward-compatible.
+
+    Optionally accepts an :class:`IUnitOfWork` so ``delete_subnet``
+    can run its three-table cascade (``subnet_join_requests``,
+    ``subnet_allowlist``, ``subnets``) inside one Postgres
+    transaction (issue #75 / ADR-0004 §"Cascade deletion: Postgres").
+    When wired together with both
+    ``subnet_join_request_repository`` and
+    ``subnet_allowlist_repository`` (the Slice 2.1.1+ production
+    composition), the cascade is genuinely atomic — a failure on
+    any of the three DELETEs rolls all three back. When omitted
+    (Redis-only deployments, legacy fixtures), the cascade falls
+    back to the Slice-2.1 sequential-commit shape: each repo
+    commits independently. ADR-0004 explicitly accepts the Redis
+    asymmetry; the legacy fallback exists only so out-of-tree
+    code that builds a bare ``SubnetService`` keeps working.
     """
 
     def __init__(
@@ -118,6 +134,7 @@ class SubnetService:
         agent_repository: IAgentRepository | None = None,
         subnet_join_request_repository: ISubnetJoinRequestRepository | None = None,
         subnet_allowlist_repository: ISubnetAllowlistRepository | None = None,
+        unit_of_work: IUnitOfWork | None = None,
     ):
         """
         Initialize Subnet Service
@@ -147,12 +164,22 @@ class SubnetService:
                 ``delete_subnet`` to cascade-delete admission
                 allowlist entries. Same opt-in pattern as
                 ``subnet_join_request_repository``.
+            unit_of_work: Optional — when present, ``delete_subnet``
+                runs the three cascade DELETEs (join_requests,
+                allowlist, subnet) inside a single
+                :meth:`IUnitOfWork.transaction` block, threading the
+                yielded session token through each repo's ``session=``
+                kwarg. When ``None``, ``delete_subnet`` falls back to
+                the Slice-2.1 sequential-commit shape (each repo
+                commits independently — see class docstring for the
+                acceptable use cases of that fallback).
         """
         self.repository = subnet_repository
         self.task_repository = task_repository
         self.agent_repository = agent_repository
         self.join_request_repository = subnet_join_request_repository
         self.allowlist_repository = subnet_allowlist_repository
+        self.unit_of_work = unit_of_work
 
     async def create_subnet(
         self,
@@ -472,6 +499,30 @@ class SubnetService:
         Both backends raise on partial failure, so callers cannot
         accidentally treat a partially-completed cascade as success.
 
+        Join-policy artifact cascade (ADR-0004 §"Cascade deletion")
+        runs immediately before the subnet record(s) are dropped:
+
+        - When :class:`IUnitOfWork` was injected at construction
+          (Postgres production wiring), the three cascade DELETEs
+          (``subnet_join_requests``, ``subnet_allowlist``, and
+          ``subnets``) are threaded through one
+          :meth:`IUnitOfWork.transaction` block so they commit or
+          roll back as a unit (issue #75 closed by Slice 2.1.1).
+        - When no UoW is wired (Redis-only deployments, legacy
+          fixtures), the cascade falls back to the Slice-2.1
+          sequential-commit shape — each repo commits independently.
+          ADR-0004 explicitly accepts the Redis asymmetry; the
+          fallback is what test fixtures predating Slice 2.1.1 rely
+          on, and it stays byte-for-byte the same as before so
+          out-of-tree callers keep working.
+
+        Agent back-reference cleanup (issue #56) deliberately stays
+        OUTSIDE the transaction in both modes — agent-side
+        ``subnet_ids`` mutations are best-effort by design (ADR-0001
+        §dual-store membership) and folding them into the cascade
+        transaction would couple agent-store reachability to subnet
+        delete success.
+
         Args:
             subnet_id: Subnet identifier
             owner: Owner identifier (or ``"system"`` for cascade)
@@ -486,7 +537,7 @@ class SubnetService:
                 ``delete_with_children_partial`` breadcrumb when a
                 child delete returned ``False`` (parent preserved).
             sqlalchemy.exc.SQLAlchemyError: PG cascade path bubbles
-                any DB error out of ``session.begin()`` after the
+                any DB error out of the UoW transaction after the
                 whole transaction is rolled back — parent + every
                 child preserved. Caller treats both backend-specific
                 exception types as "cascade aborted, retry-safe".
@@ -522,6 +573,8 @@ class SubnetService:
                 # Clear back-references for every child first, then
                 # the parent. Order mirrors the cascade delete order
                 # the repository will execute next.
+                # Stays outside the UoW transaction by design — see
+                # method docstring §"Agent back-reference cleanup".
                 for child in children:
                     await self._clear_agent_back_references(
                         child.subnet_id, child.member_agent_ids
@@ -536,19 +589,8 @@ class SubnetService:
                     child_subnet_ids=child_ids,
                     child_count=len(child_ids),
                 )
-                # ADR-0004 §"Cascade deletion" — sweep join_requests
-                # + allowlist for the parent AND every child BEFORE
-                # the subnet records themselves. Order matters: if
-                # the join_request cascade raises ``RuntimeError``
-                # (Redis partial failure), the subnet HASHes stay
-                # in place so the cascade can be retried.
-                for child in children:
-                    await self._cascade_join_policy_artifacts(
-                        child.subnet_id
-                    )
-                await self._cascade_join_policy_artifacts(subnet_id)
-                return await self.repository.delete_with_children(
-                    subnet_id, child_ids
+                return await self._run_cascade_delete(
+                    subnet_id, subnet_to_delete_with=children
                 )
 
         # No-cascade path: child subnet direct-delete OR top-level
@@ -557,18 +599,95 @@ class SubnetService:
         await self._clear_agent_back_references(
             subnet_id, subnet.member_agent_ids
         )
-        await self._cascade_join_policy_artifacts(subnet_id)
         logger.info("delete_subnet", subnet_id=subnet_id)
-        return await self.repository.delete(subnet_id)
+        return await self._run_cascade_delete(subnet_id, subnet_to_delete_with=None)
 
-    async def _cascade_join_policy_artifacts(self, subnet_id: str) -> None:
+    async def _run_cascade_delete(
+        self,
+        subnet_id: str,
+        *,
+        subnet_to_delete_with: list[Subnet] | None,
+    ) -> bool:
+        """Run the join-policy + subnet DELETE batch.
+
+        Branches on :attr:`unit_of_work` injection:
+
+        - **UoW wired (PG production)**: opens one
+          :meth:`IUnitOfWork.transaction`, threads the yielded
+          session into the join_requests + allowlist + subnet
+          DELETEs via their ``session=`` kwarg, and lets the UoW
+          commit-on-clean-exit / rollback-on-exception envelope
+          decide the batch's fate. This is the ADR-0004 §"Cascade
+          deletion: Postgres" promise.
+        - **UoW absent (Redis or legacy)**: calls each cascade
+          method without a session — the Slice-2.1 sequential-commit
+          path. Redis impls ignore the ``session`` kwarg either way;
+          legacy fixtures get the pre-Slice-2.1.1 behaviour
+          unchanged.
+
+        ``subnet_to_delete_with`` distinguishes the two delete
+        shapes:
+
+        - ``None`` → single subnet (no children, OR a child subnet
+          deleted directly). Final DELETE is
+          ``self.repository.delete(subnet_id, session=...)``.
+        - non-empty list → parent with children. Final DELETE is
+          ``self.repository.delete_with_children(parent_id,
+          [c.subnet_id for c in children], session=...)``. The
+          join-policy artifact sweep runs for every child AND the
+          parent inside the same transaction.
+        """
+        if self.unit_of_work is not None:
+            async with self.unit_of_work.transaction() as session:
+                return await self._cascade_delete_body(
+                    subnet_id, subnet_to_delete_with, session=session
+                )
+        return await self._cascade_delete_body(
+            subnet_id, subnet_to_delete_with, session=None
+        )
+
+    async def _cascade_delete_body(
+        self,
+        subnet_id: str,
+        subnet_to_delete_with: list[Subnet] | None,
+        *,
+        session: object | None,
+    ) -> bool:
+        """Inner body shared by atomic and legacy cascade paths.
+
+        Order — strictly join_requests → allowlist → subnets, for
+        every cascaded subnet (children first, then parent). The
+        order is cosmetic inside a single PG transaction (everything
+        commits together) but it matters in Redis-only / legacy
+        paths: if the join_request cascade raises ``RuntimeError``
+        (Redis partial failure), the subnet records stay in place so
+        the cascade can be retried.
+        """
+        if subnet_to_delete_with is not None:
+            children = subnet_to_delete_with
+            child_ids = [c.subnet_id for c in children]
+            for child in children:
+                await self._cascade_join_policy_artifacts(
+                    child.subnet_id, session=session
+                )
+            await self._cascade_join_policy_artifacts(subnet_id, session=session)
+            return await self.repository.delete_with_children(
+                subnet_id, child_ids, session=session
+            )
+        await self._cascade_join_policy_artifacts(subnet_id, session=session)
+        return await self.repository.delete(subnet_id, session=session)
+
+    async def _cascade_join_policy_artifacts(
+        self, subnet_id: str, *, session: object | None = None
+    ) -> None:
         """Sweep ADR-0004 join_requests + allowlist for ``subnet_id``.
 
-        Called from ``delete_subnet`` BEFORE the subnet HASH / row
-        delete. Either repository raising ``RuntimeError`` (Redis
-        partial failure) propagates here and aborts the caller's
-        subnet delete — exactly the behaviour ADR §"Cascade deletion"
-        requires so a half-cascade isn't treated as success.
+        Called from ``_cascade_delete_body`` BEFORE the subnet
+        HASH / row delete. Either repository raising
+        ``RuntimeError`` (Redis partial failure) propagates here
+        and aborts the caller's subnet delete — exactly the
+        behaviour ADR §"Cascade deletion" requires so a
+        half-cascade isn't treated as success.
 
         Silent no-op when either repo wasn't wired (legacy
         fixtures predating Slice 2.1) — same opt-in pattern
@@ -579,13 +698,23 @@ class SubnetService:
 
         Order: join_requests first, allowlist second. The order
         matches the ADR §"Cascade deletion: Postgres" example
-        statement order, though for the manual cascade it's
-        cosmetic (both DELETEs run inside the outer service-layer
-        transaction in PG; in Redis they're independent passes).
+        statement order, though for the PG-with-UoW path it's
+        cosmetic (both DELETEs commit together with the subnet
+        DELETE on UoW exit); in Redis or legacy paths they're
+        independent passes and the order matters for retry
+        recoverability.
+
+        ``session``: the opaque :class:`IUnitOfWork` token threaded
+        through from ``_run_cascade_delete``. ``None`` for legacy
+        / Redis paths (each repo manages its own session and
+        commits independently); a real token (currently
+        ``AsyncSession`` from ``PostgresUnitOfWork``) for the
+        atomic PG path — bound to ``session=`` of both repo
+        methods so they join the outer transaction.
         """
         if self.join_request_repository is not None:
             deleted = await self.join_request_repository.delete_for_subnet(
-                subnet_id
+                subnet_id, session=session
             )
             if deleted:
                 logger.info(
@@ -595,7 +724,7 @@ class SubnetService:
                 )
         if self.allowlist_repository is not None:
             deleted = await self.allowlist_repository.delete_for_subnet(
-                subnet_id
+                subnet_id, session=session
             )
             if deleted:
                 logger.info(

--- a/tests/infrastructure/test_postgres_subnet_cascade_session_scope.py
+++ b/tests/infrastructure/test_postgres_subnet_cascade_session_scope.py
@@ -1,0 +1,273 @@
+"""PG repo ``_session_scope`` dual-mode contract for ADR-0004 cascade.
+
+What this pins
+--------------
+Slice 2.1.1 / issue #75 closed a gap where the three Postgres
+cascade DELETEs (``subnet_join_requests`` / ``subnet_allowlist`` /
+``subnets``) each opened and committed their own session. Production
+PG mode now threads a single :class:`AsyncSession` through all three
+via :meth:`IUnitOfWork.transaction`, so any failure rolls the whole
+batch back.
+
+The dual-mode contract each cascade-participating repo method must
+honour:
+
+- ``session=None`` (default): open a fresh session via the
+  ``session_factory``, run the DELETE, ``await own_session.commit()``,
+  let the ``async with`` close the connection. This is the legacy /
+  Redis-only / out-of-tree path.
+- ``session=<outer AsyncSession>``: bind to the caller's session,
+  run the DELETE, **do NOT commit, do NOT close**. The outer
+  Unit-of-Work owns commit-on-clean-exit and rollback-on-exception;
+  early commit here would shatter the saga.
+
+These tests check both branches for:
+
+- ``PostgresSubnetJoinRequestRepository.delete_for_subnet``
+- ``PostgresSubnetAllowlistRepository.delete_for_subnet``
+- ``PostgresSubnetRepository.delete``
+- ``PostgresSubnetRepository.delete_with_children`` (special-cased —
+  see test docstring; the self-managed branch keeps its
+  ``async with session.begin():`` envelope for explicit rollback
+  semantics, while the outer-session branch skips ``begin()`` so it
+  composes cleanly inside the caller's ``IUnitOfWork`` transaction).
+
+The mock shape mirrors the one in
+``tests/infrastructure/test_postgres_subnet_repository_cascade.py`` —
+a ``MagicMock`` factory that returns an ``AsyncMock`` session whose
+``__aenter__`` / ``__aexit__`` are set up so ``async with
+session_factory() as own:`` works. The point of mocking is to make
+assertions about ``commit`` / ``close`` / ``begin`` call counts
+without spinning up Postgres.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.infrastructure.persistence.postgres.subnet_allowlist_repository import (
+    PostgresSubnetAllowlistRepository,
+)
+from acn.infrastructure.persistence.postgres.subnet_join_request_repository import (
+    PostgresSubnetJoinRequestRepository,
+)
+from acn.infrastructure.persistence.postgres.subnet_repository import (
+    PostgresSubnetRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _make_own_session_factory(rowcount: int = 0):
+    """Build a factory whose ``__call__`` yields an AsyncMock session.
+
+    The session's ``__aenter__`` returns itself (so
+    ``async with factory() as sess: sess.execute(...)`` works), and
+    ``execute`` returns a mock result carrying the requested
+    ``rowcount``.
+    """
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+
+    result = MagicMock()
+    result.rowcount = rowcount
+    session.execute.return_value = result
+
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+def _make_external_session(rowcount: int = 0):
+    """Build a stand-in for an outer ``AsyncSession`` already opened
+    by ``IUnitOfWork.transaction()``.
+
+    No ``__aenter__`` / ``__aexit__`` — the cascade method receives
+    the session directly, so it never enters a context manager on it.
+    """
+    session = AsyncMock()
+    result = MagicMock()
+    result.rowcount = rowcount
+    session.execute.return_value = result
+    return session
+
+
+# ---------------------------------------------------------------------------
+# PostgresSubnetJoinRequestRepository.delete_for_subnet
+# ---------------------------------------------------------------------------
+
+
+class TestJoinRequestRepoSessionScope:
+    @pytest.mark.asyncio
+    async def test_self_managed_opens_session_and_commits(self):
+        """``session=None`` (legacy / Redis-only path): factory is
+        called exactly once, DELETE runs on the borrowed session,
+        ``commit`` is awaited on it before the ``async with`` exits."""
+        factory, own_session = _make_own_session_factory(rowcount=5)
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+
+        rows = await repo.delete_for_subnet("subnet-1")
+
+        assert rows == 5
+        factory.assert_called_once()
+        own_session.execute.assert_awaited_once()
+        own_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_session_skips_factory_and_commit(self):
+        """``session=<outer>``: factory is NOT called (we reuse the
+        outer session), DELETE runs on the outer session, and we MUST
+        NOT commit — the outer UoW owns the transaction boundary."""
+        factory, _ = _make_own_session_factory()  # built to detect leakage
+        outer = _make_external_session(rowcount=7)
+        repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
+
+        rows = await repo.delete_for_subnet("subnet-1", session=outer)
+
+        assert rows == 7
+        factory.assert_not_called()
+        outer.execute.assert_awaited_once()
+        # Critical: no early commit. The outer Unit-of-Work decides
+        # commit / rollback when ITS context exits.
+        outer.commit.assert_not_awaited()
+        outer.close.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# PostgresSubnetAllowlistRepository.delete_for_subnet
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistRepoSessionScope:
+    @pytest.mark.asyncio
+    async def test_self_managed_opens_session_and_commits(self):
+        factory, own_session = _make_own_session_factory(rowcount=2)
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+
+        rows = await repo.delete_for_subnet("subnet-1")
+
+        assert rows == 2
+        factory.assert_called_once()
+        own_session.execute.assert_awaited_once()
+        own_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_session_skips_factory_and_commit(self):
+        factory, _ = _make_own_session_factory()
+        outer = _make_external_session(rowcount=3)
+        repo = PostgresSubnetAllowlistRepository(session_factory=factory)
+
+        rows = await repo.delete_for_subnet("subnet-1", session=outer)
+
+        assert rows == 3
+        factory.assert_not_called()
+        outer.execute.assert_awaited_once()
+        outer.commit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# PostgresSubnetRepository.delete
+# ---------------------------------------------------------------------------
+
+
+class TestSubnetRepoDeleteSessionScope:
+    @pytest.mark.asyncio
+    async def test_self_managed_opens_session_and_commits(self):
+        factory, own_session = _make_own_session_factory(rowcount=1)
+        repo = PostgresSubnetRepository(session_factory=factory)
+
+        deleted = await repo.delete("subnet-1")
+
+        assert deleted is True
+        factory.assert_called_once()
+        own_session.execute.assert_awaited_once()
+        own_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_session_skips_factory_and_commit(self):
+        factory, _ = _make_own_session_factory()
+        outer = _make_external_session(rowcount=1)
+        repo = PostgresSubnetRepository(session_factory=factory)
+
+        deleted = await repo.delete("subnet-1", session=outer)
+
+        assert deleted is True
+        factory.assert_not_called()
+        outer.execute.assert_awaited_once()
+        outer.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_self_managed_returns_false_when_rowcount_zero(self):
+        """Smoke: the rowcount → bool mapping survives the session
+        scope change. ``rowcount=0`` ⇒ ``False`` (idempotent
+        already-gone path)."""
+        factory, _ = _make_own_session_factory(rowcount=0)
+        repo = PostgresSubnetRepository(session_factory=factory)
+
+        assert await repo.delete("missing-subnet") is False
+
+
+# ---------------------------------------------------------------------------
+# PostgresSubnetRepository.delete_with_children
+# ---------------------------------------------------------------------------
+
+
+class TestSubnetRepoDeleteWithChildrenSessionScope:
+    """``delete_with_children`` is the only PG cascade method that
+    splits on ``session`` *outside* a shared ``_session_scope``
+    helper: the self-managed branch keeps its explicit
+    ``async with session.begin():`` envelope (the ADR-0003 §A.4
+    contract — pinned by
+    ``test_postgres_subnet_repository_cascade.py``); the outer-session
+    branch must NOT call ``begin()`` because the caller's
+    ``IUnitOfWork.transaction()`` already opened the transaction and
+    a nested ``begin()`` either creates a savepoint (wrong semantics
+    for a cross-table cascade) or raises ``InvalidRequestError`` (in
+    SQLAlchemy 2.x autobegin mode).
+    """
+
+    @pytest.mark.asyncio
+    async def test_external_session_does_not_begin_or_commit(self):
+        outer = _make_external_session(rowcount=1)
+        # Spy: ``begin`` must not be called on the outer session.
+        outer.begin = MagicMock()
+        factory, _ = _make_own_session_factory()
+        repo = PostgresSubnetRepository(session_factory=factory)
+
+        await repo.delete_with_children(
+            "parent-1", ["child-1", "child-2"], session=outer
+        )
+
+        # Factory not consulted — we reused the outer session.
+        factory.assert_not_called()
+        # Two child DELETEs + one parent DELETE.
+        assert outer.execute.await_count == 3
+        # No fresh transaction layer — outer UoW owns it.
+        outer.begin.assert_not_called()
+        outer.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_self_managed_still_uses_begin_block(self):
+        """Regression guard: don't accidentally let the
+        ``session=None`` path collapse into the no-begin shape of
+        the outer-session branch — that would weaken the legacy
+        ADR-0003 §A.4 atomicity contract."""
+        factory, own_session = _make_own_session_factory(rowcount=1)
+        begin_ctx = AsyncMock()
+        begin_ctx.__aenter__.return_value = begin_ctx
+        begin_ctx.__aexit__.return_value = None
+        own_session.begin = MagicMock(return_value=begin_ctx)
+        repo = PostgresSubnetRepository(session_factory=factory)
+
+        await repo.delete_with_children(
+            "parent-1", ["child-1"], session=None
+        )
+
+        # Single explicit transaction envelope; commit handled by
+        # the ctx manager — NO explicit ``own_session.commit()``.
+        own_session.begin.assert_called_once()
+        begin_ctx.__aenter__.assert_awaited_once()
+        begin_ctx.__aexit__.assert_awaited_once()
+        own_session.commit.assert_not_awaited()

--- a/tests/services/test_subnet_service_back_refs.py
+++ b/tests/services/test_subnet_service_back_refs.py
@@ -238,8 +238,11 @@ class TestCascadeDeleteClearsBackRefs:
 
         assert ok is True
         # Repository cascade still fires with the right child ids.
-        mock_subnet_repository.delete_with_children.assert_awaited_once_with(
-            "team", ["squad-1", "squad-2"]
+        # Session-agnostic per issue #75 acceptance signal.
+        mock_subnet_repository.delete_with_children.assert_awaited_once()
+        assert mock_subnet_repository.delete_with_children.await_args.args == (
+            "team",
+            ["squad-1", "squad-2"],
         )
         # Saved agents' subnet_ids must NOT contain any of the three
         # subnets that were deleted (this is the user-visible signal
@@ -285,7 +288,7 @@ class TestCascadeDeleteClearsBackRefs:
             call_order.append(f"save:{agent.agent_id}")
 
         async def _record_cascade(
-            parent_id: str, child_ids: list[str]
+            parent_id: str, child_ids: list[str], **_kw
         ) -> bool:
             call_order.append("delete_with_children")
             return True
@@ -361,7 +364,9 @@ class TestCleanupBestEffort:
 
         # Subnet delete must succeed despite the per-agent failure.
         assert ok is True
-        mock_subnet_repository.delete.assert_awaited_once_with("team-a")
+        # Session-agnostic per issue #75.
+        mock_subnet_repository.delete.assert_awaited_once()
+        assert mock_subnet_repository.delete.await_args.args == ("team-a",)
         # Both members were attempted; one succeeded, one failed.
         assert mock_agent_repository.save.await_count == 2
 
@@ -490,4 +495,6 @@ class TestBackwardCompatNoAgentRepository:
         # ``subnet.member_agent_ids`` is non-empty.
         ok = await service.delete_subnet("team-a", owner="alice")
         assert ok is True
-        mock_subnet_repository.delete.assert_awaited_once_with("team-a")
+        # Session-agnostic per issue #75.
+        mock_subnet_repository.delete.assert_awaited_once()
+        assert mock_subnet_repository.delete.await_args.args == ("team-a",)

--- a/tests/services/test_subnet_service_cascade.py
+++ b/tests/services/test_subnet_service_cascade.py
@@ -55,9 +55,16 @@ class TestDeleteSubnetCascade:
 
         assert ok is True
         # ONE batched cascade call — parent + children in the same
-        # repository invocation.
-        mock_subnet_repository.delete_with_children.assert_awaited_once_with(
-            "parent", ["child-1", "child-2"]
+        # repository invocation. Session-agnostic assertion (issue
+        # #75 acceptance signal): Slice 2.1.1 threads a
+        # ``session=`` kwarg through the cascade methods, but the
+        # legacy/Redis path passes ``session=None``. Pin the
+        # positional contract instead so the test doesn't lock in
+        # one or the other transactional wiring.
+        mock_subnet_repository.delete_with_children.assert_awaited_once()
+        assert mock_subnet_repository.delete_with_children.await_args.args == (
+            "parent",
+            ["child-1", "child-2"],
         )
         # Per-id ``delete()`` is no longer used on the cascade path —
         # this catches accidental regressions back to the looped impl.
@@ -82,8 +89,10 @@ class TestDeleteSubnetCascade:
         # Cascade only fires when ``parent_subnet_id is None``.
         mock_subnet_repository.find_by_parent.assert_not_called()
         mock_subnet_repository.delete_with_children.assert_not_called()
-        # Single-row delete path used directly.
-        mock_subnet_repository.delete.assert_awaited_once_with("child-1")
+        # Single-row delete path used directly. Session-agnostic per
+        # issue #75 — see sibling ``test_top_level_delegates_…``.
+        mock_subnet_repository.delete.assert_awaited_once()
+        assert mock_subnet_repository.delete.await_args.args == ("child-1",)
 
     @pytest.mark.asyncio
     async def test_cascade_failure_propagates_from_repository(
@@ -128,7 +137,9 @@ class TestDeleteSubnetCascade:
         ok = await service.delete_subnet("lonely-parent", owner="alice")
         assert ok is True
 
-        mock_subnet_repository.delete.assert_awaited_once_with("lonely-parent")
+        # Session-agnostic — see sibling ``test_top_level_delegates_…``.
+        mock_subnet_repository.delete.assert_awaited_once()
+        assert mock_subnet_repository.delete.await_args.args == ("lonely-parent",)
         mock_subnet_repository.delete_with_children.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/services/test_subnet_service_cascade_atomic.py
+++ b/tests/services/test_subnet_service_cascade_atomic.py
@@ -1,0 +1,375 @@
+"""SubnetService.delete_subnet cascade atomicity (issue #75 / Slice 2.1.1).
+
+What this pins
+--------------
+ADR-0004 §"Cascade deletion: Postgres" promises:
+
+> ``delete_subnet`` runs a single ``session.begin()`` transaction
+> containing ``DELETE FROM subnet_join_requests WHERE subnet_id=...``,
+> ``DELETE FROM subnet_allowlist WHERE subnet_id=...``, and
+> ``DELETE FROM subnets WHERE subnet_id=...`` in that order. Any
+> failure rolls back the whole batch.
+
+Slice 2.1 shipped the three cascade methods but had them each open
+and commit their own session, so a process crash between the three
+commits left a durable partial cascade. Issue #75 tracked the gap;
+Slice 2.1.1 (this PR) closes it by threading an :class:`IUnitOfWork`
+through ``SubnetService`` and passing its yielded session token into
+every cascade method's ``session=`` kwarg.
+
+The contracts pinned here are session-token-identity contracts —
+"the same opaque token flowed through join_requests → allowlist →
+subnets". We use a sentinel ``object()`` as the token so the
+assertion is exact (no value coincidence). Real semantics
+(commit-on-clean-exit, rollback-on-exception) belong to
+:class:`PostgresUnitOfWork`, which has its own test coverage; here
+we only verify the *plumbing*: that the service actually threads
+the token through, and that absence of UoW falls back to the
+Slice-2.1 sequential-commit shape unchanged.
+
+The legacy fixtures in
+``test_subnet_service_join_policy_cascade.py`` exercise the
+"no UoW wired" path and stay green — that's the Slice-2.1
+contract preserved.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet
+from acn.services.subnet_service import SubnetService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _subnet(subnet_id: str, parent_subnet_id: str | None = None) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner="alice",
+        parent_subnet_id=parent_subnet_id,
+    )
+
+
+def _make_uow(token: object):
+    """Build a mock :class:`IUnitOfWork` whose ``transaction()`` yields
+    the provided ``token``.
+
+    Two assertion seams the tests inspect:
+
+    - ``uow.transaction`` — used exactly once per ``delete_subnet``
+      cascade body (the atomic path opens one transaction; the
+      no-UoW fallback never reaches this fixture at all because we
+      pass ``unit_of_work=None`` for that case).
+    - ``entered`` / ``exited`` flags — pin commit-on-clean-exit /
+      rollback-on-exception behaviour at the *plumbing* level
+      (we don't second-guess PG semantics, only that the service
+      did enter and exit the context manager exactly once around
+      the cascade body).
+    """
+    state = {"entered": 0, "exited_ok": 0, "exited_err": 0}
+
+    @asynccontextmanager
+    async def _txn():
+        state["entered"] += 1
+        try:
+            yield token
+            state["exited_ok"] += 1
+        except BaseException:
+            state["exited_err"] += 1
+            raise
+
+    uow = MagicMock()
+    uow.transaction = MagicMock(side_effect=_txn)
+    return uow, state
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.find_by_parent.return_value = []
+    repo.delete.return_value = True
+    repo.delete_with_children.return_value = True
+    return repo
+
+
+@pytest.fixture
+def mock_jr_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.delete_for_subnet.return_value = 0
+    return repo
+
+
+@pytest.fixture
+def mock_al_repo() -> AsyncMock:
+    repo = AsyncMock()
+    repo.delete_for_subnet.return_value = 0
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Atomic path — single subnet (no children)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCascadeSingleSubnet:
+    @pytest.mark.asyncio
+    async def test_threads_same_session_token_through_all_three_deletes(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """The core acceptance signal from issue #75: when a UoW is
+        wired, the join_requests / allowlist / subnets DELETEs each
+        receive the *same* session token, and that token is the one
+        yielded by ``uow.transaction()``. This is the
+        single-PG-transaction guarantee at the plumbing level
+        (real commit / rollback is :class:`PostgresUnitOfWork`'s
+        responsibility — covered by its own tests / live PG)."""
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+
+        token = object()  # sentinel for identity comparison
+        uow, state = _make_uow(token)
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            unit_of_work=uow,
+        )
+        ok = await service.delete_subnet("s-1", owner="alice")
+        assert ok is True
+
+        # One transaction opened, exited cleanly.
+        uow.transaction.assert_called_once()
+        assert state == {"entered": 1, "exited_ok": 1, "exited_err": 0}
+
+        # All three cascade methods received the SAME token by identity.
+        jr_call = mock_jr_repo.delete_for_subnet.await_args
+        al_call = mock_al_repo.delete_for_subnet.await_args
+        sn_call = mock_subnet_repo.delete.await_args
+        assert jr_call.kwargs.get("session") is token
+        assert al_call.kwargs.get("session") is token
+        assert sn_call.kwargs.get("session") is token
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_when_no_uow_wired_passes_none(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """No UoW → service falls back to the Slice-2.1 sequential-
+        commit shape: each cascade method still receives a ``session``
+        kwarg (Liskov contract — the interface always accepts one),
+        but the value is ``None``, signalling each repo to manage
+        its own session. This is the contract Redis-only and legacy
+        out-of-tree callers rely on."""
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            # unit_of_work intentionally omitted
+        )
+        await service.delete_subnet("s-1", owner="alice")
+
+        assert mock_jr_repo.delete_for_subnet.await_args.kwargs.get(
+            "session"
+        ) is None
+        assert mock_al_repo.delete_for_subnet.await_args.kwargs.get(
+            "session"
+        ) is None
+        assert mock_subnet_repo.delete.await_args.kwargs.get("session") is None
+
+
+# ---------------------------------------------------------------------------
+# Atomic path — parent + children
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCascadeWithChildren:
+    @pytest.mark.asyncio
+    async def test_same_token_for_every_child_and_parent(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """Every per-subnet cascade sweep (both children + the
+        parent) and the final ``delete_with_children`` all use the
+        SAME UoW session token — the parent + children + their
+        join_policy artifacts must commit / roll back as a unit, not
+        as N+1 independent transactions."""
+        parent = _subnet("parent")
+        children = [
+            _subnet("child-1", parent_subnet_id="parent"),
+            _subnet("child-2", parent_subnet_id="parent"),
+        ]
+        mock_subnet_repo.find_by_id.return_value = parent
+        mock_subnet_repo.find_by_parent.return_value = children
+
+        token = object()
+        uow, state = _make_uow(token)
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            unit_of_work=uow,
+        )
+        await service.delete_subnet("parent", owner="alice")
+
+        # Exactly ONE transaction opened.
+        uow.transaction.assert_called_once()
+        assert state["exited_ok"] == 1 and state["exited_err"] == 0
+
+        # join_requests cascade: 3 calls (2 children + 1 parent),
+        # ALL carrying the same token.
+        jr_calls = mock_jr_repo.delete_for_subnet.await_args_list
+        assert len(jr_calls) == 3
+        jr_subnets = [c.args[0] for c in jr_calls]
+        assert set(jr_subnets) == {"parent", "child-1", "child-2"}
+        for c in jr_calls:
+            assert c.kwargs.get("session") is token
+
+        # allowlist cascade: same shape.
+        al_calls = mock_al_repo.delete_for_subnet.await_args_list
+        assert len(al_calls) == 3
+        for c in al_calls:
+            assert c.kwargs.get("session") is token
+
+        # The final batched cascade DELETE uses the token too.
+        dwc_call = mock_subnet_repo.delete_with_children.await_args
+        assert dwc_call.kwargs.get("session") is token
+
+
+# ---------------------------------------------------------------------------
+# Failure propagation — exception inside cascade must exit the UoW with err
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCascadeFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_join_request_raise_exits_uow_with_exception(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """A failure mid-cascade must propagate OUT of the
+        ``uow.transaction()`` context with the exception preserved,
+        so the real :class:`PostgresUnitOfWork` triggers ROLLBACK
+        (its commit-on-clean-exit shape only commits when no
+        exception escaped the block). We verify the plumbing-level
+        invariant: the context manager's exception branch fired."""
+        sn = _subnet("s-x")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_jr_repo.delete_for_subnet.side_effect = RuntimeError(
+            "simulated cascade abort"
+        )
+
+        token = object()
+        uow, state = _make_uow(token)
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            unit_of_work=uow,
+        )
+        with pytest.raises(RuntimeError, match="simulated cascade abort"):
+            await service.delete_subnet("s-x", owner="alice")
+
+        # Context manager opened and exited with an exception —
+        # this is the rollback-trigger seam.
+        assert state == {"entered": 1, "exited_ok": 0, "exited_err": 1}
+        # The subnet HASH delete must NOT have been attempted (it
+        # would have been inside the same aborted transaction — but
+        # asserting "not called" still pins the cascade ordering
+        # contract from ADR §"Cascade deletion").
+        mock_subnet_repo.delete.assert_not_called()
+        mock_subnet_repo.delete_with_children.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_subnet_delete_raise_exits_uow_with_exception(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_jr_repo: AsyncMock,
+        mock_al_repo: AsyncMock,
+    ):
+        """Symmetric case: cascade methods succeed, but the final
+        subnet DELETE raises (simulated PG IntegrityError or similar).
+        The exception must still escape the UoW context so rollback
+        unwinds the already-executed cascade DELETEs. Otherwise the
+        ADR-0004 'three DELETEs commit together' guarantee would
+        degrade into 'three DELETEs commit independently'."""
+        sn = _subnet("s-y")
+        mock_subnet_repo.find_by_id.return_value = sn
+        mock_subnet_repo.delete.side_effect = RuntimeError("simulated PG abort")
+
+        token = object()
+        uow, state = _make_uow(token)
+        service = SubnetService(
+            mock_subnet_repo,
+            subnet_join_request_repository=mock_jr_repo,
+            subnet_allowlist_repository=mock_al_repo,
+            unit_of_work=uow,
+        )
+        with pytest.raises(RuntimeError, match="simulated PG abort"):
+            await service.delete_subnet("s-y", owner="alice")
+
+        # Both cascade sweeps ran (and would have been rolled back
+        # by the real UoW once the subnet DELETE raised).
+        mock_jr_repo.delete_for_subnet.assert_awaited_once()
+        mock_al_repo.delete_for_subnet.assert_awaited_once()
+        # And the context manager saw the exception.
+        assert state["exited_err"] == 1
+        assert state["exited_ok"] == 0
+
+
+# ---------------------------------------------------------------------------
+# UoW wired but cascade repos absent — fast-path through empty cascade body
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicPathWithoutCascadeRepos:
+    @pytest.mark.asyncio
+    async def test_uow_opened_even_when_cascade_repos_omitted(
+        self, mock_subnet_repo: AsyncMock
+    ):
+        """The current production wiring shape during Slice 2.1.1
+        (this PR): ``unit_of_work`` is wired but
+        ``subnet_join_request_repository`` /
+        ``subnet_allowlist_repository`` are NOT — Slice 2.2 will
+        land those. ``delete_subnet`` must still open a UoW (so the
+        single subnet DELETE participates in it) and exit cleanly
+        without crashing on the missing cascade repos.
+
+        This pins the explicit no-op fast-path that the wiring docs
+        promise (api.py comment block on ``unit_of_work=_unit_of_work``).
+        """
+        sn = _subnet("s-1")
+        mock_subnet_repo.find_by_id.return_value = sn
+
+        token = object()
+        uow, state = _make_uow(token)
+        service = SubnetService(
+            mock_subnet_repo,
+            unit_of_work=uow,
+            # No cascade repos wired — Slice 2.1.1 transitional shape.
+        )
+        ok = await service.delete_subnet("s-1", owner="alice")
+
+        assert ok is True
+        uow.transaction.assert_called_once()
+        assert state["exited_ok"] == 1
+        # The subnet DELETE was the only call, and it received the token.
+        mock_subnet_repo.delete.assert_awaited_once()
+        assert mock_subnet_repo.delete.await_args.kwargs.get("session") is token

--- a/tests/services/test_subnet_service_join_policy_cascade.py
+++ b/tests/services/test_subnet_service_join_policy_cascade.py
@@ -105,14 +105,19 @@ class TestSingleSubnetCascade:
         mock_subnet_repo.delete.return_value = True
 
         ordered_calls: list[str] = []
+        # ``**_kw`` swallows the ``session=`` kwarg the service now
+        # threads through every cascade method (added in Slice 2.1.1
+        # for the optional :class:`IUnitOfWork` atomic path). These
+        # side-effect lambdas pin cascade *ordering*, not the session
+        # value — keep them session-agnostic per issue #75 acceptance.
         mock_jr_repo.delete_for_subnet.side_effect = (
-            lambda sid: ordered_calls.append(f"jr:{sid}") or 0
+            lambda sid, **_kw: ordered_calls.append(f"jr:{sid}") or 0
         )
         mock_al_repo.delete_for_subnet.side_effect = (
-            lambda sid: ordered_calls.append(f"al:{sid}") or 0
+            lambda sid, **_kw: ordered_calls.append(f"al:{sid}") or 0
         )
 
-        async def record_subnet_delete(sid):
+        async def record_subnet_delete(sid, **_kw):
             ordered_calls.append(f"subnet_delete:{sid}")
             return True
 
@@ -357,7 +362,14 @@ class TestPartialWiring:
             # allowlist repo intentionally omitted
         )
         await service.delete_subnet("s-1", owner="alice")
-        mock_jr_repo.delete_for_subnet.assert_awaited_once_with("s-1")
+        # Session-agnostic assertion per issue #75 acceptance signal
+        # ("the contracts pinned there are session-agnostic") — pin
+        # "called once with the subnet id", but allow either ``session``
+        # kwarg shape (Slice 2.1.1 added ``session=None`` to the legacy
+        # path's call shape, but the contract intent here is just
+        # "this repo's cascade method ran for this subnet exactly once").
+        mock_jr_repo.delete_for_subnet.assert_awaited_once()
+        assert mock_jr_repo.delete_for_subnet.await_args.args == ("s-1",)
 
     @pytest.mark.asyncio
     async def test_only_allowlist_repo_wired(
@@ -375,4 +387,7 @@ class TestPartialWiring:
             # join_request repo intentionally omitted
         )
         await service.delete_subnet("s-1", owner="alice")
-        mock_al_repo.delete_for_subnet.assert_awaited_once_with("s-1")
+        # Session-agnostic — see sibling
+        # ``test_only_join_request_repo_wired`` for the rationale.
+        mock_al_repo.delete_for_subnet.assert_awaited_once()
+        assert mock_al_repo.delete_for_subnet.await_args.args == ("s-1",)


### PR DESCRIPTION
## Summary

- Closes #75 — Slice-2.1 deferred gap where `SubnetService.delete_subnet` ran three independent PG commits instead of the single-transaction batch ADR-0004 §"Cascade deletion: Postgres" promises.
- Threads the existing `IUnitOfWork` (already used by the settlement saga) through `SubnetService` so the three cascade DELETEs (`subnet_join_requests` + `subnet_allowlist` + `subnets`) commit-or-rollback as a unit.
- Backward-compatible: when no UoW is wired (Redis-only deployments, legacy fixtures, out-of-tree callers), falls back to the Slice-2.1 sequential-commit shape byte-for-byte unchanged.
- ADR-0003 §A.4 `delete_with_children` PG atomicity contract preserved (self-managed branch keeps its explicit `async with session.begin():`).

## Why this matters / unblocks

Issue #75 marks this as **P0 for Slice 2.2** — must land before any route that writes to `subnet_join_requests` / `subnet_allowlist` is enabled in production. With this PR merged, Slice 2.2 can ship the `JoinFlowService` + route surface knowing the cascade fence is already atomic.

## What changed

### Interface contract (storage-agnostic)

Each `ISubnet*Repository` cascade method now accepts an opaque `session: Any | None = None` token per the existing `IUnitOfWork` module contract ("repositories that understand the token's type bind to it, others ignore it"):

- `ISubnetRepository.delete(..., session=)`
- `ISubnetRepository.delete_with_children(..., session=)`
- `ISubnetJoinRequestRepository.delete_for_subnet(..., session=)`
- `ISubnetAllowlistRepository.delete_for_subnet(..., session=)`

### Postgres impls

- Add the same `_session_scope` helper `PostgresSettlementOutboxRepository` uses for the settlement saga (yield outer session unchanged when one is passed, otherwise open + commit + close own session).
- `PostgresSubnetRepository.delete_with_children` keeps its self-managed branch's explicit `async with session.begin():` to preserve the ADR-0003 §A.4 rollback-on-exception contract; the outer-session branch skips `begin()` because the caller's UoW already opened the transaction (nested `begin()` would only create a savepoint or raise `InvalidRequestError` in SQLAlchemy 2.x autobegin).

### Redis impls

Accept `session=None` to satisfy the Liskov contract but explicitly `del session` — Redis has no transactional composition primitive and ADR-0004 §"Cascade deletion: Redis" already documents the asymmetry.

### SubnetService

- Optional `unit_of_work: IUnitOfWork | None` constructor param.
- When wired (PG production): `delete_subnet` opens one `uow.transaction()` and threads the yielded session into every cascade method's `session=` kwarg.
- When omitted: falls back to Slice-2.1 sequential-commit shape, unchanged.
- Agent back-reference cleanup deliberately stays OUTSIDE the transaction (best-effort by ADR-0001 §dual-store membership).
- Refactored into three layers for clarity: `delete_subnet` (auth + cascade gating + back-refs) → `_run_cascade_delete` (UoW branch) → `_cascade_delete_body` (actual cascade ordering).

### Production wiring (api.py)

Thread `_unit_of_work` (already constructed in PG mode for the settlement saga) into the `SubnetService` composition. Cascade repos themselves are **NOT** yet wired here — that lands with the Slice 2.2 route surface, matching the Slice-2.1 docstring promise ("Production composition wires both once Slice 2.2 starts creating rows"). Until then the UoW is opened around a no-op cascade body that just runs the subnet DELETE — exercises the atomicity machinery end-to-end before Slice 2.2 hooks up production rows.

## Acceptance signals (from #75)

| Signal | Status |
|---|---|
| All three DELETEs share a single PG transaction | ✅ — pinned by `tests/services/test_subnet_service_cascade_atomic.py` (sentinel `object()` flows from `uow.transaction()` through join_requests → allowlist → subnets) |
| Existing Redis cascade path unchanged | ✅ — Redis impls explicitly `del session`; no behaviour change |
| Existing `test_subnet_service_join_policy_cascade.py` suite still green (session-agnostic contracts) | ✅ — 5 legacy assertions migrated to `assert_awaited_once()` + args check; lambdas now accept `**_kw` |

## Test coverage

- **New** `tests/infrastructure/test_postgres_subnet_cascade_session_scope.py` (9 tests): pin dual-mode contract on every PG cascade method.
- **New** `tests/services/test_subnet_service_cascade_atomic.py` (6 tests): pin session-token identity across the cascade, plumbing-level rollback signal (context manager exits with exception preserved).
- **Regression**: 816 service + infrastructure + core tests green. 28 subnet route tests green (broader routes suite hangs on unrelated env issue same as PR #74 self-review — CI handles it).

## Test plan

- [x] `tests/services/` + `tests/infrastructure/` + `tests/core/` all green (816 tests, 2.83s)
- [x] New 15 tests all green
- [x] `ruff check acn/ tests/` clean
- [x] Subnet route tests green (28 verified before unrelated env hang)
- [ ] CI green
- [ ] Live PG smoke (deferred to Slice 2.2 — cascade repos not wired in production yet, so live PG can't observe the new atomicity guarantee until Slice 2.2 lands rows)


Made with [Cursor](https://cursor.com)