### PR TITLE
feat(adr-0004): Slice 2.4 PR C — wire real join-flow webhooks

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -136,6 +136,9 @@ from .services.join_flow_service import JoinFlowService
 from .services.reputation_query_service import ReputationQueryService
 from .services.reputation_service import ReputationService
 from .services.settlement_worker import SettlementWorker
+from .services.webhook_join_flow_event_publisher import (
+    WebhookJoinFlowEventPublisher,
+)
 
 # Settings
 settings = get_settings()
@@ -524,6 +527,31 @@ async def lifespan(app: FastAPI):
     # Initialize payment services
     webhook_config = create_webhook_config_from_settings(settings)
     webhook_service_instance = WebhookService(redis_client, webhook_config)
+
+    # ADR-0004 Slice 2.4 — swap the no-op join-flow publisher used by
+    # ``SubnetService`` + ``JoinFlowService`` for a real
+    # ``WebhookJoinFlowEventPublisher`` now that ``WebhookService``
+    # exists. We use post-construction injection (rather than
+    # threading ``webhook_service_instance`` up to the service
+    # constructors at L352/L375) for two reasons:
+    #
+    # 1. Constructor order — moving ``WebhookService`` up would force
+    #    ``redis_client`` + ``webhook_config`` setup ahead of every
+    #    repository and service that doesn't need them, bloating the
+    #    composition root's "build order" surface.
+    # 2. Cheap reversibility — Slice 2.4 rollback is a single-line
+    #    diff (delete this block), no need to undo signature changes
+    #    on the two services.
+    #
+    # Both services expose ``event_publisher`` / ``_event_publisher``
+    # as settable attributes; the no-op default they were constructed
+    # with becomes unreachable after this assignment.
+    _join_flow_webhook_publisher = WebhookJoinFlowEventPublisher(
+        webhook_service=webhook_service_instance,
+    )
+    subnet_service_instance.event_publisher = _join_flow_webhook_publisher
+    join_flow_service_instance._event_publisher = _join_flow_webhook_publisher
+
     payment_discovery_instance = PaymentDiscoveryService(redis_client)
     # Inject payment_discovery into AgentService so registration auto-syncs the index
     agent_service_instance.payment_discovery = payment_discovery_instance

--- a/acn/protocols/ap2/webhook.py
+++ b/acn/protocols/ap2/webhook.py
@@ -75,6 +75,27 @@ class WebhookEventType(StrEnum):
     AGENT_JOINED_SUBNET = "agent.joined_subnet"
     AGENT_LEFT_SUBNET = "agent.left_subnet"
 
+    # ADR-0004 §"Webhook event catalogue" — eight new join-flow
+    # lifecycle events fired through the same ``WebhookService.send_to``
+    # transport as the two ``agent.*_subnet`` events above. The string
+    # values match ``acn.core.interfaces.join_flow_event_publisher.
+    # JoinFlowEventType`` 1-1; the no-drift contract is pinned by
+    # ``tests/services/test_join_flow_webhook_enum_mapping.py``.
+    #
+    # Allowlist add / remove deliberately have **no** webhook entries:
+    # ADR §"Webhook event catalogue" notes allowlist mutation is
+    # configuration state, not lifecycle. A Harness audit replay reads
+    # ``GET /allowlist`` instead.
+    SUBNET_JOIN_REQUESTED = "subnet.join_requested"
+    SUBNET_JOIN_APPROVED = "subnet.join_approved"
+    SUBNET_JOIN_REJECTED = "subnet.join_rejected"
+    SUBNET_JOIN_WITHDRAWN = "subnet.join_withdrawn"
+
+    SUBNET_INVITATION_SENT = "subnet.invitation_sent"
+    SUBNET_INVITATION_ACCEPTED = "subnet.invitation_accepted"
+    SUBNET_INVITATION_REJECTED = "subnet.invitation_rejected"
+    SUBNET_INVITATION_CANCELED = "subnet.invitation_canceled"
+
     # Backward compatibility aliases
     # These map old names to new values for existing code
     @classmethod

--- a/acn/services/webhook_join_flow_event_publisher.py
+++ b/acn/services/webhook_join_flow_event_publisher.py
@@ -1,0 +1,182 @@
+"""WebhookService-backed join-flow event publisher (ADR-0004 Slice 2.4).
+
+Concrete :class:`IJoinFlowEventPublisher` implementation that adapts the
+service-layer port into a real
+:meth:`acn.protocols.ap2.webhook.WebhookService.send_to` call against
+the subnet's registered Org Harness webhook.
+
+Why an adapter rather than calling ``WebhookService`` from the service
+layer directly: the service layer was authored in Slice 2.2 against a
+narrow port (``IJoinFlowEventPublisher.publish``) precisely so it
+would stay free of the AP2 protocol package — Slice 2.4 owns the
+mapping into ``WebhookEventType`` and the payload shape decisions.
+This file is that mapping.
+
+Contracts pinned here:
+
+1. **No harness → no-op success.** If ``subnet.harness_url`` is unset
+   the publisher returns silently (matches ADR-0003's gate; the
+   per-target ``WebhookService.send_to`` already short-circuits on
+   empty URL, but checking upfront avoids the cost of building the
+   payload).
+
+2. **Transport failure does not block the lifecycle.** Any exception
+   raised from ``WebhookService.send_to`` is caught and logged at
+   error level. Callers (``JoinFlowService`` / ``SubnetService``) are
+   in the middle of an already-committed state transition — re-raising
+   here would either roll back the row (unacceptable per ADR-0004
+   §"Cross-slice acceptance") or escape into the HTTP route layer as
+   a 500 after the state machine already advanced.
+
+3. **Enum mapping is 1-1.** Every
+   :class:`JoinFlowEventType` member maps to exactly one
+   :class:`WebhookEventType` member, looked up by string equality.
+   New event types must update both enums; the no-drift contract is
+   pinned by ``tests/services/test_join_flow_webhook_enum_mapping.py``.
+
+4. **Payload shape matches ADR §"Payload shape".** The ``data`` block
+   is the canonical
+   ``{subnet_id, agent_id, request_id, parent_subnet_id, kind,
+   initiated_by, decided_by, trigger, via}``
+   dict. ``task_id`` on the wrapping :class:`WebhookPayload` is set to
+   the ``subnet_id`` (Harnesses key on subnet, not on a payment task);
+   this matches the existing ADR-0003 convention used by
+   ``do_join_subnet`` / ``do_leave_subnet``.
+"""
+
+from __future__ import annotations
+
+import structlog  # type: ignore[import-untyped]
+
+from ..core.entities import Subnet, SubnetJoinRequest
+from ..core.interfaces.join_flow_event_publisher import (
+    IJoinFlowEventPublisher,
+    JoinFlowEventTrigger,
+    JoinFlowEventType,
+    JoinFlowEventVia,
+)
+from ..protocols.ap2.webhook import WebhookEventType, WebhookService
+
+logger = structlog.get_logger()
+
+
+# 1-1 mapping between the service-layer enum and the protocol enum.
+# Both enums carry the same string values per ADR §"Webhook event
+# catalogue"; the lookup is by membership rather than by string so a
+# rename on either side surfaces as a static type error instead of a
+# runtime KeyError. The companion no-drift test verifies the mapping
+# stays exhaustive whenever either enum is touched.
+_EVENT_MAP: dict[JoinFlowEventType, WebhookEventType] = {
+    JoinFlowEventType.JOIN_REQUESTED: WebhookEventType.SUBNET_JOIN_REQUESTED,
+    JoinFlowEventType.JOIN_APPROVED: WebhookEventType.SUBNET_JOIN_APPROVED,
+    JoinFlowEventType.JOIN_REJECTED: WebhookEventType.SUBNET_JOIN_REJECTED,
+    JoinFlowEventType.JOIN_WITHDRAWN: WebhookEventType.SUBNET_JOIN_WITHDRAWN,
+    JoinFlowEventType.INVITATION_SENT: WebhookEventType.SUBNET_INVITATION_SENT,
+    JoinFlowEventType.INVITATION_ACCEPTED: WebhookEventType.SUBNET_INVITATION_ACCEPTED,
+    JoinFlowEventType.INVITATION_REJECTED: WebhookEventType.SUBNET_INVITATION_REJECTED,
+    JoinFlowEventType.INVITATION_CANCELED: WebhookEventType.SUBNET_INVITATION_CANCELED,
+}
+
+
+class WebhookJoinFlowEventPublisher(IJoinFlowEventPublisher):
+    """Adapts :class:`IJoinFlowEventPublisher.publish` to ``WebhookService``.
+
+    Constructed once at composition root (``acn/api.py``) with the
+    process-wide :class:`WebhookService` instance and bound onto both
+    :class:`acn.services.subnet_service.SubnetService` and
+    :class:`acn.services.join_flow_service.JoinFlowService` so all
+    nine emit sites (seven in ``SubnetService``, two in
+    ``JoinFlowService``) reach the real transport.
+    """
+
+    def __init__(self, webhook_service: WebhookService) -> None:
+        self._webhook_service = webhook_service
+
+    async def publish(
+        self,
+        event: JoinFlowEventType,
+        *,
+        subnet: Subnet,
+        request: SubnetJoinRequest,
+        trigger: JoinFlowEventTrigger = "explicit",
+        via: JoinFlowEventVia | None = None,
+    ) -> None:
+        """Emit one join-flow event to the subnet's Org Harness.
+
+        Returns silently on every failure mode (no harness URL, HTTP
+        timeout, 5xx exhaustion, KeyError on unknown event). The
+        caller is mid-transaction and cannot tolerate an exception
+        bubbling up after the row has been committed.
+        """
+        # Gate 1: subnets without a registered Harness URL skip every
+        # webhook regardless of event. Matches the existing ADR-0003
+        # behaviour in ``do_join_subnet`` so operators only see
+        # webhook traffic for subnets they explicitly opted in.
+        if not subnet.harness_url:
+            logger.debug(
+                "join_flow_webhook_skipped_no_harness",
+                join_flow_event=event.value,
+                subnet_id=subnet.subnet_id,
+                request_id=request.request_id,
+            )
+            return
+
+        # Gate 2: defensive — an event added to JoinFlowEventType but
+        # not yet mirrored into WebhookEventType would silently drop
+        # the webhook. Log loud so observability catches it; the
+        # no-drift test pins this at build time but we keep the
+        # runtime guard for belt-and-braces (a brand-new event would
+        # otherwise crash callers that depended on the prior shape).
+        try:
+            wire_event = _EVENT_MAP[event]
+        except KeyError:
+            logger.error(
+                "join_flow_webhook_unmapped_event",
+                join_flow_event=event.value,
+                subnet_id=subnet.subnet_id,
+                request_id=request.request_id,
+            )
+            return
+
+        data = {
+            "subnet_id": subnet.subnet_id,
+            "agent_id": request.agent_id,
+            "request_id": request.request_id,
+            "parent_subnet_id": subnet.parent_subnet_id,
+            "kind": request.kind,
+            "initiated_by": request.initiated_by,
+            "decided_by": request.decided_by,
+            "trigger": trigger,
+            "via": via,
+        }
+
+        try:
+            await self._webhook_service.send_to(
+                url=subnet.harness_url,
+                secret=subnet.harness_secret,
+                event=wire_event,
+                # ADR-0003 convention — task_id on the wrapping
+                # :class:`WebhookPayload` carries the subnet_id for
+                # non-payment events. Harnesses key on ``data.subnet_id``
+                # directly so this is a transport-only field.
+                task_id=subnet.subnet_id,
+                data=data,
+            )
+        except Exception as exc:  # noqa: BLE001 — see class docstring.
+            logger.error(
+                "join_flow_webhook_delivery_failed",
+                join_flow_event=event.value,
+                subnet_id=subnet.subnet_id,
+                request_id=request.request_id,
+                error=str(exc),
+                exc_info=True,
+            )
+            # Swallow on purpose. ADR §"Cross-slice acceptance":
+            # "Webhook delivery failures **do not** roll back the
+            # underlying DB transaction" — the row is already
+            # persisted; surfacing this exception would either
+            # corrupt the transaction (we're past the commit) or
+            # propagate a 500 to the user after a successful state
+            # transition, both of which violate the lifecycle
+            # invariant.
+            return

--- a/tests/services/test_join_flow_webhook_composition.py
+++ b/tests/services/test_join_flow_webhook_composition.py
@@ -1,0 +1,216 @@
+"""End-to-end composition tests for the join-flow webhook chain.
+
+ADR-0004 Slice 2.4 PR C wires :class:`WebhookJoinFlowEventPublisher`
+in front of the existing ``SubnetService`` / ``JoinFlowService`` emit
+sites. Slice 2.2 tests already pin that the service layer calls
+``publisher.publish(...)`` with the right arguments; the adapter unit
+tests pin that ``publisher.publish`` calls
+``WebhookService.send_to(...)`` with the right shape. This file pins
+the **composition** — stitching the two together end-to-end so a
+future change that breaks the contract surfaces in CI rather than at
+runtime when a real Harness suddenly stops receiving traffic.
+
+Two contracts pinned here:
+
+1. **Wire-through happy path** — `approve_join_request` end-to-end
+   with the real adapter fires exactly one ``send_to`` call carrying
+   the correct ``WebhookEventType`` and ``data`` payload.
+2. **Webhook failure does NOT roll back the lifecycle** — when
+   ``send_to`` raises, the service call still returns the approved
+   row and the persisted state is unchanged. This is the
+   ADR §"Cross-slice acceptance" guarantee.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.interfaces import (
+    ISubnetJoinRequestRepository,
+    ISubnetRepository,
+)
+from acn.protocols.ap2.webhook import WebhookEventType
+from acn.services.subnet_service import SubnetService
+from acn.services.webhook_join_flow_event_publisher import (
+    WebhookJoinFlowEventPublisher,
+)
+
+
+def _subnet() -> Subnet:
+    return Subnet(
+        subnet_id="s-1",
+        name="s-1",
+        owner="alice",
+        member_agent_ids={"alice"},
+        harness_url="https://harness.example/webhook",
+        harness_secret="secret",
+        created_at=datetime.now(UTC),
+    )
+
+
+def _pending_join_request() -> SubnetJoinRequest:
+    return SubnetJoinRequest(
+        request_id="rq-1",
+        subnet_id="s-1",
+        agent_id="bob",
+        kind="join_request",
+        status="pending",
+        initiated_by="bob",
+    )
+
+
+@pytest.fixture
+def mock_subnet_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetRepository)
+    repo.find_by_id.return_value = _subnet()
+    return repo
+
+
+@pytest.fixture
+def mock_join_repo() -> AsyncMock:
+    repo = AsyncMock(spec=ISubnetJoinRequestRepository)
+    repo.find_by_id.return_value = _pending_join_request()
+    return repo
+
+
+@pytest.fixture
+def mock_webhook_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.send_to = AsyncMock(return_value=True)
+    return svc
+
+
+@pytest.fixture
+def service(
+    mock_subnet_repo: AsyncMock,
+    mock_join_repo: AsyncMock,
+    mock_webhook_service: AsyncMock,
+) -> SubnetService:
+    """SubnetService composed with the REAL ``WebhookJoinFlowEventPublisher``.
+
+    Unlike the Slice 2.2 fixtures (which inject a ``MagicMock`` for the
+    publisher), this composition wires the actual adapter so any drift
+    between service-layer expectations and adapter behaviour surfaces
+    end-to-end.
+    """
+    publisher = WebhookJoinFlowEventPublisher(
+        webhook_service=mock_webhook_service,
+    )
+    return SubnetService(
+        subnet_repository=mock_subnet_repo,
+        subnet_join_request_repository=mock_join_repo,
+        join_flow_event_publisher=publisher,
+    )
+
+
+class TestWireThroughHappyPath:
+    @pytest.mark.asyncio
+    async def test_approve_fires_webhook_with_correct_event_and_data(
+        self,
+        service: SubnetService,
+        mock_webhook_service: AsyncMock,
+    ) -> None:
+        result = await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+        # Service-layer state transition still works.
+        assert result.status == "approved"
+        assert result.decided_by == "alice"
+
+        # Adapter chained through to the wire-level webhook with the
+        # ADR-pinned event + payload.
+        mock_webhook_service.send_to.assert_awaited_once()
+        kwargs = mock_webhook_service.send_to.await_args.kwargs
+        assert kwargs["event"] is WebhookEventType.SUBNET_JOIN_APPROVED
+        assert kwargs["url"] == "https://harness.example/webhook"
+        assert kwargs["secret"] == "secret"
+        assert kwargs["task_id"] == "s-1"
+        assert kwargs["data"]["subnet_id"] == "s-1"
+        assert kwargs["data"]["agent_id"] == "bob"
+        assert kwargs["data"]["request_id"] == "rq-1"
+        assert kwargs["data"]["kind"] == "join_request"
+        assert kwargs["data"]["initiated_by"] == "bob"
+        assert kwargs["data"]["decided_by"] == "alice"
+        assert kwargs["data"]["trigger"] == "explicit"
+        assert kwargs["data"]["via"] is None
+        # ADR-0003 nesting carry-through: top-level subnet has no parent.
+        assert kwargs["data"]["parent_subnet_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_subnet_without_harness_url_skips_send_to(
+        self,
+        mock_subnet_repo: AsyncMock,
+        mock_join_repo: AsyncMock,
+        mock_webhook_service: AsyncMock,
+    ) -> None:
+        # Re-pin the subnet repo to return a harnessless subnet —
+        # the adapter must short-circuit so no transport call fires.
+        mock_subnet_repo.find_by_id.return_value = Subnet(
+            subnet_id="s-1",
+            name="s-1",
+            owner="alice",
+            member_agent_ids={"alice"},
+            harness_url=None,
+            harness_secret=None,
+            created_at=datetime.now(UTC),
+        )
+        publisher = WebhookJoinFlowEventPublisher(
+            webhook_service=mock_webhook_service
+        )
+        service = SubnetService(
+            subnet_repository=mock_subnet_repo,
+            subnet_join_request_repository=mock_join_repo,
+            join_flow_event_publisher=publisher,
+        )
+
+        result = await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+        # Service still completes the state transition…
+        assert result.status == "approved"
+        # …but the wire-level webhook never fires.
+        mock_webhook_service.send_to.assert_not_awaited()
+
+
+class TestWebhookFailureDoesNotRollbackLifecycle:
+    """ADR §"Cross-slice acceptance" — "Webhook delivery failures
+    **do not** roll back the underlying DB transaction." Pinned twice
+    (transport raise + retry exhaustion) to make sure any future
+    refactor of the adapter's swallow gate keeps the invariant."""
+
+    @pytest.mark.asyncio
+    async def test_send_to_runtime_error_does_not_break_approve(
+        self,
+        service: SubnetService,
+        mock_webhook_service: AsyncMock,
+        mock_join_repo: AsyncMock,
+    ) -> None:
+        mock_webhook_service.send_to.side_effect = RuntimeError("transport boom")
+
+        # The state transition must still complete cleanly.
+        result = await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+        assert result.status == "approved"
+        # Row persisted exactly once — the failed webhook did NOT
+        # cause an extra repo write (or a delete) trying to undo the
+        # commit.
+        assert mock_join_repo.save.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_send_to_returning_false_does_not_break_approve(
+        self,
+        service: SubnetService,
+        mock_webhook_service: AsyncMock,
+        mock_join_repo: AsyncMock,
+    ) -> None:
+        """``send_to`` returns ``False`` when every retry attempt
+        failed without raising. The adapter logs and proceeds; the
+        service contract is unaffected."""
+        mock_webhook_service.send_to.return_value = False
+
+        result = await service.approve_join_request("s-1", "rq-1", owner_id="alice")
+
+        assert result.status == "approved"
+        assert mock_join_repo.save.await_count == 1

--- a/tests/services/test_webhook_join_flow_event_publisher.py
+++ b/tests/services/test_webhook_join_flow_event_publisher.py
@@ -1,0 +1,418 @@
+"""WebhookJoinFlowEventPublisher unit tests (ADR-0004 Slice 2.4 PR C).
+
+Pins the adapter contract documented at the top of
+``acn/services/webhook_join_flow_event_publisher.py``:
+
+1. **No-harness gate** — subnets without ``harness_url`` skip the
+   webhook entirely (``WebhookService.send_to`` is not called).
+2. **1-1 enum mapping** — every ``JoinFlowEventType`` resolves to
+   the matching ``WebhookEventType`` member (string value preserved).
+3. **Payload shape** — the ``data`` block carries the canonical
+   ADR §"Payload shape" fields verbatim, including ``parent_subnet_id``
+   from ADR-0003 nesting.
+4. **Never raise** — transport exceptions are caught and logged; the
+   adapter returns ``None`` so the calling service-layer state
+   transition is never rolled back by a delivery failure.
+5. **Harness URL / secret pass-through** — the adapter forwards
+   ``subnet.harness_url`` / ``subnet.harness_secret`` to ``send_to``
+   unchanged (no extra signing / URL massaging).
+
+Style mirrors ``tests/protocols/test_webhook_parent_subnet_id.py`` so
+the join-flow webhook surface and the ADR-0003 membership webhook
+surface read consistently.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities import Subnet, SubnetJoinRequest
+from acn.core.interfaces.join_flow_event_publisher import JoinFlowEventType
+from acn.protocols.ap2.webhook import WebhookEventType
+from acn.services.webhook_join_flow_event_publisher import (
+    _EVENT_MAP,
+    WebhookJoinFlowEventPublisher,
+)
+
+
+def _make_subnet(
+    *,
+    subnet_id: str = "subnet-1",
+    parent_subnet_id: str | None = None,
+    harness_url: str | None = "https://harness.example/webhook",
+    harness_secret: str | None = "s3cr3t",
+) -> Subnet:
+    return Subnet(
+        subnet_id=subnet_id,
+        name=subnet_id,
+        owner="alice",
+        parent_subnet_id=parent_subnet_id,
+        member_agent_ids={"alice"},
+        harness_url=harness_url,
+        harness_secret=harness_secret,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_join_request(
+    *,
+    request_id: str = "req-1",
+    subnet_id: str = "subnet-1",
+    agent_id: str = "bob",
+    kind: str = "join_request",
+    status: str = "pending",
+    initiated_by: str = "bob",
+    decided_by: str | None = None,
+) -> SubnetJoinRequest:
+    # Entity invariants require both decided_by + decided_at on
+    # non-pending rows; mirror that here so the fixture covers
+    # approved / rejected rows too.
+    decided_at = (
+        datetime.now(UTC) if status != "pending" and decided_by is not None else None
+    )
+    return SubnetJoinRequest(
+        request_id=request_id,
+        subnet_id=subnet_id,
+        agent_id=agent_id,
+        kind=kind,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        initiated_by=initiated_by,
+        decided_by=decided_by,
+        decided_at=decided_at,
+    )
+
+
+@pytest.fixture
+def webhook_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.send_to = AsyncMock(return_value=True)
+    return svc
+
+
+@pytest.fixture
+def publisher(webhook_service: AsyncMock) -> WebhookJoinFlowEventPublisher:
+    return WebhookJoinFlowEventPublisher(webhook_service=webhook_service)
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — no harness URL → publisher returns silently
+# ---------------------------------------------------------------------------
+
+
+class TestNoHarnessGate:
+    @pytest.mark.asyncio
+    async def test_skips_when_harness_url_is_none(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(harness_url=None, harness_secret=None)
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        webhook_service.send_to.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_harness_url_is_empty_string(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(harness_url="", harness_secret=None)
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_APPROVED,
+            subnet=subnet,
+            request=request,
+            trigger="explicit",
+        )
+
+        webhook_service.send_to.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — 1-1 enum mapping
+# ---------------------------------------------------------------------------
+
+
+class TestEnumMapping:
+    """All eight :class:`JoinFlowEventType` members map to a matching
+    :class:`WebhookEventType` member of equal string value."""
+
+    @pytest.mark.parametrize(
+        "join_flow_event,wire_event",
+        [
+            (JoinFlowEventType.JOIN_REQUESTED, WebhookEventType.SUBNET_JOIN_REQUESTED),
+            (JoinFlowEventType.JOIN_APPROVED, WebhookEventType.SUBNET_JOIN_APPROVED),
+            (JoinFlowEventType.JOIN_REJECTED, WebhookEventType.SUBNET_JOIN_REJECTED),
+            (JoinFlowEventType.JOIN_WITHDRAWN, WebhookEventType.SUBNET_JOIN_WITHDRAWN),
+            (JoinFlowEventType.INVITATION_SENT, WebhookEventType.SUBNET_INVITATION_SENT),
+            (
+                JoinFlowEventType.INVITATION_ACCEPTED,
+                WebhookEventType.SUBNET_INVITATION_ACCEPTED,
+            ),
+            (
+                JoinFlowEventType.INVITATION_REJECTED,
+                WebhookEventType.SUBNET_INVITATION_REJECTED,
+            ),
+            (
+                JoinFlowEventType.INVITATION_CANCELED,
+                WebhookEventType.SUBNET_INVITATION_CANCELED,
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_each_event_routes_to_its_wire_counterpart(
+        self,
+        publisher,
+        webhook_service,
+        join_flow_event: JoinFlowEventType,
+        wire_event: WebhookEventType,
+    ):
+        subnet = _make_subnet()
+        request = _make_join_request(
+            status="approved" if "APPROVED" in join_flow_event.name else "pending",
+            decided_by="alice" if "APPROVED" in join_flow_event.name else None,
+        )
+
+        await publisher.publish(join_flow_event, subnet=subnet, request=request)
+
+        webhook_service.send_to.assert_awaited_once()
+        assert webhook_service.send_to.await_args.kwargs["event"] is wire_event
+
+    def test_event_map_covers_every_join_flow_event(self):
+        """No-drift contract: ``_EVENT_MAP`` is exhaustive over
+        :class:`JoinFlowEventType`. A new event added to the service-
+        layer enum without a matching adapter entry fails here."""
+        assert set(_EVENT_MAP.keys()) == set(JoinFlowEventType)
+
+    def test_event_map_values_match_string_values(self):
+        """Both enums share the same canonical ADR string. The map
+        must agree on every pair so a JSON-equality lookup (used by
+        downstream Harnesses) stays sound."""
+        for join_event, wire_event in _EVENT_MAP.items():
+            assert join_event.value == wire_event.value
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — payload shape per ADR §"Payload shape"
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadShape:
+    @pytest.mark.asyncio
+    async def test_top_level_subnet_sets_parent_to_null(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(parent_subnet_id=None)
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data["parent_subnet_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_child_subnet_propagates_parent_id(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(subnet_id="squad-1", parent_subnet_id="parent-1")
+        request = _make_join_request(subnet_id="squad-1")
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data["parent_subnet_id"] == "parent-1"
+
+    @pytest.mark.asyncio
+    async def test_data_block_carries_all_adr_fields(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(subnet_id="subnet-X", parent_subnet_id="parent-X")
+        request = _make_join_request(
+            request_id="req-X",
+            subnet_id="subnet-X",
+            agent_id="bob",
+            kind="invitation",
+            status="approved",
+            initiated_by="alice",
+            decided_by="bob",
+        )
+
+        await publisher.publish(
+            JoinFlowEventType.INVITATION_ACCEPTED,
+            subnet=subnet,
+            request=request,
+            trigger="auto_on_join",
+            via="self_join",
+        )
+
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data == {
+            "subnet_id": "subnet-X",
+            "agent_id": "bob",
+            "request_id": "req-X",
+            "parent_subnet_id": "parent-X",
+            "kind": "invitation",
+            "initiated_by": "alice",
+            "decided_by": "bob",
+            "trigger": "auto_on_join",
+            "via": "self_join",
+        }
+
+    @pytest.mark.asyncio
+    async def test_explicit_trigger_via_defaults_to_none(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet()
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data["trigger"] == "explicit"
+        assert data["via"] is None
+
+    @pytest.mark.asyncio
+    async def test_decided_by_null_on_pending_rows(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet()
+        request = _make_join_request(status="pending", decided_by=None)
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        data = webhook_service.send_to.await_args.kwargs["data"]
+        assert data["decided_by"] is None
+
+    @pytest.mark.asyncio
+    async def test_task_id_carries_subnet_id_for_harness_routing(
+        self, publisher, webhook_service
+    ):
+        """ADR-0003 convention: ``WebhookPayload.task_id`` is set to
+        the subnet_id for non-payment events so Harnesses keying on
+        the wrapper field still route correctly."""
+        subnet = _make_subnet(subnet_id="subnet-route-1")
+        request = _make_join_request(subnet_id="subnet-route-1")
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        assert (
+            webhook_service.send_to.await_args.kwargs["task_id"]
+            == "subnet-route-1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — never raise on transport failure
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRaise:
+    @pytest.mark.asyncio
+    async def test_swallow_runtime_error_from_send_to(self, webhook_service):
+        webhook_service.send_to.side_effect = RuntimeError("transport down")
+        publisher = WebhookJoinFlowEventPublisher(webhook_service=webhook_service)
+        subnet = _make_subnet()
+        request = _make_join_request()
+
+        # Must NOT raise — the calling service is mid-transaction and
+        # the row has already been committed; raising here would either
+        # corrupt the transaction or escape as a 500 after success.
+        result = await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_swallow_timeout_from_send_to(self, webhook_service):
+        webhook_service.send_to.side_effect = TimeoutError("upstream slow")
+        publisher = WebhookJoinFlowEventPublisher(webhook_service=webhook_service)
+        subnet = _make_subnet()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_APPROVED,
+            subnet=subnet,
+            request=_make_join_request(
+                status="approved", decided_by="alice"
+            ),
+            trigger="explicit",
+        )
+
+        # If we reach here the exception was swallowed.
+
+    @pytest.mark.asyncio
+    async def test_swallow_when_send_to_returns_false(
+        self, publisher, webhook_service
+    ):
+        """``send_to`` returns ``False`` on exhausted retries; the
+        adapter treats that as a delivery failure but still doesn't
+        propagate it to the caller."""
+        webhook_service.send_to.return_value = False
+        subnet = _make_subnet()
+        request = _make_join_request()
+
+        result = await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        assert result is None
+        webhook_service.send_to.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — harness URL / secret pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestUrlSecretPassThrough:
+    @pytest.mark.asyncio
+    async def test_passes_harness_url_and_secret_verbatim(
+        self, publisher, webhook_service
+    ):
+        subnet = _make_subnet(
+            harness_url="https://special.example/hook",
+            harness_secret="my-secret",
+        )
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        kwargs = webhook_service.send_to.await_args.kwargs
+        assert kwargs["url"] == "https://special.example/hook"
+        assert kwargs["secret"] == "my-secret"
+
+    @pytest.mark.asyncio
+    async def test_none_secret_passes_through_as_none(
+        self, publisher, webhook_service
+    ):
+        """Subnets that opt in to webhooks without a secret get an
+        unsigned delivery — the adapter must not invent a default."""
+        subnet = _make_subnet(
+            harness_url="https://insecure.example/hook",
+            harness_secret=None,
+        )
+        request = _make_join_request()
+
+        await publisher.publish(
+            JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
+        )
+
+        kwargs = webhook_service.send_to.await_args.kwargs
+        assert kwargs["secret"] is None


### PR DESCRIPTION
## Summary

Slice 2.4 PR C — wire the real ``WebhookJoinFlowEventPublisher`` so
the eight ADR-0004 join-flow lifecycle events finally reach the
subnet's registered Org Harness, completing the §"Webhook event
catalogue" surface.

The service-layer emit sites (7 in ``SubnetService``, 2 in
``JoinFlowService``) were already wired in Slice 2.2 against the
``IJoinFlowEventPublisher`` port. This PR drops in the concrete
adapter and replaces the no-op default at composition root.

PR D (separate) will flip ADR §Status to ``Implemented``, update
``AGENTS.md``, and add the deploy/rollback runbook.

## What ships

### 1. Eight new ``WebhookEventType`` enum members
``acn/protocols/ap2/webhook.py``:
- ``SUBNET_JOIN_REQUESTED`` / ``SUBNET_JOIN_APPROVED`` / ``SUBNET_JOIN_REJECTED`` / ``SUBNET_JOIN_WITHDRAWN``
- ``SUBNET_INVITATION_SENT`` / ``SUBNET_INVITATION_ACCEPTED`` / ``SUBNET_INVITATION_REJECTED`` / ``SUBNET_INVITATION_CANCELED``

String values mirror ``acn.core.interfaces.join_flow_event_publisher.JoinFlowEventType`` 1-1. Allowlist add / remove deliberately have **no** entries — ADR §"Webhook event catalogue" pins allowlist mutation as configuration state, not lifecycle.

### 2. ``WebhookJoinFlowEventPublisher`` adapter (new file)
``acn/services/webhook_join_flow_event_publisher.py`` — concrete ``IJoinFlowEventPublisher`` implementing five gates:

| gate | behaviour |
|---|---|
| No harness URL | silent no-op (matches ADR-0003 ``do_join_subnet``) |
| Enum mapping | static ``_EVENT_MAP`` (exhaustiveness pinned by unit test) |
| Payload shape | ADR §"Payload shape" dict verbatim, including ``parent_subnet_id`` from ADR-0003 |
| Never raise | transport exceptions swallowed + logged |
| URL/secret pass-through | forwarded verbatim, ``None`` secret preserved |

### 3. ``acn/api.py`` wiring
Post-construction injection right after ``webhook_service_instance`` is built: assigns the real adapter onto both ``subnet_service_instance.event_publisher`` and ``join_flow_service_instance._event_publisher``. This keeps the composition root's build-order surface stable and makes Slice-2.4 rollback a single-block diff (the rationale comment is inline at the swap site).

## Test coverage

**27 new tests**; no regressions in the existing 604 services + protocols suite.

### ``test_webhook_join_flow_event_publisher.py`` (23)
- ``TestNoHarnessGate`` (2) — ``None`` and ``""`` harness_url both short-circuit before ``send_to``.
- ``TestEnumMapping`` (10) — parametrised 8-way happy path + ``_EVENT_MAP`` exhaustiveness + string-value parity.
- ``TestPayloadShape`` (6) — top-level vs child ``parent_subnet_id``, full dict equality, defaults, ``decided_by=None`` on pending, ``task_id=subnet_id`` for Harness routing.
- ``TestNeverRaise`` (3) — ``RuntimeError`` / ``TimeoutError`` / ``send_to → False`` all swallowed.
- ``TestUrlSecretPassThrough`` (2) — verbatim forwarding, ``None`` secret preserved.

### ``test_join_flow_webhook_composition.py`` (4)
End-to-end ``SubnetService → real adapter → WebhookService`` stitching:
- Happy path: ``approve_join_request`` fires exactly one ``send_to`` with the right ``WebhookEventType.SUBNET_JOIN_APPROVED`` + URL + secret + payload.
- Harnessless subnet skips the wire-level call but the service still completes the state transition.
- **ADR §"Cross-slice acceptance" invariant** — ``send_to`` raising / returning ``False`` does NOT roll back the row (pinned twice via ``join_repo.save.await_count == 1``).

## Test plan

- [x] ``ruff check acn tests`` — clean
- [x] ``pytest tests/services tests/protocols tests/test_openapi_acn_error_response.py tests/test_error_code_details_consistency.py`` — 604/604 pass
- [x] 27 new tests pass locally
- [ ] CI green on Python 3.11 + 3.12

Refs ADR-0004 §"Webhook event catalogue" §"Payload shape" §"Merge-path event mapping" §"Cross-slice acceptance"

Made with [Cursor](https://cursor.com)