### PR TITLE
feat(ts-sdk): SubnetCreateRequest ADR-0003 nesting parity (3 fields + tests)

### DIFF
--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+### Added (ADR-0003 nested subnets)
+
+- `SubnetCreateRequest` now exposes the three ADR-0003 nesting
+  fields, bringing the TypeScript SDK to parity with the Python
+  SDK (which has carried these since the original ADR-0003 work):
+  - `parent_subnet_id?: string` — promote a new subnet to a child
+    of an existing top-level subnet. Single-layer cap; immutable
+    after creation.
+  - `lifecycle?: SubnetLifecycle` (`'persistent' | 'task_scoped'`)
+    — defaults to `'persistent'` when omitted, preserving the
+    legacy "flat top-level persistent subnet" shape.
+  - `linked_task_id?: string` — bind a `'task_scoped'` subnet to
+    a task; the server auto-dissolves the subnet when that task
+    reaches a terminal state.
+- New `SubnetLifecycle` type alias re-exported from `index.ts`.
+- 3 vitest tests in `src/admission.test.ts` pinning round-trip
+  serialisation: `parent_subnet_id`, `lifecycle + linked_task_id`
+  pair, and the back-compat case where all three fields are
+  absent from the wire body when not set by the caller.
+
 ### Added (ADR-0004 subnet admission)
 
 - `SubnetCreateRequest.join_policy?: SubnetJoinPolicy` — opt

--- a/clients/typescript/src/admission.test.ts
+++ b/clients/typescript/src/admission.test.ts
@@ -15,6 +15,10 @@
  * - `SubnetCreateRequest.join_policy` round-trips through
  *   `createSubnet` and is omitted when not set (back-compat for
  *   legacy callers).
+ * - `SubnetCreateRequest` ADR-0003 nesting fields
+ *   (`parent_subnet_id`, `lifecycle`, `linked_task_id`)
+ *   round-trip through `createSubnet` and are all omitted when
+ *   not set (back-compat for legacy callers).
  *
  * Implementation strategy: stub `globalThis.fetch` per test and
  * assert on the (url, init) tuple. We avoid mocking the
@@ -88,6 +92,56 @@ describe('SubnetCreateRequest.join_policy', () => {
     const body = readBody(calls[0].init) as Record<string, unknown>;
     expect(body).toStrictEqual({ name: 'Open' });
     expect(body).not.toHaveProperty('join_policy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SubnetCreateRequest ADR-0003 nesting fields round-trip
+// ---------------------------------------------------------------------------
+
+describe('SubnetCreateRequest ADR-0003 nesting', () => {
+  it('serialises parent_subnet_id for nested subnets', async () => {
+    const { client, calls } = setupFetchStub(201, {
+      success: true,
+      subnet_id: 'child',
+      message: 'ok',
+    });
+    await client.createSubnet({
+      name: 'Child',
+      parent_subnet_id: 'top-level',
+    });
+    const body = readBody(calls[0].init) as Record<string, unknown>;
+    expect(body.parent_subnet_id).toBe('top-level');
+  });
+
+  it('serialises lifecycle + linked_task_id together for task-scoped subnets', async () => {
+    const { client, calls } = setupFetchStub(201, {
+      success: true,
+      subnet_id: 'scoped',
+      message: 'ok',
+    });
+    await client.createSubnet({
+      name: 'Scoped',
+      lifecycle: 'task_scoped',
+      linked_task_id: 'task-42',
+    });
+    const body = readBody(calls[0].init) as Record<string, unknown>;
+    expect(body.lifecycle).toBe('task_scoped');
+    expect(body.linked_task_id).toBe('task-42');
+  });
+
+  it('omits all nesting fields from body when not set (back-compat)', async () => {
+    const { client, calls } = setupFetchStub(201, {
+      success: true,
+      subnet_id: 'flat',
+      message: 'ok',
+    });
+    await client.createSubnet({ name: 'Flat' });
+    const body = readBody(calls[0].init) as Record<string, unknown>;
+    expect(body).toStrictEqual({ name: 'Flat' });
+    expect(body).not.toHaveProperty('parent_subnet_id');
+    expect(body).not.toHaveProperty('lifecycle');
+    expect(body).not.toHaveProperty('linked_task_id');
   });
 });
 

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -48,6 +48,7 @@ export type {
   SubnetInfo,
   SubnetCreateRequest,
   SubnetCreateResponse,
+  SubnetLifecycle,
   
   // Communication Types
   MessageType,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -141,11 +141,36 @@ export interface SubnetInfo {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Subnet lifecycle (ADR-0003). `'persistent'` is the legacy default —
+ * the subnet survives until manually deleted. `'task_scoped'` binds
+ * the subnet to a task: the server auto-dissolves it when that task
+ * reaches a terminal state. Only valid together with `linked_task_id`.
+ */
+export type SubnetLifecycle = 'persistent' | 'task_scoped';
+
 /** Subnet creation request */
 export interface SubnetCreateRequest {
   name: string;
   description?: string;
   metadata?: Record<string, unknown>;
+  /**
+   * ADR-0003 nested-subnet parent. When set, the new subnet becomes a
+   * child of `parent_subnet_id`. Single-layer cap: the parent itself
+   * must be top-level. Immutable after creation.
+   */
+  parent_subnet_id?: string;
+  /**
+   * ADR-0003 lifecycle. Defaults to `'persistent'` when omitted.
+   * `'task_scoped'` requires `linked_task_id` and the subnet
+   * auto-dissolves when that task terminates.
+   */
+  lifecycle?: SubnetLifecycle;
+  /**
+   * ADR-0003 task binding. Required when `lifecycle === 'task_scoped'`,
+   * ignored otherwise.
+   */
+  linked_task_id?: string;
   /**
    * ADR-0004 admission policy. When omitted the server defaults to
    * `'open'` (legacy unrestricted self-join). `'approval'` opts the


### PR DESCRIPTION
## What

Brings the TypeScript SDK to parity with the Python SDK on the ADR-0003 nested-subnet creation surface.

`SubnetCreateRequest` now exposes (all optional, all back-compat):

- `parent_subnet_id?: string` — promote the new subnet to a child of an existing top-level subnet. Single-layer cap; immutable after creation.
- `lifecycle?: SubnetLifecycle` (`'persistent' | 'task_scoped'`) — defaults to `'persistent'` when omitted, preserving the legacy "flat top-level persistent subnet" shape.
- `linked_task_id?: string` — bind a `'task_scoped'` subnet to a task; the server auto-dissolves the subnet when that task reaches a terminal state.

## Why

Python SDK's `SubnetCreateRequest` has carried these three fields since ADR-0003 landed. The TS counterpart only exposed `name` / `description` / `metadata` / `join_policy` — TS callers had to fall back to `Record<string, unknown>` casts to reach nesting, which silently bypassed type-checking and IntelliSense. This closes that drift.

No server change: `POST /api/v1/subnets` has accepted these fields since ADR-0003 (`acn/models.py:SubnetCreateRequest` already declares them).

## Files

| File | Change |
|------|--------|
| `clients/typescript/src/types.ts` | Add `SubnetLifecycle` type alias + three fields on `SubnetCreateRequest` with full doc-strings. |
| `clients/typescript/src/index.ts` | Re-export `SubnetLifecycle`. |
| `clients/typescript/src/admission.test.ts` | 3 new vitest cases: parent_subnet_id round-trip, lifecycle+linked_task_id paired round-trip, all-three-omitted back-compat. |
| `clients/typescript/CHANGELOG.md` | New `[Unreleased]` `### Added (ADR-0003 nested subnets)` section. |

## Verification

```
$ npx tsc --noEmit
(0 errors)

$ npx vitest run
✓ src/admission.test.ts (22 tests) 58ms
Test Files  1 passed (1)
     Tests  22 passed (22)
```

19 → 22 tests, zero regressions.

## Out of scope

- Re-export of ADR-0004 admission types from `index.ts` (`SubnetJoinPolicy`, `SubnetAllowlistEntry`, etc.) — small follow-up; tracked separately so this PR stays focused on ADR-0003 parity.
- `CommunicationProfile.unread_manifest_count` / `PolicyUpdateResponse.warning` typed mirrors of #87 — coming in a separate dual-SDK PR.

## Risk

Zero. All three fields are optional and absent from the wire body when not set (verified by the back-compat test). Legacy callers remain byte-identical on the wire.

Made with [Cursor](https://cursor.com)