### PR TITLE
feat(cli,sdk): close H1 rotate-key gap on Python SDK + CLI

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+### Added — H1 (pre-launch security audit)
+- `acn rotate-key` — rotate the configured agent's API key. The
+  previous key is invalidated on the server immediately, so by
+  default the command prints the new key plus a follow-up hint
+  (`acn config set api_key <new>`); pass `--save` to persist the
+  new key into `~/.acn/config.json` in one step. `--agent-id <id>`
+  overrides the configured agent id; `--json` emits the raw server
+  payload. The CLI authenticates with the agent's current key (the
+  scheduled-rotation path); recovery via Auth0 JWT goes through the
+  Labs web UI — the CLI fails fast with that hint instead of issuing
+  a guaranteed-401 request when the local config has no `api_key`.
+  Closes the H1 gap previously left by the TypeScript SDK 0.12.0
+  shipping `rotateApiKey()` while the CLI did not expose the route.
+
 ### Added — ADR-0004 Slice 2.3 PR B (subnet admission verbs)
 - `acn subnet create --join-policy <open|approval>` — opt the new
   subnet into the approval gate. `--private` continues to imply

--- a/clients/cli/src/commands/rotate-key.ts
+++ b/clients/cli/src/commands/rotate-key.ts
@@ -1,0 +1,88 @@
+import { Command } from 'commander';
+import { acnPost } from '../api.js';
+import { loadConfig, saveConfig } from '../config.js';
+import { output, handleError, isJsonMode } from '../output.js';
+
+interface RotateKeyResponse {
+  success: boolean;
+  agent_id: string;
+  api_key: string;
+  message?: string;
+}
+
+export function rotateKeyCommand(): Command {
+  return new Command('rotate-key')
+    .description(
+      'Rotate this agent\'s API key (H1). The old key stops working immediately.'
+    )
+    .option(
+      '-i, --agent-id <id>',
+      'Agent ID (defaults to value in ~/.acn/config.json)'
+    )
+    .option(
+      '--save',
+      'Persist the new key to ~/.acn/config.json (overwrites api_key). ' +
+        'Without this flag the new key is only printed; you must run ' +
+        '`acn config set api_key <new>` yourself, or every subsequent CLI ' +
+        'call will 401 against the freshly-invalidated old key.',
+      false
+    )
+    .action(async (opts: { agentId?: string; save?: boolean }) => {
+      const config = loadConfig();
+      const agentId = opts.agentId ?? config.agent_id;
+
+      if (!agentId) {
+        // Match the heartbeat command's "no agent" failure mode so users
+        // see the same hint regardless of which command they hit first.
+        console.error(
+          'No agent ID found. Run `acn join` first or pass --agent-id.'
+        );
+        process.exit(1);
+      }
+
+      if (!config.api_key) {
+        // The CLI only knows how to authenticate as the agent itself
+        // (Bearer <api_key>). Recovery via Auth0 JWT must go through the
+        // Labs / web UI — surfacing that explicitly is more useful than
+        // letting the request 401 with a generic message.
+        console.error(
+          'No API key found in ~/.acn/config.json. The CLI rotates with the ' +
+            'current agent key; if you have lost the key, recover via the Labs ' +
+            'web UI (Auth0-authorised owner-side rotation).'
+        );
+        process.exit(1);
+      }
+
+      try {
+        const res = await acnPost<RotateKeyResponse>(
+          `/agents/${agentId}/rotate-key`
+        );
+
+        if (opts.save) {
+          saveConfig({ api_key: res.api_key });
+        }
+
+        if (isJsonMode()) {
+          output(res, '');
+          return;
+        }
+
+        // Two-line warning + new key + follow-up. The point of separating
+        // the new key onto its own line is so an operator copy-pasting from
+        // a terminal does not accidentally include surrounding text.
+        const lines = [
+          `Agent ${res.agent_id}: API key rotated. Previous key is now INVALID.`,
+          '',
+          `New API key: ${res.api_key}`,
+          '',
+          opts.save
+            ? '~/.acn/config.json updated. CLI will use the new key on next call.'
+            : 'Store this key securely. To make this CLI use it, run:',
+          ...(opts.save ? [] : [`  acn config set api_key ${res.api_key}`]),
+        ];
+        output(res, lines.join('\n'));
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -3,6 +3,7 @@ import { setJsonMode } from './output.js';
 import { configCommand } from './commands/config.js';
 import { joinCommand } from './commands/join.js';
 import { heartbeatCommand } from './commands/heartbeat.js';
+import { rotateKeyCommand } from './commands/rotate-key.js';
 import { agentsCommand } from './commands/agents.js';
 import { tasksCommand } from './commands/tasks.js';
 import { messageCommand } from './commands/message.js';
@@ -29,6 +30,7 @@ program
 program.addCommand(configCommand());
 program.addCommand(joinCommand());
 program.addCommand(heartbeatCommand());
+program.addCommand(rotateKeyCommand());
 program.addCommand(agentsCommand());
 program.addCommand(tasksCommand());
 program.addCommand(messageCommand());

--- a/clients/cli/tests/rotate-key.test.ts
+++ b/clients/cli/tests/rotate-key.test.ts
@@ -1,0 +1,168 @@
+/**
+ * CLI tests for `acn rotate-key` (H1 — pre-launch security audit).
+ *
+ * Exercise:
+ *   - Wire shape: POST /agents/{id}/rotate-key with the configured agent_id
+ *     when --agent-id is not supplied.
+ *   - --agent-id override beats the config value.
+ *   - --save updates ~/.acn/config.json with the freshly-minted key.
+ *   - Default (no --save) does NOT touch config — defensive against
+ *     accidental writes when a script runs the command twice.
+ *   - Missing api_key in config short-circuits with a recovery hint rather
+ *     than producing a 401 from the server.
+ *   - Missing agent_id (no flag, no config) exits 1.
+ */
+
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { acnPost } from '../src/api.js';
+import { loadConfig, saveConfig } from '../src/config.js';
+import { output } from '../src/output.js';
+import { rotateKeyCommand } from '../src/commands/rotate-key.js';
+
+vi.mock('../src/api.js', () => ({
+  acnPost: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: vi.fn(),
+  isJsonMode: vi.fn(() => false),
+  handleError: vi.fn((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`handleError:${msg}`);
+  }),
+}));
+
+async function runRotateKey(args: string[]): Promise<void> {
+  const root = new Command();
+  root.addCommand(rotateKeyCommand());
+  await root.parseAsync(['node', 'acn', 'rotate-key', ...args]);
+}
+
+const successPayload = {
+  success: true,
+  agent_id: 'agent-1',
+  api_key: 'acn_NEW_KEY_xyz',
+  message: 'API key rotated.',
+};
+
+describe('acn rotate-key', () => {
+  beforeEach(() => {
+    vi.mocked(loadConfig).mockReturnValue({
+      api_key: 'acn_OLD_KEY',
+      agent_id: 'agent-1',
+      base_url: 'https://api.test',
+    });
+    vi.mocked(acnPost).mockResolvedValue(successPayload as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs /agents/{id}/rotate-key using config agent_id by default', async () => {
+    await runRotateKey([]);
+
+    expect(acnPost).toHaveBeenCalledTimes(1);
+    expect(acnPost).toHaveBeenCalledWith('/agents/agent-1/rotate-key');
+  });
+
+  it('--agent-id overrides the configured agent_id', async () => {
+    await runRotateKey(['--agent-id', 'agent-override']);
+
+    expect(acnPost).toHaveBeenCalledWith('/agents/agent-override/rotate-key');
+  });
+
+  it('does NOT write to ~/.acn/config.json by default', async () => {
+    await runRotateKey([]);
+
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('--save persists the new api_key to config', async () => {
+    await runRotateKey(['--save']);
+
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    expect(saveConfig).toHaveBeenCalledWith({ api_key: 'acn_NEW_KEY_xyz' });
+  });
+
+  it('prints the new key and a follow-up hint when not --save', async () => {
+    await runRotateKey([]);
+
+    // The new plaintext key is printed exactly once and on its own line so
+    // copy-paste from a terminal does not pull surrounding text.
+    expect(output).toHaveBeenCalledWith(
+      successPayload,
+      expect.stringContaining('New API key: acn_NEW_KEY_xyz')
+    );
+    expect(output).toHaveBeenCalledWith(
+      successPayload,
+      expect.stringContaining('acn config set api_key acn_NEW_KEY_xyz')
+    );
+  });
+
+  it('omits the manual config-set hint when --save is used', async () => {
+    await runRotateKey(['--save']);
+
+    expect(output).toHaveBeenCalledWith(
+      successPayload,
+      expect.not.stringContaining('acn config set api_key')
+    );
+    expect(output).toHaveBeenCalledWith(
+      successPayload,
+      expect.stringContaining('config.json updated')
+    );
+  });
+
+  it('exits 1 with recovery hint when the local config has no api_key', async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      agent_id: 'agent-1',
+      base_url: 'https://api.test',
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(runRotateKey([])).rejects.toThrow('EXIT:1');
+
+    expect(acnPost).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No API key found'),
+    );
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('exits 1 when neither --agent-id nor configured agent_id is present', async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      api_key: 'acn_OLD_KEY',
+      base_url: 'https://api.test',
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(runRotateKey([])).rejects.toThrow('EXIT:1');
+
+    expect(acnPost).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No agent ID found'),
+    );
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+### Added — H1 (pre-launch security audit)
+- Regression tests for `rotate_api_key` (the SDK method itself shipped
+  in 0.10.0 alongside the server-side endpoint, but had no test
+  coverage). `tests/test_rotate_api_key.py` pins the wire shape
+  (`POST /api/v1/agents/{id}/rotate-key` with no body / params),
+  the raw-`dict` return contract (forward-compatible with future
+  server fields), and path-encoded `agent_id` handling.
+
 ### Deprecated (alive-as-SSOT follow-up)
 
 - **`AgentStatus.BUSY` is deprecated and will be removed in 0.11.**

--- a/clients/python/tests/test_rotate_api_key.py
+++ b/clients/python/tests/test_rotate_api_key.py
@@ -1,0 +1,105 @@
+"""Python SDK regression tests for ``rotate_api_key`` (H1 — pre-launch
+security audit).
+
+The SDK method shipped in 0.10.0 alongside the server-side endpoint, but
+without unit-test coverage. This file pins:
+
+* The wire shape: ``POST /api/v1/agents/{id}/rotate-key`` with no body.
+* The return shape: a plain ``dict`` mirroring the server's
+  ``AgentRotateKeyResponse`` (``success``, ``agent_id``, ``api_key``,
+  ``message``) — no Pydantic wrapping, by design, to keep the field
+  surface forward-compatible if the server later adds fields.
+* Idiomatic use: caller must persist ``payload["api_key"]`` because the
+  server immediately invalidates the previous key (auth cache eviction
+  is a server-side side effect — the SDK has no rotate-side hook).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn_client.client import ACNClient
+
+
+def _make_client_with_stub(request_mock: AsyncMock) -> ACNClient:
+    """ACNClient with ``_request`` replaced by an awaitable stub.
+
+    Mirrors the helper in ``test_subnet_nesting.py`` so this file
+    follows the same pattern other SDK regression suites already use.
+    """
+    client = ACNClient(base_url="http://acn.test")
+    client._request = request_mock  # type: ignore[method-assign]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_rotate_api_key_posts_to_canonical_path():
+    """The wire path must match the server's ``/rotate-key`` route — no
+    body, no params, agent_id is path-only.
+    """
+    payload: dict[str, Any] = {
+        "success": True,
+        "agent_id": "agent-1",
+        "api_key": "acn_NEW_PLAINTEXT_xyz",
+        "message": "API key rotated. Previous key is now invalid.",
+    }
+    request_mock = AsyncMock(return_value=payload)
+    client = _make_client_with_stub(request_mock)
+
+    result = await client.rotate_api_key("agent-1")
+
+    request_mock.assert_awaited_once_with(
+        "POST", "/api/v1/agents/agent-1/rotate-key"
+    )
+    assert result is payload
+
+
+@pytest.mark.asyncio
+async def test_rotate_api_key_returns_raw_server_payload():
+    """We deliberately do not wrap the response in a Pydantic model.
+    The whole point of the H1 contract is the new ``api_key`` plaintext;
+    a too-tight schema would force a SDK release every time the server
+    adds a field. Keep it as ``dict[str, Any]`` and pin the four fields
+    callers actually depend on.
+    """
+    payload = {
+        "success": True,
+        "agent_id": "agent-42",
+        "api_key": "acn_AnotherFreshKey_abc",
+        "message": "rotated",
+        # Forward-compat: a future server might add fields like
+        # ``rotated_at`` or ``previous_key_invalidated_at``. The SDK
+        # must not strip them. ``dict[str, Any]`` is exactly that
+        # affordance.
+        "rotated_at": "2026-05-18T15:00:00Z",
+    }
+    request_mock = AsyncMock(return_value=payload)
+    client = _make_client_with_stub(request_mock)
+
+    result = await client.rotate_api_key("agent-42")
+
+    assert result["api_key"] == "acn_AnotherFreshKey_abc"
+    assert result["rotated_at"] == "2026-05-18T15:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_rotate_api_key_passes_agent_id_into_path():
+    """Regression: ensure agent_id is path-encoded by httpx via the
+    underlying ``_request`` call, not silently moved into a body field
+    or query param. A bug here would invalidate the wrong agent's key.
+    """
+    request_mock = AsyncMock(
+        return_value={"success": True, "agent_id": "weird:id", "api_key": "x"}
+    )
+    client = _make_client_with_stub(request_mock)
+
+    await client.rotate_api_key("weird:id")
+
+    # Match exactly — neither ``json=`` nor ``params=`` should be set
+    # by the SDK on the rotate path.
+    request_mock.assert_awaited_once_with(
+        "POST", "/api/v1/agents/weird:id/rotate-key"
+    )


### PR DESCRIPTION
## Summary

The TypeScript SDK 0.12.0 (PR #46) shipped `rotateApiKey()` after the
H1 pre-launch security audit added the rotate-key endpoint. The
Python SDK method itself landed alongside the server-side route in
0.10.0 but had no test coverage, and the CLI never exposed the route
at all — leaving Python and CLI users without a complete H1 key-rotation
story.

This PR finishes that story. **No version bump or release**: the
rotate-key entries are queued under each package's `[Unreleased]`
section so the next coordinated bump (which will also ship the
alive-as-SSOT BUSY deprecation, `__version__` unification, and
ADR-0004 admission verbs already attached to `[Unreleased]`) ships
them together.

## What's in the PR

### CLI (`@acnlabs/acn-cli`)

- New top-level command `acn rotate-key` (peer of `acn heartbeat`).
  Authenticates as the agent itself with the locally-configured key
  (the typical scheduled-rotation path).
- `--save` opts in to overwriting `~/.acn/config.json` with the
  freshly minted key in one step. By default the new key is printed
  plus a follow-up hint (`acn config set api_key <new>`) — never
  silently overwrites local state, never silently leaves the CLI
  401-ing against the just-invalidated old key.
- `--agent-id <id>` overrides the configured agent id; `--json`
  emits the raw server payload.
- Fails fast with a recovery hint when local config has no `api_key`
  (recovery-via-Auth0-JWT goes through the Labs web UI; the CLI
  cannot send a JWT, so issuing a guaranteed-401 request would just
  confuse callers).

### Python SDK (`acn-client`)

- `tests/test_rotate_api_key.py` adds regression coverage for the
  existing `ACNClient.rotate_api_key()` method:
  - Pins the wire shape: `POST /api/v1/agents/{id}/rotate-key` with
    no body, no params, `agent_id` on the path only.
  - Pins the raw-`dict` return contract — forward-compatible with
    future server fields (e.g. `rotated_at`) without forcing an SDK
    release.
  - Covers path-encoded `agent_id` handling.

## Test plan

- [x] `cd clients/cli && npm run typecheck` — clean
- [x] `cd clients/cli && npm run typecheck:tests` — clean
- [x] `cd clients/cli && npm test` — **45 passed** (rotate-key 8 +
  ADR-0003 subnet 6 + ADR-0004 subnet 31)
- [x] `cd clients/python && pytest tests/test_rotate_api_key.py -v` —
  **3 passed** against an `AsyncMock`-stubbed `_request`
- [ ] Manual smoke against staging: `acn config set api_key …; acn
  rotate-key; acn heartbeat` (verify old key 401, new key 200)