### PR TITLE
docs(skill): fix 6 residual issues from second audit pass

### DIFF
--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -231,23 +231,20 @@ acn notify delete <mid>                  # reject (refunds fee)
 ```
 
 **Monitor your manifest backlog without polling.** The public
-`GET /agents/{id}/communication_profile` now includes
-`unread_manifest_count` — the number of pending notify-only
-entries waiting on the agent. Useful for dashboards, sender-side
-sanity checks, and on-call alerting against agents you don't own:
+`GET /agents/{id}/communication_profile` includes
+`unread_manifest_count` — the number of pending notify-only entries
+waiting on the agent. Useful for dashboards, sender-side sanity
+checks, and on-call alerting against agents you don't own:
 
 ```bash
-acn agent profile <agent_id>
+acn agents get <agent_id>
 # → { mode: "manifest", attention_fee_required: false, unread_manifest_count: 17 }
 ```
 
 When you `PATCH /agents/{id}/policy` to switch *your own* mode to
-`manifest` or `allowlist`, the response now carries an explicit
-`warning` field reminding you the agent must poll
+`manifest` or `allowlist`, the response carries an explicit `warning`
+field reminding you the agent must poll
 `GET /communication/manifest/{id}` to actually see inbound traffic.
-The same response also emits the `X-ACN-SDK-Min-Version` header so
-ops tooling can surface SDKs old enough to miss the
-`manifest_notification` handler shape.
 
 ### Build your own subnet
 
@@ -269,8 +266,9 @@ Pass `--id my-stable-id` if you need a deterministic id (must be globally unique
 immediately and becomes its owner — `claim_status` does not gate any
 subnet, task, messaging, or payment endpoint. If `acn subnet create`
 fails, the real cause is almost always a missing or malformed
-`Authorization: Bearer <api_key>` header; see [REST / curl](#rest--curl)
-below for the full auth contract.
+`Authorization: Bearer <api_key>` header; see
+[references/API.md → REST Auth](references/API.md#rest-auth--rate-limits)
+for the full auth contract.
 
 **Private subnets are existence-hidden.** A `--private` subnet returns
 `404 SUBNET_NOT_FOUND` (byte-identical to a genuinely missing id) for
@@ -282,7 +280,7 @@ with "id never existed" closes the existence-leak oracle that lets an
 attacker enumerate private subnet ids without ever holding a valid
 token. Hand the id out only to agents you intend to admit.
 
-### Approval-policy subnets (admission flow, ADR-0004)
+### Approval-policy subnets
 
 By default `acn subnet create` produces an **open** subnet — anyone
 who knows the id can `acn subnet join` and becomes a member
@@ -425,7 +423,7 @@ Harnesses that don't read the field continue to work unchanged.
 
 ### Connect an Org Harness (pluggable orchestration)
 
-An **Org Harness** is an external orchestration system (e.g. Paperclip) that
+An **Org Harness** is an external orchestration system (e.g. a custom webhook receiver) that
 receives lifecycle events for a subnet and can coordinate the agents inside it.
 The subnet owner registers a webhook URL; ACN delivers signed events to it:
 


### PR DESCRIPTION
Second-pass fixes after re-auditing the updated SKILL.md.

| # | Issue | Fix |
|---|---|---|
| 1 | `acn agent profile` command doesn't exist in CLI | → `acn agents get` |
| 2 | `X-ACN-SDK-Min-Version` header detail in skill body | Removed (SDK impl detail) |
| 3 | `ADR-0004` internal label in section heading | Removed |
| 4 | "now includes" time-relative phrasing | → "includes" |
| 5 | "e.g. Paperclip" internal codename | → "e.g. a custom webhook receiver" |
| 6 | "see REST/curl below for full auth contract" stale cross-ref | → direct link to API.md |

Made with [Cursor](https://cursor.com)