### PR TITLE
Enforce parent ACL for child subnet creation

### DIFF
--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -251,6 +251,8 @@ class SubnetService:
           (defence in depth) any subnet whose owner is ``system``.
         - Parent's own ``parent_slug`` must be ``None`` (single-
           layer cap) — ``parent_is_nested``.
+        - Child creator must be the parent owner or one of the
+          parent's current members — ``not_parent_member``.
         - ``lifecycle == "task_scoped"`` requires
           ``linked_task_id`` to be set — ``task_scoped_requires_linked_task``.
         - ``linked_task_id`` must reference an existing task when a
@@ -295,7 +297,7 @@ class SubnetService:
 
         Raises:
             ValueError: If subnet already exists
-            SubnetInvariantError: On any of the five ADR-0003 invariant
+            SubnetInvariantError: On any ADR-0003 invariant
                 rejections, or the ADR-0004
                 ``visibility_policy_conflict`` rejection.
         """
@@ -351,6 +353,13 @@ class SubnetService:
                     REASON_PARENT_IS_NESTED,
                     f"Parent subnet '{parent_slug}' is itself nested; "
                     "single-layer cap enforced",
+                )
+            # Child-subnet ACL: only the parent owner or a current parent
+            # member may create a child under that parent.
+            if owner != parent.owner and owner not in parent.member_agent_ids:
+                raise SubnetInvariantError(
+                    REASON_NOT_PARENT_MEMBER,
+                    "child subnet creator must be the parent owner or a parent member",
                 )
 
         if linked_task_id is not None and self.task_repository is not None:
@@ -412,17 +421,10 @@ class SubnetService:
         # time so harness bootstrap (create_subnet → register_harness →
         # create_task) works without a follow-up join_subnet hack.
         #
-        # Child-subnet edge case: the membership-subset invariant
-        # (``add_member`` rejects non-parent members) is *not* tripped
-        # here because the owner-add bypasses ``SubnetService.add_member``
-        # by calling the entity method directly. For a child subnet to
-        # be useful, the owner must already be a parent member —
-        # otherwise the only person who can do anything in the squad
-        # (the owner) cannot widen its membership. We deliberately do
-        # NOT enforce this at create-time: an owner who creates a
-        # child subnet they're not in is a valid governance pattern
-        # (delegated admin), and the membership-subset invariant
-        # naturally limits what they can do afterward.
+        # Child-subnet ACL is enforced above (owner must be parent owner
+        # or parent member). We still bypass ``add_member`` here because
+        # this is the initial owner bootstrap write, not a membership
+        # mutation requested against an existing child subnet.
         subnet.add_member(owner)
 
         logger.info(

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -5,10 +5,11 @@ Pins the six subnet-create invariant rejection variants on
 filter, the new ``GET /api/v1/subnets/{id}/children`` endpoint, and
 the new ``POST /api/v1/subnets/{id}/promote`` endpoint.
 
-Each rejection variant pins ``error_code = "invalid_request"`` AND a
-stable ``details.reason`` string that the CLI / SDK error parsers
-match against — these names are part of the public contract and
-shouldn't drift.
+Each rejection variant pins its expected ``error_code`` (mostly
+``invalid_request``, with ``not_parent_member`` mapped to
+``not_subnet_member``) AND a stable ``details.reason`` string that
+the CLI / SDK error parsers match against — these names are part of
+the public contract and shouldn't drift.
 """
 
 from __future__ import annotations

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -1,6 +1,6 @@
 """Route-level contract tests for ADR-0003 Phase 2.
 
-Pins the five ``INVALID_REQUEST`` rejection variants on
+Pins the six subnet-create invariant rejection variants on
 ``POST /api/v1/subnets``, the new ``GET /api/v1/subnets?parent=<id>``
 filter, the new ``GET /api/v1/subnets/{id}/children`` endpoint, and
 the new ``POST /api/v1/subnets/{id}/promote`` endpoint.
@@ -97,7 +97,7 @@ def _wire(agent_svc, subnet_svc) -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST /api/v1/subnets — five rejection variants + happy path
+# POST /api/v1/subnets — invariant rejection variants + happy path
 # ---------------------------------------------------------------------------
 
 
@@ -106,10 +106,9 @@ _REASON_ERROR_CODE_MAP: dict[str, tuple[int, str]] = {
     REASON_PARENT_NOT_FOUND: (400, "invalid_request"),
     REASON_PARENT_IS_RESERVED: (400, "invalid_request"),
     REASON_PARENT_IS_NESTED: (400, "invalid_request"),
+    REASON_NOT_PARENT_MEMBER: (403, "not_subnet_member"),
     REASON_TASK_SCOPED_REQUIRES_LINKED_TASK: (400, "invalid_request"),
     REASON_LINKED_TASK_NOT_FOUND: (400, "invalid_request"),
-    # not_parent_member maps to 403 NOT_SUBNET_MEMBER, see the
-    # admin_add_subnet_member test below.
 }
 
 
@@ -132,8 +131,12 @@ def test_create_subnet_invariant_rejection(reason, stub_agent_service):
     # Send a body shape that *could* plausibly produce each reason —
     # the stub raises regardless, but a realistic payload helps the
     # contract test document each variant's intended call site.
-    if reason in {REASON_PARENT_NOT_FOUND, REASON_PARENT_IS_RESERVED,
-                  REASON_PARENT_IS_NESTED}:
+    if reason in {
+        REASON_PARENT_NOT_FOUND,
+        REASON_PARENT_IS_RESERVED,
+        REASON_PARENT_IS_NESTED,
+        REASON_NOT_PARENT_MEMBER,
+    }:
         body["parent_slug"] = "some-parent"
     if reason == REASON_TASK_SCOPED_REQUIRES_LINKED_TASK:
         body["lifecycle"] = "task_scoped"

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -144,7 +144,7 @@ class TestCreateSubnetNestingInvariants:
         """Child creator must be parent owner or parent member."""
         mock_subnet_repository.exists.return_value = False
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="parent-1",
+            slug="parent-1",
             owner="alice",
             members={"alice"},  # mallory is NOT a parent member
         )
@@ -152,10 +152,10 @@ class TestCreateSubnetNestingInvariants:
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="child-1",
+                slug="child-1",
                 name="Squad",
                 owner="mallory",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
             )
         assert exc.value.reason == REASON_NOT_PARENT_MEMBER
         mock_subnet_repository.save.assert_not_called()
@@ -266,20 +266,20 @@ class TestCreateSubnetNestingInvariants:
         """Parent member (not owner) may create a child subnet."""
         mock_subnet_repository.exists.return_value = False
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="parent-1",
+            slug="parent-1",
             owner="alice",
             members={"alice", "bob"},
         )
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="squad-2",
+            slug="squad-2",
             name="Bug Squad 2",
             owner="bob",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
         )
 
-        assert subnet.parent_subnet_id == "parent-1"
+        assert subnet.parent_slug == "parent-1"
         assert "bob" in subnet.member_agent_ids
         mock_subnet_repository.save.assert_awaited_once()
 

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -48,7 +48,7 @@ def _make_parent_subnet(
 
 
 # ---------------------------------------------------------------------------
-# create_subnet — five invariant rejections
+# create_subnet — invariant rejections
 # ---------------------------------------------------------------------------
 
 
@@ -136,6 +136,29 @@ class TestCreateSubnetNestingInvariants:
                 parent_slug="mid-level",
             )
         assert exc.value.reason == REASON_PARENT_IS_NESTED
+
+    @pytest.mark.asyncio
+    async def test_parent_acl_rejects_creator_outside_parent(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Child creator must be parent owner or parent member."""
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="parent-1",
+            owner="alice",
+            members={"alice"},  # mallory is NOT a parent member
+        )
+        service = SubnetService(mock_subnet_repository)
+
+        with pytest.raises(SubnetInvariantError) as exc:
+            await service.create_subnet(
+                subnet_id="child-1",
+                name="Squad",
+                owner="mallory",
+                parent_subnet_id="parent-1",
+            )
+        assert exc.value.reason == REASON_NOT_PARENT_MEMBER
+        mock_subnet_repository.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_task_scoped_requires_linked_task(
@@ -234,6 +257,30 @@ class TestCreateSubnetNestingInvariants:
         assert subnet.linked_task_id == "task-42"
         # Owner-as-member invariant preserved for child subnets too.
         assert "alice" in subnet.member_agent_ids
+        mock_subnet_repository.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_child_subnet_created_by_parent_member(
+        self, mock_subnet_repository: ISubnetRepository
+    ):
+        """Parent member (not owner) may create a child subnet."""
+        mock_subnet_repository.exists.return_value = False
+        mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
+            subnet_id="parent-1",
+            owner="alice",
+            members={"alice", "bob"},
+        )
+        service = SubnetService(mock_subnet_repository)
+
+        subnet = await service.create_subnet(
+            subnet_id="squad-2",
+            name="Bug Squad 2",
+            owner="bob",
+            parent_subnet_id="parent-1",
+        )
+
+        assert subnet.parent_subnet_id == "parent-1"
+        assert "bob" in subnet.member_agent_ids
         mock_subnet_repository.save.assert_awaited_once()
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

- Enforces child-subnet creation ACL in `SubnetService.create_subnet`: creator must be either the parent subnet owner or a current parent member.
- Reuses existing `not_parent_member` invariant so route-level error mapping remains structured (`403 not_subnet_member`).
- Adds/updates tests to cover the new reject/allow branches at service level and route invariant-contract mapping.
- Follow-up cleanup: fixes a stale route-test docstring that incorrectly stated every create invariant maps to `invalid_request`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Tests (adding or updating tests)
- [ ] 📦 Dependencies (updating dependencies)

## Related Issues

Closes #

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation (if needed)

## SDK Changes

- [ ] TypeScript SDK (`clients/typescript/`)
- [ ] Python SDK (`clients/python/`)
- [x] N/A - No SDK changes

## Screenshots (if applicable)

- N/A

## Test Notes

- ✅ `uv run pytest tests/services/test_subnet_service_nesting.py -q`
- ⚠️ `uv run pytest tests/services/test_subnet_service_nesting.py tests/routes/test_subnets_nesting.py tests/routes/test_subnets_error_schema.py -q` fails in this cloud environment because Redis dependency cannot be started (`docker-compose` unavailable, Docker daemon access denied), so route tests that boot app lifespan fail on Redis connection.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec533f13-596f-4027-a731-435750491484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec533f13-596f-4027-a731-435750491484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

