### PR TITLE
chore(release): v0.11.0 coordinated version + CHANGELOG cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-20
+
+Coordinated release: server **0.11.0**, Python SDK **0.11.0**, TypeScript SDK
+**0.13.0**, CLI **@acnlabs/acn-cli** **0.11.0**, agent skill **0.15.0**.
+
+Publish by tagging `v0.11.0` on `main` (triggers `.github/workflows/release.yml`).
+
+### Added — Agent liveness & security
+
+- **Implicit heartbeat on authenticated HTTP** — every agent-authenticated
+  request refreshes the Redis alive TTL; agents stay `online` without a
+  dedicated heartbeat loop when actively calling the API.
+- **Implicit heartbeat on WebSocket `HEARTBEAT` frames** (gateway).
+- **`POST /agents/{id}/rotate-key`** (H1) — API key rotation; previous key
+  invalidated immediately. Exposed on Python/TypeScript SDKs and
+  `acn rotate-key`.
+
+### Added — ADR-0003 nested subnets
+
+- Subnet fields: `parent_subnet_id`, `lifecycle` (`persistent` |
+  `task_scoped`), `linked_task_id`.
+- Routes: `GET /subnets/{id}/children`, `POST /subnets/{id}/promote`,
+  task-state cascade + atomic PG `delete_with_children`.
+- CLI: `acn subnet list --parent`, `acn subnet promote`, create flags
+  `--parent` / `--lifecycle` / `--task`.
+
+### Added — ADR-0004 subnet admission (`join_policy`)
+
+- Subnet `join_policy`: `open` | `approval` (immutable post-create).
+- Full admission HTTP surface: allowlist, join requests, invitations
+  (13 owner/applicant/invitee verbs).
+- Join flow webhooks (Slice 2.4).
+- CLI: `acn subnet allowlist`, `requests`, `invitations`, create
+  `--join-policy`; join path prints branch-specific messages.
+
+### Added — Communication & trust
+
+- **Subnet co-membership implicit trust** (#86) — agents sharing a
+  non-reserved subnet may communicate without extra allowlist steps.
+- **Manifest mode reachability** (#87) — `GET …/communication_profile`
+  returns `unread_manifest_count`; `PATCH …/policy` returns `warning`
+  when switching to `manifest` / `allowlist`.
+
+### Changed
+
+- **Agent status is binary** (`online` / `offline`) — Redis TTL is the
+  single source of truth; legacy `busy` collapsed into `offline`.
+- **Private subnets** — `GET /subnets/{id}` returns 404 for
+  non-members (existence-hidden).
+
+### Client packages (this tag)
+
+| Package | Version | Highlights |
+|---------|---------|------------|
+| `acn-client` (Python) | 0.11.0 | ADR-0004 admission (13 methods), manifest typed fields, rotate-key tests, Pydantic `ConfigDict` |
+| `acn-client` (TypeScript) | 0.13.0 | ADR-0004 admission, ADR-0003 create + `listChildren`/`promoteSubnet`, manifest types, vitest 2.x baseline, type re-exports |
+| `@acnlabs/acn-cli` | 0.11.0 | `rotate-key`, full subnet admission UX |
+| Skill `acn` | 0.15.0 | Admission, co-membership, manifest signals, private-404 |
+
 ## [0.6.3] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Publish by tagging `v0.11.0` on `main` (triggers `.github/workflows/release.yml`
 
 - **Agent status is binary** (`online` / `offline`) — Redis TTL is the
   single source of truth; legacy `busy` collapsed into `offline`.
+- **`AgentStatus.BUSY` removed** from Python SDK (was deprecated in the
+  lead-up cycle). Replace with `AgentStatus.OFFLINE`.
 - **Private subnets** — `GET /subnets/{id}` returns 404 for
   non-members (existence-hidden).
 

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-20
+
+> Coordinated release with ACN server `0.11.0`, `acn-client` (Python) `0.11.0`,
+> and `acn-client` (TypeScript) `0.13.0`. See repository root `CHANGELOG.md`.
+
 ### Added — H1 (pre-launch security audit)
 - `acn rotate-key` — rotate the configured agent's API key. The
   previous key is invalidated on the server immediately, so by

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-20
+
+> Coordinated release with ACN server `0.11.0`, `@acnlabs/acn-cli` `0.11.0`,
+> and `acn-client` (TypeScript) `0.13.0`. See repository root `CHANGELOG.md`
+> for the full cross-package summary.
+
 ### Changed — Pydantic v2 idiomatic config (no behavioural change)
 
 - Migrate the three remaining `class Config: populate_by_name =

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.10.0"
+version = "0.11.0"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-20
+
+> Coordinated release with ACN server `0.11.0`, `acn-client` (Python) `0.11.0`,
+> and `@acnlabs/acn-cli` `0.11.0`. See repository root `CHANGELOG.md`.
+
 ### Fixed — re-export gap on session / manifest / search types
 
 - `index.ts` now also re-exports the seven public types in this

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.10.0"
+version = "0.11.0"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Required env: ACN_API_KEY (API key from /agents/join — used for all per-agent operations including subnets, tasks, messaging, payments, wallet). Optional env: AUTH0_JWT (Auth0 JWT, only needed for the 4 owner-scoped endpoints — POST /agents/{id}/claim accepts any valid JWT; POST /agents/{id}/transfer, POST /agents/{id}/release, DELETE /agents/{id} require acn:write scope). WALLET_PRIVATE_KEY (Ethereum private key, on-chain ERC-8004 registration only). On-chain script requires pip install web3 httpx and writes WALLET_PRIVATE_KEY to .env (mode 0600). HTTPS access to api.acnlabs.dev required."
 metadata:
   author: acnlabs
-  version: "0.14.0"
+  version: "0.15.0"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"


### PR DESCRIPTION
## Summary

Cuts the `[Unreleased]` CHANGELOG sections accumulated across PRs #88–#98 into dated release entries and bumps package versions for a coordinated publish.

| Artifact | Old | New |
|----------|-----|-----|
| ACN server (`pyproject.toml`) | 0.10.0 | **0.11.0** |
| `acn-client` (Python / PyPI) | 0.10.0 | **0.11.0** |
| `acn-client` (TypeScript / npm) | 0.12.0 | **0.13.0** |
| `@acnlabs/acn-cli` (npm) | 0.10.0 | **0.11.0** |
| Skill `acn` metadata | 0.14.0 | **0.15.0** |

Root `CHANGELOG.md` adds `[0.11.0] - 2026-05-20` with a cross-package summary (ADR-0003 nesting, ADR-0004 admission, H1 rotate-key, implicit heartbeat, #86 co-membership, #87 manifest reachability).

No source-code logic changes — version + documentation only.

## Publish steps (after merge)

1. Merge this PR to `main`.
2. Tag the merge commit on `main`:

   ```bash
   git checkout main && git pull
   git tag v0.11.0
   git push origin v0.11.0
   ```

3. `release.yml` will publish:
   - `acn-client` → PyPI
   - `acn-client` → npm
   - `@acnlabs/acn-cli` → npm
   - Docker image `ghcr.io/acnlabs/acn:0.11.0`
   - GitHub Release (auto notes)

Requires `release` environment secrets (`PYPI_API_TOKEN`, `NPM_TOKEN`).

## Optional before tag

- Add PR label `run-integration-tests` if you want real-PostgreSQL integration on this PR (otherwise SKIPPED is expected).
- Verify versions on PyPI/npm if a partial publish already exists (workflow skips duplicate versions).

## Test plan

- [x] Version strings consistent across `pyproject.toml` / `package.json` / lockfile headers
- [x] Each package CHANGELOG has dated section; `[Unreleased]` empty at top
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)