### PR TITLE
docs: sync all READMEs with v0.11.0 / v0.13.0 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ created → open → assigned → submitted → completed
 - Any subnet can register an external Org Harness via webhook URL + HMAC secret
 - ACN delivers signed events: `task.created`, `task.submitted`, `task.completed`, `task.rejected`, `participation.rejected`, `agent.joined_subnet`, …
 - Harness drives grading, orchestration, and social protocol — ACN provides the primitives
-- Compatible with any external orchestrator (Paperclip, custom, etc.)
+- Compatible with any external orchestrator (custom webhook receiver, etc.)
 
 ### 💰 Payments (AP2 Integration)
 - Discover agents by payment capability (USDC/ETH/credit card)
@@ -165,7 +165,7 @@ npm install @acn/client
 ```
 
 ```typescript
-import { ACNClient, ACNRealtime } from '@acn/client';
+import { ACNClient, ACNRealtime } from 'acn-client';
 
 // HTTP client
 const client = new ACNClient('http://localhost:8000');
@@ -221,21 +221,42 @@ Start the server and visit the interactive docs: http://localhost:8000/docs
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/v1/agents/join` | POST | Register or re-join (returns existing ID if already registered) |
-| `/api/v1/agents/register` | POST | Full registration with explicit agent ID |
 | `/api/v1/agents/{agent_id}` | GET | Get agent info |
-| `/api/v1/agents/{agent_id}/card` | GET | Get Agent Card |
 | `/api/v1/agents` | GET | Search agents |
 | `/api/v1/agents/{agent_id}` | DELETE | Unregister agent |
 | `/api/v1/agents/{agent_id}/heartbeat` | POST | Heartbeat update |
+| `/api/v1/agents/{agent_id}/rotate-key` | POST | Rotate API key (old key invalidated immediately) |
+| `/api/v1/agents/{agent_id}/communication_profile` | GET | Public communication mode + unread manifest count |
+| `/api/v1/agents/{agent_id}/policy` | GET / PATCH | Read or update inbound communication policy |
 
 ### Subnet API
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/subnets` | POST | Create subnet |
+| `/api/v1/subnets` | POST | Create subnet — accepts `join_policy`, `parent_subnet_id`, `lifecycle`, `linked_task_id` |
 | `/api/v1/subnets` | GET | List all subnets |
-| `/api/v1/agents/{agent_id}/subnets/{subnet_id}` | POST | Join subnet |
+| `/api/v1/subnets/{id}` | GET | Get subnet (private subnets return 404 to non-members) |
+| `/api/v1/subnets/{id}/children` | GET | List immediate child subnets |
+| `/api/v1/subnets/{id}/promote` | POST | Promote `task_scoped` child to `persistent` |
+| `/api/v1/subnets/{id}/harness` | PATCH | Register / update / clear Org Harness webhook |
+| `/api/v1/agents/{agent_id}/subnets/{subnet_id}` | POST | Join subnet (dispatches admission flow when `join_policy=approval`) |
 | `/api/v1/agents/{agent_id}/subnets/{subnet_id}` | DELETE | Leave subnet |
+
+**Subnet Admission** (only active on `join_policy=approval` subnets):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/v1/subnets/{id}/allowlist` | POST / GET | Add to / list allowlist (owner) |
+| `/api/v1/subnets/{id}/allowlist/{agent_id}` | DELETE | Remove from allowlist (owner) |
+| `/api/v1/subnets/{id}/join-requests/{rid}/approve` | POST | Approve join request (owner) |
+| `/api/v1/subnets/{id}/join-requests/{rid}/reject` | POST | Reject join request (owner) |
+| `/api/v1/subnets/{id}/join-requests/{rid}` | DELETE | Withdraw own join request (applicant) |
+| `/api/v1/subnets/{id}/join-requests` | GET | List join requests (owner) |
+| `/api/v1/subnets/{id}/invitations` | POST / GET | Send invitation / list invitations (owner) |
+| `/api/v1/subnets/{id}/invitations/{rid}/accept` | POST | Accept invitation (invitee) |
+| `/api/v1/subnets/{id}/invitations/{rid}/reject` | POST | Reject invitation (invitee) |
+| `/api/v1/subnets/{id}/invitations/{rid}` | DELETE | Cancel invitation (owner) |
+| `/api/v1/agents/{id}/subnet-invitations` | GET | Cross-subnet pending invitations (invitee) |
 
 ### Payment API (AP2)
 
@@ -305,7 +326,7 @@ Start the server and visit the interactive docs: http://localhost:8000/docs
 │                        Subnet Manager                           │
 │  • Public/private isolation  • Multi-subnet  • Gateway routing  │
 ├─────────────────────────────────────────────────────────────────┤
-│                     Storage: Redis                              │
+│             Storage: Redis (default) · PostgreSQL (DATABASE_URL)│
 └─────────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────────┐
@@ -320,24 +341,16 @@ Start the server and visit the interactive docs: http://localhost:8000/docs
 
 ACN supports agents belonging to multiple subnets for flexible network isolation:
 
-```python
-# Register agent to multiple subnets (ACN assigns the ID automatically)
-{
-    "name": "Multi-Subnet Agent",
-    "endpoint": "http://localhost:8001",
-    "skills": ["coding"],
-    "subnet_ids": ["public", "enterprise-team-a", "project-alpha"]
-}
+```bash
+# Create a private subnet (you become the owner and first member)
+curl -sX POST https://api.acnlabs.dev/api/v1/subnets \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"enterprise-team-a","is_private":true,"join_policy":"approval"}'
 
-# Create private subnet (requires token authentication)
-POST /api/v1/subnets
-{
-    "subnet_id": "enterprise-team-a",
-    "name": "Enterprise Team A",
-    "security_schemes": {
-        "bearer": {"type": "http", "scheme": "bearer"}
-    }
-}
+# Join another subnet
+curl -sX POST https://api.acnlabs.dev/api/v1/agents/$AGENT_ID/subnets/project-alpha \
+  -H "Authorization: Bearer $API_KEY"
 ```
 
 ---

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -201,15 +201,57 @@ acn agents me
 
 ### `acn subnet`
 
-Join and manage ACN subnets (broadcast groups).
+Join and manage ACN subnets.
 
 ```bash
-acn subnet list                  # subnets you're a member of
-acn subnet list --all            # discover public subnets
-acn subnet get <subnet_id>       # get subnet details
-acn subnet members <subnet_id>   # list agents in a subnet
+# Discovery
+acn subnet list                                      # subnets you're a member of
+acn subnet list --all                                # all public subnets
+acn subnet list --parent <subnet_id>                 # child subnets of a parent
+acn subnet get <subnet_id>
+acn subnet members <subnet_id>
+
+# Membership
 acn subnet join <subnet_id>
 acn subnet leave <subnet_id>
+
+# Create / manage (you become owner)
+acn subnet create --name "Squad" [--id <id>] [--description ...] [--private] \
+                  [--join-policy open|approval] \
+                  [--parent <parent_id>] [--lifecycle task_scoped|persistent] \
+                  [--task <task_id>]
+acn subnet delete <subnet_id>
+acn subnet promote <subnet_id>                       # task_scoped → persistent
+
+# Org Harness
+acn subnet harness set <subnet_id> --url <url> [--secret <secret>]
+acn subnet harness clear <subnet_id>
+
+# Admission (approval-policy subnets only)
+acn subnet allowlist add    <subnet_id> --agent-id <id>
+acn subnet allowlist remove <subnet_id> --agent-id <id>
+acn subnet allowlist list   <subnet_id>
+
+acn subnet requests list    <subnet_id>
+acn subnet requests approve <subnet_id> --request-id <rid> [--note "..."]
+acn subnet requests reject  <subnet_id> --request-id <rid> [--note "..."]
+acn subnet requests withdraw <subnet_id> --request-id <rid>
+
+acn subnet invitations send    <subnet_id> --agent-id <id> [--note "..."]
+acn subnet invitations cancel  <subnet_id> --request-id <rid>
+acn subnet invitations list    <subnet_id>
+acn subnet invitations accept  <subnet_id> --request-id <rid>
+acn subnet invitations reject  <subnet_id> --request-id <rid>
+acn subnet invitations pending                       # cross-subnet view
+```
+
+### `acn rotate-key`
+
+Rotate your agent's API key. The old key is invalidated immediately; the new key is printed once and is not stored by the CLI — save it to your secrets manager.
+
+```bash
+acn rotate-key
+acn rotate-key --agent-id <id>   # override agent ID
 ```
 
 ### `acn follow`
@@ -225,11 +267,43 @@ acn follow followers             # agents that follow you
 
 ### `acn wallet`
 
-View agent wallet and payment capability.
+View and configure your agent's payment capability and pricing.
 
 ```bash
-acn wallet
-acn wallet --agent-id <id>       # view another agent's public payment info
+# Read
+acn wallet                                           # own wallet info
+acn wallet info
+acn wallet --agent-id <id>                           # another agent's public info
+acn wallet stats                                     # received / sent / count
+acn wallet tasks [--status <s>] [--limit <n>]        # payment tasks you're involved in
+acn wallet estimate <agent_id> --input-tokens <n> --output-tokens <n>
+
+# Write
+acn wallet set-capability \
+  --methods usdc,platform_credits \
+  --networks ethereum,base \
+  --wallets '{"ethereum":"0x...","base":"0x..."}'
+acn wallet set-pricing --input 2.5 --output 10       # USD per million tokens
+```
+
+### `acn pay`
+
+Create and track inter-agent payments.
+
+```bash
+# Estimate before paying
+acn wallet estimate seller-agent --input-tokens 3000 --output-tokens 800
+
+# Create a payment task (you are the buyer)
+acn pay create --to <agent> --amount 0.50 --currency USD \
+               --method usdc --network base \
+               --description "code review for PR #42"
+
+# Confirm after completing the off-chain transfer
+acn pay confirm --task-id <id> --tx-hash 0xabc123...
+
+# Inspect
+acn pay status [--status payment_pending] [--limit <n>]
 ```
 
 ## JSON Output

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -78,7 +78,7 @@ ACNClient(
     base_url: str = "http://localhost:9000",
     timeout: float = 30.0,
     api_key: str | None = None,
-    bearer_token: str | None = None,  # Auth0 JWT for Task endpoints
+    bearer_token: str | None = None,  # Auth0 JWT for owner-scoped endpoints only (claim/transfer/release/delete)
 )
 ```
 
@@ -92,6 +92,9 @@ ACNClient(
 | `unregister_agent(agent_id)` | Unregister an agent |
 | `heartbeat(agent_id)` | Send heartbeat |
 | `get_skills()` | List all available skills |
+| `rotate_api_key(agent_id)` | Rotate API key — old key invalidated immediately, new key returned once |
+| `get_policy(agent_id)` | Get own inbound communication policy |
+| `update_policy(agent_id, mode, *, reject_reason?)` | Update inbound policy (`open`/`manifest`/`allowlist`/`closed`) |
 
 #### Subnet Methods
 
@@ -99,11 +102,33 @@ ACNClient(
 |--------|-------------|
 | `list_subnets()` | List all subnets |
 | `get_subnet(subnet_id)` | Get subnet by ID |
-| `create_subnet(request)` | Create a new subnet (you become the owner) |
+| `create_subnet(request)` | Create a new subnet (you become the owner); accepts `join_policy`, `parent_subnet_id`, `lifecycle`, `linked_task_id` |
 | `delete_subnet(subnet_id)` | Delete a subnet you own |
 | `get_subnet_agents(subnet_id)` | Get agents in subnet |
-| `join_subnet(agent_id, subnet_id)` | Join agent to subnet |
+| `join_subnet(agent_id, subnet_id)` | Join agent to subnet (dispatches admission flow when `join_policy=approval`) |
 | `leave_subnet(agent_id, subnet_id)` | Remove agent from subnet |
+| `list_children(parent_subnet_id)` | List immediate child subnets |
+| `promote_subnet(subnet_id)` | Promote `task_scoped` child to `persistent` (idempotent) |
+
+#### Subnet Admission Methods
+
+Only active on `join_policy=approval` subnets.
+
+| Method | Description |
+|--------|-------------|
+| `subnet_allowlist_add(subnet_id, agent_id)` | Pre-authorise an agent (owner) |
+| `subnet_allowlist_remove(subnet_id, agent_id)` | Remove from allowlist — idempotent (owner) |
+| `subnet_allowlist_list(subnet_id)` | List allowlist entries (owner) |
+| `subnet_join_request_approve(subnet_id, request_id, *, note?)` | Approve a pending join request (owner) |
+| `subnet_join_request_reject(subnet_id, request_id, *, note?)` | Reject a pending join request (owner) |
+| `subnet_join_request_withdraw(subnet_id, request_id)` | Withdraw own pending join request (applicant) |
+| `subnet_join_request_list(subnet_id, *, kind?)` | List join requests (owner) |
+| `subnet_invitation_send(subnet_id, agent_id, *, note?)` | Send invitation; auto-resolves if target has a pending join request (owner) |
+| `subnet_invitation_accept(subnet_id, request_id)` | Accept invitation (invitee) |
+| `subnet_invitation_reject(subnet_id, request_id, *, note?)` | Reject invitation (invitee) |
+| `subnet_invitation_cancel(subnet_id, request_id, *, note?)` | Cancel invitation (owner) |
+| `subnet_invitation_list(subnet_id)` | List invitations (owner) |
+| `subnet_invitations_pending()` | Cross-subnet pending invitations (invitee) |
 
 #### Communication Methods
 
@@ -270,35 +295,3 @@ MIT
 - [ACN GitHub](https://github.com/acnlabs/ACN)
 - [Documentation](https://github.com/acnlabs/ACN#readme)
 - [Issues](https://github.com/acnlabs/ACN/issues)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -104,6 +104,9 @@ Options:
 | `unregisterAgent(agentId)` | Unregister an agent |
 | `heartbeat(agentId)` | Send heartbeat |
 | `getSkills()` | List all available skills |
+| `rotateApiKey(agentId)` | Rotate API key — old key invalidated immediately, new key returned once |
+| `getPolicy(agentId)` | Get own inbound communication policy |
+| `updatePolicy(agentId, mode, options?)` | Update inbound policy (`open`/`manifest`/`allowlist`/`closed`) |
 
 #### Subnet Methods
 
@@ -111,11 +114,33 @@ Options:
 |--------|-------------|
 | `listSubnets()` | List all subnets |
 | `getSubnet(subnetId)` | Get subnet by ID |
-| `createSubnet(request)` | Create a new subnet (you become the owner) |
+| `createSubnet(request)` | Create a new subnet (you become the owner); accepts `join_policy`, `parent_subnet_id`, `lifecycle`, `linked_task_id` |
 | `deleteSubnet(subnetId)` | Delete a subnet you own |
 | `getSubnetAgents(subnetId)` | Get agents in subnet |
-| `joinSubnet(agentId, subnetId)` | Join agent to subnet |
+| `joinSubnet(agentId, subnetId)` | Join agent to subnet (dispatches admission flow when `join_policy=approval`) |
 | `leaveSubnet(agentId, subnetId)` | Remove agent from subnet |
+| `listChildren(parentSubnetId)` | List immediate child subnets |
+| `promoteSubnet(subnetId)` | Promote `task_scoped` child to `persistent` (idempotent) |
+
+#### Subnet Admission Methods
+
+Only active on `join_policy=approval` subnets.
+
+| Method | Description |
+|--------|-------------|
+| `subnetAllowlistAdd(subnetId, agentId)` | Pre-authorise an agent (owner) |
+| `subnetAllowlistRemove(subnetId, agentId)` | Remove from allowlist — idempotent (owner) |
+| `subnetAllowlistList(subnetId)` | List allowlist entries (owner) |
+| `subnetJoinRequestApprove(subnetId, requestId, options?)` | Approve a pending join request (owner) |
+| `subnetJoinRequestReject(subnetId, requestId, options?)` | Reject a pending join request (owner) |
+| `subnetJoinRequestWithdraw(subnetId, requestId)` | Withdraw own pending join request (applicant) |
+| `subnetJoinRequestList(subnetId, options?)` | List join requests (owner) |
+| `subnetInvitationSend(subnetId, agentId, options?)` | Send invitation; auto-resolves if target has a pending join request (owner) |
+| `subnetInvitationAccept(subnetId, requestId)` | Accept invitation (invitee) |
+| `subnetInvitationReject(subnetId, requestId, options?)` | Reject invitation (invitee) |
+| `subnetInvitationCancel(subnetId, requestId, options?)` | Cancel invitation (owner) |
+| `subnetInvitationList(subnetId)` | List invitations (owner) |
+| `subnetInvitationsPending()` | Cross-subnet pending invitations (invitee) |
 
 #### Communication Methods
 
@@ -223,7 +248,7 @@ import type {
   AgentSearchOptions,
   PaymentCapability,
   WSMessage,
-} from '@acn/client';
+} from 'acn-client';
 ```
 
 ## Browser Support
@@ -241,35 +266,3 @@ MIT
 - [ACN GitHub](https://github.com/acnlabs/ACN)
 - [Documentation](https://github.com/acnlabs/ACN#readme)
 - [Issues](https://github.com/acnlabs/ACN/issues)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

Syncs all README files with features shipped in v0.11.0 (server / Python SDK / CLI) and v0.13.0 (TypeScript SDK) that were missing from the docs.

### README.md (root)
- Remove internal codename "Paperclip"
- Fix TypeScript import `@acn/client` → `acn-client`
- Registry API table: `rotate-key`, `communication_profile`, `policy` endpoints
- Subnet API table: `children`, `promote`, `harness`, full ADR-0004 admission surface (11 rows)
- Architecture diagram: mention PostgreSQL alongside Redis
- Multi-Subnet section: replace stale `subnet_ids` registration with correct `curl` calls

### clients/python/README.md
- Agent methods: `rotate_api_key`, `get_policy`, `update_policy`
- Subnet methods: `list_children`, `promote_subnet`, new `create_subnet` fields
- New **Subnet Admission Methods** table (13 methods)
- Fix `bearer_token` constructor comment (owner-scoped only)
- Remove 30+ trailing blank lines

### clients/typescript/README.md
- Agent methods: `rotateApiKey`, `getPolicy`, `updatePolicy`
- Subnet methods: `listChildren`, `promoteSubnet`, new `createSubnet` fields
- New **Subnet Admission Methods** table (13 camelCase methods)
- Fix type import `@acn/client` → `acn-client`
- Remove 30+ trailing blank lines

### clients/cli/README.md
- `acn subnet`: add `--join-policy/--parent/--lifecycle/--task` flags, `promote`, `harness`, full `allowlist/requests/invitations` sub-commands
- New `acn rotate-key` section
- `acn wallet`: full set (`set-capability`, `set-pricing`, `stats`, `tasks`, `estimate`)
- New `acn pay` section (`create`, `confirm`, `status`)

Made with [Cursor](https://cursor.com)