### PR TITLE
chore(python-sdk): migrate three class-based Configs to ConfigDict

### DIFF
--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+### Changed — Pydantic v2 idiomatic config (no behavioural change)
+
+- Migrate the three remaining `class Config: populate_by_name =
+  True` blocks (on `AgentInfo`, `AgentRegisterRequest`, and
+  `SubnetInfo`) to the v2-idiomatic
+  `model_config = ConfigDict(populate_by_name=True)` form.
+  Pydantic emits `PydanticDeprecatedSince20: Support for
+  class-based config is deprecated, use ConfigDict instead.
+  Deprecated in Pydantic V2.0 to be removed in V3.0.` for the
+  legacy form, so this also future-proofs the SDK for Pydantic
+  v3. `ConfigDict` was already imported and already in use by
+  every other model in the file — this is the catch-up batch.
+- The behaviour (`populate_by_name=True` lets callers construct
+  `AgentInfo` / `SubnetInfo` either by their canonical Python
+  name `id` or by the wire-side alias `agent_id` / `subnet_id`)
+  is byte-identical. Verified by running the full SDK pytest
+  suite with `-W error::DeprecationWarning` — 65 passed, zero
+  warnings.
+
 ### Added — manifest-mode reachability (mirrors server PR #87)
 - `CommunicationProfile.unread_manifest_count: int` — surfaces the
   pending manifest queue length on the typed model returned by

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -154,12 +154,10 @@ KNOWN_PAYMENT_TASK_STATUSES: tuple[str, ...] = (
 class AgentInfo(BaseModel):
     """Agent information"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str = Field(alias="agent_id")
     name: str
-
-    class Config:
-        populate_by_name = True
-
     description: str | None = None
     skills: list[str] = Field(default_factory=list)
     status: AgentStatus = AgentStatus.OFFLINE
@@ -193,6 +191,8 @@ class AgentRegisterRequest(BaseModel):
     and ``ACNClient.join_acn()``.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     owner: str = Field(..., description="Agent owner (system/user-{id}/provider-{id})")
     name: str = Field(..., description="Agent name")
     tags: list[str] = Field(default_factory=list, description="Capability tags for discoverability")
@@ -212,9 +212,6 @@ class AgentRegisterRequest(BaseModel):
             "Defaults to 'manifest' for new agents."
         ),
     )
-
-    class Config:
-        populate_by_name = True
 
 
 class AgentJoinRequest(BaseModel):
@@ -287,12 +284,10 @@ class AgentSearchOptions(BaseModel):
 class SubnetInfo(BaseModel):
     """Subnet information"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str = Field(alias="subnet_id")
     name: str
-
-    class Config:
-        populate_by_name = True
-
     # Owner agent_id of the subnet. Defaults to ``""`` so older clients
     # talking to a server that does not yet expose ``owner`` still parse
     # cleanly. Per ADR-0002 the server rejects ``backend@internal`` on


### PR DESCRIPTION
## What

Mechanical migration of the three remaining \`class Config:\` blocks in \`clients/python/acn_client/models.py\` to the v2-idiomatic \`model_config = ConfigDict(...)\` form:

- \`AgentInfo\`
- \`AgentRegisterRequest\`
- \`SubnetInfo\`

All three carried \`populate_by_name = True\`. The behaviour (callers can construct these models either by canonical Python name or by their wire-side alias — \`agent_id\` / \`subnet_id\`) is byte-identical.

## Why

Pydantic v2 emits this on every import:

\`\`\`
PydanticDeprecatedSince20: Support for class-based config is deprecated,
use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0.
\`\`\`

Every other model in \`models.py\` already uses \`ConfigDict(...)\`. These three were holdouts. This PR makes the file uniform and future-proofs the SDK for Pydantic v3.

## Files

| File | Change |
|------|--------|
| \`clients/python/acn_client/models.py\` | 3 × \`class Config:\` → \`model_config = ConfigDict(populate_by_name=True)\`. \`ConfigDict\` was already imported. |
| \`clients/python/CHANGELOG.md\` | New \`### Changed — Pydantic v2 idiomatic config (no behavioural change)\` entry under \`[Unreleased]\`. |

Net diff: +25 / -11.

## Verification

\`\`\`
$ pytest tests/ -W error::DeprecationWarning
65 passed in 1.05s

$ rg '^\s*class Config\s*:' --type py
(no matches anywhere in the repo)
\`\`\`

The \`-W error::DeprecationWarning\` flag promotes deprecation warnings to errors — the run staying green proves zero remaining \`class Config:\` warnings from the SDK. The follow-up \`rg\` confirms there are no remaining holdouts anywhere in the repo (server \`acn/\`, tests, alembic, scripts) — these three SDK models were the last ones.

## Risk

Zero. Byte-identical runtime behaviour. \`populate_by_name=True\` continues to mean what it always did.