### PR TITLE
feat(auth): ACL contract V6 foundation (B0 + B1) — production dual-protocol

### DIFF
--- a/acn/auth/middleware.py
+++ b/acn/auth/middleware.py
@@ -324,7 +324,24 @@ async def verify_token(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
 ) -> dict:
-    """FastAPI dependency: verify Bearer token and return JWT payload."""
+    """FastAPI dependency: verify Bearer token and return a payload.
+
+    Production traffic is dual-protocol:
+
+    - ``Authorization: Bearer <jwt>`` — auth0-issued user JWT, verified
+      against the JWKS, returns ``{"sub": user_sub, "type": "user", ...}``.
+    - ``Authorization: Bearer acn_<api_key>`` — agent API key, resolved
+      to the owning agent's UUID, returns
+      ``{"sub": agent_id, "type": "agent", "permissions": ["acn:read", "acn:write"]}``.
+
+    The ``acn_`` prefix is the protocol discriminator: prefix-dispatch
+    keeps API-key traffic from polluting JWT failure audit logs and
+    avoids paying a Redis lookup on every JWT request. API-key callers
+    do **not** receive ``acn:admin`` — that permission is auth0 / user-
+    domain only by design (issue #114 §3.2 admin row).
+
+    See ADR-0006 (issue #114) for the V6 ACL contract this enables.
+    """
     settings = _get_settings()
 
     if settings.dev_mode:
@@ -343,7 +360,11 @@ async def verify_token(
                 "permissions": ["acn:read", "acn:write", "acn:admin"],
             }
         sub = credentials.credentials if credentials is not None else "dev@clients"
-        return {"sub": sub, "permissions": ["acn:read", "acn:write", "acn:admin"]}
+        return {
+            "sub": sub,
+            "type": "user",
+            "permissions": ["acn:read", "acn:write", "acn:admin"],
+        }
 
     if credentials is None:
         path, method = _request_path(request)
@@ -359,7 +380,43 @@ async def verify_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    return await _verify_jwt(credentials.credentials, request=request)
+    token = credentials.credentials
+
+    # Production dual-protocol dispatch: ``acn_*`` prefix → API-key path,
+    # everything else → JWT path. Prefix dispatch (rather than try-JWT-
+    # then-fallback) keeps API-key traffic out of the JWT failure audit
+    # log and surfaces precise error reasons per protocol.
+    if token.startswith("acn_"):
+        resolved = await _resolve_agent_id_from_api_key(token)
+        if resolved is not None:
+            return {
+                "sub": resolved,
+                "type": "agent",
+                # API key callers never receive ``acn:admin``. Admin is
+                # an auth0 / user-domain permission (ops, SRE) that
+                # transcends the marketplace. Agents requiring elevated
+                # ops access must go through a human admin's JWT.
+                "permissions": ["acn:read", "acn:write"],
+            }
+        path, method = _request_path(request)
+        record_auth_failure(
+            reason="api_key_invalid",
+            source_ip=_peer_ip(request),
+            path=path,
+            method=method,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = await _verify_jwt(token, request=request)
+    # Standardise payload schema: every successful auth returns ``type``
+    # so downstream ACL code can branch user-bridge vs agent-direct
+    # without re-sniffing the token format.
+    payload.setdefault("type", "user")
+    return payload
 
 
 def require_permission(permission: str):
@@ -423,7 +480,11 @@ def require_internal_or_permission(permission: str):
                     "permissions": ["acn:read", "acn:write", "acn:admin"],
                 }
             sub = credentials.credentials if credentials is not None else "dev@clients"
-            return {"sub": sub, "permissions": ["acn:read", "acn:write", "acn:admin"]}
+            return {
+                "sub": sub,
+                "type": "user",
+                "permissions": ["acn:read", "acn:write", "acn:admin"],
+            }
 
         # Internal token: trusted backend service call. Use constant-time
         # comparison to avoid timing-side-channel leaks of token contents.
@@ -434,6 +495,7 @@ def require_internal_or_permission(permission: str):
         ):
             return {
                 "sub": "backend@internal",
+                "type": "internal",
                 "permissions": ["acn:read", "acn:write", "acn:admin"],
             }
 

--- a/tests/auth/test_middleware_production_dual_protocol.py
+++ b/tests/auth/test_middleware_production_dual_protocol.py
@@ -1,0 +1,301 @@
+"""Production dual-protocol behaviour for ``verify_token`` and
+``require_internal_or_permission`` (issue #114 Scope A B1).
+
+Pre-V6 the production branch of ``verify_token`` only accepted JWTs —
+agents calling ACL-gated read endpoints (``GET /api/v1/subnets/{id}``,
+``DELETE /api/v1/subnets/{id}``, …) with their ``acn_*`` API key were
+401'd before reaching the ACL. PR #112 documented an "owner / member /
+admin" privacy contract that consequently never fired in production for
+any caller except ``acn:admin``.
+
+This file pins the V6 dual-protocol behaviour:
+
+- ``Bearer <jwt>`` → JWT path, payload carries ``"type": "user"``.
+- ``Bearer acn_<api_key>`` → API-key path, payload carries
+  ``"type": "agent"`` and **no** ``acn:admin`` permission.
+- Invalid ``acn_*`` key → 401 with a precise audit reason
+  (``api_key_invalid``), not a JWT failure.
+- Missing credentials → 401 ``bearer_missing`` (unchanged).
+
+Tests deliberately stay below the FastAPI HTTP layer so they exercise
+the dispatch logic directly. ``_verify_jwt`` and
+``_resolve_agent_id_from_api_key`` are stubbed; only the prefix-dispatch
++ payload-shape contract is under test here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from acn.auth import middleware as mw
+from acn.core.entities import Agent
+
+
+def _make_agent(agent_id: str = "agent-uuid-prod") -> Agent:
+    return Agent(
+        agent_id=agent_id,
+        owner="user-1",
+        name="Prod Agent",
+        endpoint="https://agent.example.com",
+        description="x",
+        tags=[],
+        subnet_ids=[],
+        metadata={},
+    )
+
+
+def _bearer(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _stub_request() -> MagicMock:
+    return MagicMock(name="Request")
+
+
+@pytest.fixture(autouse=True)
+def _force_prod_mode(monkeypatch):
+    """Pin production mode regardless of env state — these tests are
+    *about* what the production branch does."""
+    fake_settings = MagicMock()
+    fake_settings.dev_mode = False
+    fake_settings.internal_api_token = "x" * 32
+    fake_settings.auth0_domain = "test.auth0.com"
+    fake_settings.auth0_audience = "test-audience"
+    monkeypatch.setattr(mw, "_get_settings", lambda: fake_settings)
+    return fake_settings
+
+
+def _patch_agent_service(monkeypatch, *, returns: Agent | None):
+    service = MagicMock()
+    service.get_agent_by_api_key = AsyncMock(return_value=returns)
+
+    from acn.routes import dependencies as deps
+
+    monkeypatch.setattr(deps, "get_agent_service", lambda: service)
+    return service
+
+
+def _patch_verify_jwt(monkeypatch, payload: dict | Exception):
+    """Stub ``_verify_jwt`` to return ``payload`` (or raise it if it's
+    an exception). The real JWKS / Auth0 path is unrelated to the
+    dispatch contract under test."""
+    if isinstance(payload, Exception):
+        async def _raise(*args, **kwargs):
+            raise payload
+        monkeypatch.setattr(mw, "_verify_jwt", _raise)
+    else:
+        async def _return(*args, **kwargs):
+            return payload
+        monkeypatch.setattr(mw, "_verify_jwt", _return)
+
+
+# ---------------------------------------------------------------------------
+# verify_token: API-key path (acn_* prefix)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenApiKeyPath:
+    @pytest.mark.asyncio
+    async def test_valid_api_key_returns_agent_payload(self, monkeypatch):
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-prod-1"))
+
+        payload = await mw.verify_token(_stub_request(), _bearer("acn_valid"))
+
+        assert payload["sub"] == "agent-prod-1"
+        assert payload["type"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_api_key_payload_excludes_admin_permission(self, monkeypatch):
+        """Agents authenticating via API key must NOT receive
+        ``acn:admin``. Admin is a user-domain platform permission
+        (ops / SRE) that does not flow through the marketplace —
+        an agent that 'self-elevates' to admin via its own API key
+        would defeat the auth0 / role-based admin model entirely.
+        """
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-prod-2"))
+
+        payload = await mw.verify_token(_stub_request(), _bearer("acn_valid"))
+
+        assert "acn:admin" not in payload["permissions"]
+        assert set(payload["permissions"]) == {"acn:read", "acn:write"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_api_key_raises_401_with_api_key_reason(
+        self, monkeypatch
+    ):
+        """Unknown ``acn_*`` token: must 401 cleanly (not silently fall
+        back to JWT, which would emit a misleading
+        ``jwt_invalid`` audit row for what is really a stale or
+        revoked API key)."""
+        _patch_agent_service(monkeypatch, returns=None)
+
+        with pytest.raises(HTTPException) as excinfo:
+            await mw.verify_token(_stub_request(), _bearer("acn_revoked"))
+
+        assert excinfo.value.status_code == 401
+        assert "Invalid API key" in excinfo.value.detail
+
+    @pytest.mark.asyncio
+    async def test_api_key_path_does_not_invoke_jwt_verification(
+        self, monkeypatch
+    ):
+        """Prefix dispatch — ``acn_*`` traffic must not reach
+        ``_verify_jwt`` and pollute its audit log with synthetic
+        ``jwt_invalid`` rows."""
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-prod-3"))
+        jwt_calls: list[str] = []
+
+        async def _spy(*args, **kwargs):
+            jwt_calls.append(args[0] if args else "")
+            return {"sub": "should-never-be-returned"}
+
+        monkeypatch.setattr(mw, "_verify_jwt", _spy)
+
+        await mw.verify_token(_stub_request(), _bearer("acn_x"))
+
+        assert jwt_calls == [], "API-key path must not call _verify_jwt"
+
+
+# ---------------------------------------------------------------------------
+# verify_token: JWT path (default)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenJwtPath:
+    @pytest.mark.asyncio
+    async def test_valid_jwt_returns_user_typed_payload(self, monkeypatch):
+        _patch_verify_jwt(
+            monkeypatch,
+            {"sub": "auth0|user-123", "permissions": ["acn:read"]},
+        )
+
+        payload = await mw.verify_token(_stub_request(), _bearer("eyJhbGciOi.fake"))
+
+        assert payload["sub"] == "auth0|user-123"
+        assert payload["type"] == "user"
+        assert payload["permissions"] == ["acn:read"]
+
+    @pytest.mark.asyncio
+    async def test_jwt_path_preserves_existing_type_field(self, monkeypatch):
+        """If ``_verify_jwt`` (or some intermediate JWT enricher) ever
+        attaches its own ``type`` field, ``verify_token`` must not
+        overwrite it — ``setdefault`` is the correct primitive here."""
+        _patch_verify_jwt(
+            monkeypatch,
+            {"sub": "auth0|x", "type": "service", "permissions": []},
+        )
+
+        payload = await mw.verify_token(_stub_request(), _bearer("jwt-with-type"))
+
+        assert payload["type"] == "service"
+
+    @pytest.mark.asyncio
+    async def test_invalid_jwt_propagates_401(self, monkeypatch):
+        """Non-prefixed garbage falls through to the JWT path; failure
+        is reported as a JWT error (not an API-key error)."""
+        _patch_verify_jwt(
+            monkeypatch,
+            HTTPException(status_code=401, detail="Invalid token."),
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await mw.verify_token(_stub_request(), _bearer("garbage"))
+
+        assert excinfo.value.status_code == 401
+        assert "Invalid token" in excinfo.value.detail
+
+
+# ---------------------------------------------------------------------------
+# verify_token: missing credentials
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenMissingCredentials:
+    @pytest.mark.asyncio
+    async def test_no_credentials_raises_401_bearer_missing(self):
+        with pytest.raises(HTTPException) as excinfo:
+            await mw.verify_token(_stub_request(), None)
+
+        assert excinfo.value.status_code == 401
+        assert "Authorization header required" in excinfo.value.detail
+        assert excinfo.value.headers == {"WWW-Authenticate": "Bearer"}
+
+
+# ---------------------------------------------------------------------------
+# require_internal_or_permission: production branches
+# ---------------------------------------------------------------------------
+
+
+class TestRequireInternalOrPermissionProduction:
+    @pytest.mark.asyncio
+    async def test_internal_token_payload_has_internal_type(self, monkeypatch):
+        """Internal-token branch returns a synthetic payload — V6 ACL
+        code branches on ``payload["type"]`` so it must carry a
+        non-user, non-agent discriminator (``"internal"``)."""
+        _patch_verify_jwt(monkeypatch, {"sub": "should-not-reach-jwt"})
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), None, "x" * 32)
+
+        assert payload["sub"] == "backend@internal"
+        assert payload["type"] == "internal"
+        assert "acn:admin" in payload["permissions"]
+
+    @pytest.mark.asyncio
+    async def test_jwt_with_permission_passes(self, monkeypatch):
+        _patch_verify_jwt(
+            monkeypatch,
+            {"sub": "auth0|alice", "permissions": ["acn:write"]},
+        )
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), _bearer("eyJ.fake"), None)
+
+        assert payload["sub"] == "auth0|alice"
+        assert payload["type"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_jwt_missing_permission_403s(self, monkeypatch):
+        _patch_verify_jwt(
+            monkeypatch,
+            {"sub": "auth0|bob", "permissions": ["acn:read"]},
+        )
+        checker = mw.require_internal_or_permission("acn:write")
+
+        with pytest.raises(HTTPException) as excinfo:
+            await checker(_stub_request(), _bearer("eyJ.fake"), None)
+
+        assert excinfo.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_api_key_propagates_through_verify_token(self, monkeypatch):
+        """``require_internal_or_permission`` delegates to
+        ``verify_token`` for the JWT/API-key branch — make sure the
+        dual-protocol contract carries through (no extra patch
+        needed; just confirm the agent payload reaches the
+        permission check)."""
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-rip"))
+        checker = mw.require_internal_or_permission("acn:write")
+
+        payload = await checker(_stub_request(), _bearer("acn_x"), None)
+
+        assert payload["sub"] == "agent-rip"
+        assert payload["type"] == "agent"
+        # Agent has acn:write, so the permission check passes.
+        assert "acn:write" in payload["permissions"]
+
+    @pytest.mark.asyncio
+    async def test_api_key_lacks_admin_403s_when_admin_required(self, monkeypatch):
+        """Closes the self-elevation hole: an agent's API key must not
+        unlock ``acn:admin``-gated endpoints."""
+        _patch_agent_service(monkeypatch, returns=_make_agent("agent-rip-admin"))
+        checker = mw.require_internal_or_permission("acn:admin")
+
+        with pytest.raises(HTTPException) as excinfo:
+            await checker(_stub_request(), _bearer("acn_x"), None)
+
+        assert excinfo.value.status_code == 403


### PR DESCRIPTION
First PR of the V6 ACL follow-up tracked in #114. Scope is intentionally minimal — just the auth foundation (B0 + B1) so it can be reviewed and merged on its own merits before the contract changes (B2–B12) layer on top.

## What this fixes

PR #112 documented an "owner / member / admin sees full SubnetInfo" privacy contract for `GET /api/v1/subnets/{id}`. Issue #114 §1 audits the production behaviour and finds that contract **never fires for any real caller except `acn:admin`** because:

- `subnet.owner` is an `agent_id` (UUID space)
- `verify_token` in production only accepts JWT, so agents using their `acn_*` API key 401 before reaching the ACL
- User JWT `sub` lives in user-id space and never matches `subnet.owner`

This PR closes the second of those gaps — the auth dispatcher itself. After this lands, agents authenticating with their API key in production reach ACL code paths with `payload["sub"] == agent_id`, which is the contract every ACL in `acn/routes/subnets.py` already assumes (and which #112's existing tests pin under `monkeypatch.setattr(verify_token, ...)` mocks). Subsequent PRs (B2–B12) will adjust the ACL implementations themselves so user-JWT callers receive the correct read knowledge through their ownership chain.

## Changes

### B0 — Audit only, no code change

`acn/config.py` already defends against the dev-mode register endpoint being reachable in production:

- `dev_mode: bool = False` default (L131)
- `_DEV_MODE_ALLOWED_HOSTS = {"localhost", "127.0.0.1", "::1"}`: dev-mode startup refuses non-loopback bind (L18 + L366-368)
- Production (`dev_mode=False`) requires Auth0 (L353-354)
- Internal API token enforced `>=32` chars regardless of dev_mode (L324-326)

The production register endpoint (`registry.py` L605-633) additionally enforces `request.owner == token_owner` via `require_permission("acn:write")` + L619 explicit match. `agent.owner` is therefore non-forgeable in production. **No code change in this PR for B0.**

### B1 — `verify_token` dual-protocol

Production traffic now dispatches by Bearer prefix:

| Bearer | Path | Payload |
|---|---|---|
| `acn_<api_key>` valid | API-key resolve | `{sub: agent_id, type: "agent", permissions: [acn:read, acn:write]}` |
| `acn_<api_key>` invalid | n/a | `401 api_key_invalid` (clean per-protocol error reason) |
| Other (JWT-shaped) | `_verify_jwt` | `{..., type: "user"}` (`setdefault` so existing `type` claims survive) |
| No credentials | n/a | `401 bearer_missing` (unchanged) |

Two non-obvious decisions documented inline:

1. **Prefix dispatch over try-JWT-then-fallback.** Most production traffic is JWT; running JWT first and falling back to API-key resolution would emit `jwt_invalid` audit rows for what are really stale/revoked API keys. Prefix dispatch keeps the audit trail clean per protocol.
2. **API-key payloads never carry `acn:admin`.** Admin is an auth0 / user-domain platform permission (ops, SRE) that does not flow through the marketplace. An agent that could self-elevate to admin via its own API key would defeat the role-based admin model. Test `test_api_key_lacks_admin_403s_when_admin_required` pins this.

`require_internal_or_permission` gets the same payload-schema treatment: internal-token branch returns `type: "internal"` so V6 ACL code can branch user/agent/internal cleanly.

## Tests

13 new tests in `tests/auth/test_middleware_production_dual_protocol.py` covering the production dispatch matrix:

- API-key path: valid → agent payload; invalid → `401 api_key_invalid`; admin permission excluded; `_verify_jwt` not invoked (audit-log isolation pinned)
- JWT path: valid → `type=user`; existing `type` field preserved (`setdefault`); `401` propagation
- Missing credentials: `401 bearer_missing` with `WWW-Authenticate: Bearer` header
- `require_internal_or_permission`: internal token `type=internal`; JWT permission gate; agent API-key permission gate; `acn:admin` requirement 403s API-key callers

Local validation (33 auth + 11 PR #112 subnet privacy = 44 ACL-path tests green; ruff clean). Full `tests/routes/` suite was not run end-to-end locally due to runtime; relying on CI for the broader sweep.

## What this does NOT do

This PR deliberately stops at the auth dispatcher. The ACL implementations in `acn/routes/subnets.py` are unchanged — they still rely on `requester == subnet.owner` and `requester in member_agent_ids` predicates. After B1, agents calling via API key reach those predicates with the right `sub` value, but **user-JWT callers still don't traverse the ownership chain to `subnet.owner`**. That's B2 / B5 / B12 in the next PR.

In other words: this PR makes #112 work for agent-via-API-key callers in production. User-JWT callers remain locked out of private subnets they own (through their agents) until the contract PR lands.

## Tracks

- #114 — full V6 contract scope
- #112 — original privacy stub PR (merged), whose ACL this PR partially unbreaks
