### PR TITLE
feat: subnet co-membership grants implicit trust for communication

### DIFF
--- a/acn/infrastructure/messaging/message_router.py
+++ b/acn/infrastructure/messaging/message_router.py
@@ -338,6 +338,7 @@ class MessageRouter:
         content_hash: str | None = None,
         message_type: str | None = None,
         ttl_seconds: int | None = None,
+        sender_subnet_ids: set[str] | None = None,
     ) -> Any:
         """
         Route an A2A message to a specific agent
@@ -355,6 +356,11 @@ class MessageRouter:
                 so the caller cannot accidentally lock funds the
                 recipient will never see (open/closed mode never
                 triggers the ack flow).
+            sender_subnet_ids: Pre-fetched subnet IDs of the sender.
+                Used to compute subnet co-membership with the
+                recipient for implicit trust bypass of manifest/
+                allowlist modes. ``None`` skips the check (e.g.
+                system callers).
 
         Returns:
             A2A response (Message or Task)
@@ -406,11 +412,25 @@ class MessageRouter:
                 if self.allowlist_service is not None
                 else None
             )
+            # Compute subnet co-membership for implicit trust.
+            # Reserved subnets ("public", "system") are excluded — they
+            # contain all agents and would make the check meaningless.
+            shared_subnets: set[str] | None = None
+            if sender_subnet_ids is not None:
+                recipient_subnets = set(
+                    getattr(agent_info, "subnet_ids", None) or []
+                )
+                reserved = {"public", "system"}
+                shared_subnets = (
+                    (sender_subnet_ids - reserved) & (recipient_subnets - reserved)
+                ) or None
+
             decision = await self.policy_service.check_inbound(
                 sender_id=from_agent,
                 recipient_id=to_agent,
                 recipient_policy=agent_info.communication_policy,
                 is_in_allowlist=is_in_allowlist,
+                shared_subnet_ids=shared_subnets,
             )
             if not decision.allow:
                 # Same surface as the Phase 1 ``check_inbound_or_raise``

--- a/acn/infrastructure/messaging/subnet_manager.py
+++ b/acn/infrastructure/messaging/subnet_manager.py
@@ -877,11 +877,16 @@ class SubnetManager:
                 if self.allowlist_service is not None
                 else None
             )
+            # Subnet-internal forward: sender and recipient share this
+            # subnet by definition. Pass it as shared_subnet_ids so the
+            # policy service can bypass manifest for subnet peers.
+            _shared = {subnet_id} - {"public", "system"}
             decision = await self.policy_service.check_inbound(
                 sender_id=from_agent or "unknown",
                 recipient_id=agent_id,
                 recipient_policy=policy,
                 is_in_allowlist=is_in_allowlist,
+                shared_subnet_ids=_shared or None,
             )
             if not decision.allow:
                 # Mirror ``check_inbound_or_raise`` semantics — the

--- a/acn/services/message_service.py
+++ b/acn/services/message_service.py
@@ -67,10 +67,12 @@ class MessageService:
         # **not** registered agents — the registry can never issue a UUID
         # colliding with ``system:`` (see 14.5-1 / 14.6 design). Skip the
         # sender table lookup; recipient validation + routing still apply.
+        sender_subnet_ids: set[str] | None = None
         if not from_agent_id.startswith("system:"):
             sender = await self.agent_repository.find_by_id(from_agent_id)
             if not sender:
                 raise AgentNotFoundException(f"Sender agent {from_agent_id} not found")
+            sender_subnet_ids = set(getattr(sender, "subnet_ids", None) or [])
 
         # Verify recipient exists
         recipient = await self.agent_repository.find_by_id(to_agent_id)
@@ -110,6 +112,7 @@ class MessageService:
             from_agent=from_agent_id,
             to_agent=to_agent_id,
             message=message,
+            sender_subnet_ids=sender_subnet_ids,
             **router_kwargs,
         )
 

--- a/acn/services/policy_service.py
+++ b/acn/services/policy_service.py
@@ -279,6 +279,7 @@ class PolicyCheckService:
         *,
         message_meta: dict[str, Any] | None = None,
         is_in_allowlist: Callable[[str, str], Awaitable[bool]] | None = None,
+        shared_subnet_ids: set[str] | None = None,
     ) -> PolicyDecision:
         """Return the access decision for ``sender_id`` -> ``recipient_id``.
 
@@ -303,6 +304,14 @@ class PolicyCheckService:
                 self) so this class has no IO dependencies — keeps
                 unit tests trivial and lets non-router callers
                 supply a stub.
+            shared_subnet_ids: Pre-computed set of non-reserved subnet
+                IDs that both sender and recipient share. When
+                non-empty, agents in ``manifest`` or ``allowlist``
+                mode treat the sender as implicitly trusted and route
+                to inbox (normal delivery) instead of manifest. The
+                ``public`` and ``system`` subnets are excluded by the
+                caller so membership in those does not grant implicit
+                trust. ``None`` or empty set means no shared subnets.
 
         Returns:
             ``PolicyDecision``. This method never raises for policy
@@ -332,15 +341,28 @@ class PolicyCheckService:
             )
 
         if mode == "manifest":
-            # Accept-but-divert. ``allow=True`` so the router doesn't
-            # increment ``acn_messages_rejected_total`` (these aren't
-            # rejections from the sender's perspective — the message
-            # is accepted, just stashed in a low-attention queue), and
-            # ``route_to="manifest"`` instructs the router to skip the
-            # inbox write and call ManifestService.write instead.
+            if shared_subnet_ids:
+                logger.debug(
+                    "policy_subnet_trust_bypass",
+                    sender_id=sender_id,
+                    recipient_id=recipient_id,
+                    shared_subnets=sorted(shared_subnet_ids),
+                )
+                return PolicyDecision(allow=True, route_to="inbox")
             return PolicyDecision(allow=True, route_to="manifest")
 
         if mode == "allowlist":
+            # Subnet co-membership grants implicit trust (checked before
+            # the explicit allowlist so we skip the IO call when possible).
+            if shared_subnet_ids:
+                logger.debug(
+                    "policy_subnet_trust_bypass",
+                    sender_id=sender_id,
+                    recipient_id=recipient_id,
+                    shared_subnets=sorted(shared_subnet_ids),
+                )
+                return PolicyDecision(allow=True, route_to="inbox")
+
             # The router is responsible for wiring
             # ``is_in_allowlist``; if it didn't, we cannot safely
             # decide — treat as configuration error and fail-closed
@@ -395,6 +417,7 @@ class PolicyCheckService:
         *,
         message_meta: dict[str, Any] | None = None,
         is_in_allowlist: Callable[[str, str], Awaitable[bool]] | None = None,
+        shared_subnet_ids: set[str] | None = None,
     ) -> None:
         """Raise ``PolicyRejected`` if the recipient's policy denies the message.
 
@@ -412,6 +435,7 @@ class PolicyCheckService:
             recipient_policy=recipient_policy,
             message_meta=message_meta,
             is_in_allowlist=is_in_allowlist,
+            shared_subnet_ids=shared_subnet_ids,
         )
         if decision.allow:
             return

--- a/tests/test_subnet_implicit_trust.py
+++ b/tests/test_subnet_implicit_trust.py
@@ -1,0 +1,123 @@
+"""Tests for subnet co-membership implicit trust in communication policy.
+
+When two agents share a non-reserved subnet (not "public" or "system"),
+manifest and allowlist modes should route to inbox instead of manifest,
+enabling direct delivery between subnet peers.
+"""
+
+import pytest
+
+from acn.services.policy_service import PolicyCheckService, PolicyDecision
+
+
+@pytest.fixture
+def policy_service():
+    return PolicyCheckService()
+
+
+class TestSubnetImplicitTrust:
+    """Verify that shared_subnet_ids bypasses manifest/allowlist divert."""
+
+    async def test_manifest_mode_bypassed_with_shared_subnet(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids={"my-subnet"},
+        )
+        assert decision.allow is True
+        assert decision.route_to == "inbox"
+
+    async def test_manifest_mode_not_bypassed_without_shared_subnet(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids=None,
+        )
+        assert decision.allow is True
+        assert decision.route_to == "manifest"
+
+    async def test_manifest_mode_not_bypassed_with_empty_set(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids=set(),
+        )
+        assert decision.allow is True
+        assert decision.route_to == "manifest"
+
+    async def test_allowlist_mode_bypassed_with_shared_subnet(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "allowlist"},
+            shared_subnet_ids={"team-subnet"},
+        )
+        assert decision.allow is True
+        assert decision.route_to == "inbox"
+
+    async def test_allowlist_mode_not_bypassed_without_shared_subnet(self, policy_service):
+        async def fake_allowlist(recipient_id, sender_id):
+            return False
+
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "allowlist"},
+            shared_subnet_ids=None,
+            is_in_allowlist=fake_allowlist,
+        )
+        assert decision.allow is True
+        assert decision.route_to == "manifest"
+
+    async def test_open_mode_unaffected_by_shared_subnet(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "open"},
+            shared_subnet_ids={"my-subnet"},
+        )
+        assert decision.allow is True
+        assert decision.route_to == "inbox"
+
+    async def test_closed_mode_unaffected_by_shared_subnet(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "closed"},
+            shared_subnet_ids={"my-subnet"},
+        )
+        assert decision.allow is False
+        assert decision.reason == "policy_closed"
+
+    async def test_system_sender_still_bypasses_everything(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="system:notifications",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids=None,
+        )
+        assert decision.allow is True
+
+    async def test_multiple_shared_subnets(self, policy_service):
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids={"subnet-1", "subnet-2"},
+        )
+        assert decision.allow is True
+        assert decision.route_to == "inbox"
+
+    async def test_only_reserved_subnets_shared_no_bypass(self, policy_service):
+        """If after removing reserved subnets the set is empty, no bypass."""
+        decision = await policy_service.check_inbound(
+            sender_id="agent-a",
+            recipient_id="agent-b",
+            recipient_policy={"mode": "manifest"},
+            shared_subnet_ids=set(),  # caller already stripped reserved
+        )
+        assert decision.allow is True
+        assert decision.route_to == "manifest"

--- a/tests/test_subnet_implicit_trust.py
+++ b/tests/test_subnet_implicit_trust.py
@@ -7,7 +7,7 @@ enabling direct delivery between subnet peers.
 
 import pytest
 
-from acn.services.policy_service import PolicyCheckService, PolicyDecision
+from acn.services.policy_service import PolicyCheckService
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

When two agents share a non-reserved subnet (excluding `public` and `system`), `manifest` and `allowlist` policy modes now route messages to inbox instead of the manifest queue. This enables direct delivery between subnet peers without requiring explicit allowlist entries or manifest polling.

**Behavior change:**

| Mode | Same subnet peer | Other agents |
|------|:---:|:---:|
| `open` | inbox (unchanged) | inbox (unchanged) |
| `closed` | rejected (unchanged) | rejected (unchanged) |
| `manifest` | **inbox** ← NEW | manifest (unchanged) |
| `allowlist` | **inbox** ← NEW | allowlist check → inbox or manifest (unchanged) |

**Design decisions:**
- `public` and `system` subnets are excluded from co-membership check (they contain all agents)
- No opt-out mechanism for now (joining a subnet is itself a trust expression; leave to revoke)
- No subnet size threshold (premature optimization for current ecosystem)
- Zero additional Redis queries: sender subnet_ids come from the existing auth lookup, recipient from the existing route discovery

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #84

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation (if needed)

## SDK Changes

- [x] N/A - No SDK changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877b240e-40af-4c35-9520-de17fede306f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877b240e-40af-4c35-9520-de17fede306f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

