### PR TITLE
docs: fix residual package names, enum case, and missing task history method

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 ### TypeScript/JavaScript
 
 ```bash
-npm install @acn/client
+npm install acn-client
 ```
 
 ```typescript
@@ -180,7 +180,7 @@ const agent = await client.getAgent('my-agent');
 const { skills } = await client.getSkills();
 
 // Discover payment-capable agents
-const paymentAgents = await client.discoverPaymentAgents({ method: 'USDC' });
+const paymentAgents = await client.discoverPaymentAgents({ method: 'usdc' });
 
 // WebSocket real-time subscription
 const realtime = new ACNRealtime('ws://localhost:8000');

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -196,6 +196,7 @@ Only active on `join_policy=approval` subnets.
 | `approve_participation(task_id, participation_id, ...)` | Approve applicant (assigned mode) |
 | `reject_participation(task_id, participation_id, ...)` | Reject applicant (assigned mode) |
 | `cancel_participation(task_id, participation_id, ...)` | Withdraw from a task |
+| `get_agent_task_history(agent_id, limit?)` | Agent's full task history — submissions, review notes, resubmit counts |
 
 Task endpoints use `bearer_token` (Auth0 JWT) in production. In dev mode they fall back to `X-Creator-Id` header or the `dev@clients` identity.
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -142,6 +142,12 @@ Only active on `join_policy=approval` subnets.
 | `subnetInvitationList(subnetId)` | List invitations (owner) |
 | `subnetInvitationsPending()` | Cross-subnet pending invitations (invitee) |
 
+#### Task Methods
+
+| Method | Description |
+|--------|-------------|
+| `getAgentTaskHistory(agentId, limit?)` | Agent's full task history — submissions, review notes, resubmit counts |
+
 #### Communication Methods
 
 | Method | Description |

--- a/docs/api.md
+++ b/docs/api.md
@@ -690,7 +690,7 @@ async with ACNClient("http://localhost:8000") as client:
 ### TypeScript
 
 ```typescript
-import { ACNClient } from '@acn/client';
+import { ACNClient } from 'acn-client';
 
 const client = new ACNClient('http://localhost:8000');
 


### PR DESCRIPTION
## Changes

- **README.md** — `npm install @acn/client` → `acn-client` (consistent with other docs)
- **README.md** — `discoverPaymentAgents({ method: 'USDC' })` → `'usdc'` (lowercase enum, per 0.7.0 migration note)
- **docs/api.md** — `import { ACNClient } from '@acn/client'` → `'acn-client'`
- **clients/python/README.md** — add `get_agent_task_history` to Task Methods table
- **clients/typescript/README.md** — add Task Methods section with `getAgentTaskHistory`

Made with [Cursor](https://cursor.com)