### PR TITLE
feat(python-sdk): ADR-0004 subnet-admission surface (13 verbs + join_policy)

### DIFF
--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -12,6 +12,45 @@ All notable changes to `acn-client` are documented here.
   the raw-`dict` return contract (forward-compatible with future
   server fields), and path-encoded `agent_id` handling.
 
+### Added (ADR-0004 subnet admission)
+- `SubnetCreateRequest.join_policy: str | None` — opt subnets into
+  the approval state machine at creation time. `None` (default) ⇒
+  server-side `"open"` (legacy unrestricted self-join);
+  `"approval"` ⇒ admission flow gates membership through
+  allowlist / join_request / invitation.
+- 13 admission methods on `ACNClient`, returning raw
+  `dict[str, Any]` (un-modeled to mirror the server's un-typed
+  JSON responses):
+  - `subnet_allowlist_add(subnet_id, agent_id)`
+  - `subnet_allowlist_remove(subnet_id, agent_id)` — idempotent
+    (204 even when entry absent).
+  - `subnet_allowlist_list(subnet_id, *, limit, offset)` —
+    owner-only.
+  - `subnet_join_request_approve(subnet_id, request_id, *, note)`
+  - `subnet_join_request_reject(subnet_id, request_id, *, note)`
+  - `subnet_join_request_withdraw(subnet_id, request_id, *, note)`
+    — applicant-only.
+  - `subnet_join_request_list(subnet_id, *, kind, status, limit,
+    offset)` — defaults `kind="join_request"`; `kind="invitation"`
+    is rejected (use `subnet_invitation_list` instead).
+  - `subnet_invitation_send(subnet_id, agent_id, *, note)` —
+    returns either the normal-path `{invitation_id, status}` or
+    the merge-path `{auto_resolved, resolved_kind, request_id}`
+    payload verbatim; branch dispatch is the caller's
+    responsibility.
+  - `subnet_invitation_accept(subnet_id, request_id, *, note)`
+  - `subnet_invitation_reject(subnet_id, request_id, *, note)`
+  - `subnet_invitation_cancel(subnet_id, request_id, *, note)` —
+    owner-side cancel; row goes to `withdrawn` (distinct from
+    invitee `rejected`).
+  - `subnet_invitation_list(subnet_id, *, status, limit, offset)`
+    — owner-only.
+  - `agent_subnet_invitations(agent_id)` — invitee's cross-subnet
+    pending-invitation view; self-only, `status=pending` only.
+- 20 regression tests in `tests/test_subnet_admission.py` pinning
+  the wire shape (verb + path + body/params) for every method,
+  plus the `SubnetCreateRequest.join_policy` round-trip.
+
 ### Deprecated (alive-as-SSOT follow-up)
 
 - **`AgentStatus.BUSY` is deprecated and will be removed in 0.11.**

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -549,6 +549,335 @@ class ACNClient:
         return subnets
 
     # ============================================
+    # ADR-0004 Subnet Admission
+    # ============================================
+    #
+    # Three resource families gated by ``subnet.join_policy ==
+    # "approval"``: allowlist (owner pre-authorisation), join_requests
+    # (applicant-initiated), invitations (owner-initiated).
+    #
+    # The plain :meth:`join_subnet` verb dispatches the six-branch
+    # decision tree on the server side — these methods are the
+    # admin-side controls used by subnet owners and the per-row
+    # decisions used by applicants and invitees.
+    #
+    # All methods return raw ``dict[str, Any]`` (matching server's
+    # un-typed JSON responses); list endpoints return paginated
+    # ``{ subnet_id|agent_id, items|entries }`` envelopes.
+
+    # ----- Allowlist (owner-only, 3 verbs) ---------------------------------
+
+    async def subnet_allowlist_add(
+        self,
+        subnet_id: str,
+        agent_id: str,
+    ) -> dict[str, Any]:
+        """Pre-authorise ``agent_id`` on ``subnet_id``'s allowlist (owner only).
+
+        Allowlisted agents skip the approval queue: their next
+        ``join_subnet`` call lands in branch 4 (allowlist hit) and
+        becomes an immediate member with an ``allowlist_auto`` audit
+        row.
+
+        Server returns 201 with the persisted entry; duplicate adds
+        return 409 ``ALREADY_ON_ALLOWLIST`` (raised as an HTTP error
+        by ``_request`` rather than being silently no-op'd).
+        """
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/allowlist",
+            json={"agent_id": agent_id},
+        )
+
+    async def subnet_allowlist_remove(
+        self,
+        subnet_id: str,
+        agent_id: str,
+    ) -> None:
+        """Remove ``agent_id`` from ``subnet_id``'s allowlist (owner only).
+
+        Idempotent — removing an entry that doesn't exist still
+        returns 204. Per ADR-0004 §"Allowlist mutation does not
+        affect agents who already joined", this does NOT revoke
+        membership for agents who already used the allowlist to
+        join; use :meth:`leave_subnet` (as the agent) or a future
+        eviction verb to remove members.
+        """
+        await self._request(
+            "DELETE",
+            f"/api/v1/subnets/{subnet_id}/allowlist/{agent_id}",
+        )
+        return None
+
+    async def subnet_allowlist_list(
+        self,
+        subnet_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List ``subnet_id``'s allowlist entries (owner only).
+
+        Owner-only by design — the allowlist is a privacy-sensitive
+        trust signal. Returns ``{ subnet_id, entries: [...] }``;
+        each entry carries ``agent_id``, ``added_by``, ``added_at``.
+        """
+        return await self._request(
+            "GET",
+            f"/api/v1/subnets/{subnet_id}/allowlist",
+            params={"limit": limit, "offset": offset},
+        )
+
+    # ----- Join requests (4 verbs: 3 owner-side + 1 applicant-side) --------
+
+    async def subnet_join_request_approve(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Owner approves a pending join_request (CAS pending → approved).
+
+        Side effects: applicant added to ``subnet.member_agent_ids``
+        and the ``subnet.join_approved`` webhook fires. The applicant
+        is still expected to call :meth:`join_subnet` to register the
+        ``agent.subnet_ids`` back-reference (per ADR-0004 §"State
+        machine edges").
+
+        Optional ``note`` (≤500 chars) is recorded on the audit row.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}/approve",
+            json=body or None,
+        )
+
+    async def subnet_join_request_reject(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Owner rejects a pending join_request (CAS pending → rejected).
+
+        No membership change. ``subnet.join_rejected`` webhook fires.
+        Optional ``note`` lets the owner record a human-readable
+        reason in the audit trail.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}/reject",
+            json=body or None,
+        )
+
+    async def subnet_join_request_withdraw(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Applicant withdraws their own pending join_request.
+
+        Self-only — caller must be the agent who originally created
+        the request (NOT the subnet owner; owner rejection is a
+        different verb). ``subnet.join_withdrawn`` webhook fires.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "DELETE",
+            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}",
+            json=body or None,
+        )
+
+    async def subnet_join_request_list(
+        self,
+        subnet_id: str,
+        *,
+        kind: str = "join_request",
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Owner lists join_request / allowlist_auto rows for ``subnet_id``.
+
+        ``kind`` defaults to ``"join_request"``; pass
+        ``"allowlist_auto"`` to inspect the audit rows synthesised
+        for allowlist-hit joins. ``kind="invitation"`` is rejected
+        with 400 ``INVALID_KIND_FILTER`` per ADR-0004 — invitations
+        are queryable through :meth:`subnet_invitation_list` only.
+        """
+        params: dict[str, Any] = {
+            "kind": kind,
+            "limit": limit,
+            "offset": offset,
+        }
+        if status is not None:
+            params["status"] = status
+        return await self._request(
+            "GET",
+            f"/api/v1/subnets/{subnet_id}/join-requests",
+            params=params,
+        )
+
+    # ----- Invitations (5 verbs on subnet path + 1 on agent path) ----------
+
+    async def subnet_invitation_send(
+        self,
+        subnet_id: str,
+        agent_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Owner sends an invitation to ``agent_id`` (or merges a pending request).
+
+        Two response shapes per ADR-0004 §"Invitation merge path":
+
+        - **Normal path** (server returns 202)::
+
+              { "invitation_id": "...", "status": "pending" }
+
+        - **Merge path** (target already had a pending join_request,
+          server returns 200, request auto-approved)::
+
+              {
+                  "auto_resolved": True,
+                  "resolved_kind": "join_request",
+                  "request_id": "...",
+              }
+
+        Pre-checks raise: target missing → 404 ``AGENT_NOT_FOUND``;
+        already a member → 409 ``ALREADY_MEMBER``; pending invitation
+        for the same target → 409 ``INVITATION_PENDING``.
+        """
+        body: dict[str, Any] = {"agent_id": agent_id}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/invitations",
+            json=body,
+        )
+
+    async def subnet_invitation_accept(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Invitee accepts a pending invitation (CAS pending → approved).
+
+        Self-only against ``row.agent_id`` (the invitee). Side
+        effects: invitee added to ``subnet.member_agent_ids``, the
+        agent's ``subnet_ids`` gains the back-reference, and
+        ``subnet.invitation_accepted`` webhook fires.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}/accept",
+            json=body or None,
+        )
+
+    async def subnet_invitation_reject(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Invitee rejects a pending invitation (CAS pending → rejected).
+
+        Self-only against ``row.agent_id``. No membership change.
+        ``subnet.invitation_rejected`` webhook fires. Optional
+        ``note`` (≤500 chars) is recorded on the audit row.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "POST",
+            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}/reject",
+            json=body or None,
+        )
+
+    async def subnet_invitation_cancel(
+        self,
+        subnet_id: str,
+        request_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Owner cancels a pending invitation (CAS pending → withdrawn).
+
+        Owner-only counterpart to applicant withdraw. The row
+        transitions to ``withdrawn`` (not ``rejected``) — distinct
+        audit token so consumers can tell "owner gave up" from
+        "invitee said no". ``subnet.invitation_canceled`` webhook
+        fires.
+        """
+        body: dict[str, Any] = {}
+        if note is not None:
+            body["note"] = note
+        return await self._request(
+            "DELETE",
+            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}",
+            json=body or None,
+        )
+
+    async def subnet_invitation_list(
+        self,
+        subnet_id: str,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Owner lists invitation rows for ``subnet_id``.
+
+        Owner-only — invitees use :meth:`agent_subnet_invitations`
+        for their own cross-subnet view. Returns ``{ subnet_id,
+        items: [...] }``.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if status is not None:
+            params["status"] = status
+        return await self._request(
+            "GET",
+            f"/api/v1/subnets/{subnet_id}/invitations",
+            params=params,
+        )
+
+    async def agent_subnet_invitations(
+        self,
+        agent_id: str,
+    ) -> dict[str, Any]:
+        """Invitee's cross-subnet pending-invitation list (self-only).
+
+        Returns only ``status=pending`` rows — the assumption is
+        that an invitee cares about "what's waiting on me to
+        decide". Historical decisions are queryable per-subnet
+        through the owner-only :meth:`subnet_invitation_list`.
+        """
+        return await self._request(
+            "GET",
+            f"/api/v1/agents/{agent_id}/subnet-invitations",
+        )
+
+    # ============================================
     # Communication
     # ============================================
 

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -323,6 +323,12 @@ class SubnetCreateRequest(BaseModel):
     ADR-0003 nesting params (``parent_subnet_id`` / ``lifecycle`` /
     ``linked_task_id``) are optional; defaults preserve the legacy
     "flat top-level persistent subnet" shape.
+
+    ADR-0004 ``join_policy`` is optional and immutable post-creation:
+    ``"open"`` (default) preserves legacy unrestricted self-join,
+    ``"approval"`` opts the subnet into the admission state machine
+    (allowlist / join_request / invitation flow). Server defaults to
+    ``"open"`` when this field is omitted.
     """
 
     name: str
@@ -331,6 +337,7 @@ class SubnetCreateRequest(BaseModel):
     parent_subnet_id: str | None = None
     lifecycle: str = "persistent"
     linked_task_id: str | None = None
+    join_policy: str | None = None
 
 
 # ============================================

--- a/clients/python/tests/test_subnet_admission.py
+++ b/clients/python/tests/test_subnet_admission.py
@@ -1,0 +1,368 @@
+"""ADR-0004 Slice 2.3 — Python SDK subnet-admission surface tests.
+
+Pin:
+
+- ``SubnetCreateRequest`` round-trips the new ``join_policy`` field
+  with default-omit semantics (back-compat for legacy callers).
+- All 13 admission methods issue the right verb + path + params
+  + body shape on the wire (canonical paths, no body for the
+  no-arg verbs, optional ``note`` is only included when set).
+- The optional-body discipline matches the server contract: body
+  argument to ``_request`` is ``None`` when no fields are set, so
+  httpx doesn't send a ``Content-Type: application/json`` header
+  on bodyless ``DELETE``.
+- ``subnet_invitation_send`` returns the raw server payload —
+  the merge-vs-normal branch shape is the caller's responsibility,
+  matching the ``rotate_api_key`` raw-dict precedent.
+- ``subnet_join_request_list`` defaults ``kind="join_request"``
+  to match the server's default + the ADR-0004 §"Application-side
+  endpoints" rule that ``kind=invitation`` is only valid on the
+  invitation list endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn_client.client import ACNClient
+from acn_client.models import SubnetCreateRequest
+
+
+def _make_client_with_stub(request_mock: AsyncMock) -> ACNClient:
+    """ACNClient with ``_request`` replaced by an awaitable stub."""
+    client = ACNClient(base_url="http://acn.test")
+    client._request = request_mock  # type: ignore[method-assign]
+    return client
+
+
+# ---------------------------------------------------------------------------
+# SubnetCreateRequest.join_policy round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSubnetCreateRequestJoinPolicy:
+    def test_serialises_join_policy_when_set(self):
+        req = SubnetCreateRequest(name="Gated", join_policy="approval")
+        dumped = req.model_dump(exclude_none=True)
+        assert dumped["join_policy"] == "approval"
+
+    def test_join_policy_omitted_when_none(self):
+        req = SubnetCreateRequest(name="Open")
+        dumped = req.model_dump(exclude_none=True)
+        # ``exclude_none=True`` drops the field. Server defaults to
+        # ``"open"`` server-side, so the wire payload stays minimal
+        # and back-compat with legacy callers who never set the
+        # field.
+        assert "join_policy" not in dumped
+
+    @pytest.mark.asyncio
+    async def test_create_subnet_wires_join_policy(self):
+        request_mock = AsyncMock(return_value={"status": "created"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.create_subnet(
+            SubnetCreateRequest(name="Gated", join_policy="approval")
+        )
+
+        body = request_mock.await_args.kwargs["json"]
+        assert body["join_policy"] == "approval"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist (3 verbs)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistVerbs:
+    @pytest.mark.asyncio
+    async def test_subnet_allowlist_add_posts_canonical_path(self):
+        request_mock = AsyncMock(
+            return_value={
+                "agent_id": "alice",
+                "added_by": "owner",
+                "added_at": "2026-05-19T00:00:00Z",
+            }
+        )
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.subnet_allowlist_add("squad-1", "alice")
+
+        assert result["agent_id"] == "alice"
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/allowlist",
+            json={"agent_id": "alice"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_subnet_allowlist_remove_uses_delete_and_returns_none(self):
+        request_mock = AsyncMock(return_value=None)
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.subnet_allowlist_remove("squad-1", "alice")
+
+        assert result is None
+        request_mock.assert_awaited_once_with(
+            "DELETE", "/api/v1/subnets/squad-1/allowlist/alice"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subnet_allowlist_list_passes_pagination_params(self):
+        request_mock = AsyncMock(
+            return_value={"subnet_id": "squad-1", "entries": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.subnet_allowlist_list(
+            "squad-1", limit=50, offset=10
+        )
+
+        assert result == {"subnet_id": "squad-1", "entries": []}
+        request_mock.assert_awaited_once_with(
+            "GET",
+            "/api/v1/subnets/squad-1/allowlist",
+            params={"limit": 50, "offset": 10},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Join requests (4 verbs)
+# ---------------------------------------------------------------------------
+
+
+class TestJoinRequestVerbs:
+    @pytest.mark.asyncio
+    async def test_approve_omits_body_when_no_note(self):
+        request_mock = AsyncMock(return_value={"status": "approved"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_approve("squad-1", "req-42")
+
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/join-requests/req-42/approve",
+            json=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_approve_includes_note_when_set(self):
+        request_mock = AsyncMock(return_value={"status": "approved"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_approve(
+            "squad-1", "req-42", note="welcome aboard"
+        )
+
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/join-requests/req-42/approve",
+            json={"note": "welcome aboard"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_reject_uses_reject_path(self):
+        request_mock = AsyncMock(return_value={"status": "rejected"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_reject(
+            "squad-1", "req-42", note="not a fit"
+        )
+
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/join-requests/req-42/reject",
+            json={"note": "not a fit"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_withdraw_uses_delete_on_join_requests_path(self):
+        request_mock = AsyncMock(return_value={"status": "withdrawn"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_withdraw("squad-1", "req-42")
+
+        request_mock.assert_awaited_once_with(
+            "DELETE",
+            "/api/v1/subnets/squad-1/join-requests/req-42",
+            json=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_defaults_kind_to_join_request(self):
+        request_mock = AsyncMock(
+            return_value={"subnet_id": "squad-1", "items": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_list("squad-1")
+
+        request_mock.assert_awaited_once_with(
+            "GET",
+            "/api/v1/subnets/squad-1/join-requests",
+            params={"kind": "join_request", "limit": 100, "offset": 0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_passes_status_and_kind_filters(self):
+        request_mock = AsyncMock(
+            return_value={"subnet_id": "squad-1", "items": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_join_request_list(
+            "squad-1",
+            kind="allowlist_auto",
+            status="approved",
+            limit=25,
+            offset=5,
+        )
+
+        request_mock.assert_awaited_once_with(
+            "GET",
+            "/api/v1/subnets/squad-1/join-requests",
+            params={
+                "kind": "allowlist_auto",
+                "limit": 25,
+                "offset": 5,
+                "status": "approved",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invitations (5 + 1 verbs)
+# ---------------------------------------------------------------------------
+
+
+class TestInvitationVerbs:
+    @pytest.mark.asyncio
+    async def test_send_normal_path_returns_pending_payload(self):
+        # 202 Accepted — normal "no overlap" send. Server returns
+        # the new invitation row.
+        normal_response: dict[str, Any] = {
+            "invitation_id": "inv-42",
+            "status": "pending",
+        }
+        request_mock = AsyncMock(return_value=normal_response)
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.subnet_invitation_send("squad-1", "bob")
+
+        assert result == normal_response
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/invitations",
+            json={"agent_id": "bob"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_merge_path_returns_auto_resolved_payload(self):
+        # Target had a pending join_request — server returns 200
+        # with the auto-resolution shape. SDK forwards verbatim;
+        # branch dispatch is the caller's responsibility.
+        merge_response: dict[str, Any] = {
+            "auto_resolved": True,
+            "resolved_kind": "join_request",
+            "request_id": "req-7",
+        }
+        request_mock = AsyncMock(return_value=merge_response)
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.subnet_invitation_send(
+            "squad-1", "bob", note="merging"
+        )
+
+        assert result == merge_response
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/invitations",
+            json={"agent_id": "bob", "note": "merging"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_accept_uses_accept_path(self):
+        request_mock = AsyncMock(return_value={"status": "approved"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_invitation_accept("squad-1", "inv-42")
+
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/invitations/inv-42/accept",
+            json=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reject_uses_reject_path_with_note(self):
+        request_mock = AsyncMock(return_value={"status": "rejected"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_invitation_reject(
+            "squad-1", "inv-42", note="too busy"
+        )
+
+        request_mock.assert_awaited_once_with(
+            "POST",
+            "/api/v1/subnets/squad-1/invitations/inv-42/reject",
+            json={"note": "too busy"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_uses_delete_on_invitations_path(self):
+        request_mock = AsyncMock(return_value={"status": "withdrawn"})
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_invitation_cancel("squad-1", "inv-42")
+
+        request_mock.assert_awaited_once_with(
+            "DELETE",
+            "/api/v1/subnets/squad-1/invitations/inv-42",
+            json=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_omits_status_when_none(self):
+        request_mock = AsyncMock(
+            return_value={"subnet_id": "squad-1", "items": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_invitation_list("squad-1")
+
+        request_mock.assert_awaited_once_with(
+            "GET",
+            "/api/v1/subnets/squad-1/invitations",
+            params={"limit": 100, "offset": 0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_includes_status_filter(self):
+        request_mock = AsyncMock(
+            return_value={"subnet_id": "squad-1", "items": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        await client.subnet_invitation_list("squad-1", status="pending")
+
+        request_mock.assert_awaited_once_with(
+            "GET",
+            "/api/v1/subnets/squad-1/invitations",
+            params={"limit": 100, "offset": 0, "status": "pending"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_subnet_invitations_uses_agent_path(self):
+        request_mock = AsyncMock(
+            return_value={"agent_id": "bob", "items": []}
+        )
+        client = _make_client_with_stub(request_mock)
+
+        result = await client.agent_subnet_invitations("bob")
+
+        assert result == {"agent_id": "bob", "items": []}
+        request_mock.assert_awaited_once_with(
+            "GET", "/api/v1/agents/bob/subnet-invitations"
+        )


### PR DESCRIPTION
## Summary

ADR-0004 Slice 2.3 (PRs #67/#74/#77/#78, server-side) added 13
admission HTTP routes — allowlist, join_request, invitation — and
a `subnet.join_policy` field on subnet creation. The CLI exposed
all 13 verbs in the same wave (`acn subnet allowlist add`,
`acn subnet join-requests approve`, etc.), but the Python SDK was
still on the pre-ADR-0004 surface. Python users wanting to drive
the admission flow programmatically had to bypass `acn-client`
and construct raw HTTP calls.

This PR closes that gap. **No version bump or release**: the
new methods are queued under `[Unreleased]` so the next
coordinated bump (which will also ship the alive-as-SSOT BUSY
deprecation, `__version__` unification, and PR #88's rotate-key
regression tests) ships them together.

## What's in the PR

### Models (`acn_client/models.py`)
- `SubnetCreateRequest.join_policy: str | None` — opt subnets
  into the approval state machine at creation time. `None`
  (default) ⇒ server-side `"open"` (legacy unrestricted
  self-join); `"approval"` ⇒ admission flow gates membership.
  Field is omitted from the wire payload via `exclude_none=True`,
  so legacy callers passing `SubnetCreateRequest(name=…)`
  continue to send the same body shape.

### Client (`acn_client/client.py`) — 13 new methods

All methods return raw `dict[str, Any]`. The 13 server routes
have no `response_model=` — they return un-typed JSON — so
modeling them on the SDK side would be inventing a contract the
server never declares. This matches the precedent already set
by `rotate_api_key`, `update_policy`, and `get_policy`. Future
work can promote high-frequency entities (e.g. `JoinRequest`,
`Invitation`) to Pydantic models without a breaking release.

Naming: `subnet_*` prefix to avoid colliding with the existing
inbox-`add_to_allowlist` surface (which lives at
`/api/v1/agents/{a}/allowlist/{target}` and is unrelated to ADR-0004's
subnet-level allowlist at `/api/v1/subnets/{s}/allowlist/…`). The
prefix mirrors the CLI verb tree (`acn subnet allowlist …`,
`acn subnet invitations …`) so SDK callers can discover methods
by analogy.

| Family | Methods | Auth |
|---|---|---|
| Allowlist | `subnet_allowlist_add` / `_remove` / `_list` | owner |
| Join requests | `subnet_join_request_approve` / `_reject` / `_list` | owner |
| Join requests | `subnet_join_request_withdraw` | applicant (self) |
| Invitations | `subnet_invitation_send` / `_cancel` / `_list` | owner |
| Invitations | `subnet_invitation_accept` / `_reject` | invitee (self) |
| Agent-side | `agent_subnet_invitations` | self |

### Tests (`tests/test_subnet_admission.py`)

20 new regression tests — `AsyncMock`-stubbed `_request`
asserting the exact wire shape (verb + path + body/params) for
every method. Plus 3 round-trip tests for
`SubnetCreateRequest.join_policy` (set / omit-when-None /
end-to-end via `create_subnet`). Test classes mirror the three
resource families.

Notable contracts pinned:

- `subnet_invitation_send` returns the raw merge-vs-normal
  payload verbatim — branch dispatch is the caller's
  responsibility.
- `subnet_join_request_list` defaults `kind=\"join_request\"` to
  match the server default + the ADR-0004 §\"Application-side
  endpoints\" rule that `kind=invitation` is queryable only via
  `subnet_invitation_list`.
- `subnet_allowlist_remove` returns `None` (server emits 204
  with no body, idempotent).
- Optional `note` is only included in the JSON body when set —
  keeps bodyless DELETE/POST off the JSON-content-type path.

## Test plan

- [x] `cd clients/python && pytest tests/test_subnet_admission.py -v` —
  **20 passed**
- [x] `cd clients/python && pytest tests/ -v` — **58 passed** (38
  pre-existing + 20 new, no regressions)
- [ ] Manual smoke against staging: create an `approval`-policy
  subnet, allowlist an agent, exercise the join → approve →
  list → invite → accept flow against the new SDK methods

Made with [Cursor](https://cursor.com)