### PR TITLE
feat(acl): B3 — agent subnet_ids filtered to public slugs for non-self/non-admin

### DIFF
--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -28,8 +28,10 @@ from fastapi import (
     Query,
     Request,
     Response,
+    Security,
 )
 from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..auth.middleware import require_permission, verify_token
@@ -53,6 +55,7 @@ from .dependencies import (  # type: ignore[import-untyped]
     PolicyServiceDep,
     ProxyCallerDep,
     SubnetManagerDep,
+    SubnetServiceDep,
     # Underscore-prefixed crossing of module boundaries is intentional:
     # ``_get_real_ip`` is the canonical proxy-aware IP resolver and we
     # need the SSRF audit hook to attribute attacks to the real client,
@@ -78,6 +81,7 @@ router = APIRouter(
 )
 logger = structlog.get_logger()
 settings = get_settings()
+_optional_bearer = HTTPBearer(auto_error=False)
 
 
 # Phase 2 review v2 P1 #10 — modes that carry an implicit SDK-version
@@ -505,6 +509,7 @@ def _agent_entity_to_info(
     *,
     is_online: bool,
     strip_sensitive: bool = False,
+    public_subnet_slugs: set[str] | None = None,
 ) -> AgentInfo:
     """Convert Agent entity to AgentInfo model.
 
@@ -520,6 +525,12 @@ def _agent_entity_to_info(
     - raw endpoint is replaced with the ACN-unified communication address
       so callers are always routed through ACN instead of contacting agents
       directly.
+
+    ``public_subnet_slugs`` controls subnet_ids visibility (ACL V6 B3):
+    - ``None`` — full list (self API key or admin caller).
+    - ``set[str]`` — filter to only slugs present in this set (everyone
+      else). Prevents private subnet slugs from leaking to callers who
+      have no membership relationship with those subnets.
     """
     metadata = {
         **agent.metadata,
@@ -541,6 +552,13 @@ def _agent_entity_to_info(
         exposed_agent_card_url = getattr(agent, "agent_card_url", None)
         exposed_agent_card = agent.agent_card
 
+    # ACL V6 B3: filter subnet_ids to public slugs when the caller is not
+    # the agent itself (self API key) and does not hold acn:admin.
+    if public_subnet_slugs is None:
+        exposed_subnet_ids = agent.subnet_ids
+    else:
+        exposed_subnet_ids = [s for s in agent.subnet_ids if s in public_subnet_slugs]
+
     return AgentInfo(
         agent_id=agent.agent_id,
         owner=agent.owner or "unowned",
@@ -551,7 +569,7 @@ def _agent_entity_to_info(
         agent_card_url=exposed_agent_card_url,
         tags=agent.tags,
         status="online" if is_online else "offline",
-        subnet_ids=agent.subnet_ids,
+        subnet_ids=exposed_subnet_ids,
         agent_card=exposed_agent_card,
         metadata=metadata,
         registered_at=agent.registered_at,
@@ -569,11 +587,15 @@ async def _agent_entity_to_info_with_alive(
     *,
     agent_service,
     strip_sensitive: bool = False,
+    public_subnet_slugs: set[str] | None = None,
 ) -> AgentInfo:
     """Async wrapper that resolves ``is_online`` from Redis alive (single shot)."""
     is_online = await agent_service.is_alive(agent.agent_id)
     return _agent_entity_to_info(
-        agent, is_online=is_online, strip_sensitive=strip_sensitive
+        agent,
+        is_online=is_online,
+        strip_sensitive=strip_sensitive,
+        public_subnet_slugs=public_subnet_slugs,
     )
 
 
@@ -582,6 +604,7 @@ async def _agent_entities_to_infos(
     *,
     agent_service,
     strip_sensitive: bool = False,
+    public_subnet_slugs: set[str] | None = None,
 ) -> list[AgentInfo]:
     """Async batch variant — one Redis round-trip for the whole list.
 
@@ -597,6 +620,7 @@ async def _agent_entities_to_infos(
             a,
             is_online=a.agent_id in alive_ids,
             strip_sensitive=strip_sensitive,
+            public_subnet_slugs=public_subnet_slugs,
         )
         for a in agents
     ]
@@ -763,20 +787,81 @@ async def list_unclaimed_agents(
     )
 
 
+async def _get_public_subnet_slugs(subnet_service) -> set[str]:
+    """Return the set of public subnet slugs from the repository.
+
+    Called once per request on the agent-read paths; the result is used
+    to filter ``subnet_ids`` for non-self / non-admin callers (ACL V6 B3).
+    Degrades to the minimal ``{"public"}`` set on any lookup failure so
+    the read path never 500s due to a subnet-service error.
+    """
+    try:
+        public_subnets = await subnet_service.list_public_subnets()
+        return {s.subnet_id for s in public_subnets}
+    except Exception:  # noqa: BLE001
+        return {"public"}
+
+
+def _caller_gets_full_subnet_ids(payload: dict, agent_id: str) -> bool:
+    """Return True when the caller is entitled to the full subnet_ids list.
+
+    Full access is granted to:
+    - The agent itself (API key caller whose ``sub == agent_id``).
+    - ``acn:admin`` (platform ops).
+
+    Everyone else — including the agent's human owner — receives only
+    public subnet slugs (ACL V6 B3).  The human owner can inspect the
+    full list via ``GET /agents/me`` using the agent's own API key.
+    """
+    if "acn:admin" in payload.get("permissions", []):
+        return True
+    return payload.get("type") == "agent" and payload.get("sub") == agent_id
+
+
 @router.get("/{agent_id}", response_model=AgentInfo)
 @limiter.limit("120/minute")
-async def get_agent(request: Request, agent_id: AgentIdPath, agent_service: AgentServiceDep = None):
+async def get_agent(
+    request: Request,
+    agent_id: AgentIdPath,
+    credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
+    agent_service: AgentServiceDep = None,
+    subnet_service: SubnetServiceDep = None,
+):
     """Get agent information (public discovery; verification_code not included).
 
     Populates ``followers_count`` / ``follows_count`` from the follow
     graph (proposal §数据模型). Falls back to ``0`` if the follow
     subsystem is not wired or its lookup fails — a missing count must
     never block agent retrieval.
+
+    ``subnet_ids`` visibility (ACL V6 B3): the agent itself (self API
+    key) and ``acn:admin`` receive the full list. All other callers —
+    including the agent's human owner — see only public subnet slugs.
+    This prevents private subnet names from leaking to anyone who
+    queries a public agent endpoint.
     """
+    # Resolve optional caller payload for subnet_ids ACL.
+    caller_payload: dict | None = None
+    if credentials:
+        try:
+            caller_payload = await verify_token(request, credentials)
+        except Exception:  # noqa: BLE001 — invalid token → treat as anon
+            caller_payload = None
+
+    full_ids = caller_payload is not None and _caller_gets_full_subnet_ids(
+        caller_payload, agent_id
+    )
+    public_slugs: set[str] | None = None if full_ids else await _get_public_subnet_slugs(
+        subnet_service
+    )
+
     try:
         agent = await agent_service.get_agent(agent_id)
         info = await _agent_entity_to_info_with_alive(
-            agent, agent_service=agent_service, strip_sensitive=True
+            agent,
+            agent_service=agent_service,
+            strip_sensitive=True,
+            public_subnet_slugs=public_slugs,
         )
         try:
             from . import dependencies as _deps
@@ -1278,17 +1363,42 @@ async def search_agents(
     ),
     owner: str | None = None,
     name: str | None = None,
+    credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     agent_service: AgentServiceDep = None,
+    subnet_service: SubnetServiceDep = None,
 ):
     """Search agents.
 
     Clean Architecture: Route → AgentService → Repository
+
+    ``subnet_ids`` visibility (ACL V6 B3): admin callers receive the
+    full list per agent. All other callers (including unauthenticated)
+    see only public subnet slugs per row. Agent self-listing is not
+    applicable on the list endpoint — use ``GET /agents/me`` for full
+    self-view.
     """
     if visibility not in _VISIBILITY_VALUES:
         raise HTTPException(
             status_code=422,
             detail=f"visibility must be one of: {', '.join(sorted(_VISIBILITY_VALUES))}",
         )
+
+    # Resolve optional caller payload for subnet_ids ACL.
+    caller_payload: dict | None = None
+    if credentials:
+        try:
+            caller_payload = await verify_token(request, credentials)
+        except Exception:  # noqa: BLE001 — invalid token → treat as anon
+            caller_payload = None
+
+    # On the list endpoint "self" semantics don't apply — check admin only.
+    # Public slugs are fetched once and reused for every row.
+    is_admin = caller_payload is not None and "acn:admin" in caller_payload.get(
+        "permissions", []
+    )
+    public_slugs: set[str] | None = None if is_admin else await _get_public_subnet_slugs(
+        subnet_service
+    )
 
     tag_param = tag or skill  # accept both; `tag` takes precedence
     tag_list = tag_param.split(",") if tag_param else None
@@ -1315,7 +1425,10 @@ async def search_agents(
         agents = [a for a in agents if name.lower() in a.name.lower()]
 
     agent_infos = await _agent_entities_to_infos(
-        agents, agent_service=agent_service, strip_sensitive=True
+        agents,
+        agent_service=agent_service,
+        strip_sensitive=True,
+        public_subnet_slugs=public_slugs,
     )
 
     return AgentSearchResponse(

--- a/tests/routes/test_agent_subnet_ids_privacy.py
+++ b/tests/routes/test_agent_subnet_ids_privacy.py
@@ -1,0 +1,242 @@
+"""ACL V6 B3 — agent subnet_ids privacy contract.
+
+``GET /api/v1/agents/{id}`` and ``GET /api/v1/agents`` (search):
+
+- Anonymous / unauthenticated callers: only public subnet slugs in
+  ``subnet_ids``.
+- User JWT (any): only public subnet slugs (user owning the agent is
+  NOT an exception — they must use the agent's own API key to see the
+  full list).
+- API key = the agent itself (self): full subnet_ids list.
+- acn:admin: full subnet_ids list.
+- API key ≠ the agent (unrelated agent): only public subnet slugs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AgentNotFoundException
+from acn.routes.dependencies import get_agent_service, get_subnet_service
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(
+    agent_id: str = "agent-target",
+    *,
+    owner: str = "user-owner",
+    subnet_ids: list[str] | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.agent_id = agent_id
+    a.owner = owner
+    a.name = "Target"
+    a.description = None
+    a.subnet_ids = subnet_ids or ["public", "subnet-private-abc"]
+    a.tags = []
+    a.endpoint = "https://example.com/agent"
+    a.agent_card_url = None
+    a.agent_card = None
+    a.metadata = {}
+    a.claim_status = None
+    a.referrer_id = None
+    a.verification_code = "acn-XXXX"
+    a.registered_at = datetime(2026, 1, 1, tzinfo=UTC)
+    a.last_heartbeat = None
+    a.wallet_address = None
+    a.wallet_addresses = None
+    a.accepts_payment = False
+    a.payment_methods = []
+    a.social_card_url = None
+    return a
+
+
+def _make_public_subnet(subnet_id: str) -> MagicMock:
+    s = MagicMock()
+    s.subnet_id = subnet_id
+    s.is_private = False
+    return s
+
+
+def _fake_verify_token(
+    *, sub: str, caller_type: str = "agent", permissions: list[str] | None = None
+) -> Any:
+    async def _impl(*args, **kwargs):
+        return {"sub": sub, "type": caller_type, "permissions": permissions or []}
+    return _impl
+
+
+@pytest.fixture
+def stub_agent_service():
+    target = _make_agent()
+    svc = AsyncMock()
+
+    async def _get_agent(agent_id: str):
+        if agent_id == "agent-target":
+            return target
+        raise AgentNotFoundException(agent_id)
+
+    svc.get_agent = AsyncMock(side_effect=_get_agent)
+    svc.is_alive = AsyncMock(return_value=True)
+    svc.batch_alive = AsyncMock(return_value={"agent-target"})
+    svc.search_agents = AsyncMock(return_value=[target])
+    return svc
+
+
+@pytest.fixture
+def stub_subnet_service():
+    svc = AsyncMock()
+    # Only "public" is a public subnet
+    svc.list_public_subnets = AsyncMock(return_value=[_make_public_subnet("public")])
+    return svc
+
+
+@pytest.fixture(autouse=True)
+def wire(stub_agent_service, stub_subnet_service):
+    app.dependency_overrides[get_agent_service] = lambda: stub_agent_service
+    app.dependency_overrides[get_subnet_service] = lambda: stub_subnet_service
+    yield
+    app.dependency_overrides.pop(get_agent_service, None)
+    app.dependency_overrides.pop(get_subnet_service, None)
+
+
+# ---------------------------------------------------------------------------
+# GET /agents/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetAgentSubnetIdsPrivacy:
+    def test_anon_sees_only_public_slugs(self):
+        """No auth → only public subnet slugs in subnet_ids."""
+        with TestClient(app) as client:
+            r = client.get("/api/v1/agents/agent-target")
+
+        assert r.status_code == 200, r.text
+        assert r.json()["subnet_ids"] == ["public"]
+
+    def test_user_jwt_sees_only_public_slugs(self, monkeypatch):
+        """User JWT (even owner) → only public slugs."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(sub="user-owner", caller_type="user"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-target",
+                headers={"Authorization": "Bearer user-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["subnet_ids"] == ["public"]
+
+    def test_unrelated_agent_apikey_sees_only_public_slugs(self, monkeypatch):
+        """API key for a different agent → only public slugs."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(sub="agent-other", caller_type="agent"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-target",
+                headers={"Authorization": "Bearer other-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["subnet_ids"] == ["public"]
+
+    def test_self_apikey_sees_full_subnet_ids(self, monkeypatch):
+        """API key = the agent itself → full subnet_ids including private."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(sub="agent-target", caller_type="agent"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-target",
+                headers={"Authorization": "Bearer self-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "subnet-private-abc" in body["subnet_ids"]
+        assert "public" in body["subnet_ids"]
+
+    def test_admin_sees_full_subnet_ids(self, monkeypatch):
+        """acn:admin → full subnet_ids."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(
+                sub="admin-user",
+                caller_type="user",
+                permissions=["acn:admin"],
+            ),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents/agent-target",
+                headers={"Authorization": "Bearer admin-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert "subnet-private-abc" in r.json()["subnet_ids"]
+
+
+# ---------------------------------------------------------------------------
+# GET /agents (search / list)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAgentsSubnetIdsPrivacy:
+    def test_anon_sees_only_public_slugs(self):
+        """Unauthenticated list → only public slugs per agent."""
+        with TestClient(app) as client:
+            r = client.get("/api/v1/agents?status=all")
+
+        assert r.status_code == 200, r.text
+        for ag in r.json()["agents"]:
+            assert ag["subnet_ids"] == ["public"], ag["subnet_ids"]
+
+    def test_user_jwt_sees_only_public_slugs(self, monkeypatch):
+        """User JWT on list endpoint → only public slugs."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(sub="user-owner", caller_type="user"),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents?status=all",
+                headers={"Authorization": "Bearer user-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        for ag in r.json()["agents"]:
+            assert ag["subnet_ids"] == ["public"]
+
+    def test_admin_sees_full_subnet_ids(self, monkeypatch):
+        """acn:admin on list → full subnet_ids per agent."""
+        monkeypatch.setattr(
+            "acn.routes.registry.verify_token",
+            _fake_verify_token(
+                sub="admin-user",
+                caller_type="user",
+                permissions=["acn:admin"],
+            ),
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/v1/agents?status=all",
+                headers={"Authorization": "Bearer admin-token"},
+            )
+
+        assert r.status_code == 200, r.text
+        for ag in r.json()["agents"]:
+            assert "subnet-private-abc" in ag["subnet_ids"]


### PR DESCRIPTION
## Summary (ACL V6 Scope A — B3)

Closes part of #114.

### Problem

`GET /api/v1/agents/{id}` and `GET /api/v1/agents` (search) previously exposed **all** `subnet_ids`, including private subnet slugs, to every caller. Any anonymous HTTP client could learn a private subnet's slug simply by querying a member agent's public profile — defeating the subnet-privacy promise.

### Contract (Issue #114 B3)

| Caller | `subnet_ids` |
|---|---|
| Anonymous / unauthenticated | public slugs only |
| User JWT (any, including agent owner) | public slugs only |
| Unrelated agent API key | public slugs only |
| **API key = the agent itself (self)** | **full list** |
| **`acn:admin`** | **full list** |

Human owners who want the full list must use `GET /agents/me` with the agent's own API key — consistent with ACL V6 principle A1.

### Changes

**`acn/routes/registry.py`**
- Both routes gain optional-bearer auth (`HTTPBearer(auto_error=False)`) so the token is resolved when present but the endpoints remain open to anonymous callers.
- Both routes accept a new `SubnetServiceDep` for public-subnet lookup.
- New helpers:
  - `_get_public_subnet_slugs(subnet_service)` — fetches public subnet slugs once per request; degrades to `{"public"}` on any error.
  - `_caller_gets_full_subnet_ids(payload, agent_id)` — encodes the self/admin predicate.
- `_agent_entity_to_info` / `_agent_entity_to_info_with_alive` / `_agent_entities_to_infos` gain `public_subnet_slugs: set[str] | None` parameter (`None` = full list, set = filter to intersection).

**`tests/routes/test_agent_subnet_ids_privacy.py`** (new)
- 8 tests across `TestGetAgentSubnetIdsPrivacy` and `TestSearchAgentsSubnetIdsPrivacy`.
- Covers: anonymous, user JWT (owner), unrelated agent key, self key, admin — for both endpoints.

### Test results

```
85 passed, 0 failed (routes + auth suites)
```

Made with [Cursor](https://cursor.com)