### PR TITLE
feat(adr-0004): Phase 2 Slice 2.2 — join flow + 10 thin service methods

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -57,6 +57,8 @@ from .infrastructure.persistence.postgres import (
     PostgresBillingRepository,
     PostgresReputationRepository,
     PostgresSettlementOutboxRepository,
+    PostgresSubnetAllowlistRepository,
+    PostgresSubnetJoinRequestRepository,
     PostgresSubnetRepository,
     PostgresTaskRepository,
     PostgresUnitOfWork,
@@ -68,6 +70,16 @@ from .infrastructure.persistence.redis import (
     RedisAllowlistRepository,
     RedisFollowRepository,
     RedisSubnetRepository,
+)
+
+# See note in acn/infrastructure/persistence/redis/__init__.py — these
+# two are imported via their submodules to keep the package-level
+# import graph cycle-free.
+from .infrastructure.persistence.redis.subnet_allowlist_repository import (
+    RedisSubnetAllowlistRepository,
+)
+from .infrastructure.persistence.redis.subnet_join_request_repository import (
+    RedisSubnetJoinRequestRepository,
 )
 from .infrastructure.persistence.redis.task_repository import RedisTaskRepository
 from .infrastructure.task_pool import TaskPool
@@ -119,6 +131,7 @@ from .services.activity_service import ActivityService
 from .services.auth0_client import Auth0CredentialClient
 from .services.erc8004_client import ERC8004Client
 from .services.escrow_client import AgentPlanetEscrowProvider
+from .services.join_flow_service import JoinFlowService
 from .services.reputation_query_service import ReputationQueryService
 from .services.reputation_service import ReputationService
 from .services.settlement_worker import SettlementWorker
@@ -132,6 +145,7 @@ def _redact_db_url(url: str) -> str:
     """Return database URL with password replaced by *** for safe logging."""
     try:
         from urllib.parse import urlparse, urlunparse
+
         parsed = urlparse(url)
         if parsed.password:
             safe_netloc = parsed.netloc.replace(f":{parsed.password}@", ":***@")
@@ -317,22 +331,53 @@ async def lifespan(app: FastAPI):
     # subnets) inside one transaction. In Redis-only mode
     # ``_unit_of_work`` is None and the service falls back to the
     # sequential-commit path, matching ADR §"Cascade deletion: Redis".
-    # The cascade ``subnet_join_request_repository`` and
-    # ``subnet_allowlist_repository`` themselves are deliberately
-    # NOT wired here yet — Slice 2.2 will land them together with
-    # the route handlers that actually create rows. Until then the
-    # join-policy cascade sweeps short-circuit over those absent
-    # repos (Slice 2.1 behaviour preserved); the subnet DELETE
-    # still runs inside the UoW transaction, which is a one-statement
-    # batch but exercises the IUnitOfWork wiring path end-to-end so
-    # Slice 2.2 can plug cascade repos in without re-touching this
-    # composition.
+    #
+    # ADR-0004 Slice 2.2 — wire the two cascade repositories so the
+    # ten new join-flow methods (add_allowlist / approve / invite /
+    # accept / reject / withdraw / cancel + reads) have real
+    # backends. Slice 2.4 will wire the real
+    # ``WebhookJoinFlowEventPublisher`` here; until then the service
+    # defaults to the in-house :class:`NoOpJoinFlowEventPublisher`
+    # so the eight join-flow webhooks are silently dropped at debug
+    # log level (call sites stay publisher-aware regardless).
+    if settings.database_url:
+        subnet_join_request_repository = PostgresSubnetJoinRequestRepository(_pg_session)
+        subnet_admission_allowlist_repository = PostgresSubnetAllowlistRepository(_pg_session)
+    else:
+        subnet_join_request_repository = RedisSubnetJoinRequestRepository(redis_client)
+        subnet_admission_allowlist_repository = RedisSubnetAllowlistRepository(redis_client)
+
     subnet_service_instance = SubnetService(
         subnet_repository,
         task_repository=task_repository,
         agent_repository=agent_repository,
+        subnet_join_request_repository=subnet_join_request_repository,
+        subnet_allowlist_repository=subnet_admission_allowlist_repository,
         unit_of_work=_unit_of_work,
+        # ``join_flow_event_publisher`` deliberately left at default
+        # (NoOpJoinFlowEventPublisher). Slice 2.4 will swap in the
+        # WebhookService-backed adapter once ``WebhookEventType`` is
+        # extended with the eight new join-flow events.
     )
+
+    # ADR-0004 Slice 2.2 — JoinFlowService implements §join's
+    # six-branch decision tree (open / owner / invitation_self /
+    # invitation_allowlist / allowlist_auto / pending_join_request).
+    # Slice 2.3 wires the HTTP routes that call it; until then this
+    # instance is held on ``app.state`` so smoke tests and ad-hoc
+    # admin tooling can reach it (matches the existing ``limiter``
+    # state-stash pattern down below). The Slice 2.3 router-factory
+    # call will read it back via ``app.state.join_flow_service`` so
+    # this composition root doesn't need re-touching when the routes
+    # land.
+    join_flow_service_instance = JoinFlowService(
+        subnet_service=subnet_service_instance,
+        join_request_repository=subnet_join_request_repository,
+        allowlist_repository=subnet_admission_allowlist_repository,
+        # Default no-op publisher matches subnet_service_instance
+        # above; same Slice-2.4 swap point.
+    )
+    app.state.join_flow_service = join_flow_service_instance
 
     # Phase 1 communication_policy gateway: a single PolicyCheckService
     # instance is shared by both the HTTP-side MessageRouter and the

--- a/acn/core/exceptions/__init__.py
+++ b/acn/core/exceptions/__init__.py
@@ -85,3 +85,155 @@ class AllowlistCapacityExceededError(ACNException):
     The route layer surfaces this as 429 with a "remove some entries
     first" hint.
     """
+
+
+# ---------------------------------------------------------------------------
+# ADR-0004 join-flow domain exceptions (Phase 2 Slice 2.2)
+# ---------------------------------------------------------------------------
+#
+# All eight surface as 4xx HTTP statuses through Slice 2.3's route layer.
+# Each carries a stable ``reason`` string so the route layer's
+# ``_join_flow_error_to_acn`` mapper can pin the ``ErrorCode`` /
+# ``details.reason`` payload without depending on (English) message text,
+# mirroring the ``SubnetInvariantError`` pattern from ADR-0003 / ADR-0004
+# Phase 1.
+class JoinFlowError(ACNException):
+    """Base class for ADR-0004 join-flow rejections.
+
+    Carries a stable ``reason`` slug (one of the ``REASON_*``
+    constants exposed by the subclasses' module). The route layer
+    catches the base and dispatches on ``isinstance`` to pick the
+    right HTTP status, so out-of-tree subclasses participate in
+    the same exception flow without re-listing themselves anywhere.
+    """
+
+    def __init__(self, reason: str, message: str | None = None) -> None:
+        self.reason = reason
+        super().__init__(message or reason)
+
+
+class JoinRequestPendingError(JoinFlowError):
+    """409 ``JOIN_REQUEST_PENDING`` — agent already has a pending join_request.
+
+    Carries the existing ``request_id`` so the route layer can echo
+    it back in the response per ADR §State machine edges
+    "Duplicate join request".
+    """
+
+    def __init__(self, existing_request_id: str) -> None:
+        self.existing_request_id = existing_request_id
+        super().__init__(
+            "join_request_pending",
+            f"pending join_request {existing_request_id} already exists",
+        )
+
+
+class InvitationPendingError(JoinFlowError):
+    """409 ``INVITATION_PENDING`` — owner already invited this agent.
+
+    Symmetric partner of :class:`JoinRequestPendingError` for the
+    push direction (ADR §State machine edges "Duplicate invitation").
+    """
+
+    def __init__(self, existing_invitation_id: str) -> None:
+        self.existing_invitation_id = existing_invitation_id
+        super().__init__(
+            "invitation_pending",
+            f"pending invitation {existing_invitation_id} already exists",
+        )
+
+
+class JoinRequestAlreadyDecidedError(JoinFlowError):
+    """409 ``JOIN_REQUEST_ALREADY_DECIDED`` — CAS race lost on transition.
+
+    Both owner-side approve / reject and applicant-side withdraw
+    raise this when the row has already moved off ``status='pending'``
+    by the time the second caller arrives. See ADR §State machine
+    edges "Concurrent decision".
+    """
+
+    def __init__(self, request_id: str, current_status: str) -> None:
+        self.request_id = request_id
+        self.current_status = current_status
+        super().__init__(
+            "join_request_already_decided",
+            f"join_request {request_id} is already {current_status}",
+        )
+
+
+class InvitationAlreadyDecidedError(JoinFlowError):
+    """409 ``INVITATION_ALREADY_DECIDED`` — symmetric partner for invitations.
+
+    Raised by accept / reject / cancel when the invitation row has
+    already moved off ``status='pending'``.
+    """
+
+    def __init__(self, invitation_id: str, current_status: str) -> None:
+        self.invitation_id = invitation_id
+        self.current_status = current_status
+        super().__init__(
+            "invitation_already_decided",
+            f"invitation {invitation_id} is already {current_status}",
+        )
+
+
+class AlreadyMemberError(JoinFlowError):
+    """409 ``ALREADY_MEMBER`` — target agent is already a subnet member.
+
+    Raised on the invite path ("Invite an existing member") and the
+    self-join path ("Agent self-join a subnet they are already in").
+    See ADR §State machine edges for both cases.
+    """
+
+    def __init__(self, subnet_id: str, agent_id: str) -> None:
+        self.subnet_id = subnet_id
+        self.agent_id = agent_id
+        super().__init__(
+            "already_member",
+            f"agent {agent_id} is already a member of subnet {subnet_id}",
+        )
+
+
+class AllowlistEntryExistsError(JoinFlowError):
+    """409 ``ALREADY_ON_ALLOWLIST`` — duplicate ``POST /allowlist``.
+
+    Idempotent removal stays a 200 / 204 (no exception). Only the
+    add path raises; ADR §"Allowlist endpoints" pins the 409 here.
+    """
+
+    def __init__(self, subnet_id: str, agent_id: str) -> None:
+        self.subnet_id = subnet_id
+        self.agent_id = agent_id
+        super().__init__(
+            "already_on_allowlist",
+            f"agent {agent_id} is already on subnet {subnet_id}'s allowlist",
+        )
+
+
+class JoinRequestNotFoundError(JoinFlowError):
+    """404 ``JOIN_REQUEST_NOT_FOUND`` — id missing, or wrong namespace.
+
+    Raised both when ``request_id`` does not exist and when it
+    exists but ``row.kind != 'join_request'`` (e.g. the caller hit
+    ``/join-requests/{id}`` with an invitation id). ADR §URL alias
+    routing rules pins the latter to the same 404 so the two-name
+    space split doesn't leak existence of cross-kind ids.
+    """
+
+    def __init__(self, request_id: str) -> None:
+        self.request_id = request_id
+        super().__init__(
+            "join_request_not_found",
+            f"join_request {request_id} not found",
+        )
+
+
+class InvitationNotFoundError(JoinFlowError):
+    """404 ``INVITATION_NOT_FOUND`` — symmetric partner for invitations."""
+
+    def __init__(self, invitation_id: str) -> None:
+        self.invitation_id = invitation_id
+        super().__init__(
+            "invitation_not_found",
+            f"invitation {invitation_id} not found",
+        )

--- a/acn/core/interfaces/__init__.py
+++ b/acn/core/interfaces/__init__.py
@@ -13,6 +13,12 @@ from .escrow_provider import (
     ReleaseResult,
 )
 from .follow_repository import IFollowRepository
+from .join_flow_event_publisher import (
+    IJoinFlowEventPublisher,
+    JoinFlowEventTrigger,
+    JoinFlowEventType,
+    JoinFlowEventVia,
+)
 from .settlement_outbox_repository import (
     ISettlementOutboxRepository,
     SettlementEvent,
@@ -30,6 +36,10 @@ __all__ = [
     "IAllowlistRepository",
     "AllowlistEntry",
     "IFollowRepository",
+    "IJoinFlowEventPublisher",
+    "JoinFlowEventTrigger",
+    "JoinFlowEventType",
+    "JoinFlowEventVia",
     "ISettlementOutboxRepository",
     "SettlementEvent",
     "ISubnetAllowlistRepository",

--- a/acn/core/interfaces/join_flow_event_publisher.py
+++ b/acn/core/interfaces/join_flow_event_publisher.py
@@ -1,0 +1,155 @@
+"""Join-flow event publisher contract (ADR-0004 Phase 2 Slice 2.2).
+
+ADR-0004 §"Webhook event catalogue" introduces eight new event
+types that fire on every state transition of the three-in-one
+``subnet_join_requests`` table. The actual webhook payload, HMAC
+signing, retry envelope, etc. live in the existing
+``acn/protocols/ap2/webhook.py::WebhookService`` and are wired in
+Slice 2.4.
+
+Slice 2.2 — this slice — implements the domain logic
+(``JoinFlowService`` + the eight new ``SubnetService`` methods)
+**without** taking a hard dependency on ``WebhookService``. Doing
+so would smear two concerns:
+
+1. Slice 2.2 would have to add eight new entries to
+   ``WebhookEventType`` (an enum that lives in the AP2 protocol
+   module and whose membership is itself an ADR-0004 §Org Harness
+   impact decision Slice 2.4 owns).
+2. Tests would need to stub the heavy ``WebhookService`` (Redis +
+   httpx + retry loop) for every code path that emits an event,
+   even though Slice 2.2's only interest in the event is "did we
+   call publish() with the right arguments".
+
+This module solves both problems with a tiny adapter:
+
+* :class:`JoinFlowEventType` — Slice 2.2-owned enum carrying the
+  eight string event names. The values are the canonical
+  ``"subnet.join_*"`` / ``"subnet.invitation_*"`` strings from
+  ADR §Webhook event catalogue, so Slice 2.4's mapping to
+  ``WebhookEventType`` is a 1-1 string lookup.
+
+* :class:`IJoinFlowEventPublisher` — the abstract port the
+  service layer depends on. Single ``publish()`` method that
+  takes the canonical ADR-0004 payload tuple plus the
+  ``trigger`` / ``via`` discriminators from §"Merge-path event
+  mapping". Slice 2.2 ships :class:`NoOpJoinFlowEventPublisher`
+  (see ``acn/services/_no_op_join_flow_event_publisher.py``)
+  bound by ``api.py``; Slice 2.4 ships a concrete
+  ``WebhookJoinFlowEventPublisher`` that adapts the call into
+  ``WebhookService.send_to``.
+
+The asymmetric ``trigger`` / ``via`` defaults match ADR
+§"Payload shape": ``trigger='explicit'`` for direct API actions
+and ``via=None`` for the non-merge branches.
+"""
+
+from abc import ABC, abstractmethod
+from enum import StrEnum
+from typing import Literal
+
+from ..entities import Subnet, SubnetJoinRequest
+
+JoinFlowEventTrigger = Literal["explicit", "auto_on_join", "auto_on_invite"]
+"""Identifies *why* a transition fired. See ADR §"Payload shape".
+
+* ``explicit`` — direct API action (owner clicked approve, applicant
+  clicked withdraw, etc.). The vast majority of events.
+* ``auto_on_join`` — the agent's ``join`` call triggered an
+  auto-resolution of a pending invitation (branches 3 / 4 in
+  §join).
+* ``auto_on_invite`` — the owner's ``invite`` call triggered an
+  auto-approval of a pending join_request (the symmetric merge
+  path in §"POST /invitations" "Merge path").
+"""
+
+JoinFlowEventVia = Literal["self_join", "owner_invite", "allowlist"]
+"""Identifies *which side* initiated the collision on a merge path.
+
+Populated only when ``trigger != 'explicit'``. ``None`` on every
+direct-action event. See ADR §"Payload shape" for the contract.
+"""
+
+
+class JoinFlowEventType(StrEnum):
+    """Canonical event names for ADR-0004 join-flow lifecycle events.
+
+    The string values match the ADR §"Webhook event catalogue"
+    table verbatim. Slice 2.4 will mirror these into
+    :class:`acn.protocols.ap2.webhook.WebhookEventType` via a
+    string-equality lookup, so any drift between the two enums
+    surfaces as a wiring-time test failure rather than a runtime
+    mystery.
+
+    Allowlist add / remove deliberately have no event types here —
+    ADR §"Webhook event catalogue" notes "Allowlist configuration
+    changes (add / remove) do NOT emit webhooks; the allowlist is
+    configuration state, not lifecycle."
+    """
+
+    JOIN_REQUESTED = "subnet.join_requested"
+    JOIN_APPROVED = "subnet.join_approved"
+    JOIN_REJECTED = "subnet.join_rejected"
+    JOIN_WITHDRAWN = "subnet.join_withdrawn"
+
+    INVITATION_SENT = "subnet.invitation_sent"
+    INVITATION_ACCEPTED = "subnet.invitation_accepted"
+    INVITATION_REJECTED = "subnet.invitation_rejected"
+    INVITATION_CANCELED = "subnet.invitation_canceled"
+
+
+class IJoinFlowEventPublisher(ABC):
+    """Port the service layer uses to emit join-flow lifecycle events.
+
+    A single ``publish()`` method intentionally covers all eight
+    event types so Slice 2.2 can dispatch on the
+    :class:`JoinFlowEventType` enum at the service-layer call site
+    (one ``publish(JoinFlowEventType.JOIN_APPROVED, ...)`` per
+    transition path) without growing eight separate method names.
+
+    The implementation is expected to be best-effort — webhook
+    delivery failures must not block the underlying state
+    transition. ADR-0004 §Webhook reuses the ADR-0003 contract
+    ("never break the lifecycle on webhook failure"); concrete
+    implementations are responsible for catching and logging
+    transport errors internally.
+    """
+
+    @abstractmethod
+    async def publish(
+        self,
+        event: JoinFlowEventType,
+        *,
+        subnet: Subnet,
+        request: SubnetJoinRequest,
+        trigger: JoinFlowEventTrigger = "explicit",
+        via: JoinFlowEventVia | None = None,
+    ) -> None:
+        """Emit a single join-flow lifecycle event.
+
+        Args:
+            event: One of the eight ``JoinFlowEventType`` members.
+            subnet: The ``Subnet`` entity the event is scoped to.
+                Implementations read ``harness_url`` /
+                ``harness_secret`` / ``parent_subnet_id`` from here
+                — Slice 2.2 callers must pass the freshly-fetched
+                subnet so a webhook fired off a stale snapshot
+                doesn't address a deleted Harness.
+            request: The ``SubnetJoinRequest`` row whose lifecycle
+                the event describes. Carries ``request_id``,
+                ``agent_id``, ``kind``, ``initiated_by``,
+                ``decided_by`` for the payload (see ADR §"Payload
+                shape").
+            trigger: ``"explicit"`` (default) for direct API
+                actions; ``"auto_on_join"`` / ``"auto_on_invite"``
+                on the three merge paths.
+            via: Populated only on merge paths; ``None`` on direct
+                actions. See ADR §"Merge-path event mapping" for
+                the (trigger, via) table.
+
+        Implementations MUST NOT raise on transport errors — the
+        caller is in the middle of a successful state transition
+        and the webhook is an audit signal, not part of the
+        atomic write. The :class:`NoOpJoinFlowEventPublisher`
+        Slice 2.2 ships honours this trivially.
+        """

--- a/acn/infrastructure/persistence/postgres/__init__.py
+++ b/acn/infrastructure/persistence/postgres/__init__.py
@@ -7,6 +7,8 @@ from .billing_repository import PostgresBillingRepository
 from .database import get_engine, get_session_factory
 from .reputation_repository import PostgresReputationRepository
 from .settlement_outbox_repository import PostgresSettlementOutboxRepository
+from .subnet_allowlist_repository import PostgresSubnetAllowlistRepository
+from .subnet_join_request_repository import PostgresSubnetJoinRequestRepository
 from .subnet_repository import PostgresSubnetRepository
 from .task_repository import PostgresTaskRepository
 from .unit_of_work import PostgresUnitOfWork
@@ -18,6 +20,8 @@ __all__ = [
     "PostgresBillingRepository",
     "PostgresReputationRepository",
     "PostgresSettlementOutboxRepository",
+    "PostgresSubnetAllowlistRepository",
+    "PostgresSubnetJoinRequestRepository",
     "PostgresSubnetRepository",
     "PostgresTaskRepository",
     "PostgresUnitOfWork",

--- a/acn/infrastructure/persistence/redis/__init__.py
+++ b/acn/infrastructure/persistence/redis/__init__.py
@@ -9,6 +9,19 @@ from .allowlist_repository import RedisAllowlistRepository
 from .follow_repository import RedisFollowRepository
 from .subnet_repository import RedisSubnetRepository
 
+# NB: ``RedisSubnetJoinRequestRepository`` and
+# ``RedisSubnetAllowlistRepository`` are deliberately NOT re-exported
+# here. Their module-level imports pull in the matching Postgres
+# repositories (for the shared ``SubnetJoinRequestPendingError`` etc.),
+# which in turn drag the rest of ``persistence/postgres/__init__.py``
+# into the import graph. The ``acn/__init__.py`` top-level import of
+# ``acn.infrastructure.messaging`` reaches this package via
+# ``broadcast_service``, and the bigger Postgres chain creates a cycle
+# back through ``services.billing_service`` → ``message_service`` →
+# ``infrastructure.messaging``. Importing the two repos directly from
+# their submodules at the call site (api.py composition root) avoids
+# the cycle without restructuring the older billing/messaging imports.
+
 __all__ = [
     "RedisAgentRepository",
     "RedisAllowlistRepository",

--- a/acn/services/_join_flow_result.py
+++ b/acn/services/_join_flow_result.py
@@ -1,0 +1,173 @@
+"""``JoinFlowService.join_subnet`` result sealed union (ADR-0004 Slice 2.2).
+
+ADR §"POST /api/v1/agents/{agent_id}/subnets/{subnet_id} (join entry)"
+defines six branches the join entry-point dispatches into. Each
+branch ends in a *different* success shape — open join, owner
+self-join, invitation auto-accept (two flavours, distinguished by
+``via``), allowlist auto-approval, or pending request creation —
+and each maps to a distinct ``200 vs 202`` + response body in
+Slice 2.3's route layer.
+
+This sealed union lets ``JoinFlowService.join_subnet`` return a
+typed result that the route layer matches on once instead of
+duplicating six ``if status == "joined"`` checks. Failures are
+still raised as :class:`acn.core.exceptions` subclasses (409 / 404
+/ 403 maps) — the union covers **success outcomes only**.
+
+The two invitation-auto-accept branches (branch 3 self-join and
+branch 4 allowlist-merge) collapse into one variant
+:class:`JoinFlowAutoAcceptedInvitationResult` with a ``via`` field
+discriminator, matching the response shapes ADR §join lays out
+(``via="self_join"`` vs ``via="allowlist"``). Five variants for
+six branches is the minimal sealed shape — anything more would
+forge a distinction the response body doesn't carry.
+
+Why frozen dataclasses, not Pydantic
+------------------------------------
+These types never cross the HTTP boundary — Slice 2.3's route
+layer converts each variant to its own Pydantic response model.
+They exist purely to give the service ↔ route handoff a typed
+contract that ``match`` statements can exhaust. Pydantic would
+add coercion semantics we don't need and serialization machinery
+we don't use.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..core.entities import SubnetJoinRequest
+
+
+@dataclass(frozen=True)
+class JoinFlowJoinedOpenResult:
+    """Branch 1 — ``join_policy='open'`` → immediate ``add_member``.
+
+    No row is created in ``subnet_join_requests``. The route layer
+    returns ``200 {status: "joined", ...}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+
+
+@dataclass(frozen=True)
+class JoinFlowJoinedAsOwnerResult:
+    """Branch 2 — owner self-joins their own subnet → immediate ``add_member``.
+
+    No row in ``subnet_join_requests``. The owner is canonically
+    a member of their subnet (ADR §State machine edges "Owner
+    self-joins their own subnet"); this branch is the no-op
+    fast path. Route layer returns ``200 {status: "joined", ...}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+
+
+@dataclass(frozen=True)
+class JoinFlowAutoAcceptedInvitationResult:
+    """Branches 3 & 4 — a pending invitation was auto-accepted on self-join.
+
+    Branch 3 fires when an agent with a pending invitation calls
+    ``join`` themselves (``via='self_join'``). Branch 4 fires when
+    an allowlisted agent calls ``join`` and a pending invitation
+    also happens to exist (``via='allowlist'`` — the invitation
+    wins to avoid a parallel ``allowlist_auto`` row).
+
+    Route layer returns ``200 {auto_resolved: true, resolved_kind:
+    "invitation", invitation_id, via}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+    invitation: SubnetJoinRequest
+    via: Literal["self_join", "allowlist"]
+
+
+@dataclass(frozen=True)
+class JoinFlowAllowlistAutoApprovedResult:
+    """Branch 5 — allowlisted agent joins, no pending invitation present.
+
+    A fresh row with ``kind='allowlist_auto', status='approved'`` is
+    born; the agent is added as a member in the same flow. Route
+    layer returns ``200 {request_id, via: "allowlist", ...}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+    request: SubnetJoinRequest
+
+
+@dataclass(frozen=True)
+class JoinFlowPendingResult:
+    """Branch 6 — fallback. Fresh ``kind='join_request'`` row, ``status='pending'``.
+
+    The agent is *not* added as a member; the owner must decide.
+    Route layer returns ``202 {request_id, status: "pending"}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+    request: SubnetJoinRequest
+
+
+JoinFlowResult = (
+    JoinFlowJoinedOpenResult
+    | JoinFlowJoinedAsOwnerResult
+    | JoinFlowAutoAcceptedInvitationResult
+    | JoinFlowAllowlistAutoApprovedResult
+    | JoinFlowPendingResult
+)
+"""Sealed union of every success outcome from ``JoinFlowService.join_subnet``.
+
+The route layer (Slice 2.3) exhaustively matches this union to
+pick the right HTTP status code + response model. Failures
+(409 / 404 / 403) are raised as :class:`ACNException` subclasses,
+not encoded in the union — the union is success-only by design.
+"""
+
+
+@dataclass(frozen=True)
+class InviteAgentSentResult:
+    """``SubnetService.invite_agent`` normal path — fresh invitation row.
+
+    The owner invited an agent who had no pre-existing pending row;
+    a ``kind='invitation', status='pending'`` row was created and
+    the invitee owes a decision. Route layer returns
+    ``202 {invitation_id}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+    invitation: SubnetJoinRequest
+
+
+@dataclass(frozen=True)
+class InviteAgentMergedToApprovedJoinRequestResult:
+    """``SubnetService.invite_agent`` merge path — auto-approved a pending join_request.
+
+    Symmetric partner of branch 3's "agent self-joins with pending
+    invitation" path. The owner's invite arrives while the agent
+    already has a ``kind='join_request', status='pending'`` row;
+    the row is CAS'd to ``approved`` (``decided_by=owner_id``,
+    ``trigger=auto_on_invite``) and the agent is added as a member.
+    No new invitation row is created — ADR §"POST /invitations"
+    "Merge path".
+
+    Route layer returns ``200 {auto_resolved: true,
+    resolved_kind: "join_request", request_id}``.
+    """
+
+    subnet_id: str
+    agent_id: str
+    request: SubnetJoinRequest
+
+
+InviteAgentResult = InviteAgentSentResult | InviteAgentMergedToApprovedJoinRequestResult
+"""Sealed union of every success outcome from ``SubnetService.invite_agent``.
+
+Failures (target is already a member, target already has a pending
+invitation, target subnet missing, etc.) raise the matching
+:class:`acn.core.exceptions.JoinFlowError` subclass; the union
+covers success outcomes only.
+"""

--- a/acn/services/_no_op_join_flow_event_publisher.py
+++ b/acn/services/_no_op_join_flow_event_publisher.py
@@ -1,0 +1,69 @@
+"""No-op join-flow event publisher (ADR-0004 Phase 2 Slice 2.2).
+
+Slice 2.2 ships the domain logic for the eight new join-flow
+lifecycle events but explicitly defers the webhook transport
+(``WebhookService.send_to``) and the
+:class:`acn.protocols.ap2.webhook.WebhookEventType` enum
+extension to Slice 2.4. This stub keeps the service layer's
+single-port contract intact in the meantime:
+:class:`acn.services.subnet_service.SubnetService` and
+:class:`acn.services.join_flow_service.JoinFlowService` always
+hold a non-``None`` publisher reference, regardless of whether
+Slice 2.4 is wired yet, so the call sites stay free of
+"``if self._publisher is not None``" guards.
+
+The stub logs every call at debug level so production logs
+(``acn.services._no_op_join_flow_event_publisher``) clearly
+distinguish "Slice 2.2 deployment, no webhook ever fired" from
+"Slice 2.4 deployment but harness_url missing on this subnet"
+once Slice 2.4 lands.
+"""
+
+import structlog  # type: ignore[import-untyped]
+
+from ..core.entities import Subnet, SubnetJoinRequest
+from ..core.interfaces.join_flow_event_publisher import (
+    IJoinFlowEventPublisher,
+    JoinFlowEventTrigger,
+    JoinFlowEventType,
+    JoinFlowEventVia,
+)
+
+logger = structlog.get_logger()
+
+
+class NoOpJoinFlowEventPublisher(IJoinFlowEventPublisher):
+    """:class:`IJoinFlowEventPublisher` no-op for Slice 2.2 deployments.
+
+    Every ``publish()`` call short-circuits to a debug log. The
+    log line carries the event type + subnet_id + request_id so
+    operators auditing a Slice-2.2-only deployment can still
+    reconstruct the join-flow timeline from log streams while
+    Slice 2.4's real publisher is en route.
+    """
+
+    async def publish(
+        self,
+        event: JoinFlowEventType,
+        *,
+        subnet: Subnet,
+        request: SubnetJoinRequest,
+        trigger: JoinFlowEventTrigger = "explicit",
+        via: JoinFlowEventVia | None = None,
+    ) -> None:
+        """Log-only stub. See class docstring."""
+        # NB: structlog reserves the ``event`` keyword for the
+        # log message itself; we name the join-flow event slot
+        # ``join_flow_event`` here so the bound logger doesn't
+        # collide on call.
+        logger.debug(
+            "join_flow_event_dropped_slice_2_2",
+            join_flow_event=event.value,
+            subnet_id=subnet.subnet_id,
+            request_id=request.request_id,
+            agent_id=request.agent_id,
+            kind=request.kind,
+            status=request.status,
+            trigger=trigger,
+            via=via,
+        )

--- a/acn/services/join_flow_service.py
+++ b/acn/services/join_flow_service.py
@@ -1,0 +1,286 @@
+"""JoinFlowService — ADR-0004 §join 6-branch dispatcher (Phase 2 Slice 2.2).
+
+The single entry point for ``POST /api/v1/agents/{agent_id}/subnets/
+{subnet_id}``. ADR §"POST /api/v1/agents/{agent_id}/subnets/
+{subnet_id} (join entry)" specifies a normative six-branch
+decision tree on the caller's relationship to the subnet:
+
+1. ``join_policy='open'``                                                 → join immediately
+2. ``join_policy='approval'`` AND caller is the subnet owner              → join immediately
+3. ``approval`` AND pending invitation for ``(subnet, agent)`` exists     → auto-accept the invitation (``via='self_join'``)
+4. ``approval`` AND agent on allowlist AND pending invitation exists      → prefer the invitation (``via='allowlist'``)
+5. ``approval`` AND agent on allowlist AND no pending invitation          → auto-create a ``kind='allowlist_auto', status='approved'`` row
+6. otherwise                                                              → fall back to ``kind='join_request', status='pending'``
+
+Branches 1–5 are 200s (the caller is, now, a member). Branch 6 is
+a 202 (caller is not yet a member, owner owes a decision).
+
+Why a separate service rather than ``SubnetService.join_subnet``
+----------------------------------------------------------------
+Two reasons:
+
+1. **Composition.** The flow needs to call
+   :meth:`SubnetService.add_member` and four other thin CAS
+   methods (accept_invitation, etc.) plus
+   :meth:`AgentService.join_subnet` — orchestrating them in a
+   sibling service keeps :class:`SubnetService` itself focussed
+   on single-table writes.
+2. **Substitution.** Slice 2.4's CLI and Slice 2.3's HTTP routes
+   both call ``JoinFlowService.join_subnet``; subnet-internal
+   callers (e.g. the cascade hook that synthetically creates
+   ``allowlist_auto`` rows during admin replay) want
+   :meth:`SubnetService.add_member` directly, without the
+   policy-branch logic. Splitting the two services makes the
+   intent at the call site unambiguous.
+
+Branches 3 and 4 are subtly different — both auto-accept a
+pending invitation, but branch 4 fires when the agent is ALSO on
+the allowlist; ADR §"State machine edges" "Allowlist hit AND
+pending invitation" pins the resolution to invitation acceptance
+(NOT a parallel ``allowlist_auto`` row) with
+``decided_by='system:allowlist'`` so the audit trail says
+"approved because pre-authorised by the allowlist", not "approved
+because the invitee accepted". The :class:`JoinFlowResult`
+sealed union carries the discriminator forward via the
+``via='self_join'`` vs ``via='allowlist'`` field on
+:class:`JoinFlowAutoAcceptedInvitationResult`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import structlog  # type: ignore[import-untyped]
+
+from ..core.entities import SubnetJoinRequest
+from ..core.entities.subnet_join_request import SYSTEM_ALLOWLIST_ACTOR
+from ..core.exceptions import (
+    AlreadyMemberError,
+    JoinRequestPendingError,
+)
+from ..core.interfaces import (
+    IJoinFlowEventPublisher,
+    ISubnetAllowlistRepository,
+    ISubnetJoinRequestRepository,
+    JoinFlowEventType,
+)
+from ._join_flow_result import (
+    JoinFlowAllowlistAutoApprovedResult,
+    JoinFlowAutoAcceptedInvitationResult,
+    JoinFlowJoinedAsOwnerResult,
+    JoinFlowJoinedOpenResult,
+    JoinFlowPendingResult,
+    JoinFlowResult,
+)
+from ._no_op_join_flow_event_publisher import NoOpJoinFlowEventPublisher
+from .subnet_service import SubnetService
+
+logger = structlog.get_logger()
+
+
+class JoinFlowService:
+    """Implements the ADR-0004 §join six-branch decision tree.
+
+    Composed over :class:`SubnetService` (for the thin CAS methods +
+    add_member) and the two new repositories (for the membership /
+    pending / allowlist checks). The agent-side back-reference
+    (``agent.subnet_ids``) is intentionally NOT touched here — Slice
+    2.3's route layer continues to call ``agent_service.join_subnet``
+    around the service call, matching the pre-existing
+    ``do_join_subnet`` flow in ``acn/routes/_subnet_membership.py``.
+    """
+
+    def __init__(
+        self,
+        subnet_service: SubnetService,
+        join_request_repository: ISubnetJoinRequestRepository,
+        allowlist_repository: ISubnetAllowlistRepository,
+        event_publisher: IJoinFlowEventPublisher | None = None,
+    ) -> None:
+        """Wire dependencies.
+
+        Args:
+            subnet_service: For ``get_subnet``, ``add_member``, and
+                the four thin CAS verbs the merge / pending paths
+                delegate to (``accept_invitation``,
+                ``approve_join_request`` — used internally by
+                ``invite_agent`` not here).
+            join_request_repository: For ``find_pending_for`` and
+                ``save`` of fresh ``allowlist_auto`` / ``join_request``
+                rows.
+            allowlist_repository: For the ``is_member`` check on
+                branches 4 and 5.
+            event_publisher: Defaults to the no-op stub for parity
+                with :class:`SubnetService`'s constructor.
+        """
+        self._subnet_service = subnet_service
+        self._join_request_repository = join_request_repository
+        self._allowlist_repository = allowlist_repository
+        self._event_publisher: IJoinFlowEventPublisher = (
+            event_publisher or NoOpJoinFlowEventPublisher()
+        )
+
+    async def join_subnet(self, subnet_id: str, agent_id: str) -> JoinFlowResult:
+        """Dispatch the six branches.
+
+        Note on branch ordering: ADR §join states "the branch order
+        matters and is normative". The branches are checked top to
+        bottom; the first one to match wins. In particular, branch 2
+        (owner self-join) checks the owner ID **after** the open
+        check, so an open subnet with the owner calling it still
+        takes branch 1 (open) — semantically equivalent (owner is a
+        member either way) but the response shape is the "open" 200.
+        """
+        subnet = await self._subnet_service.get_subnet(subnet_id)
+
+        # ADR §State machine edges "Agent self-join a subnet they
+        # are already in" → 409 ALREADY_MEMBER. Check applies to
+        # every branch including open, so we hoist it above the
+        # branch dispatch.
+        if agent_id in subnet.member_agent_ids:
+            raise AlreadyMemberError(subnet_id, agent_id)
+
+        # Branch 1 — open subnet, immediate add_member.
+        if subnet.join_policy == "open":
+            await self._subnet_service.add_member(subnet_id, agent_id)
+            logger.info(
+                "join_flow_branch_open",
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                branch=1,
+            )
+            return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+
+        # From here on ``join_policy == 'approval'``.
+
+        # Branch 2 — owner self-joins. The owner is canonically a
+        # member of their subnet (ADR §State machine edges), so the
+        # request table is bypassed entirely.
+        if agent_id == subnet.owner:
+            await self._subnet_service.add_member(subnet_id, agent_id)
+            logger.info(
+                "join_flow_branch_owner_self_join",
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                branch=2,
+            )
+            return JoinFlowJoinedAsOwnerResult(subnet_id=subnet_id, agent_id=agent_id)
+
+        # The three remaining branches all hinge on the pending row
+        # / allowlist presence. Compute both up front so the
+        # decision tree is a straight ``if/elif`` chain.
+        pending = await self._join_request_repository.find_pending_for(subnet_id, agent_id)
+        is_allowlisted = await self._allowlist_repository.is_member(subnet_id, agent_id)
+
+        # Branches 3 + 4 — pending invitation auto-accept.
+        if pending is not None and pending.kind == "invitation":
+            via = "allowlist" if is_allowlisted else "self_join"
+            accepted = await self._subnet_service.accept_invitation(
+                subnet_id,
+                pending.request_id,
+                # On the allowlist merge path ADR §"Merge-path event
+                # mapping" pins decided_by='system:allowlist'; on
+                # plain self-join it stays the invitee_id. We pass
+                # the invitee_id either way and let accept_invitation
+                # rewrite to ``system:allowlist`` when via='allowlist'.
+                invitee_id=agent_id,
+                trigger="auto_on_join",
+                via=via,
+            )
+            logger.info(
+                "join_flow_branch_invitation_auto_accept",
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                invitation_id=accepted.request_id,
+                via=via,
+                branch=4 if is_allowlisted else 3,
+            )
+            return JoinFlowAutoAcceptedInvitationResult(
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                invitation=accepted,
+                via=via,
+            )
+
+        # An ``allowlist_auto`` row in ``pending`` is structurally
+        # impossible (born approved), but if a pending join_request
+        # somehow co-exists with an invite-driven re-entry the
+        # entity-level uniqueness invariant guarantees only one
+        # pending row per (subnet, agent). We reject the
+        # join_request collision with the 409 ADR §State machine
+        # edges "Duplicate join request" pins.
+        if pending is not None and pending.kind == "join_request":
+            raise JoinRequestPendingError(pending.request_id)
+
+        # Branch 5 — allowlisted (no pending invitation, no pending
+        # join_request). Create an ``allowlist_auto`` row born
+        # approved and add_member.
+        if is_allowlisted:
+            request = SubnetJoinRequest(
+                request_id=str(uuid.uuid4()),
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                kind="allowlist_auto",
+                status="approved",
+                initiated_by=SYSTEM_ALLOWLIST_ACTOR,
+                decided_by=SYSTEM_ALLOWLIST_ACTOR,
+                decided_at=datetime.now(UTC),
+            )
+            await self._join_request_repository.save(request)
+            await self._subnet_service.add_member(subnet_id, agent_id)
+            # Slice 2.2 emits ``JOIN_APPROVED`` for the auto-approval —
+            # branch 5 doesn't go through join_request → approved, it
+            # is born approved, so the canonical "approval happened"
+            # signal is what fires. ADR §Webhook event catalogue
+            # explicitly lists this event family with
+            # ``decided_by="system:allowlist"`` for the auto path.
+            await self._event_publisher.publish(
+                JoinFlowEventType.JOIN_APPROVED,
+                subnet=subnet,
+                request=request,
+                trigger="auto_on_join",
+                via="allowlist",
+            )
+            logger.info(
+                "join_flow_branch_allowlist_auto_approved",
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                request_id=request.request_id,
+                branch=5,
+            )
+            return JoinFlowAllowlistAutoApprovedResult(
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                request=request,
+            )
+
+        # Branch 6 — fall-through. Create a pending join_request.
+        # NOTE: NO ``add_member`` here — the caller is not yet a
+        # member; the owner owes a decision.
+        request = SubnetJoinRequest(
+            request_id=str(uuid.uuid4()),
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            kind="join_request",
+            status="pending",
+            initiated_by=agent_id,
+        )
+        await self._join_request_repository.save(request)
+        await self._event_publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED,
+            subnet=subnet,
+            request=request,
+        )
+        logger.info(
+            "join_flow_branch_pending_join_request",
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            request_id=request.request_id,
+            branch=6,
+        )
+        return JoinFlowPendingResult(
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            request=request,
+        )

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -17,6 +17,7 @@ from ..core.exceptions import (
     AlreadyMemberError,
     InvitationAlreadyDecidedError,
     InvitationNotFoundError,
+    InvitationPendingError,
     JoinRequestAlreadyDecidedError,
     JoinRequestNotFoundError,
     SubnetNotFoundException,
@@ -1308,7 +1309,10 @@ class SubnetService:
         §"Application-side endpoints" (≤500 chars, enforced by
         :class:`SubnetJoinRequest.__post_init__`).
         """
-        await self.get_subnet(subnet_id)
+        # Single ``get_subnet`` covers the 404 pre-check AND the
+        # webhook payload — reject doesn't mutate subnet membership,
+        # so the entity snapshot stays valid for the event emit.
+        subnet = await self.get_subnet(subnet_id)
         row = await self._load_join_request_or_404(
             request_id,
             expected_kind="join_request",
@@ -1320,7 +1324,6 @@ class SubnetService:
         rejected = await self._save_decided_transition(
             row, new_status="rejected", decided_by=owner_id, note=note
         )
-        subnet = await self.get_subnet(subnet_id)
         await self.event_publisher.publish(
             JoinFlowEventType.JOIN_REJECTED,
             subnet=subnet,
@@ -1349,7 +1352,8 @@ class SubnetService:
         approve / reject verbs. Applicant withdraw is its own path
         (DELETE /join-requests/{rid}) and emits ``JOIN_WITHDRAWN``.
         """
-        await self.get_subnet(subnet_id)
+        # See ``reject_join_request`` for the single-fetch reasoning.
+        subnet = await self.get_subnet(subnet_id)
         row = await self._load_join_request_or_404(
             request_id,
             expected_kind="join_request",
@@ -1364,7 +1368,6 @@ class SubnetService:
             decided_by=applicant_id,
             note=note,
         )
-        subnet = await self.get_subnet(subnet_id)
         await self.event_publisher.publish(
             JoinFlowEventType.JOIN_WITHDRAWN,
             subnet=subnet,
@@ -1414,8 +1417,6 @@ class SubnetService:
         The pending-join-request collision is the merge path above,
         NOT a 409 — that's the asymmetry ADR §"Merge path" pins.
         """
-        from ..core.exceptions import InvitationPendingError
-
         subnet = await self.get_subnet(subnet_id)
         if target_agent_id in subnet.member_agent_ids:
             raise AlreadyMemberError(subnet_id, target_agent_id)
@@ -1552,7 +1553,8 @@ class SubnetService:
 
         ``INVITATION_REJECTED`` fires; no membership change.
         """
-        await self.get_subnet(subnet_id)
+        # See ``reject_join_request`` for the single-fetch reasoning.
+        subnet = await self.get_subnet(subnet_id)
         row = await self._load_join_request_or_404(
             request_id,
             expected_kind="invitation",
@@ -1564,7 +1566,6 @@ class SubnetService:
         rejected = await self._save_decided_transition(
             row, new_status="rejected", decided_by=invitee_id, note=note
         )
-        subnet = await self.get_subnet(subnet_id)
         await self.event_publisher.publish(
             JoinFlowEventType.INVITATION_REJECTED,
             subnet=subnet,
@@ -1592,7 +1593,8 @@ class SubnetService:
         Emits ``INVITATION_CANCELED`` per ADR §"Webhook event
         catalogue".
         """
-        await self.get_subnet(subnet_id)
+        # See ``reject_join_request`` for the single-fetch reasoning.
+        subnet = await self.get_subnet(subnet_id)
         row = await self._load_join_request_or_404(
             request_id,
             expected_kind="invitation",
@@ -1604,7 +1606,6 @@ class SubnetService:
         canceled = await self._save_decided_transition(
             row, new_status="withdrawn", decided_by=owner_id, note=note
         )
-        subnet = await self.get_subnet(subnet_id)
         await self.event_publisher.publish(
             JoinFlowEventType.INVITATION_CANCELED,
             subnet=subnet,

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -4,20 +4,39 @@ Business logic for subnet management.
 """
 
 import dataclasses
+import uuid
+from datetime import UTC, datetime
 from typing import Literal
 
 import structlog  # type: ignore[import-untyped]
 
-from ..core.entities import Subnet
-from ..core.exceptions import SubnetNotFoundException
+from ..core.entities import Subnet, SubnetAllowlist, SubnetJoinRequest
+from ..core.entities.subnet_join_request import SYSTEM_ALLOWLIST_ACTOR
+from ..core.exceptions import (
+    AllowlistEntryExistsError,
+    AlreadyMemberError,
+    InvitationAlreadyDecidedError,
+    InvitationNotFoundError,
+    JoinRequestAlreadyDecidedError,
+    JoinRequestNotFoundError,
+    SubnetNotFoundException,
+)
 from ..core.interfaces import (
     IAgentRepository,
+    IJoinFlowEventPublisher,
     ISubnetAllowlistRepository,
     ISubnetJoinRequestRepository,
     ISubnetRepository,
     IUnitOfWork,
+    JoinFlowEventType,
 )
 from ..core.interfaces.task_repository import ITaskRepository
+from ._join_flow_result import (
+    InviteAgentMergedToApprovedJoinRequestResult,
+    InviteAgentResult,
+    InviteAgentSentResult,
+)
+from ._no_op_join_flow_event_publisher import NoOpJoinFlowEventPublisher
 
 logger = structlog.get_logger()
 
@@ -140,6 +159,7 @@ class SubnetService:
         subnet_join_request_repository: ISubnetJoinRequestRepository | None = None,
         subnet_allowlist_repository: ISubnetAllowlistRepository | None = None,
         unit_of_work: IUnitOfWork | None = None,
+        join_flow_event_publisher: IJoinFlowEventPublisher | None = None,
     ):
         """
         Initialize Subnet Service
@@ -158,17 +178,21 @@ class SubnetService:
             subnet_join_request_repository: Optional — used by
                 ``delete_subnet`` to cascade-delete pending and
                 terminal join-requests / invitations when a subnet
-                is dissolved (ADR-0004 §"Cascade deletion"). Omit
-                for legacy fixtures that predate Slice 2.1; the
-                cascade silently skips when absent, leaving the
-                join_requests rows as dust against a no-longer-
-                existing subnet (cleaned by a future ops sweep).
-                Production composition must wire it once Slice 2.2
-                lands the route surface that actually creates rows.
+                is dissolved (ADR-0004 §"Cascade deletion"). Slice
+                2.2 onward this repo also backs the ten new
+                join-flow methods (approve / reject / withdraw /
+                invite / accept / cancel / list_join_requests /
+                list_pending_invitations_for_agent); calling those
+                methods on a service constructed without this repo
+                raises ``RuntimeError`` early (Slice 2.2 hard
+                requirement, distinct from the cascade's opt-in
+                pattern).
             subnet_allowlist_repository: Optional — used by
-                ``delete_subnet`` to cascade-delete admission
-                allowlist entries. Same opt-in pattern as
-                ``subnet_join_request_repository``.
+                ``delete_subnet`` for cascade AND by Slice 2.2's
+                three allowlist methods (add_allowlist /
+                remove_allowlist / list_allowlist). Same hard
+                requirement: methods raise ``RuntimeError`` if
+                called without this repo wired.
             unit_of_work: Optional — when present, ``delete_subnet``
                 runs the three cascade DELETEs (join_requests,
                 allowlist, subnet) inside a single
@@ -178,6 +202,14 @@ class SubnetService:
                 the Slice-2.1 sequential-commit shape (each repo
                 commits independently — see class docstring for the
                 acceptable use cases of that fallback).
+            join_flow_event_publisher: Optional — the
+                :class:`IJoinFlowEventPublisher` Slice 2.2's eight
+                join-flow methods publish lifecycle events to. When
+                omitted, the service installs the
+                :class:`NoOpJoinFlowEventPublisher` stub so call
+                sites stay free of ``if publisher is not None``
+                guards. Slice 2.4 will wire the real publisher
+                that adapts into ``WebhookService.send_to``.
         """
         self.repository = subnet_repository
         self.task_repository = task_repository
@@ -185,6 +217,12 @@ class SubnetService:
         self.join_request_repository = subnet_join_request_repository
         self.allowlist_repository = subnet_allowlist_repository
         self.unit_of_work = unit_of_work
+        # Default to the in-house no-op so Slice 2.2's call sites
+        # can always assume a live publisher. Slice 2.4 swaps in the
+        # real webhook adapter via the constructor kwarg.
+        self.event_publisher: IJoinFlowEventPublisher = (
+            join_flow_event_publisher or NoOpJoinFlowEventPublisher()
+        )
 
     async def create_subnet(
         self,
@@ -473,10 +511,7 @@ class SubnetService:
                 return True
             if requester_id is None:
                 return False
-            return (
-                subnet.owner == requester_id
-                or requester_id in subnet.member_agent_ids
-            )
+            return subnet.owner == requester_id or requester_id in subnet.member_agent_ids
 
         return [c for c in children if _visible(c)]
 
@@ -581,12 +616,8 @@ class SubnetService:
                 # Stays outside the UoW transaction by design — see
                 # method docstring §"Agent back-reference cleanup".
                 for child in children:
-                    await self._clear_agent_back_references(
-                        child.subnet_id, child.member_agent_ids
-                    )
-                await self._clear_agent_back_references(
-                    subnet_id, subnet.member_agent_ids
-                )
+                    await self._clear_agent_back_references(child.subnet_id, child.member_agent_ids)
+                await self._clear_agent_back_references(subnet_id, subnet.member_agent_ids)
                 child_ids = [c.subnet_id for c in children]
                 logger.info(
                     "delete_subnet_cascade",
@@ -594,16 +625,12 @@ class SubnetService:
                     child_subnet_ids=child_ids,
                     child_count=len(child_ids),
                 )
-                return await self._run_cascade_delete(
-                    subnet_id, subnet_to_delete_with=children
-                )
+                return await self._run_cascade_delete(subnet_id, subnet_to_delete_with=children)
 
         # No-cascade path: child subnet direct-delete OR top-level
         # subnet with zero children. Either way, clean up this one
         # subnet's back-references then drop the record.
-        await self._clear_agent_back_references(
-            subnet_id, subnet.member_agent_ids
-        )
+        await self._clear_agent_back_references(subnet_id, subnet.member_agent_ids)
         logger.info("delete_subnet", subnet_id=subnet_id)
         return await self._run_cascade_delete(subnet_id, subnet_to_delete_with=None)
 
@@ -647,9 +674,7 @@ class SubnetService:
                 return await self._cascade_delete_body(
                     subnet_id, subnet_to_delete_with, session=session
                 )
-        return await self._cascade_delete_body(
-            subnet_id, subnet_to_delete_with, session=None
-        )
+        return await self._cascade_delete_body(subnet_id, subnet_to_delete_with, session=None)
 
     async def _cascade_delete_body(
         self,
@@ -672,13 +697,9 @@ class SubnetService:
             children = subnet_to_delete_with
             child_ids = [c.subnet_id for c in children]
             for child in children:
-                await self._cascade_join_policy_artifacts(
-                    child.subnet_id, session=session
-                )
+                await self._cascade_join_policy_artifacts(child.subnet_id, session=session)
             await self._cascade_join_policy_artifacts(subnet_id, session=session)
-            return await self.repository.delete_with_children(
-                subnet_id, child_ids, session=session
-            )
+            return await self.repository.delete_with_children(subnet_id, child_ids, session=session)
         await self._cascade_join_policy_artifacts(subnet_id, session=session)
         return await self.repository.delete(subnet_id, session=session)
 
@@ -728,9 +749,7 @@ class SubnetService:
                     deleted_count=deleted,
                 )
         if self.allowlist_repository is not None:
-            deleted = await self.allowlist_repository.delete_for_subnet(
-                subnet_id, session=session
-            )
+            deleted = await self.allowlist_repository.delete_for_subnet(subnet_id, session=session)
             if deleted:
                 logger.info(
                     "delete_subnet_cascade_allowlist",
@@ -999,3 +1018,656 @@ class SubnetService:
             owner=owner,
         )
         return promoted
+
+    # ------------------------------------------------------------------
+    # ADR-0004 Phase 2 Slice 2.2 — admission-allowlist + join-flow methods
+    # ------------------------------------------------------------------
+    #
+    # Ten thin methods cover every owner / invitee / applicant verb on the
+    # ``subnet_join_requests`` and ``subnet_allowlist`` tables. Each one
+    # follows the same shape:
+    #
+    #   1. Load the subnet (404 if missing — bubbles SubnetNotFoundException).
+    #   2. Load + validate the target row (one of the JoinFlowError 404 / 409
+    #      subclasses on mismatch — kind / status / namespace / membership).
+    #   3. CAS the transition by constructing a *new* SubnetJoinRequest with
+    #      the target (status, decided_by, decided_at) and saving over the
+    #      existing row. Entity-layer __post_init__ re-validates every
+    #      invariant so a malformed transition can never reach storage.
+    #   4. Apply the membership side-effect (add_member on approval paths;
+    #      no-op on reject / withdraw / cancel) — ALWAYS after the CAS so a
+    #      service-layer crash can't leak a half-joined member.
+    #   5. Emit the matching JoinFlowEventType via self.event_publisher —
+    #      best-effort, never blocks the transition.
+    #
+    # Authorisation is intentionally NOT enforced here; ADR §"Authorization
+    # matrix" puts it in the route layer's _require_owner / _require_invitee
+    # / _require_self helpers. Keeping authz at the boundary lets internal
+    # callers (the JoinFlowService merge paths, the cascade hook, future
+    # ops tools) bypass owner checks without going through a backdoor.
+
+    def _require_join_repo(self) -> ISubnetJoinRequestRepository:
+        """Raise loudly when Slice 2.2 methods are called without the
+        join-request repo wired. Mirrors the explicit fail-fast pattern
+        already used by ``allowlist_service`` — production composition
+        always supplies these; legacy fixtures that don't exercise the
+        join flow simply don't call these methods."""
+        if self.join_request_repository is None:
+            raise RuntimeError(
+                "SubnetService.join_request_repository is required for "
+                "ADR-0004 join-flow methods; wire it in api.py"
+            )
+        return self.join_request_repository
+
+    def _require_allowlist_repo(self) -> ISubnetAllowlistRepository:
+        """Symmetric partner of :meth:`_require_join_repo` for allowlist
+        methods. See that method's docstring."""
+        if self.allowlist_repository is None:
+            raise RuntimeError(
+                "SubnetService.allowlist_repository is required for "
+                "ADR-0004 join-flow methods; wire it in api.py"
+            )
+        return self.allowlist_repository
+
+    @staticmethod
+    def _new_request_id() -> str:
+        """Server-generated UUID per ADR §SubnetJoinRequest schema."""
+        return str(uuid.uuid4())
+
+    async def _load_join_request_or_404(
+        self,
+        request_id: str,
+        *,
+        expected_kind: Literal["join_request", "invitation"],
+        expected_subnet_id: str | None = None,
+    ) -> SubnetJoinRequest:
+        """Look up a single request row + enforce kind / subnet binding.
+
+        Implements ADR §"URL alias routing rules": a request_id used
+        against the wrong path namespace returns the namespace-specific
+        404 (``JOIN_REQUEST_NOT_FOUND`` vs ``INVITATION_NOT_FOUND``).
+        This blocks cross-namespace mistakes without leaking the
+        existence of the row in the other namespace.
+
+        The optional ``expected_subnet_id`` adds an extra binding check
+        — Slice 2.3's route layer extracts the subnet from the URL,
+        and a request_id that exists but belongs to a different subnet
+        MUST return the same 404 (same anti-existence-leak reason).
+        """
+        repo = self._require_join_repo()
+        row = await repo.find_by_id(request_id)
+
+        # Single 404 surface for "doesn't exist" AND "wrong kind" AND
+        # "wrong subnet" — see method docstring for the reasoning.
+        if (
+            row is None
+            or row.kind != expected_kind
+            or (expected_subnet_id is not None and row.subnet_id != expected_subnet_id)
+        ):
+            if expected_kind == "invitation":
+                raise InvitationNotFoundError(request_id)
+            raise JoinRequestNotFoundError(request_id)
+        return row
+
+    async def _save_decided_transition(
+        self,
+        pending: SubnetJoinRequest,
+        *,
+        new_status: Literal["approved", "rejected", "withdrawn"],
+        decided_by: str,
+        note: str | None,
+    ) -> SubnetJoinRequest:
+        """Construct + persist the post-CAS row.
+
+        Building a fresh entity via ``dataclasses.replace`` re-runs
+        ``SubnetJoinRequest.__post_init__``, which verifies the full
+        invariant set (decided_by / decided_at / status coherence,
+        note length cap, etc.). A direct field flip + save would
+        silently bypass that check and let a future bug persist a
+        structurally-impossible row.
+
+        Caller is responsible for raising the ``*AlreadyDecided``
+        error when ``pending.is_pending`` is false — this helper
+        assumes the CAS pre-check already passed.
+        """
+        decided = dataclasses.replace(
+            pending,
+            status=new_status,
+            decided_by=decided_by,
+            decided_at=datetime.now(UTC),
+            note=note if note is not None else pending.note,
+        )
+        repo = self._require_join_repo()
+        await repo.save(decided)
+        return decided
+
+    # ---- allowlist (no webhook — config, not lifecycle) --------------
+
+    async def add_allowlist(
+        self, subnet_id: str, agent_id: str, *, added_by: str
+    ) -> SubnetAllowlist:
+        """Pre-authorise ``agent_id`` for ``subnet_id``'s admission allowlist.
+
+        Idempotency: ``IRepo.add`` returns ``False`` on a duplicate
+        pair; we surface this as :class:`AllowlistEntryExistsError`
+        (409 ``ALREADY_ON_ALLOWLIST``) so the route layer can return
+        409 on duplicate vs 201 on fresh insert per ADR §"Allowlist
+        endpoints". The legacy "silently no-op on duplicate" shape is
+        deliberately NOT used — duplicate adds are likely a UI bug
+        worth surfacing.
+
+        No webhook fired (ADR §"Webhook event catalogue": allowlist
+        configuration changes do not emit webhooks).
+
+        Args:
+            subnet_id: Target subnet identifier (must exist).
+            agent_id: Agent to pre-authorise (route layer has already
+                verified the agent_id exists in the registry per ADR
+                §"SubnetAllowlist schema").
+            added_by: Owner agent_id performing the add — recorded in
+                the audit field of the new row.
+
+        Raises:
+            SubnetNotFoundException: Target subnet missing.
+            AllowlistEntryExistsError: Pair already on the allowlist.
+        """
+        await self.get_subnet(subnet_id)
+        repo = self._require_allowlist_repo()
+        entry = SubnetAllowlist(
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            added_by=added_by,
+            added_at=datetime.now(UTC),
+        )
+        inserted = await repo.add(entry)
+        if not inserted:
+            raise AllowlistEntryExistsError(subnet_id, agent_id)
+        logger.info(
+            "subnet_allowlist_added",
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            added_by=added_by,
+        )
+        return entry
+
+    async def remove_allowlist(self, subnet_id: str, agent_id: str, *, remover: str) -> bool:
+        """Remove ``(subnet_id, agent_id)`` from the admission allowlist.
+
+        Idempotent per ADR §"Allowlist endpoints" — removing an absent
+        pair returns ``False`` (the route layer still returns 204).
+        Does NOT evict an already-joined member (ADR §"State machine
+        edges": "Allowlist removal does not evict members"). The
+        ``remover`` arg is kept for audit log symmetry with
+        :meth:`add_allowlist`; no rows reference it (the removed row
+        is, by definition, gone).
+        """
+        await self.get_subnet(subnet_id)
+        repo = self._require_allowlist_repo()
+        removed = await repo.remove(subnet_id, agent_id)
+        logger.info(
+            "subnet_allowlist_removed",
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+            remover=remover,
+            existed=removed,
+        )
+        return removed
+
+    async def list_allowlist(
+        self,
+        subnet_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetAllowlist]:
+        """List allowlist entries for a subnet (owner-only at route layer).
+
+        ADR §"Authorization matrix" makes the read owner-only by
+        design (privacy: leaks pre-authorised relationships). This
+        service method is authz-agnostic — the route layer's
+        ``_require_owner`` enforces the policy; internal callers
+        (e.g. the cascade pre-flight) read without restriction.
+        """
+        await self.get_subnet(subnet_id)
+        repo = self._require_allowlist_repo()
+        return await repo.list_for_subnet(subnet_id, limit=limit, offset=offset)
+
+    # ---- join_request lifecycle (owner approve / reject; applicant withdraw)
+
+    async def approve_join_request(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        owner_id: str,
+        trigger: Literal["explicit", "auto_on_invite"] = "explicit",
+    ) -> SubnetJoinRequest:
+        """CAS pending ``join_request`` → ``approved``; ``add_member`` the agent.
+
+        ``trigger`` defaults to ``"explicit"`` (direct owner approve).
+        :class:`JoinFlowService` and :meth:`invite_agent`'s merge path
+        pass ``"auto_on_invite"`` so the emitted ``JOIN_APPROVED``
+        webhook carries the right ``trigger`` field for ADR
+        §"Merge-path event mapping".
+
+        ``add_member`` runs AFTER the CAS save, inside the same
+        try/finally as the event emission. A failure between save and
+        add_member would leak an approved-but-not-joined row; we
+        accept that risk for Slice 2.2 because the ``add_member``
+        path is in-process and the alternative (wrapping both into
+        the cascade-style UoW) requires PG-only deployments. Issue
+        captured separately if it surfaces in production.
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="join_request",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise JoinRequestAlreadyDecidedError(request_id, row.status)
+
+        approved = await self._save_decided_transition(
+            row,
+            new_status="approved",
+            decided_by=owner_id,
+            note=row.note,
+        )
+        # ``add_member`` returns the post-mutation Subnet entity so
+        # the webhook ``parent_subnet_id`` / ``harness_url`` snapshot
+        # is consistent with the just-applied membership change. No
+        # need for a second ``get_subnet`` round-trip.
+        subnet = await self.add_member(subnet_id, row.agent_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.JOIN_APPROVED,
+            subnet=subnet,
+            request=approved,
+            trigger=trigger,
+        )
+        logger.info(
+            "subnet_join_request_approved",
+            subnet_id=subnet_id,
+            request_id=request_id,
+            agent_id=row.agent_id,
+            owner_id=owner_id,
+            trigger=trigger,
+        )
+        return approved
+
+    async def reject_join_request(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        owner_id: str,
+        note: str | None = None,
+    ) -> SubnetJoinRequest:
+        """CAS pending ``join_request`` → ``rejected``; emit ``JOIN_REJECTED``.
+
+        No membership side-effect. ``note`` is optional per ADR
+        §"Application-side endpoints" (≤500 chars, enforced by
+        :class:`SubnetJoinRequest.__post_init__`).
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="join_request",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise JoinRequestAlreadyDecidedError(request_id, row.status)
+
+        rejected = await self._save_decided_transition(
+            row, new_status="rejected", decided_by=owner_id, note=note
+        )
+        subnet = await self.get_subnet(subnet_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.JOIN_REJECTED,
+            subnet=subnet,
+            request=rejected,
+        )
+        logger.info(
+            "subnet_join_request_rejected",
+            subnet_id=subnet_id,
+            request_id=request_id,
+            owner_id=owner_id,
+        )
+        return rejected
+
+    async def withdraw_join_request(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        applicant_id: str,
+        note: str | None = None,
+    ) -> SubnetJoinRequest:
+        """CAS pending ``join_request`` → ``withdrawn`` (applicant-initiated).
+
+        Owner-side cancel does not exist for ``join_request`` rows —
+        ADR §"Application-side endpoints" gives the owner only the
+        approve / reject verbs. Applicant withdraw is its own path
+        (DELETE /join-requests/{rid}) and emits ``JOIN_WITHDRAWN``.
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="join_request",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise JoinRequestAlreadyDecidedError(request_id, row.status)
+
+        withdrawn = await self._save_decided_transition(
+            row,
+            new_status="withdrawn",
+            decided_by=applicant_id,
+            note=note,
+        )
+        subnet = await self.get_subnet(subnet_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.JOIN_WITHDRAWN,
+            subnet=subnet,
+            request=withdrawn,
+        )
+        logger.info(
+            "subnet_join_request_withdrawn",
+            subnet_id=subnet_id,
+            request_id=request_id,
+            applicant_id=applicant_id,
+        )
+        return withdrawn
+
+    # ---- invitation lifecycle (owner invite / cancel; invitee accept / reject)
+
+    async def invite_agent(
+        self,
+        subnet_id: str,
+        target_agent_id: str,
+        *,
+        owner_id: str,
+        note: str | None = None,
+    ) -> InviteAgentResult:
+        """Send an invitation, or merge-approve a target's pending join_request.
+
+        Per ADR §"POST /invitations" the call has two outcomes:
+
+        - **Normal path** — no membership / pending row collision. A
+          fresh ``kind='invitation', status='pending'`` row is created
+          and ``INVITATION_SENT`` fires. Result variant
+          :class:`InviteAgentSentResult`.
+        - **Merge path** — the target agent already has a pending
+          ``kind='join_request'`` row. The invite is semantically an
+          owner "yes" to the agent's pending ask: the existing row is
+          CAS'd to ``approved`` (``decided_by=owner_id``,
+          ``trigger=auto_on_invite``), the agent is added as a member,
+          ``JOIN_APPROVED`` fires (NOT ``INVITATION_SENT`` — no new
+          row exists). Result variant
+          :class:`InviteAgentMergedToApprovedJoinRequestResult`.
+
+        Pre-checks (ADR §State machine edges):
+
+        - Target is already a subnet member → 409 ``ALREADY_MEMBER``.
+        - Target already has a pending invitation → 409
+          ``INVITATION_PENDING`` with the existing ``invitation_id``.
+
+        The pending-join-request collision is the merge path above,
+        NOT a 409 — that's the asymmetry ADR §"Merge path" pins.
+        """
+        from ..core.exceptions import InvitationPendingError
+
+        subnet = await self.get_subnet(subnet_id)
+        if target_agent_id in subnet.member_agent_ids:
+            raise AlreadyMemberError(subnet_id, target_agent_id)
+
+        repo = self._require_join_repo()
+        existing = await repo.find_pending_for(subnet_id, target_agent_id)
+        if existing is not None:
+            if existing.kind == "invitation":
+                # Duplicate invitation — ADR §State machine edges
+                # "Duplicate invitation": 409 + echo existing id.
+                raise InvitationPendingError(existing.request_id)
+            if existing.kind == "join_request":
+                # Merge path — invite collapses into auto-approval
+                # of the agent's pending ask.
+                approved = await self.approve_join_request(
+                    subnet_id,
+                    existing.request_id,
+                    owner_id=owner_id,
+                    trigger="auto_on_invite",
+                )
+                logger.info(
+                    "subnet_invitation_merged_into_join_request",
+                    subnet_id=subnet_id,
+                    request_id=approved.request_id,
+                    agent_id=target_agent_id,
+                    owner_id=owner_id,
+                )
+                return InviteAgentMergedToApprovedJoinRequestResult(
+                    subnet_id=subnet_id,
+                    agent_id=target_agent_id,
+                    request=approved,
+                )
+            # ``allowlist_auto`` rows are never pending (born
+            # approved); reaching this branch means data corruption,
+            # not a state-machine edge. Fail loud.
+            raise RuntimeError(
+                f"pending row for ({subnet_id}, {target_agent_id}) has "
+                f"unexpected kind={existing.kind!r}"
+            )
+
+        invitation = SubnetJoinRequest(
+            request_id=self._new_request_id(),
+            subnet_id=subnet_id,
+            agent_id=target_agent_id,
+            kind="invitation",
+            status="pending",
+            initiated_by=owner_id,
+            note=note,
+        )
+        await repo.save(invitation)
+        await self.event_publisher.publish(
+            JoinFlowEventType.INVITATION_SENT,
+            subnet=subnet,
+            request=invitation,
+        )
+        logger.info(
+            "subnet_invitation_sent",
+            subnet_id=subnet_id,
+            invitation_id=invitation.request_id,
+            target_agent_id=target_agent_id,
+            owner_id=owner_id,
+        )
+        return InviteAgentSentResult(
+            subnet_id=subnet_id,
+            agent_id=target_agent_id,
+            invitation=invitation,
+        )
+
+    async def accept_invitation(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        invitee_id: str,
+        trigger: Literal["explicit", "auto_on_join"] = "explicit",
+        via: Literal["self_join", "allowlist"] | None = None,
+    ) -> SubnetJoinRequest:
+        """CAS pending ``invitation`` → ``approved``; ``add_member`` the invitee.
+
+        ``trigger`` / ``via`` are the merge-path hooks
+        :class:`JoinFlowService` uses (branches 3 and 4 in ADR
+        §join). Direct invitee accept uses the defaults; ``via=None``
+        on explicit accepts matches ADR §"Payload shape".
+
+        Note: ``decided_by=invitee_id`` for direct accept and
+        ``decided_by=SYSTEM_ALLOWLIST_ACTOR`` only when the caller
+        explicitly passes it (branch 4 — allowlist merge). The
+        webhook publisher reads the row's ``decided_by`` field, so
+        passing the right value here is what makes the
+        ``"system:allowlist"`` token surface in the payload.
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="invitation",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise InvitationAlreadyDecidedError(request_id, row.status)
+
+        decided_by = SYSTEM_ALLOWLIST_ACTOR if via == "allowlist" else invitee_id
+        accepted = await self._save_decided_transition(
+            row, new_status="approved", decided_by=decided_by, note=row.note
+        )
+        # See ``approve_join_request`` for the same add_member →
+        # webhook ordering reasoning.
+        subnet = await self.add_member(subnet_id, row.agent_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.INVITATION_ACCEPTED,
+            subnet=subnet,
+            request=accepted,
+            trigger=trigger,
+            via=via,
+        )
+        logger.info(
+            "subnet_invitation_accepted",
+            subnet_id=subnet_id,
+            invitation_id=request_id,
+            invitee_id=invitee_id,
+            trigger=trigger,
+            via=via,
+        )
+        return accepted
+
+    async def reject_invitation(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        invitee_id: str,
+        note: str | None = None,
+    ) -> SubnetJoinRequest:
+        """CAS pending ``invitation`` → ``rejected`` (invitee-initiated).
+
+        ``INVITATION_REJECTED`` fires; no membership change.
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="invitation",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise InvitationAlreadyDecidedError(request_id, row.status)
+
+        rejected = await self._save_decided_transition(
+            row, new_status="rejected", decided_by=invitee_id, note=note
+        )
+        subnet = await self.get_subnet(subnet_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.INVITATION_REJECTED,
+            subnet=subnet,
+            request=rejected,
+        )
+        logger.info(
+            "subnet_invitation_rejected",
+            subnet_id=subnet_id,
+            invitation_id=request_id,
+            invitee_id=invitee_id,
+        )
+        return rejected
+
+    async def cancel_invitation(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        owner_id: str,
+        note: str | None = None,
+    ) -> SubnetJoinRequest:
+        """CAS pending ``invitation`` → ``withdrawn`` (owner-initiated cancel).
+
+        Owner-side counterpart of :meth:`withdraw_join_request`.
+        Emits ``INVITATION_CANCELED`` per ADR §"Webhook event
+        catalogue".
+        """
+        await self.get_subnet(subnet_id)
+        row = await self._load_join_request_or_404(
+            request_id,
+            expected_kind="invitation",
+            expected_subnet_id=subnet_id,
+        )
+        if not row.is_pending:
+            raise InvitationAlreadyDecidedError(request_id, row.status)
+
+        canceled = await self._save_decided_transition(
+            row, new_status="withdrawn", decided_by=owner_id, note=note
+        )
+        subnet = await self.get_subnet(subnet_id)
+        await self.event_publisher.publish(
+            JoinFlowEventType.INVITATION_CANCELED,
+            subnet=subnet,
+            request=canceled,
+        )
+        logger.info(
+            "subnet_invitation_canceled",
+            subnet_id=subnet_id,
+            invitation_id=request_id,
+            owner_id=owner_id,
+        )
+        return canceled
+
+    # ---- read paths (Slice 2.3 routes wrap these) --------------------
+
+    async def list_join_requests(
+        self,
+        subnet_id: str,
+        *,
+        kind: Literal["join_request", "allowlist_auto"] = "join_request",
+        status: Literal["pending", "approved", "rejected", "withdrawn"] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetJoinRequest]:
+        """List join_request / allowlist_auto rows for a subnet.
+
+        ADR §"Application-side endpoints" forbids ``kind='invitation'``
+        on this path; we DO NOT enforce that here so internal callers
+        can list everything if they need to. Slice 2.3's route layer
+        rejects ``kind=invitation`` at the request-parse boundary
+        with ``400 INVALID_KIND_FILTER``.
+        """
+        await self.get_subnet(subnet_id)
+        repo = self._require_join_repo()
+        return await repo.list_by_subnet(
+            subnet_id, kind=kind, status=status, limit=limit, offset=offset
+        )
+
+    async def list_invitations(
+        self,
+        subnet_id: str,
+        *,
+        status: Literal["pending", "approved", "rejected", "withdrawn"] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[SubnetJoinRequest]:
+        """List invitation rows for a subnet (owner-only at route layer)."""
+        await self.get_subnet(subnet_id)
+        repo = self._require_join_repo()
+        return await repo.list_by_subnet(
+            subnet_id,
+            kind="invitation",
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def list_pending_invitations_for_agent(self, agent_id: str) -> list[SubnetJoinRequest]:
+        """Cross-subnet view: the agent's pending invitations.
+
+        Powers the invitee-facing
+        ``GET /agents/{a}/subnet-invitations`` per ADR
+        §"Invitation-side endpoints".
+        """
+        repo = self._require_join_repo()
+        return await repo.list_pending_invitations_for_agent(agent_id)

--- a/tests/services/test_join_flow_foundations.py
+++ b/tests/services/test_join_flow_foundations.py
@@ -1,0 +1,347 @@
+"""Foundation contract tests — ADR-0004 Phase 2 Slice 2.2.
+
+Pins the shapes of the four building blocks Slice 2.2's domain
+layer rests on:
+
+1. :class:`acn.core.interfaces.JoinFlowEventType` — the canonical
+   ADR §"Webhook event catalogue" string values (the Slice-2.4
+   mapping into ``WebhookEventType`` is a verbatim string lookup,
+   so a typo here would silently desync the two enums).
+
+2. :class:`acn.core.interfaces.IJoinFlowEventPublisher` — abstract
+   port + the no-op implementation Slice 2.2 binds in
+   ``api.py``. Verifies the port is genuinely abstract (you can't
+   call ``publish`` on the base) and the no-op short-circuits to
+   debug logging without raising.
+
+3. :mod:`acn.services._join_flow_result` — the five
+   sealed-union variants ``JoinFlowService.join_subnet`` returns,
+   and the matching ``via`` discriminator on the
+   invitation-merge variant.
+
+4. ADR-0004 join-flow exception hierarchy in
+   :mod:`acn.core.exceptions` — each subclass surfaces a stable
+   ``reason`` slug and the right attribute fields for the route
+   layer to echo in 4xx responses.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.exceptions import (
+    ACNException,
+    AllowlistEntryExistsError,
+    AlreadyMemberError,
+    InvitationAlreadyDecidedError,
+    InvitationNotFoundError,
+    InvitationPendingError,
+    JoinFlowError,
+    JoinRequestAlreadyDecidedError,
+    JoinRequestNotFoundError,
+    JoinRequestPendingError,
+)
+from acn.core.interfaces import (
+    IJoinFlowEventPublisher,
+    JoinFlowEventType,
+)
+from acn.services._join_flow_result import (
+    JoinFlowAllowlistAutoApprovedResult,
+    JoinFlowAutoAcceptedInvitationResult,
+    JoinFlowJoinedAsOwnerResult,
+    JoinFlowJoinedOpenResult,
+    JoinFlowPendingResult,
+)
+from acn.services._no_op_join_flow_event_publisher import (
+    NoOpJoinFlowEventPublisher,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _subnet(subnet_id: str = "s-1", owner: str = "alice") -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _pending_request(
+    request_id: str = "rq-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+    kind: str = "join_request",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind=kind,
+        status="pending",
+        initiated_by=agent_id if kind == "join_request" else "alice",
+    )
+
+
+# ---------------------------------------------------------------------------
+# JoinFlowEventType — canonical string values
+# ---------------------------------------------------------------------------
+
+
+class TestJoinFlowEventType:
+    """The eight event-type values MUST match ADR §"Webhook event
+    catalogue" verbatim — Slice 2.4's webhook publisher does a
+    string-equality lookup against the larger
+    :class:`WebhookEventType` enum, so any drift would cause silent
+    no-ops in production rather than a loud test failure."""
+
+    def test_eight_canonical_event_values(self) -> None:
+        # Order doesn't matter; values do. Pin every one.
+        actual = {member.value for member in JoinFlowEventType}
+        expected = {
+            "subnet.join_requested",
+            "subnet.join_approved",
+            "subnet.join_rejected",
+            "subnet.join_withdrawn",
+            "subnet.invitation_sent",
+            "subnet.invitation_accepted",
+            "subnet.invitation_rejected",
+            "subnet.invitation_canceled",
+        }
+        assert actual == expected
+
+    def test_str_enum_yields_string_at_call_sites(self) -> None:
+        # StrEnum members ARE strings — webhook send_to expects a
+        # WebhookEventType which is also StrEnum, so the Slice-2.4
+        # bridge will compare member.value across enums.
+        assert JoinFlowEventType.JOIN_APPROVED == "subnet.join_approved"
+        assert str(JoinFlowEventType.JOIN_APPROVED) == "subnet.join_approved"
+
+
+# ---------------------------------------------------------------------------
+# IJoinFlowEventPublisher + NoOpJoinFlowEventPublisher
+# ---------------------------------------------------------------------------
+
+
+class TestIJoinFlowEventPublisher:
+    def test_abstract_base_cannot_be_instantiated(self) -> None:
+        with pytest.raises(TypeError):
+            IJoinFlowEventPublisher()  # type: ignore[abstract]
+
+
+class TestNoOpJoinFlowEventPublisher:
+    """The Slice-2.2 no-op stub is the production publisher until
+    Slice 2.4 lands the real webhook adapter. It must satisfy the
+    interface trivially and never raise — both ``join_subnet`` and
+    the eight ``SubnetService`` transition methods call it without
+    a try/except guard."""
+
+    def test_satisfies_interface(self) -> None:
+        publisher = NoOpJoinFlowEventPublisher()
+        assert isinstance(publisher, IJoinFlowEventPublisher)
+
+    @pytest.mark.asyncio
+    async def test_publish_returns_none_and_does_not_raise(self) -> None:
+        publisher = NoOpJoinFlowEventPublisher()
+        result = await publisher.publish(
+            JoinFlowEventType.JOIN_APPROVED,
+            subnet=_subnet(),
+            request=_pending_request(),
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_publish_logs_at_debug_level_with_canonical_fields(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # structlog routes through stdlib logging at the root; the
+        # debug breadcrumb is what operators rely on for "Slice 2.2
+        # deployment, no webhook fired" audit forensics — pin its
+        # presence (without overspecifying the formatter).
+        publisher = NoOpJoinFlowEventPublisher()
+        publisher_logger = MagicMock()
+        from acn.services import _no_op_join_flow_event_publisher as mod
+
+        original = mod.logger
+        mod.logger = publisher_logger
+        try:
+            await publisher.publish(
+                JoinFlowEventType.INVITATION_ACCEPTED,
+                subnet=_subnet("s-7"),
+                request=_pending_request(
+                    "rq-9", subnet_id="s-7", agent_id="bob", kind="invitation"
+                ),
+                trigger="auto_on_join",
+                via="self_join",
+            )
+        finally:
+            mod.logger = original
+
+        publisher_logger.debug.assert_called_once()
+        kwargs = publisher_logger.debug.call_args.kwargs
+        # ``join_flow_event`` rather than ``event`` — structlog
+        # reserves the ``event`` keyword for the log message.
+        assert kwargs["join_flow_event"] == "subnet.invitation_accepted"
+        assert kwargs["subnet_id"] == "s-7"
+        assert kwargs["request_id"] == "rq-9"
+        assert kwargs["agent_id"] == "bob"
+        assert kwargs["trigger"] == "auto_on_join"
+        assert kwargs["via"] == "self_join"
+
+
+# ---------------------------------------------------------------------------
+# JoinFlowResult sealed union
+# ---------------------------------------------------------------------------
+
+
+class TestJoinFlowResultVariants:
+    """Five variants cover the six §join branches (branches 3 and 4
+    share the invitation-auto-accept variant, distinguished by the
+    ``via`` discriminator). The route layer matches on these types
+    exhaustively in Slice 2.3, so any rename / reshape here breaks
+    a downstream pattern-match."""
+
+    def test_joined_open_branch_1(self) -> None:
+        result = JoinFlowJoinedOpenResult(subnet_id="s-1", agent_id="bob")
+        assert result.subnet_id == "s-1"
+        assert result.agent_id == "bob"
+
+    def test_joined_as_owner_branch_2(self) -> None:
+        result = JoinFlowJoinedAsOwnerResult(subnet_id="s-1", agent_id="alice")
+        assert result.subnet_id == "s-1"
+        assert result.agent_id == "alice"
+
+    def test_auto_accepted_invitation_via_self_join_branch_3(self) -> None:
+        invite = _pending_request(kind="invitation")
+        result = JoinFlowAutoAcceptedInvitationResult(
+            subnet_id="s-1",
+            agent_id="bob",
+            invitation=invite,
+            via="self_join",
+        )
+        assert result.via == "self_join"
+        assert result.invitation is invite
+
+    def test_auto_accepted_invitation_via_allowlist_branch_4(self) -> None:
+        invite = _pending_request(kind="invitation")
+        result = JoinFlowAutoAcceptedInvitationResult(
+            subnet_id="s-1",
+            agent_id="bob",
+            invitation=invite,
+            via="allowlist",
+        )
+        assert result.via == "allowlist"
+
+    def test_allowlist_auto_approved_branch_5(self) -> None:
+        req = SubnetJoinRequest(
+            request_id="rq-1",
+            subnet_id="s-1",
+            agent_id="bob",
+            kind="allowlist_auto",
+            status="approved",
+            initiated_by="system:allowlist",
+            decided_by="system:allowlist",
+            decided_at=datetime.now(UTC),
+        )
+        result = JoinFlowAllowlistAutoApprovedResult(subnet_id="s-1", agent_id="bob", request=req)
+        assert result.request.kind == "allowlist_auto"
+        assert result.request.status == "approved"
+
+    def test_pending_branch_6(self) -> None:
+        req = _pending_request()
+        result = JoinFlowPendingResult(subnet_id="s-1", agent_id="bob", request=req)
+        assert result.request.status == "pending"
+
+    def test_variants_are_frozen(self) -> None:
+        # Frozen dataclass — protects against accidental mutation
+        # at the route ↔ service boundary.
+        result = JoinFlowJoinedOpenResult(subnet_id="s-1", agent_id="bob")
+        with pytest.raises((AttributeError, Exception)):
+            result.subnet_id = "s-2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy (8 join-flow rejections)
+# ---------------------------------------------------------------------------
+
+
+class TestJoinFlowExceptions:
+    """Every join-flow rejection inherits :class:`JoinFlowError` so
+    the route layer's ``_join_flow_error_to_acn`` mapper can
+    isinstance-dispatch on the base; the per-subclass attribute
+    fields (``existing_request_id`` / ``current_status`` /
+    ``subnet_id`` / ``agent_id``) are what the route echoes into
+    the 4xx response body."""
+
+    def test_join_flow_error_inherits_acn_exception(self) -> None:
+        # Base hierarchy keeps the catch-all handler in ``api.py``
+        # working (any unhandled ACNException → 500 with a
+        # canonical envelope).
+        assert issubclass(JoinFlowError, ACNException)
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            JoinRequestPendingError,
+            InvitationPendingError,
+            JoinRequestAlreadyDecidedError,
+            InvitationAlreadyDecidedError,
+            AlreadyMemberError,
+            AllowlistEntryExistsError,
+            JoinRequestNotFoundError,
+            InvitationNotFoundError,
+        ],
+    )
+    def test_each_subclass_inherits_join_flow_error(self, exc_cls: type[JoinFlowError]) -> None:
+        assert issubclass(exc_cls, JoinFlowError)
+
+    def test_join_request_pending_carries_existing_id_and_stable_reason(self) -> None:
+        err = JoinRequestPendingError("rq-1")
+        assert err.existing_request_id == "rq-1"
+        assert err.reason == "join_request_pending"
+
+    def test_invitation_pending_carries_existing_id_and_stable_reason(self) -> None:
+        err = InvitationPendingError("inv-1")
+        assert err.existing_invitation_id == "inv-1"
+        assert err.reason == "invitation_pending"
+
+    def test_join_request_already_decided_carries_status(self) -> None:
+        err = JoinRequestAlreadyDecidedError("rq-1", "approved")
+        assert err.request_id == "rq-1"
+        assert err.current_status == "approved"
+        assert err.reason == "join_request_already_decided"
+
+    def test_invitation_already_decided_carries_status(self) -> None:
+        err = InvitationAlreadyDecidedError("inv-1", "rejected")
+        assert err.invitation_id == "inv-1"
+        assert err.current_status == "rejected"
+        assert err.reason == "invitation_already_decided"
+
+    def test_already_member_carries_subnet_and_agent(self) -> None:
+        err = AlreadyMemberError("s-1", "bob")
+        assert err.subnet_id == "s-1"
+        assert err.agent_id == "bob"
+        assert err.reason == "already_member"
+
+    def test_allowlist_entry_exists_carries_subnet_and_agent(self) -> None:
+        err = AllowlistEntryExistsError("s-1", "bob")
+        assert err.subnet_id == "s-1"
+        assert err.agent_id == "bob"
+        assert err.reason == "already_on_allowlist"
+
+    def test_join_request_not_found_carries_request_id(self) -> None:
+        err = JoinRequestNotFoundError("rq-1")
+        assert err.request_id == "rq-1"
+        assert err.reason == "join_request_not_found"
+
+    def test_invitation_not_found_carries_invitation_id(self) -> None:
+        err = InvitationNotFoundError("inv-1")
+        assert err.invitation_id == "inv-1"
+        assert err.reason == "invitation_not_found"

--- a/tests/services/test_join_flow_service.py
+++ b/tests/services/test_join_flow_service.py
@@ -1,0 +1,520 @@
+"""JoinFlowService — six-branch decision tree tests (ADR-0004 Slice 2.2).
+
+Each of the six branches in ADR §"POST /api/v1/agents/{agent_id}/
+subnets/{subnet_id} (join entry)" is verified with its happy path
+plus the relevant ``State machine edges`` markers from the ADR.
+
+Branch matrix:
+
+| # | join_policy | caller relationship                         | result                                         |
+|---|-------------|---------------------------------------------|------------------------------------------------|
+| 1 | open        | any                                         | JoinFlowJoinedOpenResult                       |
+| 2 | approval    | caller == owner                             | JoinFlowJoinedAsOwnerResult                    |
+| 3 | approval    | pending invitation, NOT allowlisted         | JoinFlowAutoAcceptedInvitationResult(self_join)|
+| 4 | approval    | pending invitation AND allowlisted          | JoinFlowAutoAcceptedInvitationResult(allowlist)|
+| 5 | approval    | allowlisted, no pending invitation          | JoinFlowAllowlistAutoApprovedResult            |
+| 6 | approval    | not owner / not allowlisted / no pending    | JoinFlowPendingResult                          |
+
+State-machine edges covered:
+
+* "Owner self-joins their own subnet"          → branch 2 fast-path
+* "Invitation pending when agent self-joins"   → branch 3 auto-accept
+* "Allowlist hit AND pending invitation"       → branch 4 (invitation wins)
+* "Allowlist removal then leave then rejoin"   → branch 6 (rejoin path)
+* "Agent self-join already a member"           → 409 ALREADY_MEMBER
+* "Duplicate join request"                     → 409 JOIN_REQUEST_PENDING
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.entities.subnet_join_request import SYSTEM_ALLOWLIST_ACTOR
+from acn.core.exceptions import (
+    AlreadyMemberError,
+    JoinRequestPendingError,
+)
+from acn.core.interfaces import (
+    IJoinFlowEventPublisher,
+    ISubnetAllowlistRepository,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+    JoinFlowEventType,
+)
+from acn.services._join_flow_result import (
+    JoinFlowAllowlistAutoApprovedResult,
+    JoinFlowAutoAcceptedInvitationResult,
+    JoinFlowJoinedAsOwnerResult,
+    JoinFlowJoinedOpenResult,
+    JoinFlowPendingResult,
+)
+from acn.services.join_flow_service import JoinFlowService
+from acn.services.subnet_service import SubnetService
+
+
+def _subnet(
+    subnet_id: str = "s-1",
+    owner: str = "alice",
+    join_policy: str = "approval",
+    members: set[str] | None = None,
+    is_private: bool = False,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        is_private=is_private,
+        join_policy=join_policy,
+        created_at=datetime.now(UTC),
+        member_agent_ids=members if members is not None else {owner},
+    )
+
+
+def _pending_invitation(
+    request_id: str = "inv-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="invitation",
+        status="pending",
+        initiated_by="alice",
+    )
+
+
+def _pending_join_request(
+    request_id: str = "rq-OLD",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="join_request",
+        status="pending",
+        initiated_by=agent_id,
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_id.return_value = _subnet()
+    return repo
+
+
+@pytest.fixture
+def mock_join_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetJoinRequestRepository)
+    repo.find_pending_for.return_value = None
+    return repo
+
+
+@pytest.fixture
+def mock_allowlist_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetAllowlistRepository)
+    repo.is_member.return_value = False
+    return repo
+
+
+@pytest.fixture
+def mock_publisher() -> MagicMock:
+    publisher = MagicMock(spec=IJoinFlowEventPublisher)
+    publisher.publish = AsyncMock()
+    return publisher
+
+
+@pytest.fixture
+def subnet_service(
+    mock_subnet_repo: AsyncMock,
+    mock_join_repo: AsyncMock,
+    mock_allowlist_repo: AsyncMock,
+    mock_publisher: MagicMock,
+) -> SubnetService:
+    # The JoinFlowService composes over SubnetService; share the
+    # same publisher / repos so a test can introspect a single
+    # event-emit chain regardless of which service emitted.
+    return SubnetService(
+        subnet_repository=mock_subnet_repo,
+        subnet_join_request_repository=mock_join_repo,
+        subnet_allowlist_repository=mock_allowlist_repo,
+        join_flow_event_publisher=mock_publisher,
+    )
+
+
+@pytest.fixture
+def service(
+    subnet_service: SubnetService,
+    mock_join_repo: AsyncMock,
+    mock_allowlist_repo: AsyncMock,
+    mock_publisher: MagicMock,
+) -> JoinFlowService:
+    return JoinFlowService(
+        subnet_service=subnet_service,
+        join_request_repository=mock_join_repo,
+        allowlist_repository=mock_allowlist_repo,
+        event_publisher=mock_publisher,
+    )
+
+
+# ============================================================
+# Branch 1 — open subnet
+# ============================================================
+
+
+class TestBranch1Open:
+    @pytest.mark.asyncio
+    async def test_open_subnet_immediate_join_no_request_row(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        mock_subnet_repo.find_by_id.return_value = _subnet(join_policy="open")
+
+        result = await service.join_subnet("s-1", "bob")
+
+        assert isinstance(result, JoinFlowJoinedOpenResult)
+        assert result.subnet_id == "s-1"
+        assert result.agent_id == "bob"
+
+        # NO row created in subnet_join_requests.
+        mock_join_repo.save.assert_not_called()
+
+        # NO webhook published — open joins are implicit (no
+        # lifecycle event in ADR §"Webhook event catalogue").
+        mock_publisher.publish.assert_not_called()
+
+        # add_member ran — subnet saved.
+        mock_subnet_repo.save.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_open_subnet_owner_takes_branch_1_not_2(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+    ) -> None:
+        # ADR §join "branch order matters" — open + owner self-join
+        # takes branch 1 (the open check is first).
+        subnet = _subnet(join_policy="open", owner="alice", members={"alice"})
+        subnet.member_agent_ids = set()  # owner not yet in members
+        mock_subnet_repo.find_by_id.return_value = subnet
+
+        result = await service.join_subnet("s-1", "alice")
+        assert isinstance(result, JoinFlowJoinedOpenResult)
+
+
+# ============================================================
+# Branch 2 — approval + caller is owner
+# ============================================================
+
+
+class TestBranch2OwnerSelfJoin:
+    @pytest.mark.asyncio
+    async def test_owner_self_join_bypasses_request_table(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        # ADR §State machine edges "Owner self-joins their own
+        # subnet". Owner is canonically a member from creation
+        # already, but defence-in-depth on direct join calls.
+        subnet = _subnet(join_policy="approval", owner="alice")
+        subnet.member_agent_ids = set()
+        mock_subnet_repo.find_by_id.return_value = subnet
+
+        result = await service.join_subnet("s-1", "alice")
+
+        assert isinstance(result, JoinFlowJoinedAsOwnerResult)
+        mock_join_repo.save.assert_not_called()
+        mock_publisher.publish.assert_not_called()
+
+
+# ============================================================
+# Branch 3 — approval + pending invitation (NOT allowlisted)
+# ============================================================
+
+
+class TestBranch3InvitationSelfJoin:
+    @pytest.mark.asyncio
+    async def test_pending_invitation_auto_accept_via_self_join(
+        self,
+        service: JoinFlowService,
+        mock_join_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        invite = _pending_invitation()
+        mock_join_repo.find_pending_for.return_value = invite
+        mock_join_repo.find_by_id.return_value = invite
+        mock_allowlist_repo.is_member.return_value = False
+
+        result = await service.join_subnet("s-1", "bob")
+
+        assert isinstance(result, JoinFlowAutoAcceptedInvitationResult)
+        assert result.via == "self_join"
+        assert result.invitation.status == "approved"
+        # decided_by is the invitee (NOT system:allowlist) for
+        # plain self-join — see ADR §State transition table.
+        assert result.invitation.decided_by == "bob"
+
+        # INVITATION_ACCEPTED fired with trigger=auto_on_join,
+        # via=self_join.
+        mock_publisher.publish.assert_awaited_once()
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.INVITATION_ACCEPTED
+        assert call.kwargs["trigger"] == "auto_on_join"
+        assert call.kwargs["via"] == "self_join"
+
+
+# ============================================================
+# Branch 4 — approval + allowlist hit AND pending invitation
+# ============================================================
+
+
+class TestBranch4InvitationWithAllowlistMerge:
+    @pytest.mark.asyncio
+    async def test_invitation_wins_over_allowlist_auto(
+        self,
+        service: JoinFlowService,
+        mock_join_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        # ADR §State machine edges "Allowlist hit AND pending
+        # invitation". Crucial: NO allowlist_auto row created.
+        # The invitation is the one row that survives, with
+        # decided_by='system:allowlist'.
+        invite = _pending_invitation()
+        mock_join_repo.find_pending_for.return_value = invite
+        mock_join_repo.find_by_id.return_value = invite
+        mock_allowlist_repo.is_member.return_value = True
+
+        result = await service.join_subnet("s-1", "bob")
+
+        assert isinstance(result, JoinFlowAutoAcceptedInvitationResult)
+        assert result.via == "allowlist"
+        # ADR §Merge-path event mapping pins decided_by to
+        # 'system:allowlist' on this specific path.
+        assert result.invitation.decided_by == SYSTEM_ALLOWLIST_ACTOR
+
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.INVITATION_ACCEPTED
+        assert call.kwargs["via"] == "allowlist"
+
+        # The save count: only the invitation's transition was
+        # written (CAS to approved). No separate allowlist_auto row.
+        # The mock counts each save() call — one CAS transition.
+        assert mock_join_repo.save.await_count == 1
+
+
+# ============================================================
+# Branch 5 — approval + allowlisted (no pending invitation)
+# ============================================================
+
+
+class TestBranch5AllowlistAutoApproved:
+    @pytest.mark.asyncio
+    async def test_allowlist_creates_born_approved_row(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        mock_allowlist_repo.is_member.return_value = True
+
+        result = await service.join_subnet("s-1", "bob")
+
+        assert isinstance(result, JoinFlowAllowlistAutoApprovedResult)
+        assert result.request.kind == "allowlist_auto"
+        assert result.request.status == "approved"
+        assert result.request.initiated_by == SYSTEM_ALLOWLIST_ACTOR
+        assert result.request.decided_by == SYSTEM_ALLOWLIST_ACTOR
+
+        # Row saved via join_request_repository.save (NOT the CAS path).
+        mock_join_repo.save.assert_awaited_once()
+
+        # add_member ran.
+        mock_subnet_repo.save.assert_awaited()
+
+        # JOIN_APPROVED fires with trigger=auto_on_join, via=allowlist.
+        # (Not INVITATION_ACCEPTED — there's no invitation here.)
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.JOIN_APPROVED
+        assert call.kwargs["trigger"] == "auto_on_join"
+        assert call.kwargs["via"] == "allowlist"
+
+
+# ============================================================
+# Branch 6 — fallback: create pending join_request
+# ============================================================
+
+
+class TestBranch6PendingJoinRequest:
+    @pytest.mark.asyncio
+    async def test_no_pending_no_allowlist_creates_pending(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        result = await service.join_subnet("s-1", "bob")
+
+        assert isinstance(result, JoinFlowPendingResult)
+        assert result.request.kind == "join_request"
+        assert result.request.status == "pending"
+        assert result.request.initiated_by == "bob"
+
+        # NO add_member on branch 6 — applicant is not yet a member.
+        # add_member would call subnet_repo.save — verify no save fired
+        # on the subnet side.
+        # NOTE: mock_subnet_repo.find_by_id is called (read), but
+        # save isn't. We pin save specifically.
+        mock_subnet_repo.save.assert_not_called()
+
+        # JOIN_REQUESTED fires (the "ask submitted" signal).
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.JOIN_REQUESTED
+
+    @pytest.mark.asyncio
+    async def test_allowlist_removed_then_rejoin_takes_branch_6(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+    ) -> None:
+        # ADR §State machine edges "Allowlist removal then leave
+        # then rejoin". Agent A was on the allowlist, joined,
+        # owner removed A, A leaves, A re-joins → branch 6 (fresh
+        # join_request) because the allowlist no longer matches.
+        # The agent is not currently a member (left earlier).
+        subnet = _subnet(join_policy="approval", members={"alice"})
+        mock_subnet_repo.find_by_id.return_value = subnet
+        mock_allowlist_repo.is_member.return_value = False
+
+        result = await service.join_subnet("s-1", "bob")
+        assert isinstance(result, JoinFlowPendingResult)
+
+
+# ============================================================
+# Cross-cutting state-machine edges
+# ============================================================
+
+
+class TestStateMachineEdges:
+    @pytest.mark.asyncio
+    async def test_agent_already_member_raises_409(
+        self, service: JoinFlowService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        # ADR §State machine edges "Agent self-join a subnet they
+        # are already in" → 409 ALREADY_MEMBER. Checked BEFORE
+        # branch dispatch.
+        subnet = _subnet(join_policy="approval", members={"alice", "bob"})
+        mock_subnet_repo.find_by_id.return_value = subnet
+
+        with pytest.raises(AlreadyMemberError):
+            await service.join_subnet("s-1", "bob")
+
+    @pytest.mark.asyncio
+    async def test_open_subnet_already_member_raises_409(
+        self, service: JoinFlowService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        # Same edge but on an open subnet — the membership check
+        # hoists above the open branch, so even open joins reject
+        # duplicates rather than silently no-op.
+        subnet = _subnet(join_policy="open", members={"alice", "bob"})
+        mock_subnet_repo.find_by_id.return_value = subnet
+        with pytest.raises(AlreadyMemberError):
+            await service.join_subnet("s-1", "bob")
+
+    @pytest.mark.asyncio
+    async def test_pending_join_request_collides_with_self_join(
+        self,
+        service: JoinFlowService,
+        mock_join_repo: AsyncMock,
+    ) -> None:
+        # ADR §State machine edges "Duplicate join request" — agent
+        # has a pending join_request and calls join again. NOT a
+        # silent no-op; 409 with the existing request_id.
+        existing = _pending_join_request(request_id="rq-OLD")
+        mock_join_repo.find_pending_for.return_value = existing
+
+        with pytest.raises(JoinRequestPendingError) as exc_info:
+            await service.join_subnet("s-1", "bob")
+        assert exc_info.value.existing_request_id == "rq-OLD"
+
+
+# ============================================================
+# Branch-order normativity
+# ============================================================
+
+
+class TestBranchOrderNormativity:
+    """ADR §join: "The branch order matters and is normative."
+    These tests pin the precedence so a refactor that reorders
+    the branches loudly fails."""
+
+    @pytest.mark.asyncio
+    async def test_open_beats_owner_check(
+        self, service: JoinFlowService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        # Open + owner — branch 1 (open) wins, NOT branch 2 (owner).
+        subnet = _subnet(join_policy="open", owner="alice")
+        subnet.member_agent_ids = set()
+        mock_subnet_repo.find_by_id.return_value = subnet
+
+        result = await service.join_subnet("s-1", "alice")
+        assert isinstance(result, JoinFlowJoinedOpenResult)
+        assert not isinstance(result, JoinFlowJoinedAsOwnerResult)
+
+    @pytest.mark.asyncio
+    async def test_owner_beats_invitation_check(
+        self,
+        service: JoinFlowService,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+    ) -> None:
+        # Approval + owner + (hypothetical) pending invitation —
+        # branch 2 (owner) wins, NOT branch 3 (invitation).
+        subnet = _subnet(join_policy="approval", owner="alice")
+        subnet.member_agent_ids = set()
+        mock_subnet_repo.find_by_id.return_value = subnet
+        # The owner branch returns before we check find_pending_for,
+        # so we don't need to stub it — but stub anyway for safety.
+        mock_join_repo.find_pending_for.return_value = _pending_invitation(agent_id="alice")
+
+        result = await service.join_subnet("s-1", "alice")
+        assert isinstance(result, JoinFlowJoinedAsOwnerResult)
+
+    @pytest.mark.asyncio
+    async def test_invitation_beats_allowlist_branch(
+        self,
+        service: JoinFlowService,
+        mock_join_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+    ) -> None:
+        # Pending invitation AND on allowlist — branch 4 wins (invite
+        # auto-accept), NOT branch 5 (fresh allowlist_auto row).
+        invite = _pending_invitation()
+        mock_join_repo.find_pending_for.return_value = invite
+        mock_join_repo.find_by_id.return_value = invite
+        mock_allowlist_repo.is_member.return_value = True
+
+        result = await service.join_subnet("s-1", "bob")
+        assert isinstance(result, JoinFlowAutoAcceptedInvitationResult)
+        assert result.via == "allowlist"
+        assert not isinstance(result, JoinFlowAllowlistAutoApprovedResult)

--- a/tests/services/test_subnet_service_allowlist.py
+++ b/tests/services/test_subnet_service_allowlist.py
@@ -1,0 +1,237 @@
+"""SubnetService — admission-allowlist methods (ADR-0004 Slice 2.2).
+
+Covers the three allowlist methods on ``SubnetService``:
+``add_allowlist`` / ``remove_allowlist`` / ``list_allowlist``.
+None of them emit webhooks — ADR §"Webhook event catalogue"
+explicitly excludes allowlist mutations from the lifecycle
+event family.
+
+Authorisation is the route layer's job (Slice 2.3); these tests
+verify pure service behaviour — repo wiring, idempotency,
+existence checks, and the AllowlistEntryExistsError 409 shape.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetAllowlist
+from acn.core.exceptions import (
+    AllowlistEntryExistsError,
+    SubnetNotFoundException,
+)
+from acn.core.interfaces import (
+    ISubnetAllowlistRepository,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+)
+from acn.services._no_op_join_flow_event_publisher import (
+    NoOpJoinFlowEventPublisher,
+)
+from acn.services.subnet_service import SubnetService
+
+
+def _subnet(subnet_id: str = "s-1", owner: str = "alice") -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        created_at=datetime.now(UTC),
+        member_agent_ids={owner},
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_id.return_value = _subnet()
+    return repo
+
+
+@pytest.fixture
+def mock_join_repo() -> AsyncMock:
+    return AsyncMock(spec=ISubnetJoinRequestRepository)
+
+
+@pytest.fixture
+def mock_allowlist_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetAllowlistRepository)
+    repo.add.return_value = True  # default: row inserted (not duplicate)
+    repo.remove.return_value = True
+    repo.list_for_subnet.return_value = []
+    return repo
+
+
+@pytest.fixture
+def service(
+    mock_subnet_repo: AsyncMock,
+    mock_join_repo: AsyncMock,
+    mock_allowlist_repo: AsyncMock,
+) -> SubnetService:
+    return SubnetService(
+        subnet_repository=mock_subnet_repo,
+        subnet_join_request_repository=mock_join_repo,
+        subnet_allowlist_repository=mock_allowlist_repo,
+    )
+
+
+class TestAddAllowlist:
+    @pytest.mark.asyncio
+    async def test_inserts_new_pair_returns_entry(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        entry = await service.add_allowlist("s-1", "bob", added_by="alice")
+
+        assert entry.subnet_id == "s-1"
+        assert entry.agent_id == "bob"
+        assert entry.added_by == "alice"
+        mock_allowlist_repo.add.assert_awaited_once()
+        saved = mock_allowlist_repo.add.await_args.args[0]
+        assert isinstance(saved, SubnetAllowlist)
+        assert saved.subnet_id == "s-1"
+        assert saved.agent_id == "bob"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_raises_allowlist_entry_exists_409(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        # Repo signals "row already existed, no insert performed"
+        mock_allowlist_repo.add.return_value = False
+
+        with pytest.raises(AllowlistEntryExistsError) as exc_info:
+            await service.add_allowlist("s-1", "bob", added_by="alice")
+
+        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.agent_id == "bob"
+        assert exc_info.value.reason == "already_on_allowlist"
+
+    @pytest.mark.asyncio
+    async def test_missing_subnet_raises_404(
+        self, service: SubnetService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        mock_subnet_repo.find_by_id.return_value = None
+
+        with pytest.raises(SubnetNotFoundException):
+            await service.add_allowlist("missing", "bob", added_by="alice")
+
+    @pytest.mark.asyncio
+    async def test_raises_runtime_error_when_repo_missing(
+        self, mock_subnet_repo: AsyncMock
+    ) -> None:
+        # Service constructed without the allowlist repo → fail fast
+        # on first use rather than silently no-op.
+        svc = SubnetService(subnet_repository=mock_subnet_repo)
+        with pytest.raises(RuntimeError, match="allowlist_repository is required"):
+            await svc.add_allowlist("s-1", "bob", added_by="alice")
+
+
+class TestRemoveAllowlist:
+    @pytest.mark.asyncio
+    async def test_existing_pair_returns_true(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        mock_allowlist_repo.remove.return_value = True
+        result = await service.remove_allowlist("s-1", "bob", remover="alice")
+        assert result is True
+        mock_allowlist_repo.remove.assert_awaited_once_with("s-1", "bob")
+
+    @pytest.mark.asyncio
+    async def test_absent_pair_returns_false_idempotent(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        # ADR §"Allowlist endpoints": DELETE is idempotent —
+        # removing an absent pair is not an error.
+        mock_allowlist_repo.remove.return_value = False
+        result = await service.remove_allowlist("s-1", "bob", remover="alice")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_missing_subnet_raises_404(
+        self, service: SubnetService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        mock_subnet_repo.find_by_id.return_value = None
+        with pytest.raises(SubnetNotFoundException):
+            await service.remove_allowlist("missing", "bob", remover="alice")
+
+    @pytest.mark.asyncio
+    async def test_does_not_evict_existing_member(
+        self,
+        service: SubnetService,
+        mock_subnet_repo: AsyncMock,
+        mock_allowlist_repo: AsyncMock,
+    ) -> None:
+        # ADR §"State machine edges": "Allowlist removal does not
+        # evict members". remove_member MUST NOT be called.
+        subnet = _subnet()
+        subnet.member_agent_ids = {"alice", "bob"}
+        mock_subnet_repo.find_by_id.return_value = subnet
+
+        await service.remove_allowlist("s-1", "bob", remover="alice")
+
+        # The subnet.save() call shouldn't have been invoked — we only
+        # touch the allowlist repo. (mock_subnet_repo.save isn't called
+        # because the service doesn't mutate subnet on this path.)
+        mock_subnet_repo.save.assert_not_called()
+
+
+class TestListAllowlist:
+    @pytest.mark.asyncio
+    async def test_returns_entries_from_repo(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        entries = [
+            SubnetAllowlist(
+                subnet_id="s-1",
+                agent_id="bob",
+                added_by="alice",
+                added_at=datetime.now(UTC),
+            ),
+            SubnetAllowlist(
+                subnet_id="s-1",
+                agent_id="carol",
+                added_by="alice",
+                added_at=datetime.now(UTC),
+            ),
+        ]
+        mock_allowlist_repo.list_for_subnet.return_value = entries
+
+        result = await service.list_allowlist("s-1")
+
+        assert result == entries
+        mock_allowlist_repo.list_for_subnet.assert_awaited_once_with("s-1", limit=100, offset=0)
+
+    @pytest.mark.asyncio
+    async def test_pagination_passed_through(
+        self, service: SubnetService, mock_allowlist_repo: AsyncMock
+    ) -> None:
+        await service.list_allowlist("s-1", limit=25, offset=50)
+        mock_allowlist_repo.list_for_subnet.assert_awaited_once_with("s-1", limit=25, offset=50)
+
+    @pytest.mark.asyncio
+    async def test_missing_subnet_raises_404(
+        self, service: SubnetService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        mock_subnet_repo.find_by_id.return_value = None
+        with pytest.raises(SubnetNotFoundException):
+            await service.list_allowlist("missing")
+
+
+class TestPublisherDefaultsToNoOp:
+    """If the constructor isn't given an event publisher, the
+    service installs the NoOp stub so call sites stay
+    publisher-aware without a `if publisher is None` guard."""
+
+    def test_no_publisher_kwarg_installs_noop(self, mock_subnet_repo: AsyncMock) -> None:
+        svc = SubnetService(subnet_repository=mock_subnet_repo)
+        assert isinstance(svc.event_publisher, NoOpJoinFlowEventPublisher)
+
+    def test_publisher_kwarg_preserved_as_passed(self, mock_subnet_repo: AsyncMock) -> None:
+        stub = NoOpJoinFlowEventPublisher()
+        svc = SubnetService(
+            subnet_repository=mock_subnet_repo,
+            join_flow_event_publisher=stub,
+        )
+        assert svc.event_publisher is stub

--- a/tests/services/test_subnet_service_invitations.py
+++ b/tests/services/test_subnet_service_invitations.py
@@ -1,0 +1,407 @@
+"""SubnetService — invitation lifecycle + merge path (ADR-0004 Slice 2.2).
+
+Covers the four invitation methods on ``SubnetService``:
+
+- ``invite_agent``      — owner pushes. May take the normal path
+  (fresh invitation row + ``INVITATION_SENT``) OR the merge path
+  (target has a pending join_request → auto-approve + ``JOIN_APPROVED``
+  with ``trigger='auto_on_invite'``).
+- ``accept_invitation`` — invitee says yes; agent joins. The
+  ``trigger`` / ``via`` kwargs are the hooks ``JoinFlowService``
+  uses for branches 3 (``via='self_join'``) and 4
+  (``via='allowlist'``).
+- ``reject_invitation`` — invitee says no.
+- ``cancel_invitation`` — owner-side withdraw.
+
+State-machine edges from ADR §"State machine edges" that show up
+here: "Duplicate invitation", "Invite an existing member",
+"Join request pending when owner invites" (the merge path),
+"Concurrent decision" (CAS race on accept / reject / cancel).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.entities.subnet_join_request import SYSTEM_ALLOWLIST_ACTOR
+from acn.core.exceptions import (
+    AlreadyMemberError,
+    InvitationAlreadyDecidedError,
+    InvitationNotFoundError,
+    InvitationPendingError,
+)
+from acn.core.interfaces import (
+    IJoinFlowEventPublisher,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+    JoinFlowEventType,
+)
+from acn.services._join_flow_result import (
+    InviteAgentMergedToApprovedJoinRequestResult,
+    InviteAgentSentResult,
+)
+from acn.services.subnet_service import SubnetService
+
+
+def _subnet(
+    subnet_id: str = "s-1",
+    owner: str = "alice",
+    members: set[str] | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        created_at=datetime.now(UTC),
+        member_agent_ids=members if members is not None else {owner},
+    )
+
+
+def _pending_invitation(
+    request_id: str = "inv-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+    initiated_by: str = "alice",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="invitation",
+        status="pending",
+        initiated_by=initiated_by,
+    )
+
+
+def _pending_join_request(
+    request_id: str = "rq-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="join_request",
+        status="pending",
+        initiated_by=agent_id,
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_id.return_value = _subnet()
+    return repo
+
+
+@pytest.fixture
+def mock_join_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetJoinRequestRepository)
+    repo.find_pending_for.return_value = None  # default: no collision
+    return repo
+
+
+@pytest.fixture
+def mock_publisher() -> MagicMock:
+    publisher = MagicMock(spec=IJoinFlowEventPublisher)
+    publisher.publish = AsyncMock()
+    return publisher
+
+
+@pytest.fixture
+def service(
+    mock_subnet_repo: AsyncMock,
+    mock_join_repo: AsyncMock,
+    mock_publisher: MagicMock,
+) -> SubnetService:
+    return SubnetService(
+        subnet_repository=mock_subnet_repo,
+        subnet_join_request_repository=mock_join_repo,
+        join_flow_event_publisher=mock_publisher,
+    )
+
+
+class TestInviteAgentNormalPath:
+    @pytest.mark.asyncio
+    async def test_creates_pending_invitation_row(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        result = await service.invite_agent("s-1", "bob", owner_id="alice", note="join us")
+
+        assert isinstance(result, InviteAgentSentResult)
+        assert result.invitation.kind == "invitation"
+        assert result.invitation.status == "pending"
+        assert result.invitation.initiated_by == "alice"
+        assert result.invitation.agent_id == "bob"
+        assert result.invitation.note == "join us"
+
+        mock_join_repo.save.assert_awaited_once()
+        mock_publisher.publish.assert_awaited_once()
+        assert mock_publisher.publish.await_args.args[0] == JoinFlowEventType.INVITATION_SENT
+
+    @pytest.mark.asyncio
+    async def test_already_member_raises_409(
+        self, service: SubnetService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        # ADR §State machine edges "Invite an existing member"
+        mock_subnet_repo.find_by_id.return_value = _subnet(members={"alice", "bob"})
+
+        with pytest.raises(AlreadyMemberError) as exc_info:
+            await service.invite_agent("s-1", "bob", owner_id="alice")
+        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.agent_id == "bob"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_pending_invitation_raises_409(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        # ADR §State machine edges "Duplicate invitation" — owner
+        # re-invites while a pending invitation exists.
+        existing = _pending_invitation(request_id="inv-OLD")
+        mock_join_repo.find_pending_for.return_value = existing
+
+        with pytest.raises(InvitationPendingError) as exc_info:
+            await service.invite_agent("s-1", "bob", owner_id="alice")
+        assert exc_info.value.existing_invitation_id == "inv-OLD"
+
+
+class TestInviteAgentMergePath:
+    """ADR §"POST /invitations" "Merge path" — owner invites an
+    agent who already has a pending ``join_request``. The pending
+    row CAS's to ``approved`` with ``trigger=auto_on_invite``; no
+    invitation row is created; ``JOIN_APPROVED`` fires (NOT
+    ``INVITATION_SENT``)."""
+
+    @pytest.mark.asyncio
+    async def test_pending_join_request_merges_to_approved(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_subnet_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        pending = _pending_join_request(request_id="rq-EXISTING")
+        mock_join_repo.find_pending_for.return_value = pending
+        # The merge path calls approve_join_request which re-loads
+        # the row via find_by_id.
+        mock_join_repo.find_by_id.return_value = pending
+
+        result = await service.invite_agent("s-1", "bob", owner_id="alice")
+
+        assert isinstance(result, InviteAgentMergedToApprovedJoinRequestResult)
+        assert result.request.request_id == "rq-EXISTING"
+        assert result.request.status == "approved"
+        assert result.request.decided_by == "alice"
+
+        # Exactly one webhook fires — JOIN_APPROVED with
+        # trigger=auto_on_invite — and NO INVITATION_SENT.
+        mock_publisher.publish.assert_awaited_once()
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.JOIN_APPROVED
+        assert call.kwargs["trigger"] == "auto_on_invite"
+
+        # add_member ran — verified by the subnet repo save call.
+        mock_subnet_repo.save.assert_awaited()
+
+
+class TestAcceptInvitation:
+    @pytest.mark.asyncio
+    async def test_happy_path_explicit_invitee_accept(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_subnet_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = _pending_invitation()
+
+        result = await service.accept_invitation("s-1", "inv-1", invitee_id="bob")
+
+        assert result.status == "approved"
+        assert result.decided_by == "bob"
+
+        mock_subnet_repo.save.assert_awaited()  # add_member ran
+
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.INVITATION_ACCEPTED
+        assert call.kwargs["trigger"] == "explicit"
+        assert call.kwargs["via"] is None
+
+    @pytest.mark.asyncio
+    async def test_self_join_merge_via_self_join(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        # Branch 3 in §join — agent self-joins with pending invitation.
+        # JoinFlowService passes trigger=auto_on_join, via=self_join;
+        # decided_by remains the invitee_id (the agent self-joining).
+        mock_join_repo.find_by_id.return_value = _pending_invitation()
+
+        result = await service.accept_invitation(
+            "s-1",
+            "inv-1",
+            invitee_id="bob",
+            trigger="auto_on_join",
+            via="self_join",
+        )
+
+        assert result.decided_by == "bob"
+        call = mock_publisher.publish.await_args
+        assert call.kwargs["trigger"] == "auto_on_join"
+        assert call.kwargs["via"] == "self_join"
+
+    @pytest.mark.asyncio
+    async def test_allowlist_merge_decides_by_system_allowlist(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        # Branch 4 — allowlist hit AND pending invitation. ADR
+        # §"Merge-path event mapping" pins
+        # decided_by='system:allowlist' on this specific path,
+        # making the audit trail say "this approval came from the
+        # allowlist preauth", not "the invitee chose this".
+        mock_join_repo.find_by_id.return_value = _pending_invitation()
+
+        result = await service.accept_invitation(
+            "s-1",
+            "inv-1",
+            invitee_id="bob",
+            trigger="auto_on_join",
+            via="allowlist",
+        )
+
+        assert result.decided_by == SYSTEM_ALLOWLIST_ACTOR
+        call = mock_publisher.publish.await_args
+        assert call.kwargs["via"] == "allowlist"
+
+    @pytest.mark.asyncio
+    async def test_already_decided_raises_409(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        decided = SubnetJoinRequest(
+            request_id="inv-1",
+            subnet_id="s-1",
+            agent_id="bob",
+            kind="invitation",
+            status="approved",
+            initiated_by="alice",
+            decided_by="bob",
+            decided_at=datetime.now(UTC),
+        )
+        mock_join_repo.find_by_id.return_value = decided
+
+        with pytest.raises(InvitationAlreadyDecidedError) as exc_info:
+            await service.accept_invitation("s-1", "inv-1", invitee_id="bob")
+        assert exc_info.value.invitation_id == "inv-1"
+        assert exc_info.value.current_status == "approved"
+
+    @pytest.mark.asyncio
+    async def test_wrong_kind_returns_invitation_not_found(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        # join_request id used against accept_invitation → 404
+        # INVITATION_NOT_FOUND (ADR §URL alias routing rules).
+        mock_join_repo.find_by_id.return_value = _pending_join_request()
+        with pytest.raises(InvitationNotFoundError):
+            await service.accept_invitation("s-1", "rq-1", invitee_id="bob")
+
+    @pytest.mark.asyncio
+    async def test_missing_returns_invitation_not_found(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = None
+        with pytest.raises(InvitationNotFoundError):
+            await service.accept_invitation("s-1", "inv-1", invitee_id="bob")
+
+
+class TestRejectInvitation:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = _pending_invitation()
+
+        result = await service.reject_invitation("s-1", "inv-1", invitee_id="bob", note="not now")
+
+        assert result.status == "rejected"
+        assert result.decided_by == "bob"
+        assert result.note == "not now"
+
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.INVITATION_REJECTED
+
+
+class TestCancelInvitation:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = _pending_invitation()
+
+        result = await service.cancel_invitation("s-1", "inv-1", owner_id="alice")
+
+        assert result.status == "withdrawn"
+        assert result.decided_by == "alice"
+
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.INVITATION_CANCELED
+
+    @pytest.mark.asyncio
+    async def test_already_decided_raises_409(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        decided = SubnetJoinRequest(
+            request_id="inv-1",
+            subnet_id="s-1",
+            agent_id="bob",
+            kind="invitation",
+            status="rejected",
+            initiated_by="alice",
+            decided_by="bob",
+            decided_at=datetime.now(UTC),
+        )
+        mock_join_repo.find_by_id.return_value = decided
+
+        with pytest.raises(InvitationAlreadyDecidedError):
+            await service.cancel_invitation("s-1", "inv-1", owner_id="alice")
+
+
+class TestReadPathsInvitations:
+    @pytest.mark.asyncio
+    async def test_list_invitations_pins_kind_invitation(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.list_by_subnet.return_value = []
+        await service.list_invitations("s-1", status="pending")
+        mock_join_repo.list_by_subnet.assert_awaited_once_with(
+            "s-1", kind="invitation", status="pending", limit=100, offset=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_pending_invitations_for_agent_delegates_to_repo(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        invites = [_pending_invitation(request_id="inv-A")]
+        mock_join_repo.list_pending_invitations_for_agent.return_value = invites
+
+        result = await service.list_pending_invitations_for_agent("bob")
+        assert result == invites
+        mock_join_repo.list_pending_invitations_for_agent.assert_awaited_once_with("bob")

--- a/tests/services/test_subnet_service_join_requests.py
+++ b/tests/services/test_subnet_service_join_requests.py
@@ -1,0 +1,314 @@
+"""SubnetService — join_request lifecycle (ADR-0004 Slice 2.2).
+
+Covers the three methods that drive the ``kind='join_request'``
+state machine:
+
+- ``approve_join_request`` — owner says yes; agent joins.
+- ``reject_join_request``  — owner says no; agent stays out.
+- ``withdraw_join_request`` — applicant pulls their own request.
+
+All three CAS on ``status='pending'`` and raise
+``JoinRequestAlreadyDecidedError`` when the row has already
+moved off pending. All three fire the matching
+``JoinFlowEventType`` via the injected publisher.
+
+The merge path (owner invites an agent who already has a pending
+join_request → ``approve_join_request(trigger='auto_on_invite')``
+is exercised in ``test_subnet_service_invitations.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.exceptions import (
+    JoinRequestAlreadyDecidedError,
+    JoinRequestNotFoundError,
+    SubnetNotFoundException,
+)
+from acn.core.interfaces import (
+    IJoinFlowEventPublisher,
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+    JoinFlowEventType,
+)
+from acn.services.subnet_service import SubnetService
+
+
+def _subnet(
+    subnet_id: str = "s-1",
+    owner: str = "alice",
+    members: set[str] | None = None,
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner=owner,
+        created_at=datetime.now(UTC),
+        member_agent_ids=members if members is not None else {owner},
+    )
+
+
+def _pending_join_request(
+    request_id: str = "rq-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="join_request",
+        status="pending",
+        initiated_by=agent_id,
+    )
+
+
+def _decided_row(
+    request_id: str = "rq-1",
+    subnet_id: str = "s-1",
+    agent_id: str = "bob",
+    status: str = "approved",
+    decided_by: str = "alice",
+) -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind="join_request",
+        status=status,
+        initiated_by=agent_id,
+        decided_by=decided_by,
+        decided_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_id.return_value = _subnet()
+    return repo
+
+
+@pytest.fixture
+def mock_join_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetJoinRequestRepository)
+    repo.find_by_id.return_value = _pending_join_request()
+    return repo
+
+
+@pytest.fixture
+def mock_publisher() -> MagicMock:
+    publisher = MagicMock(spec=IJoinFlowEventPublisher)
+    publisher.publish = AsyncMock()
+    return publisher
+
+
+@pytest.fixture
+def service(
+    mock_subnet_repo: AsyncMock,
+    mock_join_repo: AsyncMock,
+    mock_publisher: MagicMock,
+) -> SubnetService:
+    return SubnetService(
+        subnet_repository=mock_subnet_repo,
+        subnet_join_request_repository=mock_join_repo,
+        join_flow_event_publisher=mock_publisher,
+    )
+
+
+class TestApproveJoinRequest:
+    @pytest.mark.asyncio
+    async def test_happy_path_cas_save_and_add_member(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_subnet_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        result = await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+        # CAS: a fresh entity was saved with status=approved.
+        assert result.status == "approved"
+        assert result.decided_by == "alice"
+        assert result.decided_at is not None
+        mock_join_repo.save.assert_awaited_once()
+
+        # add_member ran AFTER the CAS — verified by the subnet.save call.
+        # (The subnet repo's save is invoked from add_member.)
+        mock_subnet_repo.save.assert_awaited()
+
+        # JOIN_APPROVED published with trigger=explicit (default).
+        mock_publisher.publish.assert_awaited_once()
+        call = mock_publisher.publish.await_args
+        assert call.args[0] == JoinFlowEventType.JOIN_APPROVED
+        assert call.kwargs["trigger"] == "explicit"
+        assert call.kwargs["request"].status == "approved"
+
+    @pytest.mark.asyncio
+    async def test_trigger_auto_on_invite_passed_through(
+        self, service: SubnetService, mock_publisher: MagicMock
+    ) -> None:
+        # The merge path (invite collides with pending join_request)
+        # routes through approve with trigger=auto_on_invite — the
+        # webhook publisher must surface that for ADR §"Merge-path
+        # event mapping".
+        await service.approve_join_request(
+            "s-1", "rq-1", owner_id="alice", trigger="auto_on_invite"
+        )
+        assert mock_publisher.publish.await_args.kwargs["trigger"] == ("auto_on_invite")
+
+    @pytest.mark.asyncio
+    async def test_already_decided_raises_409(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        # ADR §State machine edges "Concurrent decision" — second
+        # owner's approve loses the CAS and gets 409.
+        mock_join_repo.find_by_id.return_value = _decided_row(status="approved")
+
+        with pytest.raises(JoinRequestAlreadyDecidedError) as exc_info:
+            await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+        assert exc_info.value.request_id == "rq-1"
+        assert exc_info.value.current_status == "approved"
+
+        mock_join_repo.save.assert_not_called()
+        mock_publisher.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wrong_kind_returns_404_in_join_request_namespace(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        # ADR §"URL alias routing rules": invitation id on
+        # /join-requests/ path returns JOIN_REQUEST_NOT_FOUND.
+        wrong_kind = SubnetJoinRequest(
+            request_id="rq-1",
+            subnet_id="s-1",
+            agent_id="bob",
+            kind="invitation",
+            status="pending",
+            initiated_by="alice",
+        )
+        mock_join_repo.find_by_id.return_value = wrong_kind
+        with pytest.raises(JoinRequestNotFoundError):
+            await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+    @pytest.mark.asyncio
+    async def test_wrong_subnet_returns_404(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        # request_id exists but belongs to a different subnet → 404
+        # (no existence leak across subnets).
+        other_subnet_row = _pending_join_request(subnet_id="s-OTHER")
+        mock_join_repo.find_by_id.return_value = other_subnet_row
+        with pytest.raises(JoinRequestNotFoundError):
+            await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+    @pytest.mark.asyncio
+    async def test_missing_request_id_returns_404(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = None
+        with pytest.raises(JoinRequestNotFoundError):
+            await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+    @pytest.mark.asyncio
+    async def test_missing_subnet_returns_404(
+        self, service: SubnetService, mock_subnet_repo: AsyncMock
+    ) -> None:
+        mock_subnet_repo.find_by_id.return_value = None
+        with pytest.raises(SubnetNotFoundException):
+            await service.approve_join_request("missing", "rq-1", owner_id="alice")
+
+
+class TestRejectJoinRequest:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        service: SubnetService,
+        mock_join_repo: AsyncMock,
+        mock_publisher: MagicMock,
+    ) -> None:
+        result = await service.reject_join_request(
+            "s-1", "rq-1", owner_id="alice", note="not a fit"
+        )
+
+        assert result.status == "rejected"
+        assert result.decided_by == "alice"
+        assert result.note == "not a fit"
+
+        # No add_member on rejection.
+        mock_publisher.publish.assert_awaited_once()
+        assert mock_publisher.publish.await_args.args[0] == JoinFlowEventType.JOIN_REJECTED
+
+    @pytest.mark.asyncio
+    async def test_already_decided_raises_409(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = _decided_row(status="rejected")
+        with pytest.raises(JoinRequestAlreadyDecidedError):
+            await service.reject_join_request("s-1", "rq-1", owner_id="alice")
+
+    @pytest.mark.asyncio
+    async def test_note_optional(self, service: SubnetService) -> None:
+        # Note defaults to None — verifies the kwarg is genuinely
+        # optional, not just defensively-tested.
+        result = await service.reject_join_request("s-1", "rq-1", owner_id="alice")
+        assert result.note is None
+
+
+class TestWithdrawJoinRequest:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        service: SubnetService,
+        mock_publisher: MagicMock,
+    ) -> None:
+        result = await service.withdraw_join_request("s-1", "rq-1", applicant_id="bob")
+
+        assert result.status == "withdrawn"
+        assert result.decided_by == "bob"
+
+        # WITHDRAWN event fires.
+        mock_publisher.publish.assert_awaited_once()
+        assert mock_publisher.publish.await_args.args[0] == JoinFlowEventType.JOIN_WITHDRAWN
+
+    @pytest.mark.asyncio
+    async def test_already_decided_raises_409(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.find_by_id.return_value = _decided_row(status="withdrawn", decided_by="bob")
+        with pytest.raises(JoinRequestAlreadyDecidedError):
+            await service.withdraw_join_request("s-1", "rq-1", applicant_id="bob")
+
+
+class TestReadPaths:
+    @pytest.mark.asyncio
+    async def test_list_join_requests_default_kind(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.list_by_subnet.return_value = []
+        await service.list_join_requests("s-1")
+        mock_join_repo.list_by_subnet.assert_awaited_once_with(
+            "s-1", kind="join_request", status=None, limit=100, offset=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_join_requests_allowlist_auto_filter(
+        self, service: SubnetService, mock_join_repo: AsyncMock
+    ) -> None:
+        mock_join_repo.list_by_subnet.return_value = []
+        await service.list_join_requests("s-1", kind="allowlist_auto", status="approved")
+        mock_join_repo.list_by_subnet.assert_awaited_once_with(
+            "s-1",
+            kind="allowlist_auto",
+            status="approved",
+            limit=100,
+            offset=0,
+        )


### PR DESCRIPTION
## Summary

Implements the domain layer for ADR-0004's §join six-branch decision tree + the full ten-method CRUD surface for the new `subnet_join_requests` and `subnet_allowlist` tables. **No HTTP routing yet** (deferred to Slice 2.3) and **no real webhook publisher** (Slice 2.4) — the in-house `NoOpJoinFlowEventPublisher` keeps service-layer call sites publisher-aware in the meantime.

Builds on top of Slice 2.1 (PR #74 — entities + repos + cascade) and Slice 2.1.1 (PR #76 — atomic cascade via IUnitOfWork).

## What ships

### `JoinFlowService.join_subnet` — the six-branch dispatcher

| # | join_policy | caller relationship | result |
|---|-------------|----------------------|--------|
| 1 | `open` | any | `JoinFlowJoinedOpenResult` |
| 2 | `approval` | caller == owner | `JoinFlowJoinedAsOwnerResult` |
| 3 | `approval` | pending invitation, NOT allowlisted | `JoinFlowAutoAcceptedInvitationResult(via='self_join')` |
| 4 | `approval` | pending invitation AND allowlisted | `JoinFlowAutoAcceptedInvitationResult(via='allowlist')` (invitation wins, no parallel `allowlist_auto` row) |
| 5 | `approval` | allowlisted, no pending | `JoinFlowAllowlistAutoApprovedResult` |
| 6 | `approval` | otherwise | `JoinFlowPendingResult` |

Branch order is normative per ADR §join; branch precedence tests pin it.

### `SubnetService` — ten new methods

* **Allowlist** (no webhook — config, not lifecycle): `add_allowlist`, `remove_allowlist`, `list_allowlist`
* **`join_request` lifecycle**: `approve_join_request`, `reject_join_request`, `withdraw_join_request`
* **Invitation lifecycle**: `invite_agent` (with merge path → auto-approves a pending `join_request`), `accept_invitation` (with `self_join` / `allowlist` merge variants), `reject_invitation`, `cancel_invitation`
* **Read helpers**: `list_join_requests`, `list_invitations`, `list_pending_invitations_for_agent`

Every transition runs as `dataclasses.replace` → `repo.save` so `SubnetJoinRequest.__post_init__` re-validates the full invariant set; CAS failures raise `*AlreadyDecidedError` (409); namespace mismatches raise `*NotFoundError` (404) per ADR §"URL alias routing rules".

### Foundations

* `IJoinFlowEventPublisher` Protocol + `JoinFlowEventType` enum (eight canonical values from ADR §"Webhook event catalogue")
* `NoOpJoinFlowEventPublisher` Slice-2.2 stub (debug-logs every event for audit forensics, never raises)
* Five `JoinFlowResult` + two `InviteAgentResult` frozen sealed-union variants for Slice 2.3 routes to `match` on
* Eight `JoinFlowError` subclasses with stable `reason` slugs (409 duplicate / already-decided / already-member / already-on-allowlist + 404 namespace-aware not-found)

### Wiring

* `api.py` instantiates both new repositories (PG when `DATABASE_URL` is set, Redis fallback otherwise) + `JoinFlowService`, stashed on `app.state.join_flow_service` for Slice 2.3 routes to pick up.

## Out of scope

* HTTP routes (Slice 2.3 — `/allowlist`, `/join-requests`, `/invitations` endpoint families + matching CLI verbs)
* Real `WebhookService.send_to` integration (Slice 2.4 — extends `WebhookEventType` with the eight new event names + ships `WebhookJoinFlowEventPublisher`)
* Schema migrations (already landed in Slice 2.1 / migration `b8c9d0e1f2a3`)

## Compatibility

* Legacy `SubnetService` callers without the new kwargs keep working — new methods raise `RuntimeError` on first use if cascade repos are absent (fail-fast); publisher defaults to no-op.
* Slice 2.1 cascade path is unchanged; new methods are purely additive.
* `persistence/redis/__init__.py` deliberately does NOT re-export the two new Redis repos at the package level — they pull in their Postgres counterparts whose package init drags the wider billing/messaging chain into a cycle via `broadcast_service`. `api.py` imports them from their submodules instead (documented inline at both ends).

## Notable design decisions

* **`approve_join_request` accepts a `trigger='auto_on_invite'` kwarg** so `invite_agent`'s merge path delegates rather than re-implementing the CAS+webhook dance. The merge path fires exactly one webhook (`JOIN_APPROVED` with `trigger=auto_on_invite`), NOT both — matches ADR §"Merge-path event mapping".
* **`accept_invitation` accepts `via='allowlist'`** which flips `decided_by` to `system:allowlist` (the only allowed asymmetry per ADR §State transition table). Used by branch 4 of `JoinFlowService`.
* **Branch 5 (`allowlist_auto`) doesn't go through a CAS transition** — the row is born approved per ADR §SubnetJoinRequest schema, so `JoinFlowService` instantiates and saves directly rather than misusing the `_save_decided_transition` helper.
* **The agent-already-member check hoists above branch dispatch** so even open joins reject duplicate `add_member` attempts (ADR §State machine edges "Agent self-join already a member").

## Tests

86 new tests + 902 services/core/infrastructure regression tests + 51 subnet-routes regression tests, all green.

* `test_join_flow_foundations.py` (30) — publisher Protocol + enum + result sealed-union + 8 exception subclasses
* `test_subnet_service_allowlist.py` (13) — 3 allowlist methods + duplicate-409 + idempotent-remove
* `test_subnet_service_join_requests.py` (12) — approve / reject / withdraw + CAS-race-409 + cross-kind-404 + cross-subnet-404
* `test_subnet_service_invitations.py` (17) — invite (normal + merge) / accept (3 trigger variants) / reject / cancel + already-member-409 + duplicate-409
* `test_join_flow_service.py` (14) — 6 branches happy + 3 state-machine TEST markers + 3 branch-precedence pins

## Test plan

- [x] Foundation tests
- [x] All 10 SubnetService method tests
- [x] 6 JoinFlowService branches + edges
- [x] ruff + format clean
- [x] Wider services / core / infrastructure regression (902 passed)
- [x] Subnet routes regression (51 passed — no behaviour change in existing `do_join_subnet`)
- [ ] CI green

Refs ADR-0004 Phase 2 Slice 2.2.

Made with [Cursor](https://cursor.com)