### PR TITLE
feat(api): ADR-0004 Slice 2.3 PR A — subnet admission HTTP routes

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -109,6 +109,7 @@ from .routes import (
     payments,
     registry,
     sessions,
+    subnet_admission,
     subnets,
     tasks,
     websocket,
@@ -657,6 +658,7 @@ async def lifespan(app: FastAPI):
         session_service=session_service_instance,
         reputation_service=reputation_service_instance,
         reputation_query_service=reputation_query_service_instance,
+        join_flow_service=join_flow_service_instance,
     )
 
     # Phase 1 wiring guard
@@ -1272,6 +1274,11 @@ app.include_router(follows.router)
 # ``/{agent_id}/{rest_path:path}`` does not greedily forward
 # allowlist requests to the agent's real endpoint.
 app.include_router(allowlist.router)
+# ADR-0004 Slice 2.3 — admission endpoints (allowlist / join_request /
+# invitation). Included BEFORE ``registry.router`` so the catch-all
+# ``/{agent_id}/{rest_path:path}`` proxy doesn't swallow
+# ``GET /api/v1/agents/{agent_id}/subnet-invitations``.
+app.include_router(subnet_admission.router)
 # Canonical agent-side subnet membership routes
 # (`POST/DELETE /api/v1/agents/{id}/subnets/{subnet_id}`,
 #  `GET /api/v1/agents/{id}/subnets`).

--- a/acn/core/errors.py
+++ b/acn/core/errors.py
@@ -101,6 +101,39 @@ class ErrorCode(StrEnum):
     # cross-module group below.
     SUBNET_NOT_FOUND = "subnet_not_found"
 
+    # ===== Subnet admission (ADR-0004 Slice 2.3) =====
+    # All twelve codes are emitted by the join-flow / allowlist /
+    # invitation / join_request endpoints introduced in Slice 2.3. The
+    # split into per-row-kind codes (JOIN_REQUEST_* vs INVITATION_*) is
+    # deliberate: ADR-0004 §"URL alias routing rules" routes
+    # ``/join-requests/{id}`` and ``/invitations/{id}`` against the
+    # same ``subnet_join_requests`` table but uses path-namespace 404s
+    # to avoid leaking the existence of a row in the other namespace
+    # (calling the join_request approve verb against an invitation id
+    # MUST 404 with ``JOIN_REQUEST_NOT_FOUND`` regardless of whether
+    # an invitation with that id happens to exist). Sharing one
+    # ``ROW_NOT_FOUND`` code would let SDK clients infer the leakage.
+    # See ADR §"HTTP status code conventions" for the status mapping.
+    SUBNET_NOT_OWNER = "subnet_not_owner"
+    NOT_INVITEE = "not_invitee"
+    ALREADY_MEMBER = "already_member"
+    ALREADY_ON_ALLOWLIST = "already_on_allowlist"
+    JOIN_REQUEST_NOT_FOUND = "join_request_not_found"
+    JOIN_REQUEST_PENDING = "join_request_pending"
+    JOIN_REQUEST_ALREADY_DECIDED = "join_request_already_decided"
+    INVITATION_NOT_FOUND = "invitation_not_found"
+    INVITATION_PENDING = "invitation_pending"
+    INVITATION_ALREADY_DECIDED = "invitation_already_decided"
+    INVALID_KIND_FILTER = "invalid_kind_filter"
+    # ``visibility_policy_conflict`` (``is_private=true`` +
+    # ``join_policy='open'``) stays surfaced under the generic
+    # ``INVALID_REQUEST`` ErrorCode with ``details.reason=
+    # "visibility_policy_conflict"`` — established by Slice 2.0/2.1
+    # and pinned in test_subnets_join_policy.py. Adding a dedicated
+    # slug here would silently break SDK clients that already
+    # branch on the ``invalid_request`` code; treat it as a
+    # ``details.reason`` discriminator instead.
+
     # ===== Tasks routes (sprint rows #4 + #4-followup) =====
     # ``TASK_NOT_FOUND`` is the only tasks-specific code; the remaining
     # 26 4xx sites (auth / permission / validation / private-subnet
@@ -449,6 +482,41 @@ _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
     ),
     ErrorCode.RESOURCE_CONFLICT: (
         "The request conflicts with the current state of the resource."
+    ),
+    # ===== ADR-0004 Slice 2.3 — subnet admission =====
+    ErrorCode.SUBNET_NOT_OWNER: (
+        "The authenticated agent is not the owner of this subnet."
+    ),
+    ErrorCode.NOT_INVITEE: (
+        "The authenticated agent is not the invitee of this invitation."
+    ),
+    ErrorCode.ALREADY_MEMBER: (
+        "The agent is already a member of this subnet."
+    ),
+    ErrorCode.ALREADY_ON_ALLOWLIST: (
+        "The agent is already on this subnet's allowlist."
+    ),
+    ErrorCode.JOIN_REQUEST_NOT_FOUND: (
+        "The requested join request could not be found."
+    ),
+    ErrorCode.JOIN_REQUEST_PENDING: (
+        "A pending join request for this (subnet, agent) pair already exists."
+    ),
+    ErrorCode.JOIN_REQUEST_ALREADY_DECIDED: (
+        "This join request has already been decided and cannot be modified."
+    ),
+    ErrorCode.INVITATION_NOT_FOUND: (
+        "The requested invitation could not be found."
+    ),
+    ErrorCode.INVITATION_PENDING: (
+        "A pending invitation for this (subnet, agent) pair already exists."
+    ),
+    ErrorCode.INVITATION_ALREADY_DECIDED: (
+        "This invitation has already been decided and cannot be modified."
+    ),
+    ErrorCode.INVALID_KIND_FILTER: (
+        "The supplied kind filter is not valid for this endpoint. "
+        "Invitations are queryable through the /invitations endpoint only."
     ),
 }
 

--- a/acn/routes/_subnet_admission.py
+++ b/acn/routes/_subnet_admission.py
@@ -1,0 +1,408 @@
+"""Shared business logic for ADR-0004 Slice 2.3 subnet-admission routes.
+
+The fourteen new admission endpoints (``POST /agents/{a}/subnets/{s}``
+join entry, allowlist 3, join-request 4, invitation 5, agent
+invitations 1) share three concerns:
+
+1. **Authorization** — owner-only, invitee-only, and self-only gates
+   resolve to canonical 403 surfaces with stable ``ErrorCode`` slugs.
+2. **Error mapping** — the eight :class:`JoinFlowError` subclasses
+   raised by the service layer translate to specific HTTP codes
+   (404 / 409) per ADR §"HTTP status code conventions".
+3. **Sealed-union dispatch** — :class:`JoinFlowResult` variants map to
+   six distinct HTTP responses (five 200s on different "joined now"
+   branches, one 202 on the pending fall-through). Owning the dispatch
+   in one helper keeps every callable route layer thin.
+
+Why a sibling of ``_subnet_membership.py`` rather than extending it
+-------------------------------------------------------------------
+``_subnet_membership.py`` is the pre-ADR-0004 helper for
+``do_join_subnet`` / ``do_leave_subnet`` / ``do_get_agent_subnets``.
+Slice 2.3 rewrites ``do_join_subnet`` to use ``JoinFlowService``, but
+the leave / list helpers stay untouched. Putting the admission-
+specific helpers in a new file keeps both files focused on a single
+responsibility (membership vs admission policy) and avoids a 600-line
+helper module that mixes two concerns.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import structlog  # type: ignore[import-untyped]
+
+from ..core.entities import Subnet, SubnetAllowlist, SubnetJoinRequest
+from ..core.errors import ACNHTTPError, ErrorCode
+from ..core.exceptions import (
+    AllowlistEntryExistsError,
+    AlreadyMemberError,
+    InvitationAlreadyDecidedError,
+    InvitationNotFoundError,
+    InvitationPendingError,
+    JoinFlowError,
+    JoinRequestAlreadyDecidedError,
+    JoinRequestNotFoundError,
+    JoinRequestPendingError,
+    SubnetNotFoundException,
+)
+from ..services._join_flow_result import (
+    InviteAgentMergedToApprovedJoinRequestResult,
+    InviteAgentResult,
+    InviteAgentSentResult,
+    JoinFlowAllowlistAutoApprovedResult,
+    JoinFlowAutoAcceptedInvitationResult,
+    JoinFlowJoinedAsOwnerResult,
+    JoinFlowJoinedOpenResult,
+    JoinFlowPendingResult,
+    JoinFlowResult,
+)
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Authorisation helpers
+# ---------------------------------------------------------------------------
+#
+# All three sit alongside the existing ``_require_self`` in
+# ``_subnet_membership.py`` and follow the same shape: raise
+# ``ACNHTTPError`` with a stable ``ErrorCode`` slug. They do not catch
+# anything — the caller is responsible for surrounding ``get_subnet`` /
+# ``get_row`` calls with their own try/except chains that translate
+# missing entities to canonical 404s before authz runs.
+
+
+def _require_owner(agent_info: dict, subnet: Subnet) -> None:
+    """Reject if the API key's agent_id is not the subnet's owner.
+
+    ADR §"Authorization matrix" uses this gate for every endpoint
+    that mutates allowlist / join_request / invitation rows from
+    the owner side (approve, reject, invite, cancel, the three
+    allowlist verbs). The 403 carries ``subnet_id`` + ``owner`` in
+    ``details`` to help SDK clients distinguish "wrong subnet path"
+    from "right subnet, wrong key".
+    """
+    if agent_info["agent_id"] != subnet.owner:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_OWNER,
+            403,
+            details={
+                "subnet_id": subnet.subnet_id,
+                "owner": subnet.owner,
+                "caller": agent_info["agent_id"],
+            },
+        )
+
+
+def _require_invitee(agent_info: dict, row: SubnetJoinRequest) -> None:
+    """Reject if the API key's agent_id is not the invitation's invitee.
+
+    ADR §"Authorization matrix" uses this on the two invitee verbs
+    (accept / reject). ``row.agent_id`` is the invitee in ADR's
+    ``SubnetJoinRequest`` field semantics (the agent who would, or
+    did, become a member) — invariant across all three kinds.
+    """
+    if agent_info["agent_id"] != row.agent_id:
+        raise ACNHTTPError(
+            ErrorCode.NOT_INVITEE,
+            403,
+            details={
+                "invitation_id": row.request_id,
+                "invitee": row.agent_id,
+                "caller": agent_info["agent_id"],
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service-layer exception → HTTP error mapping
+# ---------------------------------------------------------------------------
+#
+# Each :class:`JoinFlowError` subclass carries a stable ``reason``
+# slug; we map by isinstance check (rather than by reason string) so
+# the mapping is statically verifiable. Mapping table mirrors ADR
+# §"HTTP status code conventions":
+#
+#   - ``*_NOT_FOUND`` → 404 (entity / namespace miss)
+#   - ``*_PENDING``, ``*_ALREADY_DECIDED``, ``ALREADY_*`` → 409
+#
+# Anything not listed bubbles unchanged — callers add their own
+# ``ACNHTTPError`` re-raise for ACN-specific 403 / 400 surfaces.
+
+
+def _map_join_flow_error(exc: JoinFlowError) -> ACNHTTPError:
+    """Translate a service-layer ``JoinFlowError`` to a typed HTTP error.
+
+    Returns a fresh :class:`ACNHTTPError`; the caller is responsible
+    for raising the result (so ``from exc`` cause chains stay
+    explicit at the route boundary).
+    """
+    # 404s — namespace-specific NOT_FOUND for join-requests vs
+    # invitations per ADR §"URL alias routing rules".
+    if isinstance(exc, JoinRequestNotFoundError):
+        return ACNHTTPError(
+            ErrorCode.JOIN_REQUEST_NOT_FOUND,
+            404,
+            details={"request_id": exc.request_id},
+        )
+    if isinstance(exc, InvitationNotFoundError):
+        return ACNHTTPError(
+            ErrorCode.INVITATION_NOT_FOUND,
+            404,
+            details={"invitation_id": exc.invitation_id},
+        )
+
+    # 409s — every state-conflict surface gets its own slug; ADR
+    # explicitly avoids a single ``CONFLICT`` because SDK clients
+    # want to branch on the specific edge they hit.
+    if isinstance(exc, JoinRequestPendingError):
+        return ACNHTTPError(
+            ErrorCode.JOIN_REQUEST_PENDING,
+            409,
+            details={"existing_request_id": exc.existing_request_id},
+        )
+    if isinstance(exc, InvitationPendingError):
+        return ACNHTTPError(
+            ErrorCode.INVITATION_PENDING,
+            409,
+            details={"existing_invitation_id": exc.existing_invitation_id},
+        )
+    if isinstance(exc, JoinRequestAlreadyDecidedError):
+        return ACNHTTPError(
+            ErrorCode.JOIN_REQUEST_ALREADY_DECIDED,
+            409,
+            details={
+                "request_id": exc.request_id,
+                "current_status": exc.current_status,
+            },
+        )
+    if isinstance(exc, InvitationAlreadyDecidedError):
+        return ACNHTTPError(
+            ErrorCode.INVITATION_ALREADY_DECIDED,
+            409,
+            details={
+                "invitation_id": exc.invitation_id,
+                "current_status": exc.current_status,
+            },
+        )
+    if isinstance(exc, AlreadyMemberError):
+        return ACNHTTPError(
+            ErrorCode.ALREADY_MEMBER,
+            409,
+            details={
+                "subnet_id": exc.subnet_id,
+                "agent_id": exc.agent_id,
+            },
+        )
+    if isinstance(exc, AllowlistEntryExistsError):
+        return ACNHTTPError(
+            ErrorCode.ALREADY_ON_ALLOWLIST,
+            409,
+            details={
+                "subnet_id": exc.subnet_id,
+                "agent_id": exc.agent_id,
+            },
+        )
+
+    # Catch-all: any future ``JoinFlowError`` subclass added to the
+    # service layer without a matching branch here would silently
+    # fall through as 500. We promote to 409 with ``RESOURCE_CONFLICT``
+    # as a conservative default + log loud so a missing case shows
+    # up in observability rather than as a confused SDK retry loop.
+    logger.warning(
+        "join_flow_error_unmapped",
+        exception_class=type(exc).__name__,
+        reason=exc.reason,
+        message=str(exc),
+    )
+    return ACNHTTPError(
+        ErrorCode.RESOURCE_CONFLICT,
+        409,
+        details={"reason": exc.reason},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+#
+# ``Subnet*.to_dict`` exists already but its target is Redis HASH
+# storage (empty strings instead of None, datetime as ISO string).
+# HTTP responses want JSON ``null`` for unset fields, which is
+# semantically distinct from "empty string"; the two helpers below
+# do that translation in one place so the per-endpoint response code
+# stays declarative.
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    """ISO 8601 string for a datetime, or ``None`` when unset."""
+    return value.isoformat() if value is not None else None
+
+
+def serialize_join_request(row: SubnetJoinRequest) -> dict[str, Any]:
+    """JSON-ready response payload for a ``SubnetJoinRequest`` row."""
+    return {
+        "request_id": row.request_id,
+        "subnet_id": row.subnet_id,
+        "agent_id": row.agent_id,
+        "kind": row.kind,
+        "status": row.status,
+        "initiated_by": row.initiated_by,
+        "decided_by": row.decided_by,
+        "created_at": _iso_or_none(row.created_at),
+        "decided_at": _iso_or_none(row.decided_at),
+        "note": row.note,
+    }
+
+
+def serialize_allowlist_entry(entry: SubnetAllowlist) -> dict[str, Any]:
+    """JSON-ready response payload for a ``SubnetAllowlist`` entry."""
+    return {
+        "subnet_id": entry.subnet_id,
+        "agent_id": entry.agent_id,
+        "added_by": entry.added_by,
+        "added_at": _iso_or_none(entry.added_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# JoinFlowResult → (status_code, body) dispatch
+# ---------------------------------------------------------------------------
+#
+# ADR §"POST /api/v1/agents/{agent_id}/subnets/{subnet_id} (join
+# entry)" pins the response shape per branch. Five branches return
+# 200 (caller is, now, a member) and one returns 202 (caller is not
+# yet a member). Two ``200`` variants (3 and 4) share the
+# ``invitation_id + via`` shape, distinguished only by ``via``
+# value — owning that consolidation here lets the route handler
+# stay a one-liner.
+
+
+def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str, Any]]:
+    """Translate a sealed-union ``JoinFlowResult`` to ``(status, body)``.
+
+    The status code mapping is a strict function of the variant type
+    (no per-call branching needed by callers). Body shape follows
+    ADR §join branches 1–6 verbatim.
+    """
+    if isinstance(result, JoinFlowJoinedOpenResult):
+        # Branch 1 — open subnet.
+        return 200, {
+            "status": "joined",
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+        }
+
+    if isinstance(result, JoinFlowJoinedAsOwnerResult):
+        # Branch 2 — owner self-join. Same body as branch 1; the
+        # caller can tell them apart by ``subnet.owner == agent_id``
+        # but doesn't need to for any downstream logic.
+        return 200, {
+            "status": "joined",
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+        }
+
+    if isinstance(result, JoinFlowAutoAcceptedInvitationResult):
+        # Branches 3 + 4 — pending invitation auto-accept. ``via``
+        # discriminates the two: ``self_join`` for branch 3,
+        # ``allowlist`` for branch 4. ADR pins the field shape so
+        # SDK clients can branch on ``via`` if they care about the
+        # audit trail.
+        return 200, {
+            "auto_resolved": True,
+            "resolved_kind": "invitation",
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+            "invitation_id": result.invitation.request_id,
+            "via": result.via,
+        }
+
+    if isinstance(result, JoinFlowAllowlistAutoApprovedResult):
+        # Branch 5 — allowlist hit with no pending invitation. A
+        # fresh ``allowlist_auto`` row was born approved; surface
+        # its request_id so the caller can correlate audit log
+        # readings.
+        return 200, {
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+            "request_id": result.request.request_id,
+            "via": "allowlist",
+        }
+
+    if isinstance(result, JoinFlowPendingResult):
+        # Branch 6 — fall-through pending join_request. 202 because
+        # the caller is not yet a member; the owner owes a decision.
+        return 202, {
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+            "request_id": result.request.request_id,
+            "status": "pending",
+        }
+
+    # Defensive default — any new variant added to the sealed
+    # union without a matching branch here would otherwise return
+    # an empty body. Raise instead so a missed update surfaces
+    # immediately in test rather than as a silent client failure.
+    raise RuntimeError(f"unhandled JoinFlowResult variant: {type(result).__name__}")
+
+
+def invite_agent_result_to_response(
+    result: InviteAgentResult,
+) -> tuple[int, dict[str, Any]]:
+    """Translate :class:`InviteAgentResult` to ``(status, body)``.
+
+    ADR §"Invitation-side endpoints" defines two outcomes for
+    ``POST /invitations``:
+
+    - Normal path → ``202 {invitation_id}`` (the invitation row is
+      pending; the invitee owes a decision).
+    - Merge path → ``200 {auto_resolved: true, resolved_kind:
+      "join_request", request_id}`` (target had a pending
+      join_request; the invite collapses to an owner-initiated
+      auto-approval).
+    """
+    if isinstance(result, InviteAgentSentResult):
+        return 202, {
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+            "invitation_id": result.invitation.request_id,
+            "status": "pending",
+        }
+
+    if isinstance(result, InviteAgentMergedToApprovedJoinRequestResult):
+        return 200, {
+            "auto_resolved": True,
+            "resolved_kind": "join_request",
+            "subnet_id": result.subnet_id,
+            "agent_id": result.agent_id,
+            "request_id": result.request.request_id,
+        }
+
+    raise RuntimeError(
+        f"unhandled InviteAgentResult variant: {type(result).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrapper: load + 404 in one go
+# ---------------------------------------------------------------------------
+
+
+async def load_subnet_or_404(subnet_service: Any, subnet_id: str) -> Subnet:
+    """``SubnetService.get_subnet`` wrapped in the canonical 404 conversion.
+
+    Every admission endpoint starts with a subnet lookup; the
+    exception → ``ACNHTTPError(SUBNET_NOT_FOUND)`` translation is
+    boilerplate. Returns the entity so the caller can pass it to
+    ``_require_owner`` without re-fetching.
+    """
+    try:
+        return await subnet_service.get_subnet(subnet_id)
+    except SubnetNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            404,
+            details={"subnet_id": subnet_id},
+        ) from e

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -16,15 +16,27 @@ from __future__ import annotations
 
 import structlog  # type: ignore[import-untyped]
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse
 
 from ..core.errors import ACNHTTPError, ErrorCode
-from ..core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from ..core.exceptions import (
+    AgentNotFoundException,
+    AlreadyMemberError,
+    JoinFlowError,
+    SubnetNotFoundException,
+)
 from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
 from ..services import AgentService, SubnetService
+from ..services._join_flow_result import JoinFlowPendingResult
+from ..services.join_flow_service import JoinFlowService
 from ..services.subnet_service import (
     REASON_NOT_PARENT_MEMBER,
     SubnetInvariantError,
+)
+from ._subnet_admission import (
+    _map_join_flow_error,
+    join_flow_result_to_response,
 )
 
 logger = structlog.get_logger()
@@ -69,17 +81,37 @@ async def do_join_subnet(
     subnet_service: SubnetService,
     agent_service: AgentService,
     webhook_service: WebhookService | None,
-) -> dict:
-    """Join `agent_id` into `subnet_id`. Idempotent at the service layer.
+    join_flow_service: JoinFlowService,
+) -> JSONResponse:
+    """Join `agent_id` into `subnet_id` via the ADR-0004 §join six-branch flow.
 
-    Side effects:
-    - `agent.subnet_ids` gains `subnet_id`
-    - `subnet.member_agent_ids` gains `agent_id`
-    - `agent.joined_subnet` Org Harness webhook is fired best-effort
+    ADR-0004 Phase 2 Slice 2.3 rewrite — the legacy direct
+    ``add_member + agent_service.join_subnet`` path is now a
+    ``join_flow_service.join_subnet`` dispatch, which handles the
+    open-subnet, owner-self-join, allowlist-hit, pending-invitation
+    auto-accept, and pending-join-request fall-through branches in
+    one place.
+
+    Response shape per branch lives in
+    :func:`acn.routes._subnet_admission.join_flow_result_to_response`
+    (5 of the 6 branches are 200s, branch 6 is 202).
+
+    Side effects (branches 1-5 only — branch 6 is 202, no membership
+    change yet):
+
+    - ``subnet.member_agent_ids`` gains ``agent_id``
+      (already done inside ``join_flow_service.join_subnet``).
+    - ``agent.subnet_ids`` gains ``subnet_id`` (written here — the
+      service layer deliberately leaves the back-reference to the
+      route layer per ADR §"Why a separate service").
+    - ``agent.joined_subnet`` Org Harness webhook fires best-effort.
     """
     _require_self(agent_info, agent_id)
 
-    # Verify subnet exists (and capture entity for harness-webhook delivery).
+    # Verify subnet exists (and capture entity for harness-webhook
+    # delivery). The same ``Subnet`` reference is used for the
+    # parent-membership pre-check and the webhook payload, so a
+    # single fetch covers both.
     try:
         subnet = await subnet_service.get_subnet(subnet_id)
     except SubnetNotFoundException as e:
@@ -89,18 +121,14 @@ async def do_join_subnet(
             details={"subnet_id": subnet_id},
         ) from e
 
-    # ADR-0003 child-subnet pre-check. ``SubnetService.add_member``
-    # would reject the same way, but doing it *before* the
-    # agent-side ``join_subnet`` write keeps state consistent — a
-    # mid-flight rejection otherwise leaves ``agent.subnet_ids``
-    # containing a subnet whose ``member_agent_ids`` doesn't include
-    # the agent (the dreaded half-joined state). We keep the
-    # service-layer check as defence-in-depth for the admin path.
-    #
-    # ``_subnet_parent_id`` extracts the parent reference defensively
-    # (legacy MagicMock stubs don't populate the attribute) and
-    # returns ``None`` for top-level subnets — matching the
-    # webhook payload contract introduced in Phase 3.
+    # ADR-0003 child-subnet pre-check. The service layer
+    # (``SubnetService.add_member``) re-asserts this invariant, but
+    # checking up-front lets us return the canonical 403 surface
+    # **before** ``JoinFlowService`` writes any
+    # ``allowlist_auto`` / ``join_request`` row. Without the
+    # pre-check, branches 5 and 6 would create a row before
+    # ``add_member`` raises, leaving an orphan audit-trail entry
+    # for a join that never happened.
     parent_subnet_id = _subnet_parent_id(subnet)
     if parent_subnet_id is not None:
         parent = None
@@ -120,78 +148,140 @@ async def do_join_subnet(
                 },
             )
 
+    # Dispatch the six-branch decision tree. ``JoinFlowService``
+    # owns every membership-table write (add_member on branches
+    # 1-5, save() on branches 5 + 6) and emits the matching join-
+    # flow webhook via its internal publisher (currently the
+    # no-op stub until Slice 2.4). All we do here is translate the
+    # result into HTTP shape and add the agent-side back-reference.
+    try:
+        result = await join_flow_service.join_subnet(subnet_id, agent_id)
+    except AlreadyMemberError as e:
+        # ADR §State machine edges "Agent self-join a subnet they
+        # are already in" → 409 ALREADY_MEMBER. Bubble through the
+        # join-flow error mapper so the response shape stays
+        # consistent across every JoinFlowError surface.
+        raise _map_join_flow_error(e) from e
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+    except SubnetInvariantError as nest_err:
+        # Race window between the parent-membership pre-check above
+        # and ``add_member``'s defence-in-depth check (parent
+        # membership changed concurrently). Branches 5 + 6 may
+        # have written a row before raising — that row is a
+        # historical artefact of the attempt, not a leak; the
+        # admin replay tool can prune it. Surface the canonical
+        # 403 with the same reason as the pre-check.
+        raise ACNHTTPError(
+            ErrorCode.NOT_SUBNET_MEMBER,
+            403,
+            details={
+                "reason": nest_err.reason,
+                "subnet_id": subnet_id,
+                "agent_id": agent_id,
+            },
+        ) from nest_err
+    except ACNHTTPError:
+        raise
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001 — unexpected service-layer failure
+        logger.error("join_subnet_failed", error=str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to join subnet") from e
+
+    status_code, body = join_flow_result_to_response(result)
+
+    # Branch 6 (pending) returns 202 — the caller is NOT yet a
+    # member, so we skip the agent-side back-reference write and
+    # the AGENT_JOINED_SUBNET webhook. Both events fire when the
+    # owner approves (handled by the approve_join_request handler,
+    # not here).
+    if isinstance(result, JoinFlowPendingResult):
+        return JSONResponse(status_code=status_code, content=body)
+
+    # Branches 1-5 — caller is now a member. Write the agent-side
+    # back-reference. Failure here leaves a half-joined state
+    # (subnet has the member; agent doesn't know about the
+    # subnet); best-effort roll back ``subnet.member_agent_ids``
+    # so the next retry sees a clean slate. We do NOT roll back
+    # any join_request / invitation row CAS that branches 3-5
+    # performed — those audit rows are valid history of the
+    # successful service-layer decision.
     try:
         await agent_service.join_subnet(agent_id, subnet_id)
-        try:
-            await subnet_service.add_member(subnet_id, agent_id)
-        except SubnetInvariantError as nest_err:
-            # Race window between the pre-check above and the
-            # service-layer write (parent membership changed
-            # concurrently). Roll back the agent-side write so we
-            # don't leave a half-joined state, then surface the
-            # 403 with the same canonical reason as the pre-check.
-            try:
-                await agent_service.leave_subnet(agent_id, subnet_id)
-            except Exception as rollback_err:  # noqa: BLE001
-                logger.warning(
-                    "join_subnet_rollback_failed",
-                    agent_id=agent_id,
-                    subnet_id=subnet_id,
-                    error=str(rollback_err),
-                )
-            raise ACNHTTPError(
-                ErrorCode.NOT_SUBNET_MEMBER,
-                403,
-                details={
-                    "reason": nest_err.reason,
-                    "subnet_id": subnet_id,
-                    "agent_id": agent_id,
-                },
-            ) from nest_err
-
-        logger.info("agent_joined_subnet", agent_id=agent_id, subnet_id=subnet_id)
-
-        if subnet.harness_url and webhook_service is not None:
-            try:
-                await webhook_service.send_to(
-                    url=subnet.harness_url,
-                    secret=subnet.harness_secret,
-                    event=WebhookEventType.AGENT_JOINED_SUBNET,
-                    task_id=subnet_id,  # no task; use subnet_id for trace correlation
-                    data={
-                        "subnet_id": subnet_id,
-                        "agent_id": agent_id,
-                        # ADR-0003 Phase 3 — Org Harnesses that want
-                        # parent-includes-children fan-out read this
-                        # field to discover the parent. Top-level
-                        # subnets emit ``None``; harnesses that
-                        # ignore the field continue to work.
-                        "parent_subnet_id": parent_subnet_id,
-                    },
-                )
-            except Exception as e:  # noqa: BLE001 - never break join on webhook failure
-                logger.warning(
-                    "subnet_harness_webhook_failed",
-                    subnet_id=subnet_id,
-                    agent_id=agent_id,
-                    webhook_event="agent.joined_subnet",
-                    error=str(e),
-                )
-
-        return {"status": "joined", "agent_id": agent_id, "subnet_id": subnet_id}
     except AgentNotFoundException as e:
+        # Agent disappeared between auth and join — improbable
+        # but possible if the agent was deleted concurrently.
+        try:
+            await subnet_service.remove_member(subnet_id, agent_id)
+        except Exception as rollback_err:  # noqa: BLE001
+            logger.warning(
+                "join_subnet_back_ref_rollback_failed",
+                agent_id=agent_id,
+                subnet_id=subnet_id,
+                error=str(rollback_err),
+            )
         raise ACNHTTPError(
             ErrorCode.AGENT_NOT_FOUND,
             404,
             details={"agent_id": agent_id},
         ) from e
-    except ACNHTTPError:
-        raise
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("join_subnet_failed", error=str(e), exc_info=True)
+    except Exception as e:  # noqa: BLE001
+        # Same half-joined recovery; treat as 500.
+        try:
+            await subnet_service.remove_member(subnet_id, agent_id)
+        except Exception as rollback_err:  # noqa: BLE001
+            logger.warning(
+                "join_subnet_back_ref_rollback_failed",
+                agent_id=agent_id,
+                subnet_id=subnet_id,
+                error=str(rollback_err),
+            )
+        logger.error(
+            "join_subnet_back_ref_failed",
+            agent_id=agent_id,
+            subnet_id=subnet_id,
+            error=str(e),
+            exc_info=True,
+        )
         raise HTTPException(status_code=500, detail="Failed to join subnet") from e
+
+    logger.info(
+        "agent_joined_subnet",
+        agent_id=agent_id,
+        subnet_id=subnet_id,
+        branch=type(result).__name__,
+    )
+
+    # ADR-0003 harness webhook — fires for every successful join
+    # regardless of branch. The ADR-0004 join-flow webhooks
+    # (subnet.join_requested / .approved / .invitation_accepted /
+    # etc.) are emitted independently by JoinFlowService via its
+    # event publisher; the AGENT_JOINED_SUBNET event below stays
+    # the ADR-0003 "an agent is now a member" signal.
+    if subnet.harness_url and webhook_service is not None:
+        try:
+            await webhook_service.send_to(
+                url=subnet.harness_url,
+                secret=subnet.harness_secret,
+                event=WebhookEventType.AGENT_JOINED_SUBNET,
+                task_id=subnet_id,
+                data={
+                    "subnet_id": subnet_id,
+                    "agent_id": agent_id,
+                    "parent_subnet_id": parent_subnet_id,
+                },
+            )
+        except Exception as e:  # noqa: BLE001 - never break join on webhook failure
+            logger.warning(
+                "subnet_harness_webhook_failed",
+                subnet_id=subnet_id,
+                agent_id=agent_id,
+                webhook_event="agent.joined_subnet",
+                error=str(e),
+            )
+
+    return JSONResponse(status_code=status_code, content=body)
 
 
 async def do_leave_subnet(

--- a/acn/routes/agent_subnets.py
+++ b/acn/routes/agent_subnets.py
@@ -27,6 +27,7 @@ from .dependencies import (  # type: ignore[import-untyped]
     AgentApiKeyDep,
     AgentIdPath,
     AgentServiceDep,
+    JoinFlowServiceDep,
     SubnetIdPath,
     SubnetServiceDep,
     WebhookServiceDep,
@@ -49,12 +50,17 @@ async def join_subnet(
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
+    join_flow_service: JoinFlowServiceDep = None,
 ):
     """Agent joins a subnet (requires Agent API Key).
 
-    The authenticated agent must match the path `agent_id`. On success the
-    subnet's `member_agent_ids` is updated and (if configured) the subnet's
-    Org Harness receives an `agent.joined_subnet` webhook.
+    ADR-0004 Phase 2 Slice 2.3 — behaviour now branches on
+    ``subnet.join_policy`` and the caller's relationship to the
+    subnet (member, owner, pending invitation, allowlist hit, or
+    fresh applicant). Response status varies per branch (200 for
+    immediate admission, 202 for pending join_request) — see
+    ``acn/routes/_subnet_admission.py::join_flow_result_to_response``
+    for the per-branch shape table.
     """
     return await do_join_subnet(
         agent_id=agent_id,
@@ -63,6 +69,7 @@ async def join_subnet(
         subnet_service=subnet_service,
         agent_service=agent_service,
         webhook_service=webhook_service,
+        join_flow_service=join_flow_service,
     )
 
 

--- a/acn/routes/dependencies.py
+++ b/acn/routes/dependencies.py
@@ -47,6 +47,7 @@ from ..services import (
 )
 from ..services.activity_service import ActivityService
 from ..services.agent_service import hash_api_key
+from ..services.join_flow_service import JoinFlowService
 from ..services.reputation_query_service import ReputationQueryService
 from ..services.reputation_service import ReputationService
 
@@ -79,6 +80,10 @@ MAX_SUBNET_ID_LEN: int = 100  # matches Postgres String(100) on tasks.subnet_id
 MAX_AGENT_ID_LEN: int = 128
 MAX_TASK_ID_LEN: int = 128
 MAX_PARTICIPATION_ID_LEN: int = 128
+# ADR-0004 §SubnetJoinRequest schema fixes ``request_id`` at UUID4
+# shape (36 chars). Cap at 64 chars for forward compatibility with
+# any future longer encoding (matches the AGENT_ID cap pattern).
+MAX_REQUEST_ID_LEN: int = 64
 
 SubnetIdPath = Annotated[
     str,
@@ -95,6 +100,13 @@ TaskIdPath = Annotated[
 ParticipationIdPath = Annotated[
     str,
     Path(max_length=MAX_PARTICIPATION_ID_LEN, description="Participation identifier"),
+]
+RequestIdPath = Annotated[
+    str,
+    Path(
+        max_length=MAX_REQUEST_ID_LEN,
+        description="SubnetJoinRequest identifier (join-request or invitation row id)",
+    ),
 ]
 
 
@@ -319,6 +331,14 @@ _session_service: SessionService | None = None
 # the per-request fallback construction up to lifespan time.
 _reputation_service: ReputationService | None = None
 _reputation_query_service: ReputationQueryService | None = None
+# ADR-0004 Slice 2.3 join flow. Composes SubnetService + the two
+# admission-related repositories; routes layer holds it so the 14
+# new admission endpoints (POST /agents/{a}/subnets/{s} entry,
+# allowlist / join_request / invitation verbs) can dispatch the
+# six-branch decision tree without re-wiring on every request.
+# ``None`` default mirrors the SubnetService pattern: legacy test
+# fixtures that don't exercise admission can still bring the app up.
+_join_flow_service: JoinFlowService | None = None
 
 
 def init_services(
@@ -345,6 +365,7 @@ def init_services(
     session_service: SessionService | None = None,
     reputation_service: ReputationService | None = None,
     reputation_query_service: ReputationQueryService | None = None,
+    join_flow_service: JoinFlowService | None = None,
 ) -> None:
     """Initialize global service instances (called from lifespan)"""
     global \
@@ -360,6 +381,7 @@ def init_services(
     global _activity_service, _follow_service, _policy_service, _manifest_service
     global _allowlist_service, _escrow_provider, _session_service
     global _reputation_service, _reputation_query_service
+    global _join_flow_service
 
     _agent_service = agent_service
     _message_service = message_service
@@ -385,6 +407,7 @@ def init_services(
     _session_service = session_service
     _reputation_service = reputation_service
     _reputation_query_service = reputation_query_service
+    _join_flow_service = join_flow_service
 
 
 # Dependency functions
@@ -625,6 +648,20 @@ def get_reputation_service() -> ReputationService | None:
     return _reputation_service
 
 
+def get_join_flow_service() -> JoinFlowService:
+    """Get the JoinFlowService instance.
+
+    Required for the 14 admission endpoints introduced by ADR-0004
+    Slice 2.3 (``POST /agents/{a}/subnets/{s}`` join entry, allowlist /
+    join_request / invitation verbs). Raises loudly when not wired —
+    production lifespan always installs it; legacy test fixtures that
+    bring up the app without admission must stub these routes.
+    """
+    if _join_flow_service is None:
+        raise RuntimeError("JoinFlowService not initialized")
+    return _join_flow_service
+
+
 def get_reputation_query_service() -> ReputationQueryService | None:
     """Get the ReputationQueryService instance.
 
@@ -668,6 +705,7 @@ ReputationServiceDep = Annotated[
 ReputationQueryServiceDep = Annotated[
     "ReputationQueryService | None", Depends(get_reputation_query_service)
 ]
+JoinFlowServiceDep = Annotated[JoinFlowService, Depends(get_join_flow_service)]
 
 # Auth dependencies
 SubjectDep = Annotated[str, Depends(get_subject)]

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -403,15 +403,19 @@ async def withdraw_join_request(
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
 
-    # Applicant-only: must match the row's initiated_by.
+    # Applicant-only: must match the row's initiated_by. Use the
+    # canonical ``{key_agent, path_agent}`` details shape per
+    # ``tests/test_error_code_details_consistency.py`` cross-sprint
+    # uniformity contract — ``path_agent`` is the agent the URL
+    # *implies* (the row's applicant), ``key_agent`` is whoever the
+    # caller actually authenticated as.
     if agent_info["agent_id"] != row.initiated_by:
         raise ACNHTTPError(
             ErrorCode.API_KEY_AGENT_MISMATCH,
             403,
             details={
-                "request_id": request_id,
-                "initiated_by": row.initiated_by,
-                "caller": agent_info["agent_id"],
+                "path_agent": row.initiated_by,
+                "key_agent": agent_info["agent_id"],
             },
         )
 

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -1,0 +1,763 @@
+"""ADR-0004 Slice 2.3 subnet-admission endpoints (allowlist / join_request / invitation).
+
+Fourteen handlers covering the three resources the ADR introduces:
+
+- **Allowlist** (3): pre-authorise / revoke / list owner-side trust set.
+- **Join requests** (4): owner approve / reject; applicant withdraw;
+  owner list.
+- **Invitations** (5): owner invite (with auto-merge of pending
+  join_requests) / cancel / list; invitee accept / reject.
+- **Agent-side invitations list** (1): invitee's cross-subnet
+  pending-invitation view.
+
+The join-entry verb (``POST /api/v1/agents/{agent_id}/subnets/
+{subnet_id}``) still lives in ``routes/agent_subnets.py`` (and the
+legacy mirror in ``routes/subnets.py``); both delegate to
+``_subnet_membership.do_join_subnet`` which now dispatches the
+six-branch decision tree via ``JoinFlowService``.
+
+URL precedence
+--------------
+This router is included BEFORE ``registry.router`` in ``api.py``
+because ``registry`` has a catch-all
+``/{agent_id}/{rest_path:path}`` proxy that would otherwise swallow
+``GET /api/v1/agents/{agent_id}/subnet-invitations``. Same precedence
+discipline as ``follows.py`` / ``manifest.py`` / ``allowlist.py``.
+
+Response shapes
+---------------
+Per ADR §"HTTP status code conventions":
+- 200 — request settled inline (any approve / reject / cancel /
+  withdraw verb; merge-path POST /invitations; GET).
+- 201 — new configuration resource (POST /allowlist).
+- 202 — pending request created (normal POST /invitations).
+- 204 — no body (DELETE /allowlist/{agent_id} — idempotent).
+
+All 4xx surfaces flow through ``ACNHTTPError`` with stable
+``ErrorCode`` slugs (see ``acn/core/errors.py``); the
+``_subnet_admission._map_join_flow_error`` helper covers the eight
+:class:`JoinFlowError` subclasses that the service layer raises.
+
+Authorization
+-------------
+Per ADR §"Authorization matrix":
+- Owner-only: every allowlist verb, approve / reject / list
+  join_requests, send / list / cancel invitations.
+- Invitee-only: accept / reject invitation.
+- Self-only: applicant withdraw, agent-side invitations list.
+
+The pre-existing ``_require_self`` (from ``_subnet_membership.py``)
+covers the self-only paths; ``_require_owner`` / ``_require_invitee``
+(in ``_subnet_admission.py``) cover the new gates.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import structlog  # type: ignore[import-untyped]
+from fastapi import APIRouter, HTTPException, Query, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
+from ..core.exceptions import (
+    AgentNotFoundException,
+    AlreadyMemberError,
+    JoinFlowError,
+)
+from ._subnet_admission import (
+    _map_join_flow_error,
+    _require_invitee,
+    _require_owner,
+    invite_agent_result_to_response,
+    load_subnet_or_404,
+    serialize_allowlist_entry,
+    serialize_join_request,
+)
+from ._subnet_membership import _require_self
+from .dependencies import (
+    AgentApiKeyDep,
+    AgentIdPath,
+    AgentServiceDep,
+    RequestIdPath,
+    SubnetIdPath,
+    SubnetServiceDep,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter(
+    prefix="/api/v1",
+    tags=["subnet_admission"],
+    responses=ACN_DEFAULT_RESPONSES,
+)
+
+
+# Length cap for the optional ``note`` body on every approve / reject
+# / withdraw / invite endpoint. Pinned to 500 chars to match the
+# entity-layer ``SubnetJoinRequest`` invariant; validating at the
+# route layer gives the caller a 422 (Pydantic) instead of a 500
+# (entity-raised ValueError) for over-long notes.
+_MAX_NOTE_LEN: int = 500
+
+
+# ---------------------------------------------------------------------------
+# Pydantic request bodies
+# ---------------------------------------------------------------------------
+
+
+class AllowlistAddBody(BaseModel):
+    """POST /api/v1/subnets/{subnet_id}/allowlist body."""
+
+    agent_id: str = Field(..., min_length=1, max_length=128)
+
+
+class _OptionalNoteBody(BaseModel):
+    """Shared body shape for verbs that accept an audit note."""
+
+    note: str | None = Field(default=None, max_length=_MAX_NOTE_LEN)
+
+
+class ApproveBody(_OptionalNoteBody):
+    """POST /api/v1/subnets/{s}/join-requests/{rid}/approve body."""
+
+
+class RejectBody(_OptionalNoteBody):
+    """POST /api/v1/subnets/{s}/join-requests/{rid}/reject body."""
+
+
+class WithdrawBody(_OptionalNoteBody):
+    """DELETE /api/v1/subnets/{s}/join-requests/{rid} body (optional)."""
+
+
+class InviteBody(_OptionalNoteBody):
+    """POST /api/v1/subnets/{s}/invitations body."""
+
+    agent_id: str = Field(..., min_length=1, max_length=128)
+
+
+class AcceptInvitationBody(_OptionalNoteBody):
+    """POST /api/v1/subnets/{s}/invitations/{iid}/accept body (optional)."""
+
+
+class RejectInvitationBody(_OptionalNoteBody):
+    """POST /api/v1/subnets/{s}/invitations/{iid}/reject body (optional)."""
+
+
+class CancelInvitationBody(_OptionalNoteBody):
+    """DELETE /api/v1/subnets/{s}/invitations/{iid} body (optional)."""
+
+
+# ---------------------------------------------------------------------------
+# Allowlist endpoints (3)
+# ---------------------------------------------------------------------------
+#
+# All three are owner-only. POST returns 201 on first add (matching
+# ADR §"Allowlist endpoints") and 409 ALREADY_ON_ALLOWLIST on
+# duplicate. DELETE is idempotent (returns 204 even when the entry
+# wasn't present — service layer raises AllowlistEntryNotFoundError
+# which we silently swallow). GET is owner-only by design (allowlist
+# leaks relationship metadata if exposed publicly).
+
+
+@router.post("/subnets/{subnet_id}/allowlist", status_code=201)
+async def add_to_allowlist(
+    subnet_id: SubnetIdPath,
+    body: AllowlistAddBody,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
+):
+    """Pre-authorise ``body.agent_id`` for ``subnet_id``'s allowlist.
+
+    Owner-only. Idempotent failure (existing entry) returns 409
+    ``ALREADY_ON_ALLOWLIST`` per ADR §"Allowlist endpoints" — the
+    legacy "silently no-op on duplicate" shape is rejected so a
+    misconfigured UI surfaces the bug instead of silently
+    succeeding.
+
+    The target agent must exist; missing agent → 404
+    ``AGENT_NOT_FOUND``. (We don't validate at the entity layer
+    because the route is the only caller — pushing the existence
+    check up here keeps the service-layer shape minimal.)
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    try:
+        await agent_service.get_agent(body.agent_id)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": body.agent_id},
+        ) from e
+
+    try:
+        entry = await subnet_service.add_allowlist(
+            subnet_id, body.agent_id, added_by=agent_info["agent_id"]
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    logger.info(
+        "subnet_allowlist_added_via_http",
+        subnet_id=subnet_id,
+        agent_id=body.agent_id,
+        added_by=agent_info["agent_id"],
+    )
+    return serialize_allowlist_entry(entry)
+
+
+@router.delete(
+    "/subnets/{subnet_id}/allowlist/{agent_id}",
+    status_code=204,
+    responses={**ACN_DEFAULT_RESPONSES, 204: {"description": "Entry removed"}},
+)
+async def remove_from_allowlist(
+    subnet_id: SubnetIdPath,
+    agent_id: AgentIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Remove ``agent_id`` from ``subnet_id``'s allowlist (owner-only).
+
+    Idempotent per ADR §"Allowlist endpoints" — removing an entry
+    that doesn't exist is a 204 (not a 404). This matches the
+    semantics SDK clients expect from declarative state-sync calls
+    (``ensure_not_on_allowlist``).
+
+    NB: ADR §"Allowlist mutation does not affect agents who already
+    joined" — an agent removed from the allowlist remains a subnet
+    member if they had already joined. The route layer does not
+    revoke membership.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    # Service-layer ``remove_allowlist`` is already idempotent (returns
+    # False when the pair wasn't present); the 204 response is the
+    # same either way per ADR §"Allowlist endpoints".
+    try:
+        await subnet_service.remove_allowlist(
+            subnet_id, agent_id, remover=agent_info["agent_id"]
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    logger.info(
+        "subnet_allowlist_removed_via_http",
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        removed_by=agent_info["agent_id"],
+    )
+    return Response(status_code=204)
+
+
+@router.get("/subnets/{subnet_id}/allowlist")
+async def list_allowlist(
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """List allowlist entries for ``subnet_id`` (owner-only).
+
+    Owner-only by design per ADR §"GET /subnets/{s}/allowlist is
+    owner-only deliberately" — the allowlist is a privacy-sensitive
+    trust signal and exposing it publicly would leak relationship
+    metadata for both the operator and the listed agents.
+
+    Pagination matches ``follows`` / ``allowlist`` conventions: 100
+    default page, 500 max page. Allowlists are bounded (no
+    universal cap, but practical sizes are well under 500).
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    entries = await subnet_service.list_allowlist(
+        subnet_id, limit=limit, offset=offset
+    )
+    return {
+        "subnet_id": subnet_id,
+        "entries": [serialize_allowlist_entry(e) for e in entries],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Join-request endpoints (4)
+# ---------------------------------------------------------------------------
+#
+# Owner approves / rejects; applicant withdraws; owner lists.
+#
+# ADR §"URL alias routing rules": ``/join-requests/{id}`` paths reject
+# rows where ``row.kind != "join_request"`` with 404
+# JOIN_REQUEST_NOT_FOUND — the service-layer helper
+# ``_load_join_request_or_404`` enforces this and raises
+# ``JoinRequestNotFoundError`` on mismatch. We pass it through the
+# mapper unchanged so namespace-cross attempts (using a join-request
+# verb against an invitation id) emit JOIN_REQUEST_NOT_FOUND, never
+# leaking the existence of a row in the other namespace.
+
+
+@router.post("/subnets/{subnet_id}/join-requests/{request_id}/approve")
+async def approve_join_request(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: ApproveBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Owner approves a pending ``join_request`` (CAS pending → approved).
+
+    Side effects:
+    - Row CAS'd to ``approved``, ``decided_by=owner_agent_id``,
+      ``decided_at=now()``.
+    - Applicant added to ``subnet.member_agent_ids`` (no agent-side
+      back-reference write — the applicant is expected to re-join
+      via ``POST /agents/{a}/subnets/{s}`` to register the
+      back-ref; ADR §"State machine edges" pins this).
+    - ``subnet.join_approved`` webhook fires (logged-only stub
+      pending Slice 2.4).
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+    note = body.note if body is not None else None
+
+    try:
+        row = await subnet_service.approve_join_request(
+            subnet_id,
+            request_id,
+            owner_id=agent_info["agent_id"],
+            note=note,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    return serialize_join_request(row)
+
+
+@router.post("/subnets/{subnet_id}/join-requests/{request_id}/reject")
+async def reject_join_request(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: RejectBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Owner rejects a pending ``join_request`` (CAS pending → rejected).
+
+    No membership change. ``subnet.join_rejected`` webhook fires.
+    Optional ``note`` (≤500 chars) per ADR §"Application-side
+    endpoints" lets the owner record a human-readable reason in the
+    audit trail.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+    note = body.note if body is not None else None
+
+    try:
+        row = await subnet_service.reject_join_request(
+            subnet_id,
+            request_id,
+            owner_id=agent_info["agent_id"],
+            note=note,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    return serialize_join_request(row)
+
+
+@router.delete("/subnets/{subnet_id}/join-requests/{request_id}")
+async def withdraw_join_request(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: WithdrawBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Applicant withdraws their own pending ``join_request``.
+
+    ADR §"Authorization matrix" pins this to ``_require_self
+    against row.initiated_by``: the caller must be the agent who
+    originally created the request (NOT the subnet owner — owner
+    rejection is a separate verb). The check happens *after* the
+    row load so we can validate ``initiated_by`` without a separate
+    repo call.
+
+    No membership change. ``subnet.join_withdrawn`` webhook fires.
+    """
+    await load_subnet_or_404(subnet_service, subnet_id)
+
+    # Load + namespace-check the row up front so we can authz
+    # against initiated_by. Wrong namespace → 404 surfaces here.
+    try:
+        row = await subnet_service._load_join_request_or_404(
+            request_id,
+            expected_kind="join_request",
+            expected_subnet_id=subnet_id,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    # Applicant-only: must match the row's initiated_by.
+    if agent_info["agent_id"] != row.initiated_by:
+        raise ACNHTTPError(
+            ErrorCode.API_KEY_AGENT_MISMATCH,
+            403,
+            details={
+                "request_id": request_id,
+                "initiated_by": row.initiated_by,
+                "caller": agent_info["agent_id"],
+            },
+        )
+
+    note = body.note if body is not None else None
+
+    try:
+        withdrawn = await subnet_service.withdraw_join_request(
+            subnet_id,
+            request_id,
+            applicant_id=agent_info["agent_id"],
+            note=note,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    return serialize_join_request(withdrawn)
+
+
+@router.get("/subnets/{subnet_id}/join-requests")
+async def list_join_requests(
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    status: Literal["pending", "approved", "rejected", "withdrawn"] | None = Query(
+        default=None
+    ),
+    kind: Literal["join_request", "allowlist_auto", "invitation"] = Query(
+        default="join_request",
+        description=(
+            "kind filter — defaults to join_request. Supplying "
+            "kind=invitation returns 400 INVALID_KIND_FILTER per "
+            "ADR §'Application-side endpoints' (invitations are "
+            "queryable through /invitations only)."
+        ),
+    ),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """Owner lists join_request / allowlist_auto rows for ``subnet_id``.
+
+    ADR §"Application-side endpoints" forbids ``kind=invitation`` on
+    this path; rejecting at the request boundary with 400
+    ``INVALID_KIND_FILTER`` prevents SDK clients from accidentally
+    surfacing invitation rows through the join-request channel.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    if kind == "invitation":
+        raise ACNHTTPError(
+            ErrorCode.INVALID_KIND_FILTER,
+            400,
+            details={"kind": kind, "allowed": ["join_request", "allowlist_auto"]},
+        )
+
+    rows = await subnet_service.list_join_requests(
+        subnet_id,
+        kind=kind,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "subnet_id": subnet_id,
+        "items": [serialize_join_request(r) for r in rows],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Invitation endpoints (5 on the subnet path + 1 on the agent path)
+# ---------------------------------------------------------------------------
+#
+# Owner sends / cancels / lists; invitee accepts / rejects. The send
+# verb has a merge path (target has pending join_request → owner
+# invite collapses to auto-approval of that request); the response
+# discriminates 202 (normal send) vs 200 (merge).
+
+
+@router.post("/subnets/{subnet_id}/invitations")
+async def send_invitation(
+    subnet_id: SubnetIdPath,
+    body: InviteBody,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
+):
+    """Owner sends an invitation, or merges into a pending join_request.
+
+    See :meth:`SubnetService.invite_agent` for the merge path —
+    return shape is the sealed ``InviteAgentResult`` translated to
+    HTTP by :func:`invite_agent_result_to_response`:
+
+    - **Normal path** — 202 ``{invitation_id, status: "pending"}``.
+    - **Merge path** — 200 ``{auto_resolved: true, resolved_kind:
+      "join_request", request_id}``.
+
+    Pre-checks:
+    - Target agent must exist → 404 ``AGENT_NOT_FOUND``.
+    - Target already a member → 409 ``ALREADY_MEMBER``.
+    - Target already has a pending invitation → 409
+      ``INVITATION_PENDING`` with the existing id echoed.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    try:
+        await agent_service.get_agent(body.agent_id)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": body.agent_id},
+        ) from e
+
+    try:
+        result = await subnet_service.invite_agent(
+            subnet_id,
+            body.agent_id,
+            owner_id=agent_info["agent_id"],
+            note=body.note,
+        )
+    except AlreadyMemberError as e:
+        raise _map_join_flow_error(e) from e
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    status_code, payload = invite_agent_result_to_response(result)
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+@router.post("/subnets/{subnet_id}/invitations/{request_id}/accept")
+async def accept_invitation(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: AcceptInvitationBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
+):
+    """Invitee accepts a pending invitation.
+
+    Owner-side cancel of the same row is a different verb (DELETE
+    /invitations/{iid}). ``_require_invitee`` gates this against
+    ``row.agent_id`` (the invitee, per the entity field semantics).
+
+    Side effects on success:
+    - Row CAS'd to ``approved``, ``decided_by=invitee_id``.
+    - Invitee added to ``subnet.member_agent_ids``.
+    - Invitee's ``agent.subnet_ids`` gains the back-reference
+      (written here in the route layer for parity with the join
+      path).
+    - ``subnet.invitation_accepted`` webhook fires.
+    """
+    await load_subnet_or_404(subnet_service, subnet_id)
+
+    # Load + namespace-check up front so authz uses the loaded row.
+    try:
+        row = await subnet_service._load_join_request_or_404(
+            request_id,
+            expected_kind="invitation",
+            expected_subnet_id=subnet_id,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    _require_invitee(agent_info, row)
+
+    try:
+        accepted = await subnet_service.accept_invitation(
+            subnet_id,
+            request_id,
+            invitee_id=agent_info["agent_id"],
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    # Agent-side back-reference. Same pattern + rollback semantics
+    # as ``do_join_subnet``: the service layer has already added
+    # the member; failure to write the back-ref leaves a
+    # half-joined state we best-effort recover.
+    try:
+        await agent_service.join_subnet(agent_info["agent_id"], subnet_id)
+    except AgentNotFoundException as e:
+        logger.warning(
+            "accept_invitation_back_ref_failed_agent_not_found",
+            agent_id=agent_info["agent_id"],
+            subnet_id=subnet_id,
+        )
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_info["agent_id"]},
+        ) from e
+    except Exception as e:  # noqa: BLE001
+        logger.error(
+            "accept_invitation_back_ref_failed",
+            agent_id=agent_info["agent_id"],
+            subnet_id=subnet_id,
+            error=str(e),
+            exc_info=True,
+        )
+        # Unlike join, we do NOT roll back ``add_member`` here —
+        # the invitation row has already been CAS'd to approved,
+        # and reversing that CAS would leak a partial-success
+        # signal to Harness consumers. Surface 500 and let the SDK
+        # retry (idempotent CAS will then succeed at the
+        # already-decided check, surfacing 409
+        # INVITATION_ALREADY_DECIDED — SDK can treat that as
+        # success).
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to write agent back-reference",
+        ) from e
+
+    return serialize_join_request(accepted)
+
+
+@router.post("/subnets/{subnet_id}/invitations/{request_id}/reject")
+async def reject_invitation(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: RejectInvitationBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Invitee rejects a pending invitation (CAS pending → rejected).
+
+    No membership change. ``subnet.invitation_rejected`` webhook
+    fires. Optional ``note`` lets the invitee record a reason.
+    """
+    await load_subnet_or_404(subnet_service, subnet_id)
+
+    try:
+        row = await subnet_service._load_join_request_or_404(
+            request_id,
+            expected_kind="invitation",
+            expected_subnet_id=subnet_id,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    _require_invitee(agent_info, row)
+    note = body.note if body is not None else None
+
+    try:
+        rejected = await subnet_service.reject_invitation(
+            subnet_id,
+            request_id,
+            invitee_id=agent_info["agent_id"],
+            note=note,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    return serialize_join_request(rejected)
+
+
+@router.delete("/subnets/{subnet_id}/invitations/{request_id}")
+async def cancel_invitation(
+    subnet_id: SubnetIdPath,
+    request_id: RequestIdPath,
+    agent_info: AgentApiKeyDep,
+    body: CancelInvitationBody | None = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Owner cancels a pending invitation (CAS pending → withdrawn).
+
+    Owner-only counterpart to applicant withdraw. Per ADR §"State
+    transition table", ``invitation`` rows transition to
+    ``withdrawn`` (not ``rejected``) on owner cancel — distinct
+    audit token so consumers can tell "owner gave up" from "invitee
+    said no".
+
+    ``subnet.invitation_canceled`` webhook fires.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+    note = body.note if body is not None else None
+
+    try:
+        canceled = await subnet_service.cancel_invitation(
+            subnet_id,
+            request_id,
+            owner_id=agent_info["agent_id"],
+            note=note,
+        )
+    except JoinFlowError as e:
+        raise _map_join_flow_error(e) from e
+
+    return serialize_join_request(canceled)
+
+
+@router.get("/subnets/{subnet_id}/invitations")
+async def list_invitations(
+    subnet_id: SubnetIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+    status: Literal["pending", "approved", "rejected", "withdrawn"] | None = Query(
+        default=None
+    ),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """Owner lists invitation rows for ``subnet_id``.
+
+    Owner-only — invitees use the per-agent endpoint
+    ``GET /agents/{a}/subnet-invitations`` for their own view.
+    """
+    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    _require_owner(agent_info, subnet)
+
+    rows = await subnet_service.list_invitations(
+        subnet_id,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "subnet_id": subnet_id,
+        "items": [serialize_join_request(r) for r in rows],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Agent-side invitations list
+# ---------------------------------------------------------------------------
+
+
+@router.get("/agents/{agent_id}/subnet-invitations")
+async def list_agent_pending_invitations(
+    agent_id: AgentIdPath,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Invitee's cross-subnet pending-invitation list.
+
+    Self-only per ADR §"Authorization matrix". Returns only
+    ``status=pending`` rows — the assumption is that an invitee
+    cares about "what's waiting on me to decide", not historical
+    decisions. (Historical view is available per-subnet through
+    the owner-only ``GET /subnets/{s}/invitations``.)
+    """
+    _require_self(agent_info, agent_id)
+
+    rows = await subnet_service.list_pending_invitations_for_agent(agent_id)
+    return {
+        "agent_id": agent_id,
+        "items": [serialize_join_request(r) for r in rows],
+    }

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -27,6 +27,7 @@ from .dependencies import (  # type: ignore[import-untyped]
     AgentApiKeyDep,
     AgentIdPath,
     AgentServiceDep,
+    JoinFlowServiceDep,
     SubnetIdPath,
     SubnetServiceDep,
     WebhookServiceDep,
@@ -581,6 +582,7 @@ async def join_subnet(
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
+    join_flow_service: JoinFlowServiceDep = None,
 ):
     """[Deprecated] Use POST /api/v1/agents/{agent_id}/subnets/{subnet_id}."""
     logger.warning(
@@ -596,6 +598,7 @@ async def join_subnet(
         subnet_service=subnet_service,
         agent_service=agent_service,
         webhook_service=webhook_service,
+        join_flow_service=join_flow_service,
     )
 
 

--- a/tests/protocols/test_webhook_parent_subnet_id.py
+++ b/tests/protocols/test_webhook_parent_subnet_id.py
@@ -33,6 +33,7 @@ import pytest
 from acn.core.entities import Subnet
 from acn.protocols.ap2 import WebhookEventType
 from acn.routes._subnet_membership import do_join_subnet, do_leave_subnet
+from acn.services._join_flow_result import JoinFlowJoinedOpenResult
 
 
 def _make_subnet(
@@ -68,6 +69,26 @@ def agent_service() -> AsyncMock:
     svc = AsyncMock()
     svc.join_subnet = AsyncMock(return_value=None)
     svc.leave_subnet = AsyncMock(return_value=None)
+    return svc
+
+
+def _build_join_flow_service(subnet_service: AsyncMock) -> AsyncMock:
+    """Stub ``JoinFlowService`` that forwards open-branch to subnet_service.
+
+    ADR-0004 Slice 2.3 — ``do_join_subnet`` now dispatches the
+    six-branch decision tree through ``JoinFlowService.join_subnet``
+    rather than calling ``subnet_service.add_member`` directly. The
+    webhook assertions still want ``add_member`` to fire (it now
+    happens inside the service), so the stub forwards to the same
+    underlying ``subnet_service`` mock the tests already pin.
+    """
+    svc = AsyncMock()
+
+    async def _join(subnet_id: str, agent_id: str):
+        await subnet_service.add_member(subnet_id, agent_id)
+        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+
+    svc.join_subnet = AsyncMock(side_effect=_join)
     return svc
 
 
@@ -113,6 +134,7 @@ class TestJoinSubnetWebhookParentField:
     ):
         subnet = _make_subnet(parent_subnet_id=None)
         subnet_service = _build_subnet_service_for_join(subnet)
+        join_flow_service = _build_join_flow_service(subnet_service)
 
         await do_join_subnet(
             agent_id="alice",
@@ -121,6 +143,7 @@ class TestJoinSubnetWebhookParentField:
             subnet_service=subnet_service,
             agent_service=agent_service,
             webhook_service=webhook_service,
+            join_flow_service=join_flow_service,
         )
 
         webhook_service.send_to.assert_awaited_once()
@@ -152,6 +175,7 @@ class TestJoinSubnetWebhookParentField:
             harness_secret=None,
         )
         subnet_service = _build_subnet_service_for_join(child, parent_subnet=parent)
+        join_flow_service = _build_join_flow_service(subnet_service)
 
         await do_join_subnet(
             agent_id="alice",
@@ -160,6 +184,7 @@ class TestJoinSubnetWebhookParentField:
             subnet_service=subnet_service,
             agent_service=agent_service,
             webhook_service=webhook_service,
+            join_flow_service=join_flow_service,
         )
 
         webhook_service.send_to.assert_awaited_once()
@@ -185,6 +210,7 @@ class TestJoinSubnetWebhookParentField:
             harness_secret=None,
         )
         subnet_service = _build_subnet_service_for_join(subnet)
+        join_flow_service = _build_join_flow_service(subnet_service)
 
         await do_join_subnet(
             agent_id="alice",
@@ -193,6 +219,7 @@ class TestJoinSubnetWebhookParentField:
             subnet_service=subnet_service,
             agent_service=agent_service,
             webhook_service=webhook_service,
+            join_flow_service=join_flow_service,
         )
 
         webhook_service.send_to.assert_not_awaited()

--- a/tests/routes/_admission_helpers.py
+++ b/tests/routes/_admission_helpers.py
@@ -1,0 +1,250 @@
+"""Shared test fixtures for ADR-0004 Slice 2.3 admission route tests.
+
+The four ``test_subnet_admission_*.py`` files all need the same
+service stubs (subnet / agent / join_flow) and the same TestClient
+wiring. Centralising here keeps each file under ~300 lines and
+ensures the mock surface is consistent — a change to
+``SubnetService`` admission method shape only needs to update one
+fixture file.
+
+Not a ``conftest.py`` (which would auto-apply to every test under
+``tests/routes/``): each admission test imports the fixtures
+explicitly via ``pytest_plugins = ["tests.routes._admission_helpers"]``
+at module top so the broader regression suite is unaffected.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.api import app
+from acn.core.entities import SubnetAllowlist, SubnetJoinRequest
+from acn.core.exceptions import (
+    AgentNotFoundException,
+    SubnetNotFoundException,
+)
+from acn.routes.dependencies import (
+    get_agent_service,
+    get_join_flow_service,
+    get_subnet_service,
+    get_webhook_service,
+)
+
+# Canonical actors used across admission tests. The owner key
+# authenticates as the owner of ``subnet-1``; the invitee key
+# authenticates as the would-be member. Other-key is for
+# cross-tenant 403 checks. Stub agent_service.get_agent_by_api_key
+# returns the matching agent MagicMock.
+OWNER_AGENT_ID = "agent-owner"
+INVITEE_AGENT_ID = "agent-invitee"
+OTHER_AGENT_ID = "agent-other"
+OWNER_KEY = "owner-key"
+INVITEE_KEY = "invitee-key"
+OTHER_KEY = "other-key"
+
+SUBNET_ID = "subnet-1"
+
+
+def _make_agent(agent_id: str) -> MagicMock:
+    a = MagicMock()
+    a.agent_id = agent_id
+    a.name = agent_id
+    a.subnet_ids = []
+    return a
+
+
+def _make_subnet(
+    subnet_id: str = SUBNET_ID,
+    owner: str = OWNER_AGENT_ID,
+    join_policy: str = "approval",
+    harness_url: str | None = None,
+    harness_secret: str | None = None,
+) -> MagicMock:
+    sn = MagicMock()
+    sn.subnet_id = subnet_id
+    sn.owner = owner
+    sn.join_policy = join_policy
+    sn.harness_url = harness_url
+    sn.harness_secret = harness_secret
+    sn.is_private = join_policy == "approval"
+    sn.member_agent_ids = set()
+    return sn
+
+
+def make_join_request(
+    *,
+    request_id: str = "req-1",
+    subnet_id: str = SUBNET_ID,
+    agent_id: str = INVITEE_AGENT_ID,
+    kind: str = "join_request",
+    status: str = "pending",
+    initiated_by: str | None = None,
+    decided_by: str | None = None,
+    note: str | None = None,
+) -> SubnetJoinRequest:
+    """Build a real :class:`SubnetJoinRequest` entity for route tests."""
+    if initiated_by is None:
+        initiated_by = (
+            agent_id
+            if kind == "join_request"
+            else (OWNER_AGENT_ID if kind == "invitation" else "system:allowlist")
+        )
+    decided_at = datetime.now(UTC) if status != "pending" else None
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind=kind,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        initiated_by=initiated_by,
+        decided_by=decided_by,
+        decided_at=decided_at,
+        note=note,
+    )
+
+
+def make_allowlist_entry(
+    *,
+    subnet_id: str = SUBNET_ID,
+    agent_id: str = INVITEE_AGENT_ID,
+    added_by: str = OWNER_AGENT_ID,
+) -> SubnetAllowlist:
+    return SubnetAllowlist(
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        added_by=added_by,
+    )
+
+
+@pytest.fixture
+def stub_agent_service():
+    """Three known agents + three known API keys."""
+    svc = AsyncMock()
+    agents = {
+        OWNER_AGENT_ID: _make_agent(OWNER_AGENT_ID),
+        INVITEE_AGENT_ID: _make_agent(INVITEE_AGENT_ID),
+        OTHER_AGENT_ID: _make_agent(OTHER_AGENT_ID),
+    }
+    keys = {
+        OWNER_KEY: agents[OWNER_AGENT_ID],
+        INVITEE_KEY: agents[INVITEE_AGENT_ID],
+        OTHER_KEY: agents[OTHER_AGENT_ID],
+    }
+
+    async def _by_key(key: str):
+        return keys.get(key)
+
+    async def _get_agent(agent_id: str):
+        if agent_id in agents:
+            return agents[agent_id]
+        raise AgentNotFoundException(agent_id)
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_key)
+    svc.get_agent = AsyncMock(side_effect=_get_agent)
+    svc.join_subnet = AsyncMock(return_value=None)
+    svc.leave_subnet = AsyncMock(return_value=None)
+    svc._agents = agents
+    return svc
+
+
+@pytest.fixture
+def stub_subnet_service():
+    """SubnetService with ``subnet-1`` (approval policy, owner=agent-owner).
+
+    Returns an ``AsyncMock`` configured with the admission method
+    surface used by ``acn/routes/subnet_admission.py``. Individual
+    tests configure per-method ``return_value`` / ``side_effect``
+    as needed.
+    """
+    svc = AsyncMock()
+    subnet = _make_subnet()
+
+    async def _get_subnet(subnet_id: str):
+        if subnet_id == SUBNET_ID:
+            return subnet
+        raise SubnetNotFoundException(subnet_id)
+
+    svc.get_subnet = AsyncMock(side_effect=_get_subnet)
+    svc._subnet = subnet
+    # Admission methods — default to AsyncMock so individual tests
+    # can override via ``.return_value`` / ``.side_effect``.
+    svc.add_allowlist = AsyncMock()
+    svc.remove_allowlist = AsyncMock(return_value=True)
+    svc.list_allowlist = AsyncMock(return_value=[])
+    svc.approve_join_request = AsyncMock()
+    svc.reject_join_request = AsyncMock()
+    svc.withdraw_join_request = AsyncMock()
+    svc.list_join_requests = AsyncMock(return_value=[])
+    svc.invite_agent = AsyncMock()
+    svc.accept_invitation = AsyncMock()
+    svc.reject_invitation = AsyncMock()
+    svc.cancel_invitation = AsyncMock()
+    svc.list_invitations = AsyncMock(return_value=[])
+    svc.list_pending_invitations_for_agent = AsyncMock(return_value=[])
+    svc._load_join_request_or_404 = AsyncMock()
+    svc.add_member = AsyncMock()
+    svc.remove_member = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def stub_webhook_service():
+    svc = AsyncMock()
+    svc.send_to = AsyncMock(return_value=True)
+    return svc
+
+
+@pytest.fixture
+def stub_join_flow_service():
+    """Pass-through JoinFlowService; admission routes don't use it directly.
+
+    The fixture is wired so ``do_join_subnet`` (still reachable via
+    the canonical join URL) sees a stub instead of the lifespan-
+    wired real service. Default is a bare AsyncMock; tests that
+    exercise ``POST /agents/{a}/subnets/{s}`` configure
+    ``join_subnet.return_value`` per-branch.
+    """
+    svc = AsyncMock()
+    svc.join_subnet = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def wire(
+    stub_agent_service,
+    stub_subnet_service,
+    stub_webhook_service,
+    stub_join_flow_service,
+):
+    """Install dependency overrides + yield the four-tuple of stubs.
+
+    Cleans up the overrides on test exit so cross-test pollution
+    can't leak through ``app.dependency_overrides``.
+    """
+    overrides: dict[Any, Any] = {
+        get_agent_service: lambda: stub_agent_service,
+        get_subnet_service: lambda: stub_subnet_service,
+        get_webhook_service: lambda: stub_webhook_service,
+        get_join_flow_service: lambda: stub_join_flow_service,
+    }
+    for key, fn in overrides.items():
+        app.dependency_overrides[key] = fn
+    try:
+        yield (
+            stub_agent_service,
+            stub_subnet_service,
+            stub_webhook_service,
+            stub_join_flow_service,
+        )
+    finally:
+        for key in overrides:
+            app.dependency_overrides.pop(key, None)
+
+
+def auth_headers(api_key: str = OWNER_KEY) -> dict[str, str]:
+    """Bearer header for the given key."""
+    return {"Authorization": f"Bearer {api_key}"}

--- a/tests/routes/test_agent_subnets.py
+++ b/tests/routes/test_agent_subnets.py
@@ -25,9 +25,11 @@ from acn.core.exceptions import AgentNotFoundException, SubnetNotFoundException
 from acn.protocols.ap2.webhook import WebhookEventType
 from acn.routes.dependencies import (
     get_agent_service,
+    get_join_flow_service,
     get_subnet_service,
     get_webhook_service,
 )
+from acn.services._join_flow_result import JoinFlowJoinedOpenResult
 from tests.routes.conftest import _assert_flat_shape
 
 # ---------------------------------------------------------------------------
@@ -98,6 +100,40 @@ def stub_webhook_service():
     svc.send_to = AsyncMock(return_value=True)
     svc.send_event = AsyncMock(return_value=True)
     return svc
+
+
+@pytest.fixture(autouse=True)
+def stub_join_flow_service(stub_subnet_service):
+    """JoinFlowService stub: delegates to the subnet_service mock.
+
+    Auto-applied to every test in this module because the canonical
+    ``POST /api/v1/agents/{a}/subnets/{s}`` route now depends on
+    ``JoinFlowService`` (ADR-0004 Slice 2.3 rewrote
+    ``do_join_subnet`` to use the six-branch decision tree). Tests
+    that don't exercise join still pick this fixture up — it is a
+    no-op for leave / list paths because the routes never call
+    ``join_flow_service.join_subnet`` outside the join handler.
+
+    The stub mirrors the open-branch behaviour of the real service:
+    it validates the subnet exists (via the underlying subnet
+    service stub) and calls ``add_member``, then returns a
+    ``JoinFlowJoinedOpenResult``. Pre-existing assertions on
+    ``stub_subnet_service.add_member.assert_awaited_once_with(...)``
+    continue to hold because the forwarding preserves the call.
+    """
+    svc = AsyncMock()
+
+    async def _join_subnet(subnet_id: str, agent_id: str):
+        await stub_subnet_service.get_subnet(subnet_id)
+        await stub_subnet_service.add_member(subnet_id, agent_id)
+        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+
+    svc.join_subnet = AsyncMock(side_effect=_join_subnet)
+    app.dependency_overrides[get_join_flow_service] = lambda: svc
+    try:
+        yield svc
+    finally:
+        app.dependency_overrides.pop(get_join_flow_service, None)
 
 
 def _wire(agent_svc, subnet_svc, webhook_svc=None) -> None:

--- a/tests/routes/test_subnet_admission_allowlist.py
+++ b/tests/routes/test_subnet_admission_allowlist.py
@@ -1,0 +1,254 @@
+"""Route tests for ADR-0004 Slice 2.3 allowlist endpoints (3 verbs).
+
+Covers:
+- POST   /api/v1/subnets/{s}/allowlist                  # owner-only
+- DELETE /api/v1/subnets/{s}/allowlist/{agent_id}       # owner-only
+- GET    /api/v1/subnets/{s}/allowlist                  # owner-only
+
+Per ADR §"Allowlist endpoints" and §"Authorization matrix".
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AllowlistEntryExistsError
+from tests.routes._admission_helpers import (
+    INVITEE_AGENT_ID,
+    INVITEE_KEY,
+    OTHER_KEY,
+    OWNER_KEY,
+    SUBNET_ID,
+    auth_headers,
+    make_allowlist_entry,
+    stub_agent_service,
+    stub_join_flow_service,
+    stub_subnet_service,
+    stub_webhook_service,
+    wire,
+)
+from tests.routes.conftest import _assert_flat_shape
+
+# Re-export so pytest discovers them as fixtures in this module.
+__all__ = [
+    "stub_agent_service",
+    "stub_subnet_service",
+    "stub_webhook_service",
+    "stub_join_flow_service",
+    "wire",
+]
+
+
+class TestAddToAllowlist:
+    def test_owner_can_add_entry_returns_201(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.add_allowlist.return_value = make_allowlist_entry()
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["subnet_id"] == SUBNET_ID
+        assert body["agent_id"] == INVITEE_AGENT_ID
+        assert body["added_by"] == "agent-owner"
+        subnet_svc.add_allowlist.assert_awaited_once()
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(INVITEE_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 403
+        body = r.json()
+        _assert_flat_shape(body)
+        assert body["error_code"] == "subnet_not_owner"
+
+    def test_unknown_subnet_returns_404(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/subnets/ghost/allowlist",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "subnet_not_found"
+
+    def test_unknown_target_agent_returns_404(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": "ghost-agent"},
+            )
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body["error_code"] == "agent_not_found"
+        assert body["details"]["agent_id"] == "ghost-agent"
+
+    def test_duplicate_entry_returns_409_already_on_allowlist(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.add_allowlist.side_effect = AllowlistEntryExistsError(
+            SUBNET_ID, INVITEE_AGENT_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error_code"] == "already_on_allowlist"
+        assert body["details"]["subnet_id"] == SUBNET_ID
+        assert body["details"]["agent_id"] == INVITEE_AGENT_ID
+
+    def test_missing_body_returns_422(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        # 422 from Pydantic body validation — caller did not supply
+        # the required ``agent_id`` field.
+        assert r.status_code == 422
+
+    def test_unauthenticated_request_rejected(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert 400 <= r.status_code < 500
+
+
+class TestRemoveFromAllowlist:
+    def test_owner_can_remove_entry_returns_204(self, wire):
+        _, subnet_svc, _, _ = wire
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist/{INVITEE_AGENT_ID}",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 204
+        # Empty body on 204 — TestClient surfaces ``.content == b""``.
+        assert r.content == b""
+        subnet_svc.remove_allowlist.assert_awaited_once_with(
+            SUBNET_ID, INVITEE_AGENT_ID, remover="agent-owner"
+        )
+
+    def test_remove_is_idempotent_returns_204_even_when_missing(self, wire):
+        """ADR §"Allowlist endpoints" — DELETE is idempotent."""
+        _, subnet_svc, _, _ = wire
+        # Service returns ``False`` when the pair wasn't present;
+        # route still returns 204.
+        subnet_svc.remove_allowlist.return_value = False
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist/{INVITEE_AGENT_ID}",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 204
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist/{INVITEE_AGENT_ID}",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+    def test_unknown_subnet_returns_404(self, wire):
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/ghost/allowlist/{INVITEE_AGENT_ID}",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 404
+
+
+class TestListAllowlist:
+    def test_owner_can_list_entries(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.list_allowlist.return_value = [
+            make_allowlist_entry(agent_id="agent-a"),
+            make_allowlist_entry(agent_id="agent-b"),
+        ]
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["subnet_id"] == SUBNET_ID
+        assert len(body["entries"]) == 2
+        assert {e["agent_id"] for e in body["entries"]} == {"agent-a", "agent-b"}
+
+    def test_empty_list_returns_200(self, wire):
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        assert r.json() == {"subnet_id": SUBNET_ID, "entries": []}
+
+    def test_non_owner_gets_403(self, wire):
+        """ADR §"GET /subnets/{s}/allowlist is owner-only deliberately"."""
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+    def test_pagination_params_pass_through(self, wire):
+        _, subnet_svc, _, _ = wire
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist?limit=50&offset=10",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        subnet_svc.list_allowlist.assert_awaited_once_with(
+            SUBNET_ID, limit=50, offset=10
+        )
+
+    def test_limit_capped_at_500(self, wire):
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/allowlist?limit=10000",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        # Pydantic rejects with 422 — pagination ceiling enforced.
+        assert r.status_code == 422

--- a/tests/routes/test_subnet_admission_invitations.py
+++ b/tests/routes/test_subnet_admission_invitations.py
@@ -1,0 +1,410 @@
+"""Route tests for ADR-0004 Slice 2.3 invitation endpoints (5 + 1).
+
+Covers:
+- POST   /api/v1/subnets/{s}/invitations                     # owner sends
+- GET    /api/v1/subnets/{s}/invitations                     # owner lists
+- POST   /api/v1/subnets/{s}/invitations/{iid}/accept        # invitee
+- POST   /api/v1/subnets/{s}/invitations/{iid}/reject        # invitee
+- DELETE /api/v1/subnets/{s}/invitations/{iid}               # owner cancels
+- GET    /api/v1/agents/{a}/subnet-invitations               # invitee lists
+
+Plus the namespace separation guard and the merge-path
+(``invite_agent`` collapsing into auto-approval of a pending
+join_request).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import (
+    AlreadyMemberError,
+    InvitationNotFoundError,
+    InvitationPendingError,
+)
+from acn.services._join_flow_result import (
+    InviteAgentMergedToApprovedJoinRequestResult,
+    InviteAgentSentResult,
+)
+from tests.routes._admission_helpers import (
+    INVITEE_AGENT_ID,
+    INVITEE_KEY,
+    OTHER_KEY,
+    OWNER_AGENT_ID,
+    OWNER_KEY,
+    SUBNET_ID,
+    auth_headers,
+    make_join_request,
+    stub_agent_service,
+    stub_join_flow_service,
+    stub_subnet_service,
+    stub_webhook_service,
+    wire,
+)
+
+__all__ = [
+    "stub_agent_service",
+    "stub_subnet_service",
+    "stub_webhook_service",
+    "stub_join_flow_service",
+    "wire",
+]
+
+
+INVITATION_ID = "inv-abc"
+
+
+class TestSendInvitation:
+    def test_owner_sends_invitation_returns_202(self, wire):
+        _, subnet_svc, _, _ = wire
+        invitation = make_join_request(
+            request_id=INVITATION_ID, kind="invitation"
+        )
+        subnet_svc.invite_agent.return_value = InviteAgentSentResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+            invitation=invitation,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID, "note": "join us"},
+            )
+
+        assert r.status_code == 202, r.text
+        body = r.json()
+        assert body["invitation_id"] == INVITATION_ID
+        assert body["status"] == "pending"
+        subnet_svc.invite_agent.assert_awaited_once_with(
+            SUBNET_ID,
+            INVITEE_AGENT_ID,
+            owner_id=OWNER_AGENT_ID,
+            note="join us",
+        )
+
+    def test_merge_path_returns_200_resolved_kind_join_request(self, wire):
+        """Target had pending join_request → invite collapses to auto-approval."""
+        _, subnet_svc, _, _ = wire
+        approved = make_join_request(
+            request_id="merged-req",
+            status="approved",
+            decided_by=OWNER_AGENT_ID,
+        )
+        subnet_svc.invite_agent.return_value = (
+            InviteAgentMergedToApprovedJoinRequestResult(
+                subnet_id=SUBNET_ID,
+                agent_id=INVITEE_AGENT_ID,
+                request=approved,
+            )
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["auto_resolved"] is True
+        assert body["resolved_kind"] == "join_request"
+        assert body["request_id"] == "merged-req"
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(INVITEE_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+    def test_unknown_target_agent_returns_404(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": "ghost-agent"},
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "agent_not_found"
+
+    def test_already_member_returns_409(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.invite_agent.side_effect = AlreadyMemberError(
+            SUBNET_ID, INVITEE_AGENT_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 409
+        assert r.json()["error_code"] == "already_member"
+
+    def test_pending_invitation_returns_409(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.invite_agent.side_effect = InvitationPendingError(
+            existing_invitation_id="other-inv"
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+                json={"agent_id": INVITEE_AGENT_ID},
+            )
+
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error_code"] == "invitation_pending"
+        assert body["details"]["existing_invitation_id"] == "other-inv"
+
+
+class TestAcceptInvitation:
+    def test_invitee_can_accept_returns_200(self, wire):
+        agent_svc, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=INVITATION_ID,
+            kind="invitation",
+        )
+        accepted = make_join_request(
+            request_id=INVITATION_ID,
+            kind="invitation",
+            status="approved",
+            decided_by=INVITEE_AGENT_ID,
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.accept_invitation.return_value = accepted
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}/accept",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "approved"
+        assert body["decided_by"] == INVITEE_AGENT_ID
+        # Back-reference write must have fired on success.
+        agent_svc.join_subnet.assert_awaited_once_with(
+            INVITEE_AGENT_ID, SUBNET_ID
+        )
+
+    def test_non_invitee_gets_403_not_invitee(self, wire):
+        _, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=INVITATION_ID,
+            kind="invitation",
+            agent_id=INVITEE_AGENT_ID,
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}/accept",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "not_invitee"
+        subnet_svc.accept_invitation.assert_not_awaited()
+
+    def test_namespace_mismatch_returns_invitation_not_found(self, wire):
+        """Hitting /invitations/{id} with a join_request row → 404."""
+        _, subnet_svc, _, _ = wire
+        subnet_svc._load_join_request_or_404.side_effect = InvitationNotFoundError(
+            INVITATION_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}/accept",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "invitation_not_found"
+
+
+class TestRejectInvitation:
+    def test_invitee_can_reject(self, wire):
+        _, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=INVITATION_ID, kind="invitation"
+        )
+        rejected = make_join_request(
+            request_id=INVITATION_ID,
+            kind="invitation",
+            status="rejected",
+            decided_by=INVITEE_AGENT_ID,
+            note="not now",
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.reject_invitation.return_value = rejected
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}/reject",
+                headers=auth_headers(INVITEE_KEY),
+                json={"note": "not now"},
+            )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "rejected"
+        assert body["note"] == "not now"
+
+    def test_non_invitee_gets_403(self, wire):
+        _, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=INVITATION_ID, kind="invitation"
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}/reject",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "not_invitee"
+
+
+class TestCancelInvitation:
+    def test_owner_can_cancel(self, wire):
+        _, subnet_svc, _, _ = wire
+        canceled = make_join_request(
+            request_id=INVITATION_ID,
+            kind="invitation",
+            status="withdrawn",
+            decided_by=OWNER_AGENT_ID,
+        )
+        subnet_svc.cancel_invitation.return_value = canceled
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "withdrawn"
+        subnet_svc.cancel_invitation.assert_awaited_once()
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations/{INVITATION_ID}",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+
+class TestListInvitations:
+    def test_owner_lists_invitations(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.list_invitations.return_value = [
+            make_join_request(request_id="inv-1", kind="invitation"),
+            make_join_request(
+                request_id="inv-2", kind="invitation", agent_id="agent-x"
+            ),
+        ]
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["items"]) == 2
+        assert all(item["kind"] == "invitation" for item in body["items"])
+
+    def test_status_filter_passes_through(self, wire):
+        _, subnet_svc, _, _ = wire
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations?status=pending",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        subnet_svc.list_invitations.assert_awaited_once_with(
+            SUBNET_ID, status="pending", limit=100, offset=0
+        )
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/invitations",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+
+
+class TestAgentPendingInvitations:
+    def test_invitee_can_list_own_pending(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.list_pending_invitations_for_agent.return_value = [
+            make_join_request(
+                request_id="inv-1",
+                kind="invitation",
+                subnet_id="subnet-A",
+            ),
+            make_join_request(
+                request_id="inv-2",
+                kind="invitation",
+                subnet_id="subnet-B",
+            ),
+        ]
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/agents/{INVITEE_AGENT_ID}/subnet-invitations",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["agent_id"] == INVITEE_AGENT_ID
+        assert len(body["items"]) == 2
+
+    def test_cross_agent_query_rejected_403(self, wire):
+        """OTHER_KEY trying to read INVITEE's pending invitations."""
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/agents/{INVITEE_AGENT_ID}/subnet-invitations",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "api_key_agent_mismatch"
+
+    def test_empty_pending_list_returns_200(self, wire):
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/agents/{INVITEE_AGENT_ID}/subnet-invitations",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 200
+        assert r.json() == {"agent_id": INVITEE_AGENT_ID, "items": []}

--- a/tests/routes/test_subnet_admission_join_flow.py
+++ b/tests/routes/test_subnet_admission_join_flow.py
@@ -1,0 +1,248 @@
+"""Route tests for ADR-0004 Slice 2.3 join-entry six-branch decision tree.
+
+Covers ``POST /api/v1/agents/{agent_id}/subnets/{subnet_id}`` —
+the rewritten join handler that now dispatches via
+``JoinFlowService.join_subnet``. The six branches per ADR §"POST
+/api/v1/agents/{agent_id}/subnets/{subnet_id} (join entry)":
+
+  1. open subnet → 200 ``{status: "joined"}``
+  2. approval subnet, caller == owner → 200 ``{status: "joined"}``
+  3. approval subnet, pending invitation → 200 ``{auto_resolved,
+     resolved_kind: "invitation", via: "self_join"}``
+  4. approval subnet, allowlist hit + pending invitation → 200
+     ``{auto_resolved, resolved_kind: "invitation", via:
+     "allowlist"}``
+  5. approval subnet, allowlist hit, no invitation → 200
+     ``{request_id, via: "allowlist"}``
+  6. approval subnet, fall-through → 202 ``{request_id, status:
+     "pending"}``
+
+Plus ALREADY_MEMBER (409) and JoinFlowError surface tests.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AlreadyMemberError
+from acn.services._join_flow_result import (
+    JoinFlowAllowlistAutoApprovedResult,
+    JoinFlowAutoAcceptedInvitationResult,
+    JoinFlowJoinedAsOwnerResult,
+    JoinFlowJoinedOpenResult,
+    JoinFlowPendingResult,
+)
+from tests.routes._admission_helpers import (
+    INVITEE_AGENT_ID,
+    INVITEE_KEY,
+    OTHER_KEY,
+    OWNER_AGENT_ID,
+    OWNER_KEY,
+    SUBNET_ID,
+    auth_headers,
+    make_join_request,
+    stub_agent_service,
+    stub_join_flow_service,
+    stub_subnet_service,
+    stub_webhook_service,
+    wire,
+)
+
+__all__ = [
+    "stub_agent_service",
+    "stub_subnet_service",
+    "stub_webhook_service",
+    "stub_join_flow_service",
+    "wire",
+]
+
+
+JOIN_PATH = f"/api/v1/agents/{INVITEE_AGENT_ID}/subnets/{SUBNET_ID}"
+
+
+class TestBranch1OpenSubnet:
+    def test_open_subnet_returns_200_joined(self, wire):
+        agent_svc, _, _, jfs = wire
+        jfs.join_subnet.return_value = JoinFlowJoinedOpenResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body == {
+            "status": "joined",
+            "subnet_id": SUBNET_ID,
+            "agent_id": INVITEE_AGENT_ID,
+        }
+        # Back-reference must be written on every 200 branch.
+        agent_svc.join_subnet.assert_awaited_once_with(INVITEE_AGENT_ID, SUBNET_ID)
+
+
+class TestBranch2OwnerSelfJoin:
+    def test_owner_self_join_returns_200_joined(self, wire):
+        # Owner authenticates as themselves and joins their own subnet.
+        agent_svc, _, _, jfs = wire
+        jfs.join_subnet.return_value = JoinFlowJoinedAsOwnerResult(
+            subnet_id=SUBNET_ID,
+            agent_id=OWNER_AGENT_ID,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/agents/{OWNER_AGENT_ID}/subnets/{SUBNET_ID}",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "joined"
+        assert body["agent_id"] == OWNER_AGENT_ID
+        agent_svc.join_subnet.assert_awaited_once_with(OWNER_AGENT_ID, SUBNET_ID)
+
+
+class TestBranch3SelfJoinWithPendingInvitation:
+    def test_pending_invitation_auto_accepts_via_self_join(self, wire):
+        agent_svc, _, _, jfs = wire
+        invitation = make_join_request(
+            request_id="inv-self", kind="invitation"
+        )
+        jfs.join_subnet.return_value = JoinFlowAutoAcceptedInvitationResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+            invitation=invitation,
+            via="self_join",
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["auto_resolved"] is True
+        assert body["resolved_kind"] == "invitation"
+        assert body["invitation_id"] == "inv-self"
+        assert body["via"] == "self_join"
+        agent_svc.join_subnet.assert_awaited_once()
+
+
+class TestBranch4AllowlistAndPendingInvitation:
+    def test_via_allowlist_with_invitation_collapses_to_invitation(self, wire):
+        agent_svc, _, _, jfs = wire
+        invitation = make_join_request(
+            request_id="inv-merged", kind="invitation"
+        )
+        jfs.join_subnet.return_value = JoinFlowAutoAcceptedInvitationResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+            invitation=invitation,
+            via="allowlist",
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["resolved_kind"] == "invitation"
+        assert body["invitation_id"] == "inv-merged"
+        assert body["via"] == "allowlist"
+        # ``request_id`` MUST NOT appear — ADR §"Merge-path event
+        # mapping" forbids creating an ``allowlist_auto`` row when
+        # an invitation is collapsed.
+        assert "request_id" not in body
+        agent_svc.join_subnet.assert_awaited_once()
+
+
+class TestBranch5AllowlistAutoApproved:
+    def test_allowlist_hit_no_invitation_creates_allowlist_auto(self, wire):
+        agent_svc, _, _, jfs = wire
+        auto_row = make_join_request(
+            request_id="auto-1",
+            kind="allowlist_auto",
+            status="approved",
+            initiated_by="system:allowlist",
+            decided_by="system:allowlist",
+        )
+        jfs.join_subnet.return_value = JoinFlowAllowlistAutoApprovedResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+            request=auto_row,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["request_id"] == "auto-1"
+        assert body["via"] == "allowlist"
+        agent_svc.join_subnet.assert_awaited_once()
+
+
+class TestBranch6PendingJoinRequest:
+    def test_fall_through_creates_pending_join_request_202(self, wire):
+        agent_svc, _, _, jfs = wire
+        pending = make_join_request(request_id="req-pending")
+        jfs.join_subnet.return_value = JoinFlowPendingResult(
+            subnet_id=SUBNET_ID,
+            agent_id=INVITEE_AGENT_ID,
+            request=pending,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 202, r.text
+        body = r.json()
+        assert body["request_id"] == "req-pending"
+        assert body["status"] == "pending"
+        # Critical contract: branch 6 must NOT write the agent-side
+        # back-reference (caller is not yet a member).
+        agent_svc.join_subnet.assert_not_awaited()
+
+
+class TestErrorSurfaces:
+    def test_already_member_returns_409_already_member(self, wire):
+        _, _, _, jfs = wire
+        jfs.join_subnet.side_effect = AlreadyMemberError(
+            SUBNET_ID, INVITEE_AGENT_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.post(JOIN_PATH, headers=auth_headers(INVITEE_KEY))
+
+        assert r.status_code == 409, r.text
+        body = r.json()
+        assert body["error_code"] == "already_member"
+        assert body["details"]["subnet_id"] == SUBNET_ID
+        assert body["details"]["agent_id"] == INVITEE_AGENT_ID
+
+    def test_path_agent_mismatch_returns_403_before_dispatch(self, wire):
+        """API key for INVITEE → path agent_id == OTHER → 403 + no dispatch."""
+        _, _, _, jfs = wire
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/agents/{OWNER_AGENT_ID}/subnets/{SUBNET_ID}",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "api_key_agent_mismatch"
+        # JoinFlowService must not be invoked when authz fails up-front.
+        jfs.join_subnet.assert_not_awaited()
+
+    def test_missing_subnet_returns_404(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/agents/{INVITEE_AGENT_ID}/subnets/ghost",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "subnet_not_found"

--- a/tests/routes/test_subnet_admission_join_requests.py
+++ b/tests/routes/test_subnet_admission_join_requests.py
@@ -1,0 +1,333 @@
+"""Route tests for ADR-0004 Slice 2.3 join_request endpoints (4 verbs).
+
+Covers:
+- POST   /api/v1/subnets/{s}/join-requests/{rid}/approve   # owner-only
+- POST   /api/v1/subnets/{s}/join-requests/{rid}/reject    # owner-only
+- DELETE /api/v1/subnets/{s}/join-requests/{rid}            # applicant withdraw
+- GET    /api/v1/subnets/{s}/join-requests                  # owner-only list
+
+Plus the namespace separation guard (calling a join-request verb
+with an invitation row id → 404 ``JOIN_REQUEST_NOT_FOUND``).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import (
+    JoinRequestAlreadyDecidedError,
+    JoinRequestNotFoundError,
+)
+from tests.routes._admission_helpers import (
+    INVITEE_AGENT_ID,
+    INVITEE_KEY,
+    OTHER_KEY,
+    OWNER_AGENT_ID,
+    OWNER_KEY,
+    SUBNET_ID,
+    auth_headers,
+    make_join_request,
+    stub_agent_service,
+    stub_join_flow_service,
+    stub_subnet_service,
+    stub_webhook_service,
+    wire,
+)
+
+__all__ = [
+    "stub_agent_service",
+    "stub_subnet_service",
+    "stub_webhook_service",
+    "stub_join_flow_service",
+    "wire",
+]
+
+
+REQUEST_ID = "req-abc"
+
+
+class TestApproveJoinRequest:
+    def test_owner_can_approve(self, wire):
+        _, subnet_svc, _, _ = wire
+        approved = make_join_request(
+            request_id=REQUEST_ID,
+            status="approved",
+            decided_by=OWNER_AGENT_ID,
+        )
+        subnet_svc.approve_join_request.return_value = approved
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+                json={"note": "welcome aboard"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["request_id"] == REQUEST_ID
+        assert body["status"] == "approved"
+        assert body["decided_by"] == OWNER_AGENT_ID
+        subnet_svc.approve_join_request.assert_awaited_once_with(
+            SUBNET_ID, REQUEST_ID, owner_id=OWNER_AGENT_ID, note="welcome aboard"
+        )
+
+    def test_approve_without_body_works(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.approve_join_request.return_value = make_join_request(
+            request_id=REQUEST_ID,
+            status="approved",
+            decided_by=OWNER_AGENT_ID,
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+    def test_unknown_subnet_returns_404_subnet_not_found(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/ghost/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "subnet_not_found"
+
+    def test_missing_request_returns_404_join_request_not_found(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.approve_join_request.side_effect = JoinRequestNotFoundError(
+            REQUEST_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body["error_code"] == "join_request_not_found"
+        assert body["details"]["request_id"] == REQUEST_ID
+
+    def test_already_decided_returns_409(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.approve_join_request.side_effect = JoinRequestAlreadyDecidedError(
+            REQUEST_ID, "approved"
+        )
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 409
+        body = r.json()
+        assert body["error_code"] == "join_request_already_decided"
+        assert body["details"]["current_status"] == "approved"
+
+    def test_long_note_returns_422(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/approve",
+                headers=auth_headers(OWNER_KEY),
+                json={"note": "x" * 501},
+            )
+
+        assert r.status_code == 422
+
+
+class TestRejectJoinRequest:
+    def test_owner_can_reject_with_note(self, wire):
+        _, subnet_svc, _, _ = wire
+        rejected = make_join_request(
+            request_id=REQUEST_ID,
+            status="rejected",
+            decided_by=OWNER_AGENT_ID,
+            note="not a fit",
+        )
+        subnet_svc.reject_join_request.return_value = rejected
+
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/reject",
+                headers=auth_headers(OWNER_KEY),
+                json={"note": "not a fit"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "rejected"
+        assert body["note"] == "not a fit"
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.post(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}/reject",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+
+
+class TestWithdrawJoinRequest:
+    def test_applicant_can_withdraw_own_request(self, wire):
+        _, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=REQUEST_ID,
+            initiated_by=INVITEE_AGENT_ID,
+        )
+        withdrawn = make_join_request(
+            request_id=REQUEST_ID,
+            status="withdrawn",
+            initiated_by=INVITEE_AGENT_ID,
+            decided_by=INVITEE_AGENT_ID,
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.withdraw_join_request.return_value = withdrawn
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "withdrawn"
+        subnet_svc.withdraw_join_request.assert_awaited_once()
+
+    def test_cross_applicant_withdraw_rejected_403(self, wire):
+        """OTHER_KEY tries to withdraw a request initiated by INVITEE."""
+        _, subnet_svc, _, _ = wire
+        pending = make_join_request(
+            request_id=REQUEST_ID,
+            initiated_by=INVITEE_AGENT_ID,
+        )
+        subnet_svc._load_join_request_or_404.return_value = pending
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}",
+                headers=auth_headers(OTHER_KEY),
+            )
+
+        assert r.status_code == 403
+        body = r.json()
+        assert body["error_code"] == "api_key_agent_mismatch"
+        subnet_svc.withdraw_join_request.assert_not_awaited()
+
+    def test_namespace_mismatch_returns_join_request_not_found(self, wire):
+        """Hitting /join-requests/{id} with an invitation id → 404."""
+        _, subnet_svc, _, _ = wire
+        subnet_svc._load_join_request_or_404.side_effect = JoinRequestNotFoundError(
+            REQUEST_ID
+        )
+
+        with TestClient(app) as client:
+            r = client.delete(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests/{REQUEST_ID}",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 404
+        assert r.json()["error_code"] == "join_request_not_found"
+
+
+class TestListJoinRequests:
+    def test_owner_lists_pending_join_requests(self, wire):
+        _, subnet_svc, _, _ = wire
+        subnet_svc.list_join_requests.return_value = [
+            make_join_request(request_id="req-1"),
+            make_join_request(request_id="req-2", agent_id="agent-x"),
+        ]
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["subnet_id"] == SUBNET_ID
+        assert len(body["items"]) == 2
+        # Default kind filter is join_request.
+        subnet_svc.list_join_requests.assert_awaited_once_with(
+            SUBNET_ID, kind="join_request", status=None, limit=100, offset=0
+        )
+
+    def test_kind_invitation_filter_rejected_400(self, wire):
+        """ADR §"Application-side endpoints" — kind=invitation is forbidden."""
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests?kind=invitation",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 400
+        body = r.json()
+        assert body["error_code"] == "invalid_kind_filter"
+        assert body["details"]["kind"] == "invitation"
+
+    def test_status_filter_passes_through(self, wire):
+        _, subnet_svc, _, _ = wire
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests?status=rejected",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        subnet_svc.list_join_requests.assert_awaited_once_with(
+            SUBNET_ID,
+            kind="join_request",
+            status="rejected",
+            limit=100,
+            offset=0,
+        )
+
+    def test_non_owner_gets_403(self, wire):
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests",
+                headers=auth_headers(INVITEE_KEY),
+            )
+
+        assert r.status_code == 403
+        assert r.json()["error_code"] == "subnet_not_owner"
+
+    def test_kind_allowlist_auto_allowed(self, wire):
+        _, subnet_svc, _, _ = wire
+
+        with TestClient(app) as client:
+            r = client.get(
+                f"/api/v1/subnets/{SUBNET_ID}/join-requests?kind=allowlist_auto",
+                headers=auth_headers(OWNER_KEY),
+            )
+
+        assert r.status_code == 200
+        subnet_svc.list_join_requests.assert_awaited_once_with(
+            SUBNET_ID,
+            kind="allowlist_auto",
+            status=None,
+            limit=100,
+            offset=0,
+        )

--- a/tests/routes/test_subnets_error_schema.py
+++ b/tests/routes/test_subnets_error_schema.py
@@ -76,8 +76,10 @@ from acn.api import app
 from acn.core.exceptions import AgentNotFoundException, SubnetNotFoundException
 from acn.routes.dependencies import (
     get_agent_service,
+    get_join_flow_service,
     get_subnet_service,
 )
+from acn.services._join_flow_result import JoinFlowJoinedOpenResult
 from tests.routes.conftest import _assert_flat_shape
 
 
@@ -156,6 +158,29 @@ def stub_subnet_service():
     svc.add_member = AsyncMock(return_value=None)
     svc.remove_member = AsyncMock(return_value=None)
     return svc
+
+
+@pytest.fixture(autouse=True)
+def stub_join_flow_service(stub_subnet_service):
+    """JoinFlowService stub forwarding open-branch to stub_subnet_service.
+
+    Auto-applied for ADR-0004 Slice 2.3 — ``do_join_subnet`` now
+    routes through ``JoinFlowService.join_subnet``. See
+    ``tests/routes/test_agent_subnets.py`` for the same pattern.
+    """
+    svc = AsyncMock()
+
+    async def _join_subnet(subnet_id: str, agent_id: str):
+        await stub_subnet_service.get_subnet(subnet_id)
+        await stub_subnet_service.add_member(subnet_id, agent_id)
+        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+
+    svc.join_subnet = AsyncMock(side_effect=_join_subnet)
+    app.dependency_overrides[get_join_flow_service] = lambda: svc
+    try:
+        yield svc
+    finally:
+        app.dependency_overrides.pop(get_join_flow_service, None)
 
 
 def _wire(agent_svc, subnet_svc) -> None:

--- a/tests/routes/test_subnets_harness.py
+++ b/tests/routes/test_subnets_harness.py
@@ -24,9 +24,11 @@ from acn.core.exceptions import SubnetNotFoundException
 from acn.protocols.ap2.webhook import WebhookEventType
 from acn.routes.dependencies import (
     get_agent_service,
+    get_join_flow_service,
     get_subnet_service,
     get_webhook_service,
 )
+from acn.services._join_flow_result import JoinFlowJoinedOpenResult
 from tests.routes.conftest import _assert_flat_shape
 
 # ---------------------------------------------------------------------------
@@ -98,6 +100,31 @@ def stub_webhook_service():
     svc.send_to = AsyncMock(return_value=True)
     svc.send_event = AsyncMock(return_value=True)
     return svc
+
+
+@pytest.fixture(autouse=True)
+def stub_join_flow_service(stub_subnet_service):
+    """JoinFlowService stub forwarding open-branch to stub_subnet_service.
+
+    Auto-applied so the harness webhook tests (which exercise the
+    join path under the new ADR-0004 Slice 2.3 dispatcher) pick up
+    a stubbed JoinFlowService instead of the real lifespan-wired
+    instance. See ``tests/routes/test_agent_subnets.py`` for the
+    same pattern + extended rationale.
+    """
+    svc = AsyncMock()
+
+    async def _join_subnet(subnet_id: str, agent_id: str):
+        await stub_subnet_service.get_subnet(subnet_id)
+        await stub_subnet_service.add_member(subnet_id, agent_id)
+        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+
+    svc.join_subnet = AsyncMock(side_effect=_join_subnet)
+    app.dependency_overrides[get_join_flow_service] = lambda: svc
+    try:
+        yield svc
+    finally:
+        app.dependency_overrides.pop(get_join_flow_service, None)
 
 
 def _wire(agent_svc, subnet_svc, webhook_svc=None) -> None:


### PR DESCRIPTION
## Summary

ADR-0004 Phase 2 **Slice 2.3 PR A** — wires the 14 new admission HTTP endpoints introduced by ADR-0004 §"API changes" and rewrites the canonical join handler to dispatch the six-branch decision tree through ``JoinFlowService`` (built in [PR #77](https://github.com/acnlabs/ACN/pull/77)). PR B (CLI verbs) follows separately and stacks on this branch.

This is the first of two stacked PRs for Slice 2.3:
- **PR A (this one)** — HTTP routes + authz + error mapping + 61 route tests
- **PR B (next)** — ``acn`` CLI verbs (``subnet allowlist add``, ``subnet invite``, ``subnet approve``, etc.) + CLI-level tests

### What's in this PR

**14 new endpoints** (3 allowlist + 4 join_request + 5 invitation + 1 agent invitations + 1 rewritten join entry):

| Verb | URL | Auth |
|------|-----|------|
| POST | ``/api/v1/subnets/{s}/allowlist`` | owner |
| DELETE | ``/api/v1/subnets/{s}/allowlist/{aid}`` | owner |
| GET | ``/api/v1/subnets/{s}/allowlist`` | owner |
| POST | ``/api/v1/subnets/{s}/join-requests/{rid}/approve`` | owner |
| POST | ``/api/v1/subnets/{s}/join-requests/{rid}/reject`` | owner |
| DELETE | ``/api/v1/subnets/{s}/join-requests/{rid}`` | applicant (self) |
| GET | ``/api/v1/subnets/{s}/join-requests`` | owner |
| POST | ``/api/v1/subnets/{s}/invitations`` | owner |
| POST | ``/api/v1/subnets/{s}/invitations/{iid}/accept`` | invitee |
| POST | ``/api/v1/subnets/{s}/invitations/{iid}/reject`` | invitee |
| DELETE | ``/api/v1/subnets/{s}/invitations/{iid}`` | owner |
| GET | ``/api/v1/subnets/{s}/invitations`` | owner |
| GET | ``/api/v1/agents/{a}/subnet-invitations`` | self |
| POST | ``/api/v1/agents/{a}/subnets/{s}`` (rewritten) | self |

**Key behaviour**:
- **Six-branch dispatch** — ``do_join_subnet`` translates ``JoinFlowResult`` to HTTP shape: branches 1-5 return 200, branch 6 returns 202; agent-side back-reference is written only on 200 branches (caller is now a member).
- **Namespace 404s** — ADR §"URL alias routing rules" — calling a ``/join-requests/{id}`` verb against an invitation row returns ``JOIN_REQUEST_NOT_FOUND``, and vice versa, so the two-namespace split doesn't leak cross-kind existence.
- **Merge-path responses** — ``POST /invitations`` against a target with a pending join_request returns 200 with ``resolved_kind: "join_request"`` instead of creating a duplicate row.
- **Idempotent DELETE allowlist** — 204 even when the entry wasn't present.
- **INVALID_KIND_FILTER** — ``GET /join-requests?kind=invitation`` rejected with 400.

**12 new ErrorCode slugs** added to ``acn/core/errors.py``: ``SUBNET_NOT_OWNER``, ``NOT_INVITEE``, ``ALREADY_MEMBER``, ``ALREADY_ON_ALLOWLIST``, ``JOIN_REQUEST_{NOT_FOUND,PENDING,ALREADY_DECIDED}``, ``INVITATION_{NOT_FOUND,PENDING,ALREADY_DECIDED}``, ``INVALID_KIND_FILTER``. ``visibility_policy_conflict`` stays on the existing ``INVALID_REQUEST`` slug (Slice 2.0/2.1 contract).

### Test plan

- [x] **61 new admission route tests** across 4 files:
  - ``test_subnet_admission_allowlist.py`` (16)
  - ``test_subnet_admission_join_requests.py`` (17)
  - ``test_subnet_admission_invitations.py`` (19)
  - ``test_subnet_admission_join_flow.py`` (9 — all six branches via HTTP)
- [x] **Pre-existing route regression updated** — ``test_agent_subnets.py`` / ``test_subnets_harness.py`` / ``test_subnets_error_schema.py`` pick up a stubbed ``JoinFlowService`` via autouse fixture so the rewrite is invisible.
- [x] **Full local regression** — 1361 / 1361 tests pass (630 services+core, 731 routes).
- [x] **Lint** — ``ruff check acn/ tests/`` clean.

### Notes for reviewer

- ``_admission_helpers.py`` (not ``conftest.py``) centralises the four-stub fixture used by the admission tests; explicit imports make it visible per-file.
- The accept-invitation back-reference write deliberately does NOT roll back ``add_member`` on failure (the invitation row CAS has already happened; reversing would leak partial-success). The retry path picks up ``INVITATION_ALREADY_DECIDED`` 409 which SDK can treat as success.
- ``_subnet_admission.py`` is a sibling of ``_subnet_membership.py`` — keeps both files focused on a single responsibility (membership vs admission policy).

Refs ADR-0004 §"API changes", §"Authorization matrix", §"HTTP status code conventions", §"URL alias routing rules".

Made with [Cursor](https://cursor.com)