### PR TITLE
feat(ts-sdk): ADR-0003 listChildren + promoteSubnet (nesting ops parity)

### DIFF
--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -73,6 +73,23 @@ Wire / runtime behaviour unchanged. Verified locally:
 
 ### Added (ADR-0003 nested subnets)
 
+- `listChildren(parentSubnetId)` — `GET
+  /api/v1/subnets/{parentSubnetId}/children`; returns the
+  `subnets` array from `{ count, subnets }`. Parity with Python
+  SDK `list_children` and CLI `acn subnet list --parent`.
+- `promoteSubnet(subnetId)` — `POST /api/v1/subnets/{subnetId}/promote`;
+  promotes a `task_scoped` subnet to `persistent` (owner-only,
+  idempotent). Parity with Python SDK `promote_subnet` and CLI
+  `acn subnet promote`.
+- `SubnetInfo` extended with optional ADR-0003 / harness fields
+  (`subnet_id`, `parent_subnet_id`, `lifecycle`, `linked_task_id`,
+  …) plus an index signature so future server fields do not
+  break callers — matches the Python SDK's forward-compat posture.
+- New `SubnetChildrenListResponse` type for the children-list
+  envelope.
+- 2 vitest cases in `src/admission.test.ts` pinning verb + path
+  for `listChildren` and `promoteSubnet`.
+
 - `SubnetCreateRequest` now exposes the three ADR-0003 nesting
   fields, bringing the TypeScript SDK to parity with the Python
   SDK (which has carried these since the original ADR-0003 work):

--- a/clients/typescript/src/admission.test.ts
+++ b/clients/typescript/src/admission.test.ts
@@ -19,6 +19,8 @@
  *   (`parent_subnet_id`, `lifecycle`, `linked_task_id`)
  *   round-trip through `createSubnet` and are all omitted when
  *   not set (back-compat for legacy callers).
+ * - `listChildren` / `promoteSubnet` issue the ADR-0003
+ *   dedicated endpoints and parse the wire payloads.
  *
  * Implementation strategy: stub `globalThis.fetch` per test and
  * assert on the (url, init) tuple. We avoid mocking the
@@ -142,6 +144,58 @@ describe('SubnetCreateRequest ADR-0003 nesting', () => {
     expect(body).not.toHaveProperty('parent_subnet_id');
     expect(body).not.toHaveProperty('lifecycle');
     expect(body).not.toHaveProperty('linked_task_id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR-0003 nesting operations (listChildren / promoteSubnet)
+// ---------------------------------------------------------------------------
+
+function serverSubnetPayload(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    subnet_id: 'squad-1',
+    name: 'Squad 1',
+    owner: 'alice',
+    parent_subnet_id: 'parent-1',
+    lifecycle: 'task_scoped',
+    linked_task_id: 'task-42',
+    ...overrides,
+  };
+}
+
+describe('ADR-0003 listChildren / promoteSubnet', () => {
+  it('listChildren GETs /subnets/{parent}/children and returns subnets array', async () => {
+    const child = serverSubnetPayload({ subnet_id: 'child-1' });
+    const { client, calls } = setupFetchStub(200, {
+      count: 1,
+      subnets: [child],
+    });
+
+    const children = await client.listChildren('parent-1');
+
+    expect(children).toHaveLength(1);
+    expect(children[0].subnet_id).toBe('child-1');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init.method).toBe('GET');
+    expect(calls[0].url.pathname).toBe('/api/v1/subnets/parent-1/children');
+  });
+
+  it('promoteSubnet POSTs /subnets/{id}/promote and returns SubnetInfo', async () => {
+    const promoted = serverSubnetPayload({
+      lifecycle: 'persistent',
+      linked_task_id: null,
+    });
+    const { client, calls } = setupFetchStub(200, promoted);
+
+    const info = await client.promoteSubnet('squad-1');
+
+    expect(info.lifecycle).toBe('persistent');
+    expect(info.linked_task_id).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0].url.pathname).toBe('/api/v1/subnets/squad-1/promote');
   });
 });
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -55,6 +55,7 @@ import type {
   AgentSubnetInvitationsResponse,
   SubnetAllowlistEntry,
   SubnetAllowlistListResponse,
+  SubnetChildrenListResponse,
   SubnetCreateRequest,
   SubnetCreateResponse,
   SubnetInfo,
@@ -343,6 +344,31 @@ export class ACNClient {
   /** Get subnet by ID */
   async getSubnet(subnetId: string): Promise<SubnetInfo> {
     return this.get(`/api/v1/subnets/${subnetId}`);
+  }
+
+  /**
+   * List immediate children of a subnet (ADR-0003).
+   *
+   * Wraps `GET /api/v1/subnets/{parentSubnetId}/children`. Returns
+   * `SUBNET_NOT_FOUND` when the parent does not exist. Visibility
+   * matches `listSubnets` — private children you cannot see are
+   * omitted from the result set.
+   */
+  async listChildren(parentSubnetId: string): Promise<SubnetInfo[]> {
+    const data = await this.get<SubnetChildrenListResponse>(
+      `/api/v1/subnets/${parentSubnetId}/children`,
+    );
+    return data.subnets;
+  }
+
+  /**
+   * Promote a `task_scoped` subnet to `persistent` (ADR-0003).
+   *
+   * Owner-only. Idempotent — promoting an already-persistent subnet
+   * returns its current state unchanged.
+   */
+  async promoteSubnet(subnetId: string): Promise<SubnetInfo> {
+    return this.post(`/api/v1/subnets/${subnetId}/promote`);
   }
 
   /** Delete a subnet you own (requires Agent API Key — only the owning agent can delete) */

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -47,6 +47,7 @@ export type {
   
   // Subnet Types
   SubnetInfo,
+  SubnetChildrenListResponse,
   SubnetCreateRequest,
   SubnetCreateResponse,
   SubnetLifecycle,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -133,12 +133,35 @@ export interface AgentSearchOptions {
 
 /** Subnet information */
 export interface SubnetInfo {
+  /**
+   * Subnet identifier. The server wire field is `subnet_id`; some
+   * older responses may also surface `id`. Prefer `subnet_id` when
+   * present, falling back to `id`.
+   */
   id: string;
+  /** Wire-side identifier (ADR-0003+ servers always emit this). */
+  subnet_id?: string;
   name: string;
   description?: string;
-  created_at: string;
-  agent_count: number;
+  created_at?: string;
+  agent_count?: number;
   metadata?: Record<string, unknown>;
+  owner?: string;
+  harness_url?: string;
+  harness_registered?: boolean;
+  /** ADR-0003 — parent subnet when this is a nested child. */
+  parent_subnet_id?: string | null;
+  /** ADR-0003 — defaults to `'persistent'` on the server. */
+  lifecycle?: SubnetLifecycle;
+  /** ADR-0003 — bound task when `lifecycle === 'task_scoped'`. */
+  linked_task_id?: string | null;
+  [key: string]: unknown;
+}
+
+/** Response from `GET /api/v1/subnets/{id}/children` (ADR-0003). */
+export interface SubnetChildrenListResponse {
+  count: number;
+  subnets: SubnetInfo[];
 }
 
 /**

--- a/skills/acn/references/SDK.md
+++ b/skills/acn/references/SDK.md
@@ -91,9 +91,14 @@ const client = new ACNClient({
 // Same method surface as Python SDK (camelCase):
 // joinACN, searchAgents, sendMessage, manifestSend, listManifest,
 // inviteSession, follow, unfollow, checkFollow, listFollows, listFollowers,
-// getPolicy, updatePolicy, addToAllowlist, removeFromAllowlist, listAllowlist,
+// getPolicy, updatePolicy, getCommunicationProfile, addToAllowlist,
+// removeFromAllowlist, listAllowlist,
 // createTask, acceptTask, submitTask, reviewTask, cancelTask,
 // rotateApiKey,
+//
+// Subnets (ADR-0003 nesting):
+// createSubnet({ parent_subnet_id, lifecycle, linked_task_id, join_policy }),
+// listChildren, promoteSubnet
 //
 // Subnet Admission (ADR-0004):
 // subnetAllowlistAdd, subnetAllowlistRemove, subnetAllowlistList,


### PR DESCRIPTION
## What

Closes the last ADR-0003 TypeScript SDK gap. PR #93 added `SubnetCreateRequest` nesting **fields**; Python SDK and CLI already had the two **operations** — TS did not:

| Endpoint | Python SDK | CLI | TypeScript (before) |
|----------|------------|-----|---------------------|
| `GET /subnets/{parent}/children` | `list_children` | `acn subnet list --parent` | **missing** |
| `POST /subnets/{id}/promote` | `promote_subnet` | `acn subnet promote` | **missing** |

This PR adds `listChildren` and `promoteSubnet` on `ACNClient`, extends `SubnetInfo` with optional ADR-0003 wire fields, and updates `skills/acn/references/SDK.md`.

## Files

| File | Change |
|------|--------|
| `clients/typescript/src/client.ts` | `listChildren`, `promoteSubnet` |
| `clients/typescript/src/types.ts` | `SubnetInfo` ADR-0003 fields + `SubnetChildrenListResponse` |
| `clients/typescript/src/index.ts` | re-export `SubnetChildrenListResponse` |
| `clients/typescript/src/admission.test.ts` | +2 vitest (29 total) |
| `clients/typescript/CHANGELOG.md` | `[Unreleased]` entry |
| `skills/acn/references/SDK.md` | TS comment block lists nesting ops |

## Verification

\`\`\`
$ npx tsc --noEmit
(0 errors)

$ npx vitest run
✓ src/communication.test.ts (5)
✓ src/admission.test.ts (24)
29 passed
\`\`\`

## Risk

Low. Additive API surface only; existing callers unchanged.

Made with [Cursor](https://cursor.com)