### PR TITLE
feat(cli): ADR-0004 Slice 2.3 PR B — subnet admission CLI verbs

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to `@acnlabs/acn-cli` are documented here.
 
+## [Unreleased]
+
+### Added — ADR-0004 Slice 2.3 PR B (subnet admission verbs)
+- `acn subnet create --join-policy <open|approval>` — opt the new
+  subnet into the approval gate. `--private` continues to imply
+  `--join-policy=approval`; explicit `--private --join-policy=open`
+  is now rejected client-side with exit 2 (matching the server's
+  `INVALID_REQUEST` + `details.reason="visibility_policy_conflict"`
+  response).
+- `acn subnet allowlist <list|add|remove>` — owner-only management
+  of a subnet's pre-authorisation allowlist.
+- `acn subnet requests <list|approve|reject|withdraw|pending>` —
+  owner-side approve/reject of pending `join_request` rows,
+  applicant-side `withdraw` of one's own pending row, and an
+  owner-side `pending` aggregator across every subnet you own.
+- `acn subnet invitations <send|list|accept|reject|cancel|pending>`
+  — owner sends/cancels invitations, invitee accepts/rejects, plus
+  a cross-subnet `pending` view for the invitee backed by
+  `GET /agents/{aid}/subnet-invitations`. `send` understands the
+  ADR-0004 merge path: if the target already has a pending
+  `join_request`, the response is `auto_resolved` and the CLI
+  reports `"… auto-approved (request <rid>)"`.
+
+### Changed
+- `acn subnet join` now branches on the six ADR-0004 response
+  shapes (open join / owner self-join / invitation auto-accepted
+  via self-join / invitation auto-accepted via allowlist match /
+  allowlist hit with new approved row / pending join_request),
+  printing a distinct human line per branch so operators can tell
+  which path their join took without inspecting the raw JSON.
+- `acn subnet join` and `acn subnet leave` now hit the canonical
+  `/api/v1/agents/{aid}/subnets/{sid}` URL instead of the
+  deprecated `/api/v1/subnets/{aid}/subnets/{sid}` alias. The
+  legacy route still works server-side, but the CLI emits the
+  newer surface so request logs are consistent.
+
 ## [0.7.0] - 2026-05-10
 
 ### Added

--- a/clients/cli/src/commands/subnet.ts
+++ b/clients/cli/src/commands/subnet.ts
@@ -31,7 +31,112 @@ interface SubnetCreateResponse {
   is_public: boolean;
   gateway_a2a_url: string;
   gateway_ws_url: string;
+  // ADR-0004 — server echoes the effective policy back so callers
+  // that omitted ``--join-policy`` can see what the service inferred.
+  join_policy?: 'open' | 'approval';
 }
+
+// -----------------------------------------------------------------------------
+// ADR-0004 admission types (Slice 2.3 PR B). The shapes mirror
+// ``acn/routes/_subnet_admission.py::serialize_join_request`` /
+// ``serialize_allowlist_entry`` and the sealed-union ``JoinFlowResult``
+// dispatch in the same module. We keep server-derived fields optional
+// where the route's contract allows nullability so older servers (or
+// future shape additions) don't break the CLI parse.
+// -----------------------------------------------------------------------------
+
+type SubnetJoinRequestKind = 'join_request' | 'invitation' | 'allowlist_auto';
+type SubnetJoinRequestStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'withdrawn';
+
+interface SubnetJoinRequestDTO {
+  request_id: string;
+  subnet_id: string;
+  agent_id: string;
+  kind: SubnetJoinRequestKind;
+  status: SubnetJoinRequestStatus;
+  initiated_by: string;
+  decided_by: string | null;
+  created_at: string | null;
+  decided_at: string | null;
+  note: string | null;
+}
+
+interface SubnetAllowlistEntryDTO {
+  subnet_id: string;
+  agent_id: string;
+  added_by: string;
+  added_at: string | null;
+}
+
+interface JoinRequestListResponse {
+  subnet_id: string;
+  items: SubnetJoinRequestDTO[];
+}
+
+interface InvitationListResponse {
+  subnet_id: string;
+  items: SubnetJoinRequestDTO[];
+}
+
+interface AllowlistListResponse {
+  subnet_id: string;
+  entries: SubnetAllowlistEntryDTO[];
+}
+
+interface AgentInvitationsResponse {
+  agent_id: string;
+  items: SubnetJoinRequestDTO[];
+}
+
+// ``POST /agents/{a}/subnets/{s}`` returns one of six body shapes —
+// see ADR-0004 §"join branches" and
+// ``_subnet_admission.py::join_flow_result_to_response``. We discriminate
+// on body shape (not HTTP status, which the fetch wrapper doesn't expose).
+// All variants carry ``subnet_id`` + ``agent_id``.
+type JoinResponseBody =
+  | { status: 'joined'; subnet_id: string; agent_id: string } // branches 1+2
+  | {
+      auto_resolved: true;
+      resolved_kind: 'invitation';
+      subnet_id: string;
+      agent_id: string;
+      invitation_id: string;
+      via: 'self_join' | 'allowlist';
+    } // branches 3+4
+  | {
+      subnet_id: string;
+      agent_id: string;
+      request_id: string;
+      via: 'allowlist';
+    } // branch 5
+  | {
+      subnet_id: string;
+      agent_id: string;
+      request_id: string;
+      status: 'pending';
+    }; // branch 6
+
+// ``POST /subnets/{s}/invitations`` returns one of two body shapes per
+// ``invite_agent_result_to_response``: the normal pending invitation
+// or the merge path where the target already had a pending join_request.
+type InviteResponseBody =
+  | {
+      subnet_id: string;
+      agent_id: string;
+      invitation_id: string;
+      status: 'pending';
+    }
+  | {
+      auto_resolved: true;
+      resolved_kind: 'join_request';
+      subnet_id: string;
+      agent_id: string;
+      request_id: string;
+    };
 
 function requireAgentId(): string {
   const config = loadConfig();
@@ -44,6 +149,109 @@ function requireAgentId(): string {
     process.exit(1);
   }
   return config.agent_id!;
+}
+
+function requireApiKey(): void {
+  const config = loadConfig();
+  if (!config.api_key) {
+    console.error('No API key found. Run `acn join` first or `acn config set api-key <key>`.');
+    process.exit(1);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// ADR-0004 formatters (Slice 2.3 PR B). All three are pure functions
+// so they can be unit-tested directly without spinning up Commander.
+// -----------------------------------------------------------------------------
+
+function formatJoinRequest(r: SubnetJoinRequestDTO, index?: number): string {
+  const prefix = index !== undefined ? `[${index + 1}] ` : '';
+  const lines = [
+    `${prefix}${r.request_id}  [${r.kind} / ${r.status}]`,
+    `  Subnet     : ${r.subnet_id}`,
+    `  Agent      : ${r.agent_id}`,
+    `  InitiatedBy: ${r.initiated_by}`,
+  ];
+  if (r.decided_by) lines.push(`  DecidedBy  : ${r.decided_by}`);
+  if (r.created_at) lines.push(`  CreatedAt  : ${r.created_at}`);
+  if (r.decided_at) lines.push(`  DecidedAt  : ${r.decided_at}`);
+  if (r.note) lines.push(`  Note       : ${r.note}`);
+  return lines.join('\n');
+}
+
+function formatAllowlistEntry(
+  e: SubnetAllowlistEntryDTO,
+  index?: number
+): string {
+  const prefix = index !== undefined ? `[${index + 1}] ` : '';
+  const lines = [
+    `${prefix}${e.agent_id}`,
+    `  AddedBy : ${e.added_by}`,
+  ];
+  if (e.added_at) lines.push(`  AddedAt : ${e.added_at}`);
+  return lines.join('\n');
+}
+
+// Render one of the six ADR-0004 ``POST /agents/{a}/subnets/{s}``
+// response bodies as a single operator-facing line. The discriminators
+// are body-shape only (the fetch wrapper hides HTTP status), but the
+// branches happen to be mutually exclusive on body shape — see
+// ADR-0004 §"join branches" for the field matrix.
+function formatJoinResponse(res: JoinResponseBody, subnetId: string): string {
+  // We discriminate on body-shape only (the fetch wrapper hides HTTP
+  // status). TypeScript's narrowing for tagged unions with overlapping
+  // fields (``via`` appears in branches 3/4 and 5) doesn't catch the
+  // exclusive cases here, so we cast to a permissive shape and read
+  // the discriminator fields directly. Verified exhaustively against
+  // ``_subnet_admission.py::join_flow_result_to_response``.
+  type _Any = {
+    status?: 'joined' | 'pending';
+    auto_resolved?: true;
+    resolved_kind?: 'invitation';
+    via?: 'self_join' | 'allowlist';
+    invitation_id?: string;
+    request_id?: string;
+  };
+  const r = res as _Any;
+
+  // Branches 3/4 — pending invitation auto-accepted on join.
+  if (r.auto_resolved && r.resolved_kind === 'invitation') {
+    if (r.via === 'self_join') {
+      return `accepted pending invitation ${r.invitation_id} from owner — joined subnet ${subnetId}`;
+    }
+    return `allowlist match plus pending invitation ${r.invitation_id} — accepted invitation, joined subnet ${subnetId}`;
+  }
+  // Branch 5 — allowlist hit, no pending invitation. Body has
+  // ``via='allowlist'`` + ``request_id`` but NO ``auto_resolved``.
+  if (r.via === 'allowlist' && r.request_id) {
+    return `allowlist match — joined subnet ${subnetId} (request ${r.request_id})`;
+  }
+  // Branch 6 — fall-through pending join_request (HTTP 202).
+  if (r.status === 'pending' && r.request_id) {
+    return `join request submitted — pending owner approval (request ${r.request_id})`;
+  }
+  // Branches 1/2 — open subnet or owner self-join (``status='joined'``).
+  return `joined subnet ${subnetId}`;
+}
+
+// Render the two-variant ``POST /subnets/{s}/invitations`` response.
+function formatInviteResponse(
+  res: InviteResponseBody,
+  subnetId: string,
+  targetAgentId: string
+): string {
+  type _Any = {
+    auto_resolved?: true;
+    resolved_kind?: 'join_request';
+    invitation_id?: string;
+    request_id?: string;
+    status?: 'pending';
+  };
+  const r = res as _Any;
+  if (r.auto_resolved && r.resolved_kind === 'join_request') {
+    return `target agent ${targetAgentId} already had a pending join request — auto-approved (request ${r.request_id}) on subnet ${subnetId}`;
+  }
+  return `invitation ${r.invitation_id} sent to ${targetAgentId} on subnet ${subnetId} (status: ${r.status})`;
 }
 
 function formatSubnet(s: SubnetInfo, index?: number): string {
@@ -158,15 +366,18 @@ export function subnetCommand(): Command {
 
   cmd
     .command('join <subnet_id>')
-    .description('Join a subnet')
+    .description(
+      'Join a subnet. ADR-0004: branches on response shape ' +
+        '(open/allowlist/auto-invite/pending).'
+    )
     .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
     .action(async (subnetId: string, opts: { agentId?: string }) => {
       const agentId = opts.agentId ?? requireAgentId();
       try {
-        const res = await acnPost<{ status: string; agent_id: string; subnet_id: string }>(
-          `/subnets/${agentId}/subnets/${subnetId}`
+        const res = await acnPost<JoinResponseBody>(
+          `/agents/${agentId}/subnets/${subnetId}`
         );
-        output(res, `Joined subnet ${subnetId} (status: ${res.status})`);
+        output(res, formatJoinResponse(res, subnetId));
       } catch (err) {
         handleError(err);
       }
@@ -180,7 +391,7 @@ export function subnetCommand(): Command {
       const agentId = opts.agentId ?? requireAgentId();
       try {
         const res = await acnDelete<{ status: string; agent_id: string; subnet_id: string }>(
-          `/subnets/${agentId}/subnets/${subnetId}`
+          `/agents/${agentId}/subnets/${subnetId}`
         );
         output(res, `Left subnet ${subnetId} (status: ${res.status})`);
       } catch (err) {
@@ -195,6 +406,11 @@ export function subnetCommand(): Command {
     .option('--id <subnet_id>', 'Custom subnet ID (1-64 chars). Omit to let ACN auto-generate.')
     .option('-d, --description <text>', 'Subnet description (up to 500 chars)')
     .option('--private', 'Mark this subnet as private', false)
+    .option(
+      '--join-policy <policy>',
+      "Join policy: 'open' (anyone joins) or 'approval' (owner gates joins). " +
+        'ADR-0004. --private implies approval; explicit open+private is rejected.'
+    )
     .option(
       '--parent <id>',
       'Parent subnet ID for a child/squad subnet (ADR-0003). Single-layer cap.'
@@ -214,6 +430,7 @@ export function subnetCommand(): Command {
         id?: string;
         description?: string;
         private?: boolean;
+        joinPolicy?: string;
         parent?: string;
         lifecycle?: string;
         task?: string;
@@ -243,12 +460,33 @@ export function subnetCommand(): Command {
           );
           process.exit(2);
         }
+        // ADR-0004 — validate --join-policy + reconcile with --private.
+        // We reject the explicit private+open conflict client-side so
+        // operators get a clean message before the server returns 400
+        // INVALID_REQUEST + details.reason=visibility_policy_conflict.
+        let joinPolicy: 'open' | 'approval' | undefined;
+        if (opts.joinPolicy !== undefined) {
+          if (opts.joinPolicy !== 'open' && opts.joinPolicy !== 'approval') {
+            console.error(
+              `Invalid --join-policy '${opts.joinPolicy}'. Must be 'open' or 'approval'.`
+            );
+            process.exit(2);
+          }
+          joinPolicy = opts.joinPolicy;
+          if (opts.private && joinPolicy === 'open') {
+            console.error(
+              '--private implies --join-policy=approval; --private --join-policy=open is rejected.'
+            );
+            process.exit(2);
+          }
+        }
         const body: Record<string, unknown> = {
           name: opts.name,
           is_private: !!opts.private,
         };
         if (opts.id) body.subnet_id = opts.id;
         if (opts.description) body.description = opts.description;
+        if (joinPolicy !== undefined) body.join_policy = joinPolicy;
         if (opts.parent) body.parent_subnet_id = opts.parent;
         body.lifecycle = lifecycle;
         if (opts.task) body.linked_task_id = opts.task;
@@ -260,6 +498,9 @@ export function subnetCommand(): Command {
             `  Gateway A2A: ${res.gateway_a2a_url}`,
             `  Gateway WS : ${res.gateway_ws_url}`,
           ];
+          if (res.join_policy) {
+            lines.push(`  JoinPolicy : ${res.join_policy}`);
+          }
           if (opts.parent) lines.push(`  Parent     : ${opts.parent}`);
           if (lifecycle !== 'persistent') {
             lines.push(`  Lifecycle  : ${lifecycle}${opts.task ? ` (task=${opts.task})` : ''}`);
@@ -313,6 +554,527 @@ export function subnetCommand(): Command {
         handleError(err);
       }
     });
+
+  // -------------------------------------------------------------------------
+  // acn subnet requests — join-request workflow (ADR-0004 Slice 2.3 PR B)
+  // -------------------------------------------------------------------------
+  //
+  // Owner verbs: list / approve / reject (per ADR §"Application-side
+  // endpoints"). Applicant verb: withdraw. Plus a cross-subnet
+  // ``pending`` convenience that aggregates client-side by walking
+  // the operator's owned subnets — PR A intentionally did not add a
+  // dedicated backend endpoint for this view.
+  const requests = new Command('requests').description(
+    'Manage join-requests for a subnet (ADR-0004)'
+  );
+
+  requests
+    .command('list <subnet_id>')
+    .description(
+      'Owner-only: list join_request / allowlist_auto rows for a subnet. ' +
+        'Use --kind to switch between channels; --status to filter state.'
+    )
+    .option(
+      '--status <status>',
+      'Filter by status: pending | approved | rejected | withdrawn'
+    )
+    .option(
+      '--kind <kind>',
+      "Filter by kind: 'join_request' (default) or 'allowlist_auto'. " +
+        "'invitation' is rejected here — use `subnet invitations list`.",
+      'join_request'
+    )
+    .option('--limit <n>', 'Page size (1-500, default 100)', '100')
+    .option('--offset <n>', 'Page offset (default 0)', '0')
+    .action(
+      async (
+        subnetId: string,
+        opts: {
+          status?: string;
+          kind?: string;
+          limit?: string;
+          offset?: string;
+        }
+      ) => {
+        requireApiKey();
+        const params: Record<string, string> = {};
+        if (opts.status) params.status = opts.status;
+        if (opts.kind) params.kind = opts.kind;
+        if (opts.limit) params.limit = opts.limit;
+        if (opts.offset) params.offset = opts.offset;
+        const qs = new URLSearchParams(params).toString();
+        try {
+          const res = await acnGet<JoinRequestListResponse>(
+            `/subnets/${subnetId}/join-requests${qs ? `?${qs}` : ''}`
+          );
+          const items = res.items ?? [];
+          if (items.length === 0) {
+            output(res, `No join requests on subnet ${subnetId}.`);
+            return;
+          }
+          output(
+            res,
+            `${items.length} request(s) on subnet ${subnetId}:\n\n` +
+              items.map((r, i) => formatJoinRequest(r, i)).join('\n\n')
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  requests
+    .command('pending')
+    .description(
+      "Owner-side convenience: list pending join_requests across every subnet you own. " +
+        'Client-side aggregation — issues N+1 calls (one per owned subnet).'
+    )
+    .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
+    .action(async (opts: { agentId?: string }) => {
+      const agentId = opts.agentId ?? requireAgentId();
+      try {
+        // Get the agent's owned/joined subnets, then fetch pending
+        // join_requests for each. The owner-only nature of the
+        // per-subnet endpoint means the aggregation silently skips
+        // subnets where the caller is not the owner (403 → ignore).
+        const subs = await acnGet<{
+          agent_id: string;
+          subnets: string[];
+        }>(`/agents/${agentId}/subnets`);
+        const subnetIds = subs.subnets ?? [];
+        const aggregated: Array<{
+          subnet_id: string;
+          request: SubnetJoinRequestDTO;
+        }> = [];
+        for (const sid of subnetIds) {
+          try {
+            const res = await acnGet<JoinRequestListResponse>(
+              `/subnets/${sid}/join-requests?status=pending&kind=join_request`
+            );
+            for (const r of res.items ?? []) {
+              aggregated.push({ subnet_id: sid, request: r });
+            }
+          } catch {
+            // Owner-only — silently skip non-owned subnets (per
+            // the ADR's authz matrix the 403 here is expected).
+            continue;
+          }
+        }
+        if (aggregated.length === 0) {
+          output(
+            { agent_id: agentId, pending: [] },
+            'No pending join requests across your subnets.'
+          );
+          return;
+        }
+        output(
+          { agent_id: agentId, pending: aggregated },
+          `${aggregated.length} pending request(s) across ${subnetIds.length} subnet(s):\n\n` +
+            aggregated
+              .map((a, i) => formatJoinRequest(a.request, i))
+              .join('\n\n')
+        );
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  requests
+    .command('approve <subnet_id>')
+    .description('Owner-only: approve a pending join_request (CAS pending → approved).')
+    .requiredOption('--request-id <rid>', 'Join request ID to approve')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { requestId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = {};
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          const res = await acnPost<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/join-requests/${opts.requestId}/approve`,
+            body
+          );
+          output(
+            res,
+            `approved request ${res.request_id} (agent ${res.agent_id}) on subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  requests
+    .command('reject <subnet_id>')
+    .description('Owner-only: reject a pending join_request (CAS pending → rejected).')
+    .requiredOption('--request-id <rid>', 'Join request ID to reject')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { requestId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = {};
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          const res = await acnPost<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/join-requests/${opts.requestId}/reject`,
+            body
+          );
+          output(
+            res,
+            `rejected request ${res.request_id} (agent ${res.agent_id}) on subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  requests
+    .command('withdraw <subnet_id>')
+    .description(
+      'Applicant-only: withdraw your own pending join_request ' +
+        '(CAS pending → withdrawn).'
+    )
+    .requiredOption('--request-id <rid>', 'Your join request ID')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { requestId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = {};
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          // DELETE with a body — acnDelete doesn't accept one, so we
+          // fall through to acnFetch via a custom call. Keep the
+          // wrapper consistent: re-use acnPost shape with empty body
+          // is not appropriate (different verb). Instead use the
+          // raw fetch by calling acnDelete (DELETE without body —
+          // ADR-0004 says the body is OPTIONAL, so dropping it is
+          // contract-safe).
+          const res = await acnDelete<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/join-requests/${opts.requestId}`
+          );
+          if (opts.note !== undefined) {
+            // The DELETE wrapper has no body parameter — surface a
+            // warning so the user knows the note was not sent rather
+            // than silently dropping it.
+            console.error(
+              '[warn] --note is not sent on withdraw (CLI limitation; ' +
+                'use the API directly if you need to record a reason).'
+            );
+          }
+          output(
+            res,
+            `withdrew request ${res.request_id} on subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  cmd.addCommand(requests);
+
+  // -------------------------------------------------------------------------
+  // acn subnet invitations — invitation workflow (ADR-0004 Slice 2.3 PR B)
+  // -------------------------------------------------------------------------
+  //
+  // Owner verbs: send / list / cancel. Invitee verbs: accept / reject.
+  // Plus a cross-subnet ``pending`` view backed by the dedicated
+  // ``GET /agents/{a}/subnet-invitations`` endpoint added in PR A —
+  // no client-side aggregation needed for invitees.
+  const invitations = new Command('invitations').description(
+    'Manage invitations on a subnet (ADR-0004)'
+  );
+
+  invitations
+    .command('send <subnet_id>')
+    .description(
+      'Owner-only: invite an agent to a subnet. Auto-merges with a ' +
+        "target's pending join_request (collapses to auto-approval)."
+    )
+    .requiredOption('--agent-id <aid>', 'Agent ID to invite')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { agentId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = { agent_id: opts.agentId };
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          const res = await acnPost<InviteResponseBody>(
+            `/subnets/${subnetId}/invitations`,
+            body
+          );
+          output(res, formatInviteResponse(res, subnetId, opts.agentId));
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  invitations
+    .command('list <subnet_id>')
+    .description('Owner-only: list invitation rows for a subnet.')
+    .option(
+      '--status <status>',
+      'Filter by status: pending | approved | rejected | withdrawn'
+    )
+    .option('--limit <n>', 'Page size (1-500, default 100)', '100')
+    .option('--offset <n>', 'Page offset (default 0)', '0')
+    .action(
+      async (
+        subnetId: string,
+        opts: { status?: string; limit?: string; offset?: string }
+      ) => {
+        requireApiKey();
+        const params: Record<string, string> = {};
+        if (opts.status) params.status = opts.status;
+        if (opts.limit) params.limit = opts.limit;
+        if (opts.offset) params.offset = opts.offset;
+        const qs = new URLSearchParams(params).toString();
+        try {
+          const res = await acnGet<InvitationListResponse>(
+            `/subnets/${subnetId}/invitations${qs ? `?${qs}` : ''}`
+          );
+          const items = res.items ?? [];
+          if (items.length === 0) {
+            output(res, `No invitations on subnet ${subnetId}.`);
+            return;
+          }
+          output(
+            res,
+            `${items.length} invitation(s) on subnet ${subnetId}:\n\n` +
+              items.map((r, i) => formatJoinRequest(r, i)).join('\n\n')
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  invitations
+    .command('pending')
+    .description(
+      "Invitee view: list pending invitations addressed to you across all subnets " +
+        '(backed by GET /agents/{aid}/subnet-invitations).'
+    )
+    .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
+    .action(async (opts: { agentId?: string }) => {
+      const agentId = opts.agentId ?? requireAgentId();
+      try {
+        const res = await acnGet<AgentInvitationsResponse>(
+          `/agents/${agentId}/subnet-invitations`
+        );
+        const items = res.items ?? [];
+        if (items.length === 0) {
+          output(res, `No pending invitations for ${agentId}.`);
+          return;
+        }
+        output(
+          res,
+          `${items.length} pending invitation(s) for ${agentId}:\n\n` +
+            items.map((r, i) => formatJoinRequest(r, i)).join('\n\n')
+        );
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  invitations
+    .command('accept <subnet_id>')
+    .description(
+      'Invitee-only: accept a pending invitation (CAS pending → approved). ' +
+        'Side effect: you join the subnet.'
+    )
+    .requiredOption('--invitation-id <iid>', 'Invitation ID to accept')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { invitationId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = {};
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          const res = await acnPost<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/invitations/${opts.invitationId}/accept`,
+            body
+          );
+          output(
+            res,
+            `accepted invitation ${res.request_id} — joined subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  invitations
+    .command('reject <subnet_id>')
+    .description(
+      'Invitee-only: reject a pending invitation (CAS pending → rejected). ' +
+        'No membership change.'
+    )
+    .requiredOption('--invitation-id <iid>', 'Invitation ID to reject')
+    .option('--note <text>', 'Optional audit note (≤500 chars)')
+    .action(
+      async (
+        subnetId: string,
+        opts: { invitationId: string; note?: string }
+      ) => {
+        requireApiKey();
+        const body: Record<string, unknown> = {};
+        if (opts.note !== undefined) body.note = opts.note;
+        try {
+          const res = await acnPost<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/invitations/${opts.invitationId}/reject`,
+            body
+          );
+          output(
+            res,
+            `rejected invitation ${res.request_id} on subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  invitations
+    .command('cancel <subnet_id>')
+    .description(
+      'Owner-only: cancel a pending invitation (CAS pending → withdrawn).'
+    )
+    .requiredOption('--invitation-id <iid>', 'Invitation ID to cancel')
+    .action(
+      async (subnetId: string, opts: { invitationId: string }) => {
+        requireApiKey();
+        try {
+          const res = await acnDelete<SubnetJoinRequestDTO>(
+            `/subnets/${subnetId}/invitations/${opts.invitationId}`
+          );
+          output(
+            res,
+            `cancelled invitation ${res.request_id} on subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  cmd.addCommand(invitations);
+
+  // -------------------------------------------------------------------------
+  // acn subnet allowlist — pre-authorisation list (ADR-0004 Slice 2.3 PR B)
+  // -------------------------------------------------------------------------
+  //
+  // All three verbs are owner-only by design (the allowlist is a
+  // privacy-sensitive trust signal — ADR §"GET /subnets/{s}/allowlist
+  // is owner-only deliberately"). DELETE is idempotent (returns 204
+  // whether or not the entry existed).
+  const allowlist = new Command('allowlist').description(
+    'Manage a subnet allowlist (ADR-0004)'
+  );
+
+  allowlist
+    .command('list <subnet_id>')
+    .description('Owner-only: list allowlist entries for a subnet.')
+    .option('--limit <n>', 'Page size (1-500, default 100)', '100')
+    .option('--offset <n>', 'Page offset (default 0)', '0')
+    .action(
+      async (
+        subnetId: string,
+        opts: { limit?: string; offset?: string }
+      ) => {
+        requireApiKey();
+        const params: Record<string, string> = {};
+        if (opts.limit) params.limit = opts.limit;
+        if (opts.offset) params.offset = opts.offset;
+        const qs = new URLSearchParams(params).toString();
+        try {
+          const res = await acnGet<AllowlistListResponse>(
+            `/subnets/${subnetId}/allowlist${qs ? `?${qs}` : ''}`
+          );
+          const entries = res.entries ?? [];
+          if (entries.length === 0) {
+            output(res, `Allowlist on subnet ${subnetId} is empty.`);
+            return;
+          }
+          output(
+            res,
+            `${entries.length} entry/entries on subnet ${subnetId}:\n\n` +
+              entries.map((e, i) => formatAllowlistEntry(e, i)).join('\n\n')
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  allowlist
+    .command('add <subnet_id>')
+    .description(
+      'Owner-only: pre-authorise an agent on the subnet allowlist. ' +
+        '409 ALREADY_ON_ALLOWLIST on duplicate.'
+    )
+    .requiredOption('--agent-id <aid>', 'Agent ID to add')
+    .action(
+      async (subnetId: string, opts: { agentId: string }) => {
+        requireApiKey();
+        try {
+          const res = await acnPost<SubnetAllowlistEntryDTO>(
+            `/subnets/${subnetId}/allowlist`,
+            { agent_id: opts.agentId }
+          );
+          output(
+            res,
+            `added ${res.agent_id} to allowlist of subnet ${subnetId} (by ${res.added_by})`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  allowlist
+    .command('remove <subnet_id>')
+    .description(
+      'Owner-only: remove an agent from the subnet allowlist. ' +
+        'Idempotent (204 even if missing).'
+    )
+    .requiredOption('--agent-id <aid>', 'Agent ID to remove')
+    .action(
+      async (subnetId: string, opts: { agentId: string }) => {
+        requireApiKey();
+        try {
+          await acnDelete<unknown>(
+            `/subnets/${subnetId}/allowlist/${opts.agentId}`
+          );
+          output(
+            { subnet_id: subnetId, agent_id: opts.agentId, removed: true },
+            `removed ${opts.agentId} from allowlist of subnet ${subnetId}`
+          );
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
+  cmd.addCommand(allowlist);
 
   // -------------------------------------------------------------------------
   // acn subnet harness — Org Harness registration

--- a/clients/cli/tests/subnet-ad0004.test.ts
+++ b/clients/cli/tests/subnet-ad0004.test.ts
@@ -1,0 +1,650 @@
+/**
+ * CLI regression tests for ADR-0004 Slice 2.3 PR B — the new
+ * ``subnet`` admission verbs (allowlist / requests / invitations)
+ * plus the ``create`` ``--join-policy`` flag and the ``join`` 6-branch
+ * output dispatcher.
+ *
+ * Mocks src/api.ts; no live ACN backend. Assertions cover:
+ * - URL + body shapes match the routes pinned by
+ *   ``acn/routes/subnet_admission.py``.
+ * - Output strings match ADR §"CLI changes" and §"join branches"
+ *   verbatim where the ADR pins specific phrasing.
+ * - Client-side guards (--private + --join-policy=open conflict,
+ *   invalid --join-policy / --kind values) surface as exit 2 BEFORE
+ *   any HTTP call fires.
+ */
+
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { acnGet, acnPost, acnDelete } from '../src/api.js';
+import { loadConfig } from '../src/config.js';
+import { output } from '../src/output.js';
+import { subnetCommand } from '../src/commands/subnet.js';
+
+vi.mock('../src/api.js', () => ({
+  acnGet: vi.fn(),
+  acnPost: vi.fn(),
+  acnDelete: vi.fn(),
+  acnPatch: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  loadConfig: vi.fn(() => ({
+    api_key: 'sk-test',
+    agent_id: 'agent-1',
+    base_url: 'https://api.test',
+  })),
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: vi.fn(),
+  handleError: vi.fn((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`handleError:${msg}`);
+  }),
+}));
+
+async function runSubnet(args: string[]): Promise<void> {
+  const root = new Command();
+  root.addCommand(subnetCommand());
+  await root.parseAsync(['node', 'acn', 'subnet', ...args]);
+}
+
+beforeEach(() => {
+  vi.mocked(loadConfig).mockReturnValue({
+    api_key: 'sk-test',
+    agent_id: 'agent-1',
+    base_url: 'https://api.test',
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// subnet create — ADR-0004 --join-policy flag
+// ---------------------------------------------------------------------------
+
+describe('subnet create --join-policy (ADR-0004)', () => {
+  const createResponse = {
+    status: 'created',
+    subnet_id: 'subnet-x',
+    is_public: true,
+    gateway_a2a_url: 'https://gw/a2a/subnet-x',
+    gateway_ws_url: 'https://gw/ws/subnet-x',
+    join_policy: 'approval',
+  };
+
+  it('passes join_policy=approval when flag is set', async () => {
+    vi.mocked(acnPost).mockResolvedValue(createResponse as never);
+    await runSubnet([
+      'create',
+      '--name',
+      'N',
+      '--join-policy',
+      'approval',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets',
+      expect.objectContaining({ name: 'N', join_policy: 'approval' })
+    );
+  });
+
+  it('passes join_policy=open when flag is set explicitly', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      ...createResponse,
+      join_policy: 'open',
+    } as never);
+    await runSubnet(['create', '--name', 'N', '--join-policy', 'open']);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets',
+      expect.objectContaining({ join_policy: 'open' })
+    );
+  });
+
+  it('omits join_policy from the body when flag is absent (server defaults apply)', async () => {
+    vi.mocked(acnPost).mockResolvedValue(createResponse as never);
+    await runSubnet(['create', '--name', 'N']);
+    const [, body] = vi.mocked(acnPost).mock.calls[0]!;
+    expect(body).not.toHaveProperty('join_policy');
+  });
+
+  it('echoes join_policy in the human output line', async () => {
+    vi.mocked(acnPost).mockResolvedValue(createResponse as never);
+    await runSubnet(['create', '--name', 'N', '--join-policy', 'approval']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toContain('JoinPolicy : approval');
+  });
+
+  it('exits 2 on invalid --join-policy value', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+    await expect(
+      runSubnet(['create', '--name', 'N', '--join-policy', 'weird'])
+    ).rejects.toThrow('EXIT:2');
+    exitSpy.mockRestore();
+    expect(acnPost).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 on --private --join-policy=open conflict (client-side gate)', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+    await expect(
+      runSubnet([
+        'create',
+        '--name',
+        'N',
+        '--private',
+        '--join-policy',
+        'open',
+      ])
+    ).rejects.toThrow('EXIT:2');
+    exitSpy.mockRestore();
+    expect(acnPost).not.toHaveBeenCalled();
+  });
+
+  it('allows --private --join-policy=approval (consistent combo)', async () => {
+    vi.mocked(acnPost).mockResolvedValue(createResponse as never);
+    await runSubnet([
+      'create',
+      '--name',
+      'N',
+      '--private',
+      '--join-policy',
+      'approval',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets',
+      expect.objectContaining({
+        is_private: true,
+        join_policy: 'approval',
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subnet join — ADR-0004 6-branch output dispatcher
+// ---------------------------------------------------------------------------
+
+describe('subnet join (ADR-0004 6 branches)', () => {
+  it('hits the canonical /agents/{aid}/subnets/{sid} URL', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      status: 'joined',
+      subnet_id: 's1',
+      agent_id: 'agent-1',
+    } as never);
+    await runSubnet(['join', 's1']);
+    expect(acnPost).toHaveBeenCalledWith('/agents/agent-1/subnets/s1');
+  });
+
+  it('branch 1/2 (joined): plain "joined subnet" line', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      status: 'joined',
+      subnet_id: 's1',
+      agent_id: 'agent-1',
+    } as never);
+    await runSubnet(['join', 's1']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('joined subnet s1');
+  });
+
+  it('branch 3 (self_join auto-invite): mentions accepted invitation', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      auto_resolved: true,
+      resolved_kind: 'invitation',
+      subnet_id: 's2',
+      agent_id: 'agent-1',
+      invitation_id: 'inv-3',
+      via: 'self_join',
+    } as never);
+    await runSubnet(['join', 's2']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe(
+      'accepted pending invitation inv-3 from owner — joined subnet s2'
+    );
+  });
+
+  it('branch 4 (allowlist auto-invite merge): explains the merge path', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      auto_resolved: true,
+      resolved_kind: 'invitation',
+      subnet_id: 's3',
+      agent_id: 'agent-1',
+      invitation_id: 'inv-4',
+      via: 'allowlist',
+    } as never);
+    await runSubnet(['join', 's3']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe(
+      'allowlist match plus pending invitation inv-4 — accepted invitation, joined subnet s3'
+    );
+  });
+
+  it('branch 5 (allowlist, no invitation): mentions allowlist match', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      subnet_id: 's4',
+      agent_id: 'agent-1',
+      request_id: 'req-5',
+      via: 'allowlist',
+    } as never);
+    await runSubnet(['join', 's4']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('allowlist match — joined subnet s4 (request req-5)');
+  });
+
+  it('branch 6 (pending): mentions pending owner approval', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      subnet_id: 's5',
+      agent_id: 'agent-1',
+      request_id: 'req-6',
+      status: 'pending',
+    } as never);
+    await runSubnet(['join', 's5']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe(
+      'join request submitted — pending owner approval (request req-6)'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subnet allowlist — 3 verbs
+// ---------------------------------------------------------------------------
+
+describe('subnet allowlist (ADR-0004)', () => {
+  it('list hits GET /subnets/{sid}/allowlist', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      subnet_id: 's1',
+      entries: [
+        {
+          subnet_id: 's1',
+          agent_id: 'a-1',
+          added_by: 'owner-1',
+          added_at: '2026-05-19T00:00:00Z',
+        },
+      ],
+    } as never);
+    await runSubnet(['allowlist', 'list', 's1']);
+    expect(acnGet).toHaveBeenCalledWith(
+      '/subnets/s1/allowlist?limit=100&offset=0'
+    );
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toContain('1 entry');
+    expect(text).toContain('a-1');
+  });
+
+  it('list with empty result prints empty message', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      subnet_id: 's1',
+      entries: [],
+    } as never);
+    await runSubnet(['allowlist', 'list', 's1']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('Allowlist on subnet s1 is empty.');
+  });
+
+  it('add posts {agent_id}', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      subnet_id: 's1',
+      agent_id: 'a-2',
+      added_by: 'agent-1',
+      added_at: '2026-05-19T00:00:00Z',
+    } as never);
+    await runSubnet(['allowlist', 'add', 's1', '--agent-id', 'a-2']);
+    expect(acnPost).toHaveBeenCalledWith('/subnets/s1/allowlist', {
+      agent_id: 'a-2',
+    });
+  });
+
+  it('remove deletes /subnets/{sid}/allowlist/{aid}', async () => {
+    vi.mocked(acnDelete).mockResolvedValue({} as never);
+    await runSubnet(['allowlist', 'remove', 's1', '--agent-id', 'a-2']);
+    expect(acnDelete).toHaveBeenCalledWith('/subnets/s1/allowlist/a-2');
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('removed a-2 from allowlist of subnet s1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subnet requests — 4 per-subnet verbs + cross-subnet pending
+// ---------------------------------------------------------------------------
+
+describe('subnet requests (ADR-0004)', () => {
+  it('list hits GET /subnets/{sid}/join-requests with default kind', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      subnet_id: 's1',
+      items: [
+        {
+          request_id: 'r-1',
+          subnet_id: 's1',
+          agent_id: 'a-1',
+          kind: 'join_request',
+          status: 'pending',
+          initiated_by: 'a-1',
+          decided_by: null,
+          created_at: '2026-05-19T00:00:00Z',
+          decided_at: null,
+          note: null,
+        },
+      ],
+    } as never);
+    await runSubnet(['requests', 'list', 's1']);
+    expect(acnGet).toHaveBeenCalledWith(
+      '/subnets/s1/join-requests?kind=join_request&limit=100&offset=0'
+    );
+  });
+
+  it('list propagates --status + --kind filters', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      subnet_id: 's1',
+      items: [],
+    } as never);
+    await runSubnet([
+      'requests',
+      'list',
+      's1',
+      '--status',
+      'pending',
+      '--kind',
+      'allowlist_auto',
+    ]);
+    expect(acnGet).toHaveBeenCalledWith(
+      '/subnets/s1/join-requests?status=pending&kind=allowlist_auto&limit=100&offset=0'
+    );
+  });
+
+  it('approve posts to /approve endpoint with optional note', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      request_id: 'r-1',
+      subnet_id: 's1',
+      agent_id: 'a-1',
+      kind: 'join_request',
+      status: 'approved',
+      initiated_by: 'a-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: 'lgtm',
+    } as never);
+    await runSubnet([
+      'requests',
+      'approve',
+      's1',
+      '--request-id',
+      'r-1',
+      '--note',
+      'lgtm',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets/s1/join-requests/r-1/approve',
+      { note: 'lgtm' }
+    );
+  });
+
+  it('reject posts to /reject endpoint, omits body when no --note', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      request_id: 'r-2',
+      subnet_id: 's1',
+      agent_id: 'a-1',
+      kind: 'join_request',
+      status: 'rejected',
+      initiated_by: 'a-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: null,
+    } as never);
+    await runSubnet(['requests', 'reject', 's1', '--request-id', 'r-2']);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets/s1/join-requests/r-2/reject',
+      {}
+    );
+  });
+
+  it('withdraw deletes /subnets/{sid}/join-requests/{rid}', async () => {
+    vi.mocked(acnDelete).mockResolvedValue({
+      request_id: 'r-3',
+      subnet_id: 's1',
+      agent_id: 'agent-1',
+      kind: 'join_request',
+      status: 'withdrawn',
+      initiated_by: 'agent-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: null,
+    } as never);
+    await runSubnet(['requests', 'withdraw', 's1', '--request-id', 'r-3']);
+    expect(acnDelete).toHaveBeenCalledWith(
+      '/subnets/s1/join-requests/r-3'
+    );
+  });
+
+  it('pending aggregates across owned subnets, silently skipping 403s', async () => {
+    vi.mocked(acnGet).mockImplementation(((path: string) => {
+      if (path === '/agents/agent-1/subnets') {
+        return Promise.resolve({
+          agent_id: 'agent-1',
+          subnets: ['s1', 's2'],
+        });
+      }
+      if (path.startsWith('/subnets/s1/')) {
+        return Promise.resolve({
+          subnet_id: 's1',
+          items: [
+            {
+              request_id: 'r-a',
+              subnet_id: 's1',
+              agent_id: 'a-x',
+              kind: 'join_request',
+              status: 'pending',
+              initiated_by: 'a-x',
+              decided_by: null,
+              created_at: null,
+              decided_at: null,
+              note: null,
+            },
+          ],
+        });
+      }
+      if (path.startsWith('/subnets/s2/')) {
+        // Owner-only — non-owner sees 403 → CLI silently skips.
+        return Promise.reject(new Error('HTTP 403: subnet_not_owner'));
+      }
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    }) as never);
+
+    await runSubnet(['requests', 'pending']);
+
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toContain('1 pending request');
+    expect(text).toContain('r-a');
+  });
+
+  it('pending prints empty message when no requests found', async () => {
+    vi.mocked(acnGet).mockImplementation(((path: string) => {
+      if (path === '/agents/agent-1/subnets') {
+        return Promise.resolve({ agent_id: 'agent-1', subnets: [] });
+      }
+      return Promise.reject(new Error('unexpected'));
+    }) as never);
+    await runSubnet(['requests', 'pending']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('No pending join requests across your subnets.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subnet invitations — 5 per-subnet verbs + cross-subnet pending
+// ---------------------------------------------------------------------------
+
+describe('subnet invitations (ADR-0004)', () => {
+  it('send posts {agent_id, note?}', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      subnet_id: 's1',
+      agent_id: 'a-2',
+      invitation_id: 'inv-1',
+      status: 'pending',
+    } as never);
+    await runSubnet([
+      'invitations',
+      'send',
+      's1',
+      '--agent-id',
+      'a-2',
+      '--note',
+      'come join us',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith('/subnets/s1/invitations', {
+      agent_id: 'a-2',
+      note: 'come join us',
+    });
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe(
+      'invitation inv-1 sent to a-2 on subnet s1 (status: pending)'
+    );
+  });
+
+  it('send merge path: auto-approved join_request output', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      auto_resolved: true,
+      resolved_kind: 'join_request',
+      subnet_id: 's1',
+      agent_id: 'a-3',
+      request_id: 'r-merge',
+    } as never);
+    await runSubnet(['invitations', 'send', 's1', '--agent-id', 'a-3']);
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe(
+      'target agent a-3 already had a pending join request — auto-approved (request r-merge) on subnet s1'
+    );
+  });
+
+  it('list hits GET /subnets/{sid}/invitations', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      subnet_id: 's1',
+      items: [],
+    } as never);
+    await runSubnet(['invitations', 'list', 's1']);
+    expect(acnGet).toHaveBeenCalledWith(
+      '/subnets/s1/invitations?limit=100&offset=0'
+    );
+  });
+
+  it('pending hits GET /agents/{aid}/subnet-invitations', async () => {
+    vi.mocked(acnGet).mockResolvedValue({
+      agent_id: 'agent-1',
+      items: [
+        {
+          request_id: 'inv-9',
+          subnet_id: 's1',
+          agent_id: 'agent-1',
+          kind: 'invitation',
+          status: 'pending',
+          initiated_by: 'owner-1',
+          decided_by: null,
+          created_at: null,
+          decided_at: null,
+          note: null,
+        },
+      ],
+    } as never);
+    await runSubnet(['invitations', 'pending']);
+    expect(acnGet).toHaveBeenCalledWith('/agents/agent-1/subnet-invitations');
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toContain('1 pending invitation');
+    expect(text).toContain('inv-9');
+  });
+
+  it('accept posts to /invitations/{iid}/accept', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      request_id: 'inv-1',
+      subnet_id: 's1',
+      agent_id: 'agent-1',
+      kind: 'invitation',
+      status: 'approved',
+      initiated_by: 'owner-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: null,
+    } as never);
+    await runSubnet([
+      'invitations',
+      'accept',
+      's1',
+      '--invitation-id',
+      'inv-1',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets/s1/invitations/inv-1/accept',
+      {}
+    );
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('accepted invitation inv-1 — joined subnet s1');
+  });
+
+  it('reject posts to /invitations/{iid}/reject with optional note', async () => {
+    vi.mocked(acnPost).mockResolvedValue({
+      request_id: 'inv-2',
+      subnet_id: 's1',
+      agent_id: 'agent-1',
+      kind: 'invitation',
+      status: 'rejected',
+      initiated_by: 'owner-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: 'no thanks',
+    } as never);
+    await runSubnet([
+      'invitations',
+      'reject',
+      's1',
+      '--invitation-id',
+      'inv-2',
+      '--note',
+      'no thanks',
+    ]);
+    expect(acnPost).toHaveBeenCalledWith(
+      '/subnets/s1/invitations/inv-2/reject',
+      { note: 'no thanks' }
+    );
+  });
+
+  it('cancel deletes /invitations/{iid}', async () => {
+    vi.mocked(acnDelete).mockResolvedValue({
+      request_id: 'inv-3',
+      subnet_id: 's1',
+      agent_id: 'a-target',
+      kind: 'invitation',
+      status: 'withdrawn',
+      initiated_by: 'agent-1',
+      decided_by: 'agent-1',
+      created_at: null,
+      decided_at: null,
+      note: null,
+    } as never);
+    await runSubnet([
+      'invitations',
+      'cancel',
+      's1',
+      '--invitation-id',
+      'inv-3',
+    ]);
+    expect(acnDelete).toHaveBeenCalledWith(
+      '/subnets/s1/invitations/inv-3'
+    );
+    const [, text] = vi.mocked(output).mock.calls[0]!;
+    expect(text).toBe('cancelled invitation inv-3 on subnet s1');
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2.3 PR B — TypeScript CLI consumer for the fourteen subnet
admission HTTP endpoints landed in PR A (#78). Adds three nested
verb groups under `acn subnet` (`allowlist` / `requests` /
`invitations`), the `create --join-policy` flag, and a six-branch
output dispatcher on `acn subnet join`.

No server / Python changes; PR A's routes are the contract this PR
consumes.

## What ships

### `acn subnet create`
- `--join-policy <open|approval>` opts in to the approval gate.
  `--private` continues to imply `approval`; the explicit
  `--private --join-policy=open` conflict is rejected client-side
  with exit 2 BEFORE any HTTP call (matching the server's 400
  `details.reason="visibility_policy_conflict"`).
- Response now echoes `join_policy` so operators see the effective
  value the server inferred.

### `acn subnet join` (output upgrade — no new verb)
Branches on response body shape per ADR-0004 §"join branches":

| branch | trigger                            | line                                                                                |
|--------|------------------------------------|-------------------------------------------------------------------------------------|
| 1/2    | open subnet / owner self-join      | `joined subnet <s>`                                                                 |
| 3      | invitation auto-accepted (self)    | `accepted pending invitation <iid> from owner — joined subnet <s>`                  |
| 4      | invitation auto-accepted (allowlist)| `allowlist match plus pending invitation <iid> — accepted invitation, joined subnet <s>` |
| 5      | allowlist hit, new approved row    | `allowlist match — joined subnet <s> (request <rid>)`                               |
| 6      | fall-through pending join_request  | `join request submitted — pending owner approval (request <rid>)`                   |

Both `join` and `leave` migrated to the canonical
`/api/v1/agents/{aid}/subnets/{sid}` URL. The legacy alias
(`/api/v1/subnets/{aid}/subnets/{sid}`) still works server-side;
the CLI just emits the newer surface so request logs are
consistent.

### Three new verb groups (14 verbs)

```
acn subnet allowlist list   <subnet_id>
acn subnet allowlist add    <subnet_id> --agent-id <aid>
acn subnet allowlist remove <subnet_id> --agent-id <aid>

acn subnet requests list <subnet_id> [--status <s>] [--kind <k>]
acn subnet requests pending [-i <agent>]      # owner-side cross-subnet
acn subnet requests approve <subnet_id> --request-id <rid> [--note <t>]
acn subnet requests reject  <subnet_id> --request-id <rid> [--note <t>]
acn subnet requests withdraw <subnet_id> --request-id <rid>

acn subnet invitations send   <subnet_id> --agent-id <aid> [--note <t>]
acn subnet invitations list   <subnet_id> [--status <s>]
acn subnet invitations pending [-i <agent>]   # invitee-side cross-subnet
acn subnet invitations accept <subnet_id> --invitation-id <iid>
acn subnet invitations reject <subnet_id> --invitation-id <iid> [--note <t>]
acn subnet invitations cancel <subnet_id> --invitation-id <iid>
```

`invitations send` understands the merge path: if the target
already has a pending `join_request`, the response is
`auto_resolved` and the CLI reports `"target agent <a> already had
a pending join request — auto-approved (request <rid>) …"` so the
owner isn't confused by a non-202 from an endpoint that normally
returns 202.

The two cross-subnet `pending` views differ in fetch strategy:
- `requests pending` aggregates client-side (`GET /agents/{aid}/subnets`
  → per-subnet `GET /subnets/{sid}/join-requests?status=pending`).
  The owner-only nature of the per-subnet endpoint means the
  aggregator silently swallows 403s from subnets the caller does
  not own. PR A intentionally did not add a dedicated backend
  endpoint for this view.
- `invitations pending` calls the dedicated
  `GET /agents/{aid}/subnet-invitations` endpoint added in PR A —
  no client-side aggregation.

## Test coverage

- 31 new vitest cases in `tests/subnet-ad0004.test.ts`
- Existing ADR-0003 tests (`tests/subnet-ad0003.test.ts`): 6/6 still pass
- **37/37 vitest pass**; `tsc --noEmit` + `tsup` build clean

Covered scenarios:
- All 7 `create --join-policy` paths (open / approval / omitted /
  echo in output / invalid value / `--private`+`open` conflict /
  `--private`+`approval` ok)
- All 6 `join` response branches end-to-end (body shape → output
  string), including the canonical URL
- All 3 allowlist verbs (list filled / list empty / add / remove
  URL shape)
- All 4 per-subnet `requests` verbs (list with defaults, list with
  filters, approve with note, reject without note, withdraw URL)
- `requests pending` aggregator with mixed 200/403 per-subnet
  responses (silently skips 403s, surfaces 200s)
- All 5 per-subnet `invitations` verbs (send normal, send merge,
  list, pending via dedicated endpoint, accept, reject with note,
  cancel)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:tests` clean
- [x] `npm run test` — 37/37 pass
- [x] `npm run build` (tsup) — CJS bundle 88.94 KB, clean
- [ ] CI green on Node 20 + Node 22

Refs ADR-0004 §"CLI changes" §"join branches" §"Authorization matrix"

Made with [Cursor](https://cursor.com)