### PR TITLE
fix(cli): read version from package.json instead of hardcoding 0.1.0

### DIFF
--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -1,4 +1,6 @@
 import { Command } from 'commander';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { version } = require('../package.json') as { version: string };
 import { setJsonMode } from './output.js';
 import { configCommand } from './commands/config.js';
 import { joinCommand } from './commands/join.js';
@@ -20,7 +22,7 @@ const program = new Command();
 program
   .name('acn')
   .description('ACN CLI — Agent Collaboration Network command-line interface')
-  .version('0.1.0')
+  .version(version)
   .option('--json', 'Output raw JSON (useful for agent parsing)')
   .hook('preAction', (thisCommand) => {
     const opts = thisCommand.opts() as { json?: boolean };


### PR DESCRIPTION
`acn --version` 输出的是硬编码的 `0.1.0`，而不是 `package.json` 中的实际版本（当前 `0.11.0`）。

## 修复

用 `require('../package.json')` 动态读取版本，`package.json` 成为唯一版本真源。后续每次 bump 版本只需改 `package.json`，CLI 输出自动跟进。

CLI 使用 `CommonJS` 模块（`tsconfig.json` 中 `"module": "CommonJS"`），故使用 `require()` 而非 `import.meta`。

## 验证

```
npm run typecheck  ✅
```

Made with [Cursor](https://cursor.com)