### PR TITLE
chore(ts-sdk): re-export session / manifest / search types

### DIFF
--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+### Fixed — re-export gap on session / manifest / search types
+
+- `index.ts` now also re-exports the seven public types in this
+  group that had been quietly missing for longer than the recent
+  feature work — same fix shape as the previous PR (PR-H), just
+  for older surfaces:
+  - `AgentSearchStatus` — the `'online' | 'offline' | 'all'`
+    literal used by `AgentSearchOptions.status`.
+  - `ManifestMessageType` / `ManifestSendRequest` — the input
+    type for `manifestSend` and the literal used by
+    `manifestList({ messageType })`.
+  - `SessionStatus` / `SessionEntry` / `SessionInviteRequest` /
+    `PendingSessionsResponse` — return / argument types for
+    `inviteSession`, `acceptSession`, `rejectSession`,
+    `closeSession`, and `listPendingSessions`.
+- All seven types were already public (used in `client.ts`
+  method signatures), so callers reaching them through the
+  inferred return type kept working — but there was no clean
+  way to spell e.g. `function handle(s: SessionEntry)` without
+  the deep import workaround. This closes that gap.
+
+Wire / runtime behaviour unchanged. Verified locally:
+`npx tsc --noEmit` clean, all 27 vitest cases still pass.
+
 ### Fixed — re-export gap on public types
 
 - `index.ts` now re-exports the ten ADR-0004 admission types

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -36,6 +36,7 @@ export type {
   
   // Agent Types
   AgentStatus,
+  AgentSearchStatus,
   AgentInfo,
   AgentJoinRequest,
   AgentJoinResponse,
@@ -75,8 +76,16 @@ export type {
   ManifestEntry,
   ManifestListResponse,
   ManifestContentResponse,
+  ManifestMessageType,
+  ManifestSendRequest,
   CommunicationProfile,
-  
+
+  // Session Types
+  SessionStatus,
+  SessionEntry,
+  SessionInviteRequest,
+  PendingSessionsResponse,
+
   // Payment Types
   PaymentMethod,
   PaymentNetwork,


### PR DESCRIPTION
## What

Follow-up to PR #95. Same shape — surface seven long-standing public types through \`src/index.ts\`:

**Agent search**
- \`AgentSearchStatus\` — used by \`AgentSearchOptions.status\`.

**Manifest**
- \`ManifestMessageType\` — literal used by \`manifestList({ messageType })\`.
- \`ManifestSendRequest\` — input type for \`manifestSend\`.

**Session**
- \`SessionStatus\` — literal used by \`SessionEntry.status\`.
- \`SessionEntry\` — return type for \`inviteSession\` / \`acceptSession\` / \`rejectSession\` / \`closeSession\`.
- \`SessionInviteRequest\` — argument type for \`inviteSession\`.
- \`PendingSessionsResponse\` — return type for \`listPendingSessions\`.

## Why

All seven were already public — verified by grepping each name against \`client.ts\` method signatures — but had never been re-exported via \`src/index.ts\`. Callers reaching them through inferred return types kept working, but writing e.g. \`function handleSession(s: SessionEntry)\` required either a deep import (\`'acn-client/dist/types'\` — breaks under bundling) or inference gymnastics.

This is a pure re-export plumbing fix. PR #95 covered the recent ADR-0004 / PR #87 surface; this PR closes the last gap I found in a quick audit so callers have a clean top-level type-import story across the SDK.

## Files

| File | Change |
|------|--------|
| \`clients/typescript/src/index.ts\` | Add the 7 type re-exports under \`// Agent Types\`, \`// Communication Types\`, and a new \`// Session Types\` block. |
| \`clients/typescript/CHANGELOG.md\` | New \`### Fixed — re-export gap on session / manifest / search types\` entry under \`[Unreleased]\`. |

## Verification

\`\`\`
$ npx tsc --noEmit
(0 errors)

$ npx vitest run
✓ src/communication.test.ts (5 tests)
✓ src/admission.test.ts (22 tests)
Test Files  2 passed (2)
     Tests  27 passed (27)
\`\`\`

## Risk

Zero. Re-export only. No runtime code changes. No test changes. Wire / ABI unchanged.

After this PR, every type that appears in a public \`ACNClient\` method signature is reachable via \`import type { … } from 'acn-client'\`.

Made with [Cursor](https://cursor.com)