### PR TITLE
fix(ci): use step output to detect CONSUMER_REPOS_PAT (fixes workflow file issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,22 @@ jobs:
           # Expose the installed SDK on the PATH-visible venv for the smoke step
           echo "CONSUMER_VENV=$(pwd)/.venv" >> $GITHUB_ENV
 
+      # Detect whether the PAT is configured. Secrets cannot be compared
+      # directly in step `if:` expressions; we expose it via a step output
+      # instead.
+      - name: Detect CONSUMER_REPOS_PAT availability
+        id: pat-check
+        run: |
+          if [ -n "$PAT" ]; then
+            echo "available=true"  >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          PAT: ${{ secrets.CONSUMER_REPOS_PAT }}
+
       - name: Fetch Agentplanet-backend SDK wrapper
-        if: ${{ secrets.CONSUMER_REPOS_PAT != '' }}
+        if: steps.pat-check.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ secrets.CONSUMER_REPOS_PAT }}
         run: |
@@ -339,7 +353,7 @@ jobs:
           echo "✅ Fetched Agentplanet-backend/app/services/acn_client.py"
 
       - name: Smoke test — Agentplanet-backend (Python)
-        if: ${{ secrets.CONSUMER_REPOS_PAT != '' }}
+        if: steps.pat-check.outputs.available == 'true'
         run: |
           $CONSUMER_VENV/bin/python3 - <<'PYEOF'
           import ast, sys
@@ -380,7 +394,7 @@ jobs:
           PYEOF
 
       - name: Skip notice — CONSUMER_REPOS_PAT not configured
-        if: ${{ secrets.CONSUMER_REPOS_PAT == '' }}
+        if: steps.pat-check.outputs.available != 'true'
         run: |
           echo "⚠️  CONSUMER_REPOS_PAT secret is not set."
           echo "   Consumer-compat checks were skipped. To enable full coverage:"


### PR DESCRIPTION
## Problem

Since PR #108 merged, **every `ci.yml` run on `main` fails with "workflow file issue" and 0 jobs executed** (runs taking 0 s).

Root cause: three step-level `if:` conditions used `secrets` context directly:

```yaml
if: ${{ secrets.CONSUMER_REPOS_PAT != '' }}
```

GitHub Actions **does not allow** comparing the `secrets` context in step `if:` expressions. The secret context is only supported in `env:` and `with:` fields. Using it in `if:` causes the entire workflow to be rejected before any job starts.

## Fix

Add a dedicated detection step `pat-check` that:
1. Reads the secret into a bash env var (`PAT:` field — the supported location)
2. Checks if the env var is non-empty in bash
3. Writes a `available=true/false` output

Subsequent steps use `steps.pat-check.outputs.available == 'true'` which is a plain string comparison — no `secrets` context involved.

## Verification

- `ci.yml` YAML passes `python -c "import yaml; yaml.safe_load(...)"` ✅
- No `secrets.*` context in any step `if:` condition ✅
- Secrets only appear in `env:` fields (supported) ✅

Made with [Cursor](https://cursor.com)