### PR TITLE
feat(acl): V6 caller-aware rendering — B2 ownership chain + B5 list + B6 parent-slug + B12 member-list

### DIFF
--- a/acn/models.py
+++ b/acn/models.py
@@ -406,9 +406,30 @@ class SubnetInfo(BaseModel):
     # surfaced so consumers can render "auto-dissolving" UX hints
     # and so prospective joiners can avoid task_scoped squads
     # they'd rather not be auto-removed from.
+    #
+    # Privacy (ACL V6 / issue #114 B6): ``parent_subnet_id`` (the
+    # human-readable slug) is intentionally suppressed in API responses
+    # from ``_subnet_entity_to_info`` — the route always emits ``None``.
+    # Suppressing the slug prevents a public child subnet from leaking
+    # its private parent's naming convention to anonymous callers.
+    # Consumers needing the parent relationship use ``parent_id``
+    # (the opaque UUID below) and call ``GET /subnets/{parent_id}``
+    # to resolve the slug under their own access level.
     parent_subnet_id: str | None = Field(
         None,
-        description="Parent subnet ID for a child subnet (ADR-0003). None for top-level subnets.",
+        description=(
+            "Deprecated — always None in responses from the routes layer "
+            "(ACL V6 B6). Use parent_id (UUID) instead."
+        ),
+    )
+    parent_id: str | None = Field(
+        None,
+        description=(
+            "Parent subnet's opaque UUID (ACL V6 B6). "
+            "None for top-level subnets. "
+            "Mirrors SubnetStub.parent_id so graph clients can join "
+            "SubnetInfo and SubnetStub rows by a single stable key."
+        ),
     )
     lifecycle: Literal["persistent", "task_scoped"] = Field(
         "persistent",

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -82,13 +82,19 @@ def _coerce_lifecycle(value: object) -> Literal["persistent", "task_scoped"]:
     return "persistent"
 
 
-def _subnet_entity_to_info(subnet) -> SubnetInfo:
+def _subnet_entity_to_info(subnet, *, parent_uuid: str | None = None) -> SubnetInfo:
     """Convert Subnet entity to SubnetInfo model.
 
-    ADR-0003 surfaces ``parent_subnet_id`` / ``lifecycle`` /
-    ``linked_task_id`` so consumers can render hierarchy / lifecycle
-    UI hints. ``harness_secret`` stays write-only — never exposed
-    through this conversion.
+    ADR-0003 hierarchy fields:
+    - ``parent_id`` carries the parent subnet's **opaque UUID** (ACL V6
+      B6). The human-readable ``parent_subnet_id`` slug is intentionally
+      suppressed to prevent a public child subnet from leaking its
+      private parent's naming convention to anonymous callers. Callers
+      pass the resolved UUID via the ``parent_uuid`` keyword argument;
+      the route is responsible for resolving slug → UUID before calling
+      this function.
+    - ``lifecycle`` / ``linked_task_id`` are surfaced as-is.
+    - ``harness_secret`` stays write-only — never exposed.
     """
     return SubnetInfo(
         subnet_id=subnet.subnet_id,
@@ -107,14 +113,77 @@ def _subnet_entity_to_info(subnet) -> SubnetInfo:
         metadata=subnet.metadata,
         harness_url=subnet.harness_url,
         harness_registered=subnet.harness_url is not None,
-        parent_subnet_id=_coerce_optional_str(
-            getattr(subnet, "parent_subnet_id", None)
-        ),
+        # parent_subnet_id (slug) is always None in API responses — ACL V6 B6.
+        parent_subnet_id=None,
+        parent_id=parent_uuid,
         lifecycle=_coerce_lifecycle(getattr(subnet, "lifecycle", "persistent")),
         linked_task_id=_coerce_optional_str(
             getattr(subnet, "linked_task_id", None)
         ),
     )
+
+
+async def _resolve_parent_uuid(
+    subnet,
+    subnet_service,
+) -> str | None:
+    """Return the parent subnet's opaque UUID, or None if top-level / orphaned.
+
+    Resolves the slug stored in ``subnet.parent_subnet_id`` to the stable
+    UUID needed by ``_subnet_entity_to_info`` (ACL V6 B6).  Silently
+    degrades to ``None`` on lookup failure so orphaned references don't
+    surface a 500 to callers.
+    """
+    parent_slug = _coerce_optional_str(getattr(subnet, "parent_subnet_id", None))
+    if not parent_slug:
+        return None
+    try:
+        parent_entity = await subnet_service.get_subnet(parent_slug)
+        return _coerce_optional_str(getattr(parent_entity, "id", None))
+    except Exception:  # noqa: BLE001  # SubnetNotFound or any infra error
+        return None
+
+
+async def _resolve_caller_access(
+    payload: dict,
+    subnet,
+    agent_service,
+) -> bool:
+    """Return True when the caller is entitled to see full SubnetInfo.
+
+    Implements the V6 ownership-chain bridge (ACL V6 / issue #114 B2):
+
+    - ``acn:admin`` always gets full access.
+    - Agent API key callers (``type == "agent"``): full access when
+      ``sub == subnet.owner`` OR ``sub ∈ subnet.member_agent_ids``.
+    - User JWT callers (``type == "user"``): full access when they own
+      the subnet's owning agent — i.e. when ``subnet.owner`` is in the
+      set of agent-ids owned by ``sub`` (the ownership-chain bridge).
+      Owning a *member* agent only is NOT sufficient; membership is an
+      employment relationship and does not extend read trust upward to
+      the agent's human holder (see V6 contract § 2 ownership edge).
+
+    Called ONLY for private subnets; public subnets short-circuit to
+    full SubnetInfo before this function is reached.
+    """
+    permissions = payload.get("permissions", [])
+    if "acn:admin" in permissions:
+        return True
+
+    sub = payload.get("sub", "")
+    caller_type = payload.get("type", "user")
+
+    if caller_type == "agent":
+        member_ids: set = getattr(subnet, "member_agent_ids", None) or set()
+        return sub == subnet.owner or sub in member_ids
+
+    # User JWT path — ownership-chain bridge.
+    try:
+        owned_agents = await agent_service.find_by_owner(sub)
+        owned_agent_ids = {a.agent_id for a in owned_agents}
+    except Exception:  # noqa: BLE001  # any infra failure → deny
+        return False
+    return subnet.owner in owned_agent_ids
 
 
 def _invariant_error_to_acn(
@@ -290,6 +359,7 @@ async def list_subnets(
     parent: str | None = None,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
 ):
     """List all subnets.
 
@@ -306,22 +376,35 @@ async def list_subnets(
       parent is unknown or has no visible children — cross-tenant
       probes get the same shape as legitimate empty results
       (no existence leak).
+
+    Per-row caller-aware rendering (ACL V6 B5): each row in the result
+    set is independently graded by the V6 privacy matrix. Public subnets
+    return full ``SubnetInfo``; private subnets return ``SubnetStub``
+    unless the caller is authorised (owner agent, member agent, user JWT
+    holding ownership-chain access to the owning agent, or admin).
     """
     try:
+        # Resolve caller payload once for per-row ACL.
+        caller_payload: dict | None = None
+        if credentials:
+            try:
+                caller_payload = await verify_token(request, credentials)
+            except Exception:  # noqa: BLE001  # invalid token → treat as anon
+                caller_payload = None
+
         if parent is not None:
             # ``?parent=`` filter takes precedence and gates on the
             # same identity primitive used by ``list_children``.
-            requester_id: str | None = None
-            if credentials:
-                payload = await verify_token(request, credentials)
-                requester_id = payload.get("sub") or None
+            requester_id: str | None = (
+                caller_payload.get("sub") or None if caller_payload else None
+            )
             subnets = await subnet_service.list_children(
                 parent_subnet_id=parent,
                 requester_id=requester_id,
             )
         elif owner:
             # Require auth when filtering by owner to prevent private subnet enumeration
-            if not credentials:
+            if not credentials or caller_payload is None:
                 raise ACNHTTPError(
                     ErrorCode.AUTHENTICATION_REQUIRED,
                     401,
@@ -329,9 +412,8 @@ async def list_subnets(
                     details={"reason": "owner_filter_requires_auth"},
                     headers={"WWW-Authenticate": "Bearer"},
                 )
-            payload = await verify_token(request, credentials)
-            requester = payload.get("sub", "")
-            permissions = payload.get("permissions", [])
+            requester = caller_payload.get("sub", "")
+            permissions = caller_payload.get("permissions", [])
             if requester != owner and "acn:admin" not in permissions:
                 raise ACNHTTPError(
                     ErrorCode.OWNERSHIP_MISMATCH,
@@ -343,8 +425,33 @@ async def list_subnets(
         else:
             subnets = await subnet_service.list_public_subnets()
 
-        # Convert to SubnetInfo
-        subnet_infos = [_subnet_entity_to_info(s) for s in subnets]
+        # Per-row caller-aware rendering (ACL V6 B5).
+        subnet_infos: list = []
+        for s in subnets:
+            if not getattr(s, "is_private", False):
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(_subnet_entity_to_info(s, parent_uuid=parent_uuid))
+            elif caller_payload and await _resolve_caller_access(
+                caller_payload, s, agent_service
+            ):
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(_subnet_entity_to_info(s, parent_uuid=parent_uuid))
+            else:
+                # Private subnet the caller cannot see in full → SubnetStub.
+                # ``_resolve_parent_uuid`` is intentionally called here too
+                # so graph clients can trace the hierarchy edge even for
+                # stubs they are not authorised to expand.
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(
+                    SubnetStub(
+                        id=_coerce_optional_str(getattr(s, "id", None)) or s.subnet_id,
+                        is_private=True,
+                        parent_id=parent_uuid,
+                        lifecycle=_coerce_lifecycle(
+                            getattr(s, "lifecycle", "persistent")
+                        ),
+                    )
+                )
 
         return {"subnets": subnet_infos, "count": len(subnet_infos)}
     except ACNHTTPError:
@@ -362,32 +469,43 @@ async def get_subnet(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
 ):
     """Get subnet details.
 
     Clean Architecture: Route → SubnetService → Repository.
 
-    Privacy contract
+    Privacy contract (ACL V6 / issue #114)
         Public subnets are fully visible to anyone.
 
         Private subnets use a two-tier response:
 
-        * **Authorised callers** (owner, current member, ``acn:admin``)
-          receive the full ``SubnetInfo`` payload including ``harness_url``
-          and ``metadata``.
+        * **Authorised callers** — owner agent (API key), member agent
+          (API key), the owner agent's human holder via ownership-chain
+          bridge (user JWT), or ``acn:admin`` — receive the full
+          ``SubnetInfo`` payload.
 
-        * **Everyone else** (anonymous or authenticated non-member)
-          receives a ``SubnetStub`` — structural metadata only
-          (``subnet_id``, ``name``, ``is_private``, ``parent_subnet_id``,
-          ``lifecycle``).  Sensitive fields (``owner``, ``description``,
-          ``harness_url``, ``security_schemes``, ``metadata``) are omitted.
+        * **Everyone else** (anonymous, or authenticated but unrelated)
+          receives a ``SubnetStub`` — opaque UUID + structural metadata
+          only.  The human-readable slug, ``name``, ``owner``,
+          ``description``, ``harness_url``, and ``security_schemes`` are
+          omitted.
 
-        Rationale: a private subnet's ``subnet_id`` is already discoverable
-        through any public agent's ``subnet_ids`` field, so existence-hiding
-        provides no real security.  Surfacing hierarchy metadata lets graph
-        clients draw correct topology without leaking sensitive details.
+        Rationale: a private subnet's ``subnet_id`` is already
+        discoverable through public agent listings, so existence-hiding
+        provides no real security.  Surfacing hierarchy metadata lets
+        graph clients draw correct topology without leaking sensitive
+        details.
 
-        Genuinely missing subnets still return ``SUBNET_NOT_FOUND`` (404).
+        Ownership-chain bridge: a user JWT caller that owns the subnet's
+        owning agent gets full access (A2 principle — humans need
+        read-only knowledge of their agents' activities). Owning a
+        *member* agent only is not sufficient (membership is an
+        employment relationship and does not extend read trust upward to
+        the agent's human holder — V6 contract § 2 ownership edge).
+
+        Genuinely missing subnets still return ``SUBNET_NOT_FOUND``
+        (404).
     """
     try:
         subnet = await subnet_service.get_subnet(subnet_id)
@@ -398,8 +516,12 @@ async def get_subnet(
             details={"subnet_id": subnet_id},
         ) from e
 
+    # Resolve parent UUID once — used by both SubnetStub and SubnetInfo
+    # (ACL V6 B6: slug is never exposed in API responses).
+    parent_uuid = await _resolve_parent_uuid(subnet, subnet_service)
+
     if not getattr(subnet, "is_private", False):
-        return _subnet_entity_to_info(subnet)
+        return _subnet_entity_to_info(subnet, parent_uuid=parent_uuid)
 
     # Private subnet — check authorisation.
     # Unauthenticated or unauthorised callers receive a SubnetStub
@@ -408,23 +530,6 @@ async def get_subnet(
     # naming patterns like ``acnlabs-core`` would otherwise leak
     # organisational structure to anyone who happens to know an
     # agent_id that's a member.
-    #
-    # ``parent_id`` is the parent subnet's UUID (resolved from
-    # ``subnet.parent_subnet_id`` slug). Frontend graph clients
-    # join hierarchy edges on the UUID across SubnetInfo / SubnetStub.
-    parent_slug = _coerce_optional_str(
-        getattr(subnet, "parent_subnet_id", None)
-    )
-    parent_uuid: str | None = None
-    if parent_slug:
-        try:
-            parent_entity = await subnet_service.get_subnet(parent_slug)
-            parent_uuid = _coerce_optional_str(getattr(parent_entity, "id", None))
-        except SubnetNotFoundException:
-            # Orphaned reference — surface as if top-level rather than
-            # leaking a 500 to anonymous callers.
-            parent_uuid = None
-
     def _stub() -> SubnetStub:
         return SubnetStub(
             id=_coerce_optional_str(getattr(subnet, "id", None)) or subnet.subnet_id,
@@ -437,17 +542,11 @@ async def get_subnet(
         return _stub()
 
     payload = await verify_token(request, credentials)
-    requester = payload.get("sub", "")
-    permissions = payload.get("permissions", [])
 
-    is_owner = requester == subnet.owner
-    is_admin = "acn:admin" in permissions
-    is_member = requester in (getattr(subnet, "member_agent_ids", None) or set())
-
-    if not (is_owner or is_admin or is_member):
+    if not await _resolve_caller_access(payload, subnet, agent_service):
         return _stub()
 
-    return _subnet_entity_to_info(subnet)
+    return _subnet_entity_to_info(subnet, parent_uuid=parent_uuid)
 
 
 @router.get("/{subnet_id}/children")
@@ -456,12 +555,14 @@ async def get_subnet_children(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
+    agent_service: AgentServiceDep = None,
 ):
     """List immediate children of a subnet (ADR-0003).
 
     Visibility matches ``GET /api/v1/subnets?parent=<id>``: anonymous
-    callers see only public children; authenticated callers
-    additionally see private children they own or are members of.
+    callers see public children in full; private children are returned
+    as ``SubnetStub`` unless the caller is authorised (V6 B5 per-row
+    caller-aware rendering, same logic as ``list_subnets``).
 
     Returns ``SUBNET_NOT_FOUND`` if the parent itself does not exist.
     Cross-tenant probes against an existing-but-not-visible parent
@@ -482,15 +583,45 @@ async def get_subnet_children(
         ) from e
 
     try:
-        requester_id: str | None = None
+        caller_payload: dict | None = None
         if credentials:
-            payload = await verify_token(request, credentials)
-            requester_id = payload.get("sub") or None
+            try:
+                caller_payload = await verify_token(request, credentials)
+            except Exception:  # noqa: BLE001  # invalid token → treat as anon
+                caller_payload = None
+
+        requester_id: str | None = (
+            caller_payload.get("sub") or None if caller_payload else None
+        )
         children = await subnet_service.list_children(
             parent_subnet_id=subnet_id,
             requester_id=requester_id,
         )
-        subnet_infos = [_subnet_entity_to_info(s) for s in children]
+
+        # Per-row caller-aware rendering (ACL V6 B5) — same logic as list_subnets.
+        subnet_infos: list = []
+        for s in children:
+            if not getattr(s, "is_private", False):
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(_subnet_entity_to_info(s, parent_uuid=parent_uuid))
+            elif caller_payload and await _resolve_caller_access(
+                caller_payload, s, agent_service
+            ):
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(_subnet_entity_to_info(s, parent_uuid=parent_uuid))
+            else:
+                parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+                subnet_infos.append(
+                    SubnetStub(
+                        id=_coerce_optional_str(getattr(s, "id", None)) or s.subnet_id,
+                        is_private=True,
+                        parent_id=parent_uuid,
+                        lifecycle=_coerce_lifecycle(
+                            getattr(s, "lifecycle", "persistent")
+                        ),
+                    )
+                )
+
         return {"count": len(subnet_infos), "subnets": subnet_infos}
     except ACNHTTPError:
         raise
@@ -570,13 +701,23 @@ async def get_subnet_agents(
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
 ):
-    """Get all agents in a subnet
+    """Get all agents in a subnet.
 
-    Clean Architecture: Route → Service → Repository
-    Private subnets require authentication; the caller must be the owner
-    or hold acn:admin permission.
+    Clean Architecture: Route → Service → Repository.
+
+    Privacy contract (ACL V6 / issue #114 B12):
+
+    * **Public subnets**: full member list for all callers.
+    * **Private subnets** — authorised callers (owner agent, member
+      agent, user JWT with ownership-chain access to the owning agent,
+      or ``acn:admin``) receive the full member list.
+    * **Everyone else** on a private subnet: ``200`` with an empty
+      ``agents`` list — identical in shape to a legitimate empty subnet
+      so that unauthorised callers cannot determine whether the subnet
+      has any members (existence-hiding contract, same approach as
+      ``list_children`` stubs).  No ``401`` / ``403`` is returned for
+      private-subnet membership queries.
     """
-    # Verify subnet exists and check privacy
     try:
         subnet = await subnet_service.get_subnet(subnet_id)
     except SubnetNotFoundException as e:
@@ -586,26 +727,18 @@ async def get_subnet_agents(
             details={"subnet_id": subnet_id},
         ) from e
 
-    # Enforce auth for private subnets
+    # For private subnets, check caller access.  For public subnets this
+    # block is skipped entirely — the member list is openly visible.
+    _empty_response = {"subnet_id": subnet_id, "agents": [], "count": 0}
     if getattr(subnet, "is_private", False):
         if not credentials:
-            raise ACNHTTPError(
-                ErrorCode.AUTHENTICATION_REQUIRED,
-                401,
-                message="Authentication required to view private subnet members.",
-                details={"subnet_id": subnet_id, "reason": "private_subnet"},
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-        payload = await verify_token(request, credentials)
-        requester = payload.get("sub", "")
-        permissions = payload.get("permissions", [])
-        if requester != subnet.owner and "acn:admin" not in permissions:
-            raise ACNHTTPError(
-                ErrorCode.NOT_SUBNET_MEMBER,
-                403,
-                message="Access denied: private subnet.",
-                details={"subnet_id": subnet_id, "agent_id": requester},
-            )
+            return _empty_response
+        try:
+            payload = await verify_token(request, credentials)
+        except Exception:  # noqa: BLE001  # invalid token → empty list
+            return _empty_response
+        if not await _resolve_caller_access(payload, subnet, agent_service):
+            return _empty_response
 
     try:
         agents = await agent_service.search_agents(subnet_id=subnet_id)

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -279,7 +279,13 @@ class SubnetInfo(BaseModel):
 
     # ADR-0003 nesting fields — optional + defaulted so older
     # servers that don't yet emit them still parse cleanly.
+    #
+    # ACL V6 B6: the server no longer emits ``parent_subnet_id`` (slug)
+    # in ``SubnetInfo`` responses — use ``parent_id`` (UUID) instead.
+    # ``parent_subnet_id`` is kept here for backward-compat parsing of
+    # responses from older server versions.
     parent_subnet_id: str | None = None
+    parent_id: str | None = None
     lifecycle: str = "persistent"
     linked_task_id: str | None = None
 

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -149,8 +149,14 @@ export interface SubnetInfo {
   owner?: string;
   harness_url?: string;
   harness_registered?: boolean;
-  /** ADR-0003 — parent subnet when this is a nested child. */
+  /**
+   * Deprecated — ACL V6 B6: the server no longer emits the slug.
+   * Use `parent_id` (UUID) instead.  Kept for backward-compat parsing
+   * of responses from older server versions.
+   */
   parent_subnet_id?: string | null;
+  /** ACL V6 B6 — parent subnet's opaque UUID. */
+  parent_id?: string | null;
   /** ADR-0003 — defaults to `'persistent'` on the server. */
   lifecycle?: SubnetLifecycle;
   /** ADR-0003 — bound task when `lifecycle === 'task_scoped'`. */

--- a/tests/routes/test_subnets_error_schema.py
+++ b/tests/routes/test_subnets_error_schema.py
@@ -436,25 +436,23 @@ class TestSubnetsFlatErrorSchemaCrossModule:
             "token_owner": "user-1",
         }
 
-    def test_get_subnet_agents_private_no_auth_returns_authentication_required(
+    def test_get_subnet_agents_private_no_auth_returns_empty_list(
         self, stub_agent_service, stub_subnet_service
     ):
-        """``GET /api/v1/subnets/{id}/agents`` against a private
-        subnet without auth — pins ``AUTHENTICATION_REQUIRED`` with
-        the ``private_subnet`` reason and ``subnet_id`` in details.
+        """ACL V6 B12: ``GET /api/v1/subnets/{id}/agents`` against a
+        private subnet without auth returns ``200 {"agents": [], "count": 0}``
+        (existence-hiding — same shape as a legitimate empty subnet).
 
-        Distinct from the owner-filter ``AUTHENTICATION_REQUIRED``
-        test above: same ErrorCode but the SDK can branch on
-        ``details.reason`` to give a more specific UX (e.g. "join
-        this subnet" vs "log in to filter by owner").
+        Previous contract (pre-B12) returned 401 AUTHENTICATION_REQUIRED.
+        B12 changes this to a 200 empty response so unauthorised callers
+        cannot determine whether a private subnet has members.
         """
-        # Override stub to mark the subnet as private so the auth
-        # check fires.
         stub_subnet_service.get_subnet.side_effect = None
         target_subnet = MagicMock()
         target_subnet.subnet_id = "subnet-private"
         target_subnet.owner = "user-1"
         target_subnet.is_private = True
+        target_subnet.member_agent_ids = set()
         stub_subnet_service.get_subnet.return_value = target_subnet
 
         _wire(stub_agent_service, stub_subnet_service)
@@ -462,32 +460,33 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         with TestClient(app) as client:
             r = client.get("/api/v1/subnets/subnet-private/agents")
 
-        assert r.status_code == 401
+        assert r.status_code == 200, r.text
         body = r.json()
-        _assert_flat_shape(body)
-        assert body["error_code"] == "authentication_required"
-        assert body["details"] == {
-            "subnet_id": "subnet-private",
-            "reason": "private_subnet",
-        }
+        assert body["agents"] == []
+        assert body["count"] == 0
+        assert body["subnet_id"] == "subnet-private"
 
-    def test_get_subnet_agents_private_cross_tenant_returns_not_subnet_member(
+    def test_get_subnet_agents_private_cross_tenant_returns_empty_list(
         self, stub_agent_service, stub_subnet_service, monkeypatch
     ):
-        """``GET /api/v1/subnets/{id}/agents`` against a private
-        subnet with a non-owner non-admin token — pins
-        ``NOT_SUBNET_MEMBER``. Same monkeypatch pattern as the
-        cross-tenant list_subnets test above (``verify_token`` is
-        called directly, not via Depends)."""
+        """ACL V6 B12: ``GET /api/v1/subnets/{id}/agents`` against a
+        private subnet with a non-member token returns
+        ``200 {"agents": [], "count": 0}`` (existence-hiding).
+
+        Previous contract (pre-B12) returned 403 NOT_SUBNET_MEMBER.
+        B12 changes this so that the membership list is
+        indistinguishable from a legitimately empty subnet.
+        """
         stub_subnet_service.get_subnet.side_effect = None
         target_subnet = MagicMock()
         target_subnet.subnet_id = "subnet-private"
         target_subnet.owner = "user-1"
         target_subnet.is_private = True
+        target_subnet.member_agent_ids = set()
         stub_subnet_service.get_subnet.return_value = target_subnet
 
         async def _fake_verify_token(*args, **kwargs):
-            return {"sub": "user-2", "permissions": ["acn:read"]}
+            return {"sub": "user-2", "type": "agent", "permissions": ["acn:read"]}
 
         monkeypatch.setattr(
             "acn.routes.subnets.verify_token", _fake_verify_token
@@ -500,14 +499,11 @@ class TestSubnetsFlatErrorSchemaCrossModule:
                 headers={"Authorization": "Bearer non-member-token"},
             )
 
-        assert r.status_code == 403
+        assert r.status_code == 200, r.text
         body = r.json()
-        _assert_flat_shape(body)
-        assert body["error_code"] == "not_subnet_member"
-        assert body["details"] == {
-            "subnet_id": "subnet-private",
-            "agent_id": "user-2",
-        }
+        assert body["agents"] == []
+        assert body["count"] == 0
+        assert body["subnet_id"] == "subnet-private"
 
     def test_delete_subnet_permission_error_returns_ownership_mismatch(
         self, stub_agent_service, stub_subnet_service

--- a/tests/routes/test_subnets_get_detail_privacy.py
+++ b/tests/routes/test_subnets_get_detail_privacy.py
@@ -1,24 +1,20 @@
 """Route-level tests for ``GET /api/v1/subnets/{subnet_id}`` privacy
-contract.
+contract (ACL V6 / issue #114).
 
 Contract:
 
 1. **Public subnets** — fully visible to anyone, no auth required.
-2. **Private subnets — owner, member, and ``acn:admin``** see the
-   full ``SubnetInfo`` payload (200).
+2. **Private subnets — owner agent (API key), member agent (API key),
+   user JWT with ownership-chain access to the owning agent, or
+   ``acn:admin``** see the full ``SubnetInfo`` payload (200).
 3. **Private subnets — anon or authed non-member** receive a
-   ``SubnetStub`` (200) — structural metadata only (subnet_id, name,
-   is_private, parent_subnet_id, lifecycle).  Sensitive fields such as
-   owner, description, harness_url, and security_schemes are omitted.
-   Rationale: the subnet_id is already discoverable via public agent
-   subnet_ids, so existence-hiding provides no real security; surfacing
-   hierarchy metadata lets graph clients render correct topology.
+   ``SubnetStub`` (200) — opaque UUID plus minimal structural metadata.
+   Sensitive fields (slug, name, owner, description, harness_url,
+   security_schemes, parent_subnet_id) are omitted.
 4. **Genuinely missing subnets** still 404 with ``SUBNET_NOT_FOUND``.
-
-The membership check reads ``subnet.member_agent_ids`` directly off
-the loaded entity — no extra DB call — so the test fixture exposes
-it as a real attribute (not a ``MagicMock`` autospec) and asserts
-the route does not invent a separate roster lookup.
+5. **``SubnetInfo`` no longer leaks ``parent_subnet_id`` slug** (B6) —
+   the field is always ``None`` in responses; ``parent_id`` UUID is
+   used instead.
 """
 
 from __future__ import annotations
@@ -32,7 +28,7 @@ from fastapi.testclient import TestClient
 
 from acn.api import app
 from acn.core.exceptions import SubnetNotFoundException
-from acn.routes.dependencies import get_subnet_service
+from acn.routes.dependencies import get_agent_service, get_subnet_service
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -69,6 +65,13 @@ def _make_subnet(
     return sn
 
 
+def _make_agent(agent_id: str, owner: str) -> MagicMock:
+    a = MagicMock()
+    a.agent_id = agent_id
+    a.owner = owner
+    return a
+
+
 @pytest.fixture
 def public_subnet() -> MagicMock:
     return _make_subnet("subnet-public", owner="agent-owner", is_private=False)
@@ -98,18 +101,55 @@ def stub_subnet_service(public_subnet, private_subnet):
     return svc
 
 
+@pytest.fixture
+def stub_agent_service():
+    """Agent service stub for ownership-chain tests.
+
+    ``find_by_owner("user-owns-owner")`` returns the agent whose
+    ``agent_id == "agent-owner"``, modelling a user who owns the subnet's
+    owning agent (V6 ownership-chain bridge).
+
+    All other owners return an empty list.
+    """
+    svc = AsyncMock()
+
+    async def _find_by_owner(owner_sub: str):
+        if owner_sub == "user-owns-owner":
+            return [_make_agent("agent-owner", owner_sub)]
+        if owner_sub == "user-owns-member":
+            return [_make_agent("agent-member", owner_sub)]
+        return []
+
+    svc.find_by_owner = AsyncMock(side_effect=_find_by_owner)
+    return svc
+
+
 @pytest.fixture(autouse=True)
-def wire(stub_subnet_service):
+def wire(stub_subnet_service, stub_agent_service):
     app.dependency_overrides[get_subnet_service] = lambda: stub_subnet_service
+    app.dependency_overrides[get_agent_service] = lambda: stub_agent_service
     yield
     app.dependency_overrides.pop(get_subnet_service, None)
+    app.dependency_overrides.pop(get_agent_service, None)
 
 
 def _fake_verify_token(
-    *, sub: str, permissions: list[str] | None = None
+    *,
+    sub: str,
+    caller_type: str = "agent",
+    permissions: list[str] | None = None,
 ) -> Any:
+    """Return a fake ``verify_token`` dependency.
+
+    ``caller_type`` defaults to ``"agent"`` for owner/member test cases
+    (API key callers).  Pass ``caller_type="user"`` for user JWT tests.
+    """
     async def _impl(*args, **kwargs):
-        return {"sub": sub, "permissions": permissions or []}
+        return {
+            "sub": sub,
+            "type": caller_type,
+            "permissions": permissions or [],
+        }
 
     return _impl
 
@@ -163,6 +203,16 @@ class TestPublicSubnetUnchanged:
 
         assert r.status_code == 200, r.text
 
+    def test_public_subnet_parent_subnet_id_suppressed(self):
+        """B6: SubnetInfo must never expose parent_subnet_id slug."""
+        with TestClient(app) as client:
+            r = client.get("/api/v1/subnets/subnet-public")
+
+        assert r.status_code == 200
+        body = r.json()
+        # parent_subnet_id slug is always None; parent_id UUID is the new field.
+        assert body.get("parent_subnet_id") is None
+
 
 # ---------------------------------------------------------------------------
 # 2. Private subnets — authorised callers see full payload
@@ -170,10 +220,11 @@ class TestPublicSubnetUnchanged:
 
 
 class TestPrivateSubnetAuthorisedCallers:
-    def test_owner_sees_full_payload(self, monkeypatch):
+    def test_owner_agent_apikey_sees_full_payload(self, monkeypatch):
+        """API key caller whose agent_id == subnet.owner gets full access."""
         monkeypatch.setattr(
             "acn.routes.subnets.verify_token",
-            _fake_verify_token(sub="agent-owner"),
+            _fake_verify_token(sub="agent-owner", caller_type="agent"),
         )
         with TestClient(app) as client:
             r = client.get(
@@ -187,10 +238,11 @@ class TestPrivateSubnetAuthorisedCallers:
         assert body["owner"] == "agent-owner"
         assert body["harness_url"] == "https://harness.example.org"
 
-    def test_member_sees_full_payload(self, monkeypatch):
+    def test_member_agent_apikey_sees_full_payload(self, monkeypatch):
+        """API key caller in member_agent_ids gets full access."""
         monkeypatch.setattr(
             "acn.routes.subnets.verify_token",
-            _fake_verify_token(sub="agent-member"),
+            _fake_verify_token(sub="agent-member", caller_type="agent"),
         )
         with TestClient(app) as client:
             r = client.get(
@@ -210,6 +262,7 @@ class TestPrivateSubnetAuthorisedCallers:
             "acn.routes.subnets.verify_token",
             _fake_verify_token(
                 sub="agent-support",
+                caller_type="user",
                 permissions=["acn:admin"],
             ),
         )
@@ -221,6 +274,40 @@ class TestPrivateSubnetAuthorisedCallers:
 
         assert r.status_code == 200, r.text
         assert r.json()["owner"] == "agent-owner"
+
+    def test_user_jwt_owning_owner_agent_gets_full_payload(self, monkeypatch):
+        """V6 ownership-chain bridge: user JWT whose owned agents include
+        subnet.owner gets full SubnetInfo (read-knowledge via ownership edge).
+        """
+        monkeypatch.setattr(
+            "acn.routes.subnets.verify_token",
+            _fake_verify_token(sub="user-owns-owner", caller_type="user"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/subnets/subnet-private",
+                headers={"Authorization": "Bearer user-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["subnet_id"] == "subnet-private"
+        assert body["owner"] == "agent-owner"
+
+    def test_full_payload_parent_subnet_id_suppressed(self, monkeypatch):
+        """B6: even authorised callers must not receive parent_subnet_id slug."""
+        monkeypatch.setattr(
+            "acn.routes.subnets.verify_token",
+            _fake_verify_token(sub="agent-owner", caller_type="agent"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/subnets/subnet-private",
+                headers={"Authorization": "Bearer owner-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json().get("parent_subnet_id") is None
 
 
 # ---------------------------------------------------------------------------
@@ -240,15 +327,50 @@ class TestPrivateSubnetDiscoverable:
         assert r.status_code == 200, r.text
         _assert_stub(r.json())
 
-    def test_authed_non_member_gets_stub(self, monkeypatch):
+    def test_authed_non_member_agent_gets_stub(self, monkeypatch):
+        """API key caller not in member_agent_ids gets SubnetStub."""
         monkeypatch.setattr(
             "acn.routes.subnets.verify_token",
-            _fake_verify_token(sub="agent-outsider"),
+            _fake_verify_token(sub="agent-outsider", caller_type="agent"),
         )
         with TestClient(app) as client:
             r = client.get(
                 "/api/v1/subnets/subnet-private",
                 headers={"Authorization": "Bearer outsider-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        _assert_stub(r.json())
+
+    def test_user_jwt_owning_only_member_agent_gets_stub(self, monkeypatch):
+        """User who owns a member agent (not the owner agent) gets SubnetStub.
+
+        Membership is an employment relationship — read trust does NOT
+        flow upward from member → member's owner (V6 ownership-edge contract).
+        """
+        monkeypatch.setattr(
+            "acn.routes.subnets.verify_token",
+            _fake_verify_token(sub="user-owns-member", caller_type="user"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/subnets/subnet-private",
+                headers={"Authorization": "Bearer user-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        _assert_stub(r.json())
+
+    def test_user_jwt_unrelated_gets_stub(self, monkeypatch):
+        """User JWT with no ownership relationship gets SubnetStub."""
+        monkeypatch.setattr(
+            "acn.routes.subnets.verify_token",
+            _fake_verify_token(sub="user-unrelated", caller_type="user"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/subnets/subnet-private",
+                headers={"Authorization": "Bearer user-token"},
             )
 
         assert r.status_code == 200, r.text
@@ -261,6 +383,7 @@ class TestPrivateSubnetDiscoverable:
             "acn.routes.subnets.verify_token",
             _fake_verify_token(
                 sub="agent-reader",
+                caller_type="agent",
                 permissions=["acn:read", "acn:write"],
             ),
         )

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -282,7 +282,10 @@ class TestGetSubnetChildren:
         body = r.json()
         assert body["count"] == 1
         assert body["subnets"][0]["subnet_id"] == "child-A"
-        assert body["subnets"][0]["parent_subnet_id"] == "parent-1"
+        # ACL V6 B6: parent_subnet_id slug is always suppressed in responses.
+        assert body["subnets"][0].get("parent_subnet_id") is None
+        # parent_id (UUID) is the new field — non-None for child subnets.
+        assert body["subnets"][0].get("parent_id") is not None
 
     def test_children_endpoint_404_for_missing_parent(self, stub_agent_service):
         subnet_svc = AsyncMock()


### PR DESCRIPTION
## Summary

Implements four ACL V6 contract items from issue #114, building on the dual-protocol authentication foundation in PR #115.

| Item | Change |
|---|---|
| **B2** — ownership-chain bridge | `GET /subnets/{id}` — user JWT can reach full SubnetInfo by owning the subnet's owning agent. Agent API keys checked directly. |
| **B5** — per-row list rendering | `GET /subnets` + `GET /subnets/{id}/children` — each row independently graded: private rows return SubnetStub for unauthorised callers. |
| **B6** — parent-slug suppression | `SubnetInfo.parent_subnet_id` always `None`; new `parent_id` UUID field. Closes public-child → private-parent slug leak. |
| **B12** — member-list V6 ACL | `GET /subnets/{id}/agents` — unauthorised callers on private subnets get `200 {"agents":[],"count":0}` (existence-hiding) instead of 401/403. |

## Key design points

- `_resolve_caller_access(payload, subnet, agent_service)` — shared predicate used by `get_subnet`, `list_subnets`, `get_subnet_children`, and `get_subnet_agents`.
- `_resolve_parent_uuid(subnet, subnet_service)` — slug→UUID lookup; degrades to `None` on orphaned references so anonymous callers never see a 500.
- Python and TypeScript SDK models gain `parent_id` field; `parent_subnet_id` kept for backward-compat parsing of old server responses.

## Test plan

- [ ] `tests/routes/test_subnets_get_detail_privacy.py` rewritten for V6 (13 cases). Added: ownership-chain bridge grants full access; user owning only a member agent gets SubnetStub; B6 parent_subnet_id always None assertions.
- [ ] `tests/auth/` suite (49 tests) green — no regression to B1 dual-protocol auth.
- [ ] CI Python 3.11 / 3.12 checks pass.

Tracks: #114

Made with [Cursor](https://cursor.com)