### PR TITLE
docs(adr-0004): post-merge audit fixes — runbook log keys + stale refs

### DIFF
--- a/acn/core/entities/subnet.py
+++ b/acn/core/entities/subnet.py
@@ -49,8 +49,9 @@ class Subnet:
     # Join admission policy (ADR-0004). Decouples admission control from
     # discoverability (``is_private``). ``"open"`` keeps today's "any
     # registered agent may join" behaviour; ``"approval"`` requires an
-    # owner-side decision (the request / invitation / allowlist state
-    # machine lands in Phase 2 with the service layer). Defaults to
+    # owner-side decision via the request / invitation / allowlist
+    # state machine implemented in ``acn/services/join_flow_service.py``
+    # and surfaced through ``acn/routes/subnet_admission.py``. Defaults to
     # ``"open"`` so legacy callers that never set the field behave
     # exactly as before; the ``__post_init__`` invariant below rejects
     # the ``is_private=True + join_policy="open"`` combination that the

--- a/docs/adr/0004-subnet-join-policy.md
+++ b/docs/adr/0004-subnet-join-policy.md
@@ -1692,9 +1692,9 @@ order.
 
 The ADR §Cross-slice acceptance checklist is satisfied as follows:
 
-- **State machine convergence** — pinned by `tests/services/test_join_flow_service.py` (60+ tests across the six branches, all approval-entry paths, and the `Invited?` ⊳ `Allow?` ordering invariant).
-- **No double-membership** — pinned by `tests/services/test_subnet_service_allowlist.py` and the invitation-folds-into-allowlist tests in `test_join_flow_service.py`.
-- **ADR-0003 cascade preserved** — `tests/services/test_subnet_service_cascade.py` + `tests/infrastructure/test_unit_of_work_cascade.py` (#76).
+- **State machine convergence** — pinned by `tests/services/test_join_flow_service.py` (14 tests across `TestBranch{1..6}` covering each of the six branches, plus `TestStateMachineEdges` and `TestBranchOrderNormativity` for the `Invited?` ⊳ `Allow?` precedence and other edge orderings).
+- **No double-membership** — pinned by `tests/services/test_subnet_service_allowlist.py` and `tests/services/test_join_flow_service.py::TestBranch4InvitationWithAllowlistMerge::test_invitation_wins_over_allowlist_auto` (the invitation-folds-into-allowlist test).
+- **ADR-0003 cascade preserved** — `tests/services/test_subnet_service_cascade.py` (Slice 2.1 surface) + `tests/services/test_subnet_service_cascade_atomic.py` (#76 single-transaction guarantee, threading `IUnitOfWork`'s session token through all three cascade methods).
 - **Webhook lifecycle invariant** — `tests/services/test_join_flow_webhook_composition.py` pins that webhook transport failure (exception or `return False`) does **not** roll back the underlying state transition.
 - **No-drift enum contract** — `tests/services/test_webhook_join_flow_event_publisher.py::TestEnumMapping` asserts `_EVENT_MAP` is exhaustive over `JoinFlowEventType` and every pair shares the same string value.
 - **Backward compatibility** — `tests/test_openapi_acn_error_response.py` + `tests/test_error_code_details_consistency.py` keep the error-shape contract stable across the 11 new `ErrorCode`s; existing `is_private` + `POST /agents/{id}/subnets/{id}` callers behave identically when they omit the new fields.

--- a/docs/runbooks/adr-0004-join-policy.md
+++ b/docs/runbooks/adr-0004-join-policy.md
@@ -85,14 +85,23 @@ modifications required.
 
 ### Log keys to watch
 
-| `structlog` event | What it means | Severity |
-|-------------------|---------------|----------|
-| `join_flow_webhook_delivery_failed` | Webhook `send_to` raised or returned `False`; **state machine still advanced** (per ADR §Cross-slice acceptance) | warn — only alert on sustained rate ≥ N/min |
-| `join_flow_webhook_skipped_no_harness` | Subnet has no `harness_url`; webhook intentionally skipped | debug |
-| `join_flow_webhook_unmapped_event` | Brand-new `JoinFlowEventType` member not in `_EVENT_MAP` — should be impossible (pinned by test) | **error → page** |
-| `join_request_approved` / `_rejected` / `_withdrawn` | Lifecycle audit trail | info |
-| `invitation_sent` / `_accepted` / `_rejected` / `_canceled` | Lifecycle audit trail | info |
-| `visibility_policy_conflict` | Caller tried `is_private=True + join_policy='open'` | info (4xx, not a service bug) |
+All keys verified emitted at the source files listed in the rightmost
+column. Greppable in production logs as the literal string.
+
+| `structlog` event | Emitted from | What it means | Severity |
+|-------------------|--------------|---------------|----------|
+| `join_flow_webhook_delivery_failed` | `acn/services/webhook_join_flow_event_publisher.py` | Webhook `send_to` raised or returned `False`; **state machine still advanced** (per ADR §Cross-slice acceptance) | warn — only alert on sustained rate ≥ N/min |
+| `join_flow_webhook_skipped_no_harness` | `acn/services/webhook_join_flow_event_publisher.py` | Subnet has no `harness_url`; webhook intentionally skipped | debug |
+| `join_flow_webhook_unmapped_event` | `acn/services/webhook_join_flow_event_publisher.py` | Brand-new `JoinFlowEventType` member not in `_EVENT_MAP` — should be impossible (pinned by test) | **error → page** |
+| `subnet_join_request_approved` / `_rejected` / `_withdrawn` | `acn/services/subnet_service.py` | Lifecycle audit trail | info |
+| `subnet_invitation_sent` / `_accepted` / `_rejected` / `_canceled` | `acn/services/subnet_service.py` | Lifecycle audit trail | info |
+
+The `visibility_policy_conflict` reason is **not** a structlog event
+— it's a string surfaced on the wire inside `ACNHTTPError.details.reason`
+for the `is_private=True + join_policy='open'` 4xx rejection at
+entity construction (raised from `acn/core/entities/subnet.py`). Find
+it in production via HTTP access logs / 4xx dashboards, not a log
+key search.
 
 ### Prometheus
 
@@ -127,7 +136,7 @@ reverting #74's PG migration is high.
 ## 6) Known gotchas
 
 - **Allowlist add/remove has no webhook**. ADR §"Webhook event catalogue" classifies allowlist mutation as configuration state. If a Harness needs a snapshot, replay via `GET /api/v1/subnets/{id}/allowlist` (owner-only). Don't add webhooks for these without re-reading the ADR's reasoning.
-- **`Invited?` is evaluated before `Allow?`**. If both an invitation and an allowlist entry exist for the same agent, the invitation's `accept` is the canonical path; the allowlist entry is "absorbed" as `via=allowlist` on the invitation row. This prevents two membership events for one join. The order is pinned by `tests/services/test_join_flow_service.py::TestInvitationBeforeAllowlist`.
+- **`Invited?` is evaluated before `Allow?`**. If both an invitation and an allowlist entry exist for the same agent, the invitation's `accept` is the canonical path; the allowlist entry is "absorbed" as `via=allowlist` on the invitation row, `decided_by=system:allowlist`, and **no separate `allowlist_auto` row is written** (the merge is the test contract). This prevents two membership events for one join. Pinned by `tests/services/test_join_flow_service.py::TestBranch4InvitationWithAllowlistMerge::test_invitation_wins_over_allowlist_auto` (the merge invariant) and `TestBranchOrderNormativity` (general branch precedence).
 - **`is_private` is read visibility, `join_policy` is admission**. Don't conflate them. A `is_private=False, join_policy='approval'` subnet (curated public community) is a legitimate configuration. The two axes are intentionally orthogonal; see `acnlabs/ACN#68` for the orthogonal read-side ACL fix.
 - **Webhook failures must not roll back state transitions**. This is pinned twice in `tests/services/test_join_flow_webhook_composition.py`. If you're adding a new emit site to `SubnetService` or `JoinFlowService`, the publish call must be the **last** thing the method does after commit, and must not re-raise. Use `WebhookJoinFlowEventPublisher` as the reference.
 

--- a/tests/core/test_subnet_join_policy.py
+++ b/tests/core/test_subnet_join_policy.py
@@ -14,9 +14,11 @@ Pins the entity-layer invariants introduced by ADR-0004:
   the Redis backfill script runs).
 
 Service-layer invariants (the actual admission state machine that
-reads ``join_policy``) ship in Phase 2; that file is
-``tests/services/test_subnet_join_request_service.py`` and is out
-of scope here.
+reads ``join_policy``) live in
+``tests/services/test_join_flow_service.py`` (one ``TestBranch{N}``
+class per branch of the six-branch decision tree, plus
+``TestStateMachineEdges`` and ``TestBranchOrderNormativity`` for
+the cross-branch precedence rules) and are out of scope here.
 """
 
 import pytest

--- a/tests/infrastructure/test_postgres_subnet_repository_join_policy.py
+++ b/tests/infrastructure/test_postgres_subnet_repository_join_policy.py
@@ -15,9 +15,11 @@ Three contracts pinned here:
    trip the ``_JOIN_POLICY_VALUES`` invariant and refuse to
    reconstruct, breaking every read of an affected row.
 4. ``save()`` 's UPDATE branch carries ``join_policy`` so subsequent
-   mutations (Phase 2 promote-to-approval, future ``rotate_policy``
-   flows) actually persist a changed value rather than silently
-   no-op'ing on existing rows.
+   mutations (any future ``promote-to-approval`` / ``rotate_policy``
+   flow — neither shipped yet, but Phase 2's admission gate already
+   reads the field and a future toggle endpoint must round-trip it)
+   actually persist a changed value rather than silently no-op'ing
+   on existing rows.
 
 Exercised against a mock session — schema correctness lives in
 ``test_alembic_subnet_join_policy_migration.py``.
@@ -180,7 +182,7 @@ class TestModelToSubnetNullJoinPolicyAutoUpgrade:
 async def test_save_update_path_includes_join_policy():
     """When ``session.get`` finds an existing row, ``save()`` issues
     an ``UPDATE`` rather than ``session.add``. The UPDATE's value
-    bag MUST include ``join_policy`` — otherwise a Phase 2
+    bag MUST include ``join_policy`` — otherwise a future
     policy-rotation flow (or any caller that just wants to flip
     ``open`` → ``approval``) would silently no-op on rows that
     already exist in the DB."""


### PR DESCRIPTION
## Summary

Post-merge audit of [#82](https://github.com/acnlabs/ACN/pull/82) caught **6 factual errors in the docs/runbook I shipped** plus **3 stale code comments #82 missed**. This PR fixes all 9. Pure docs / comments; no behaviour change.

## PR #82's mistakes

| # | File | What was wrong | Why it matters |
|---|------|----------------|----------------|
| 1 | `docs/runbooks/adr-0004-join-policy.md` §Monitoring | 7 lifecycle log keys missing `subnet_` prefix (e.g. `join_request_approved` → real `subnet_join_request_approved`) | An SRE following the runbook verbatim would grep zero hits in prod |
| 2 | `docs/runbooks/adr-0004-join-policy.md` §Monitoring | `visibility_policy_conflict` listed as a structlog event | It's actually an `ACNHTTPError.details.reason` string; moved to a callout pointing at HTTP 4xx dashboards |
| 3 | `docs/runbooks/adr-0004-join-policy.md` §Gotchas | Cited `TestInvitationBeforeAllowlist` class | Class doesn't exist; real ones are `TestBranch4InvitationWithAllowlistMerge::test_invitation_wins_over_allowlist_auto` (merge contract) + `TestBranchOrderNormativity` (precedence) |
| 4 | `docs/adr/0004-subnet-join-policy.md` §Implementation evidence | Cited `tests/infrastructure/test_unit_of_work_cascade.py` | File doesn't exist; real one is `tests/services/test_subnet_service_cascade_atomic.py` |
| 5 | `docs/adr/0004-subnet-join-policy.md` §Implementation evidence | "60+ tests across the six branches" | Actual count is 14 `def test_` functions; replaced with accurate count + class-by-class breakdown |

## Stale comments PR #82 missed

| # | File:line | Fix |
|---|-----------|-----|
| 6 | `acn/core/entities/subnet.py:52-53` | "state machine lands in Phase 2" → points at the real landing sites (`join_flow_service.py` + `subnet_admission.py`) |
| 7 | `tests/core/test_subnet_join_policy.py:17-19` | Pointed at non-existent `test_subnet_join_request_service.py`; fixed to `test_join_flow_service.py` + listed the actual class breakdown |
| 8 | `tests/infrastructure/test_postgres_subnet_repository_join_policy.py:18, 183` | Two "Phase 2 promote-to-approval / policy-rotation" labels softened to "future" (those features genuinely haven't shipped; the "Phase 2" label was ambiguous post-merge) |

## Why this matters

The runbook is the operations-facing surface. If an on-call SRE is debugging a webhook delivery problem at 2 AM and the runbook tells them to grep `join_request_approved`, they get zero hits and conclude "no requests are being approved" — when in fact the real key is `subnet_join_request_approved` and approvals are happening fine. Fix is mechanical but the operational cost of leaving it wrong is high.

## Test plan

- [x] `ruff check` on the four touched code files — clean.
- [x] `pytest` on the two touched test files — 19/19 pass (comment-only changes).
- [x] Verified every replacement string against `grep`/`Glob` so this PR doesn't re-introduce another wrong reference.
- [ ] Reviewer skim of the diffs.

## Audit trail

Surfaced by my own follow-up audit, not external review. Lesson learned: the next time I write a doc claiming "tested by X" or citing a specific log key, I should `grep` it before publish, not after.

Made with [Cursor](https://cursor.com)