### PR TITLE
chore(ts-sdk): re-export ADR-0004 admission types + CommunicationProfile

### DIFF
--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+### Fixed — re-export gap on public types
+
+- `index.ts` now re-exports the ten ADR-0004 admission types
+  alongside the methods that were already public:
+  `SubnetJoinPolicy`, `SubnetAllowlistEntry`,
+  `SubnetAllowlistListResponse`, `SubnetJoinRequestRow`,
+  `SubnetJoinRequestListResponse`,
+  `SubnetJoinRequestListOptions`,
+  `SubnetInvitationListResponse`,
+  `SubnetInvitationListOptions`,
+  `SubnetInvitationSendResponse`,
+  `AgentSubnetInvitationsResponse`. Pre-this-PR, callers had to
+  reach into `'acn-client/dist/types'` (deep import) or fall back
+  to `Parameters<typeof client.subnetAllowlistAdd>[…]` gymnastics
+  to type a variable holding e.g. an invitation row. Now a clean
+  top-level `import type { SubnetInvitationSendResponse } from 'acn-client'`
+  works as expected. Wire / runtime behaviour unchanged.
+- Same fix for `CommunicationProfile` (the typed return of
+  `getCommunicationProfile`) — also missing from the top-level
+  re-exports despite being a long-standing public type, and
+  newly carrying the `unread_manifest_count: number` field from
+  the previous PR.
+
 ### Added — manifest-mode reachability (mirrors server PR #87)
 
 - `CommunicationProfile.unread_manifest_count: number` — surfaces

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -49,7 +49,19 @@ export type {
   SubnetCreateRequest,
   SubnetCreateResponse,
   SubnetLifecycle,
-  
+
+  // Subnet Admission Types (ADR-0004)
+  SubnetJoinPolicy,
+  SubnetAllowlistEntry,
+  SubnetAllowlistListResponse,
+  SubnetJoinRequestRow,
+  SubnetJoinRequestListResponse,
+  SubnetJoinRequestListOptions,
+  SubnetInvitationListResponse,
+  SubnetInvitationListOptions,
+  SubnetInvitationSendResponse,
+  AgentSubnetInvitationsResponse,
+
   // Communication Types
   MessageType,
   Message,
@@ -63,6 +75,7 @@ export type {
   ManifestEntry,
   ManifestListResponse,
   ManifestContentResponse,
+  CommunicationProfile,
   
   // Payment Types
   PaymentMethod,


### PR DESCRIPTION
## What

Adds eleven missing entries to the TypeScript SDK's top-level type re-export list (`src/index.ts`):

**ADR-0004 admission (10 — PR-C follow-up)**
- `SubnetJoinPolicy`
- `SubnetAllowlistEntry`
- `SubnetAllowlistListResponse`
- `SubnetJoinRequestRow`
- `SubnetJoinRequestListResponse`
- `SubnetJoinRequestListOptions`
- `SubnetInvitationListResponse`
- `SubnetInvitationListOptions`
- `SubnetInvitationSendResponse`
- `AgentSubnetInvitationsResponse`

**Communication profile (1 — PR-G follow-up)**
- `CommunicationProfile` — quietly missing from the top-level re-exports for longer than the new \`unread_manifest_count\` field that landed in #94, but worth fixing in the same PR since both are part of the recent feature surface.

## Why

PR #90 (ADR-0004 admission methods) and PR #94 (manifest reachability typed fields) added the public types to \`src/types.ts\` but forgot to surface them via \`src/index.ts\`. Effect on callers:

\`\`\`ts
// Before this PR — none of the following compile from a top-level import:
import type {
  SubnetJoinPolicy,
  SubnetInvitationSendResponse,
  CommunicationProfile,
} from 'acn-client';
// → TS2724: '\"acn-client\"' has no exported member named …

// Workarounds users were forced into:
import type { SubnetJoinPolicy } from 'acn-client/dist/types';            // deep import, breaks under bundling
type Row = Parameters<ACNClient['subnetAllowlistAdd']>[2];                 // gymnastics, doesn't work for return shapes
\`\`\`

After this PR, the obvious top-level import works.

## Files

| File | Change |
|------|--------|
| \`clients/typescript/src/index.ts\` | Add the 11 type re-exports under their respective \`// Subnet Admission Types (ADR-0004)\` and \`// Communication Types\` blocks. |
| \`clients/typescript/CHANGELOG.md\` | New \`### Fixed — re-export gap on public types\` entry under \`[Unreleased]\`. |

## Verification

\`\`\`
$ npx tsc --noEmit
(0 errors)

$ npx vitest run
✓ src/communication.test.ts (5 tests)
✓ src/admission.test.ts (22 tests)
Test Files  2 passed (2)
     Tests  27 passed (27)
\`\`\`

No new tests added — this PR is purely re-export plumbing. \`tsc --noEmit\` in CI already serves as the type-level regression guard, and any caller who relied on the old workarounds (deep imports / Parameters gymnastics) keeps working unchanged.

## Out of scope

A small remaining batch of long-standing re-export gaps unrelated to ADR-0004 / PR #87 — \`SessionEntry\` / \`SessionInviteRequest\` / \`PendingSessionsResponse\` / \`ManifestSendRequest\` / \`ManifestMessageType\` / \`AgentSearchStatus\`. Those will land in a separate cleanup PR so this one stays focused on the recent feature surface.

## Risk

Zero. Re-export only. No runtime code changes. No test changes. Wire / ABI unchanged.

Made with [Cursor](https://cursor.com)