### PR TITLE
ci: add version/CHANGELOG sync check job (D-5, issue #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,57 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ===========================================
+  # D-5: Version / CHANGELOG sync check
+  # Ensures pyproject.toml / package.json version has a matching dated
+  # entry in CHANGELOG.md. Prevents the "version was bumped but CHANGELOG
+  # only has [Unreleased]" drift (root-cause category from issue #73).
+  #
+  # Logic: if the package declares version X.Y.Z, then CHANGELOG.md must
+  # contain a "## [X.Y.Z]" line. Normal development PRs (no version bump)
+  # always pass because the current release version already has its entry.
+  # ===========================================
+  version-sync:
+    name: Version / CHANGELOG sync
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Python SDK (clients/python)
+        run: |
+          cd clients/python
+          PKG_VER=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if ! grep -qF "## [$PKG_VER]" CHANGELOG.md; then
+            echo "❌ clients/python: pyproject.toml version $PKG_VER has no matching '## [$PKG_VER]' entry in CHANGELOG.md"
+            echo "   Either add a dated CHANGELOG entry (release PR) or revert the version bump (dev PR)."
+            exit 1
+          fi
+          echo "✅ Python SDK $PKG_VER — in sync"
+
+      - name: Check TypeScript SDK (clients/typescript)
+        run: |
+          cd clients/typescript
+          PKG_VER=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+          if ! grep -qF "## [$PKG_VER]" CHANGELOG.md; then
+            echo "❌ clients/typescript: package.json version $PKG_VER has no matching '## [$PKG_VER]' entry in CHANGELOG.md"
+            echo "   Either add a dated CHANGELOG entry (release PR) or revert the version bump (dev PR)."
+            exit 1
+          fi
+          echo "✅ TypeScript SDK $PKG_VER — in sync"
+
+      - name: Check CLI (clients/cli)
+        run: |
+          cd clients/cli
+          PKG_VER=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+          if ! grep -qF "## [$PKG_VER]" CHANGELOG.md; then
+            echo "❌ clients/cli: package.json version $PKG_VER has no matching '## [$PKG_VER]' entry in CHANGELOG.md"
+            echo "   Either add a dated CHANGELOG entry (release PR) or revert the version bump (dev PR)."
+            exit 1
+          fi
+          echo "✅ CLI $PKG_VER — in sync"
+
+  # ===========================================
   # Integration — real-PG tests (opt-in)
   # Triggered by:
   #   • PR label "run-integration-tests"


### PR DESCRIPTION
Closes D-5 from #73.

## What this adds

New `version-sync` CI job in `ci.yml` (runs on every PR):

- Reads the declared version from each package (`pyproject.toml` / `package.json`)
- Checks that `CHANGELOG.md` contains a matching `## [X.Y.Z]` dated entry
- Fails with a clear error message if the entry is missing

**Behaviour by PR type:**

| PR type | Result |
|---------|--------|
| Normal feature PR (no version bump) | ✅ passes — current release version already has its CHANGELOG entry |
| Release PR with version bump + dated CHANGELOG entry | ✅ passes |
| Release PR with version bump but only `[Unreleased]` | ❌ fails — blocks the drift pattern from issue #73 |

## Verification

Tested locally against current repo state — all three packages (Python SDK 0.11.0, TypeScript SDK 0.13.0, CLI 0.11.0) pass.

## What's next
- B: `consumer-compat` CI job

Made with [Cursor](https://cursor.com)