### PR TITLE
feat(acl): B8 — ?confirm=true safety guard on destructive DELETE endpoints

### DIFF
--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -2235,11 +2235,31 @@ async def unregister_agent(
     agent_id: AgentIdPath,
     payload: dict = Depends(require_permission("acn:write")),
     agent_service: AgentServiceDep = None,
+    confirm: bool = Query(
+        default=False,
+        description=(
+            "Safety guard (ACL V6 B8): must be `true` to execute this "
+            "destructive operation. Omitting it or passing `false` returns "
+            "a 400 so accidental calls cannot silently unregister agents."
+        ),
+    ),
 ):
-    """Unregister an agent
+    """Unregister an agent.
+
+    **Destructive operation** — requires ``?confirm=true``.
 
     Clean Architecture: Route → AgentService → Repository
     """
+    if not confirm:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            details={
+                "agent_id": agent_id,
+                "hint": "Add ?confirm=true to confirm this destructive operation.",
+            },
+        )
+
     token_owner: str = payload.get("sub", "")
 
     try:
@@ -2248,7 +2268,16 @@ async def unregister_agent(
 
         if success:
             evict_agent_from_cache(agent_id)  # M3: immediate cache invalidation
-            logger.info("agent_unregistered", agent_id=agent_id)
+            logger.info("agent_unregistered", agent_id=agent_id, actor=token_owner)
+            fire_and_forget_event(
+                get_audit_singleton(),
+                event_type=AuditEventType.AGENT_UNREGISTERED,
+                actor_id=token_owner,
+                actor_type=payload.get("type", "user"),
+                target_id=agent_id,
+                target_type="agent",
+                details={"confirmed": True},
+            )
             return {"status": "unregistered", "agent_id": agent_id}
         else:
             raise ACNHTTPError(

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -8,7 +8,7 @@ import secrets
 from typing import Literal
 
 import structlog  # type: ignore[import-untyped]
-from fastapi import APIRouter, Depends, HTTPException, Request, Security
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 
@@ -17,6 +17,7 @@ from ..config import get_settings
 from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
 from ..core.exceptions import SubnetNotFoundException
 from ..models import SubnetCreateRequest, SubnetCreateResponse, SubnetInfo, SubnetStub
+from ..monitoring import AuditEventType, fire_and_forget_event, get_audit_singleton
 from ..services.subnet_service import SubnetInvariantError
 from ._subnet_membership import (
     do_get_agent_subnets,
@@ -951,17 +952,46 @@ async def delete_subnet(
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
+    confirm: bool = Query(
+        default=False,
+        description=(
+            "Safety guard (ACL V6 B8): must be `true` to execute this "
+            "destructive operation. Omitting it or passing `false` returns "
+            "a 400 so accidental calls cannot silently delete subnets."
+        ),
+    ),
 ):
     """Delete a subnet (requires Agent API Key — only the owning agent can delete).
 
+    **Destructive operation** — requires ``?confirm=true``.
+
     Clean Architecture: Route → SubnetService → Repository
     """
+    if not confirm:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            details={
+                "subnet_id": subnet_id,
+                "hint": "Add ?confirm=true to confirm this destructive operation.",
+            },
+        )
+
     owner = agent_info["agent_id"]
 
     try:
         success = await subnet_service.delete_subnet(subnet_id, owner)
         if success:
             logger.info("subnet_deleted", subnet_id=subnet_id, owner=owner)
+            fire_and_forget_event(
+                get_audit_singleton(),
+                event_type=AuditEventType.SUBNET_DELETED,
+                actor_id=owner,
+                actor_type="agent",
+                target_id=subnet_id,
+                target_type="subnet",
+                details={"confirmed": True},
+            )
             return {"status": "deleted", "subnet_id": subnet_id}
         else:
             # This in-try raise is now correctly propagated thanks to the

--- a/tests/routes/test_delete_confirm_b8.py
+++ b/tests/routes/test_delete_confirm_b8.py
@@ -1,0 +1,240 @@
+"""ACL V6 B8 — ?confirm=true safety guard on destructive DELETE endpoints.
+
+Both ``DELETE /api/v1/subnets/{subnet_id}`` and
+``DELETE /api/v1/agents/{agent_id}`` now require ``?confirm=true``.
+Omitting it or passing ``?confirm=false`` must return ``400 INVALID_REQUEST``
+with a hint in ``details``, leaving the resource untouched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from acn.routes.dependencies import get_agent_service, get_subnet_service
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_subnet(subnet_id: str = "subnet-1", owner: str = "agent-owner") -> MagicMock:
+    s = MagicMock()
+    s.subnet_id = subnet_id
+    s.owner = owner
+    s.is_private = False
+    s.is_public = True
+    s.member_count = 0
+    s.name = "Test Subnet"
+    s.description = None
+    s.security_config = {}
+    s.created_at = "2026-01-01T00:00:00Z"
+    s.metadata = {}
+    s.parent_subnet_id = None
+    s.lifecycle = "persistent"
+    return s
+
+
+@pytest.fixture
+def stub_agent_service():
+    svc = AsyncMock()
+    owner_agent = MagicMock()
+    owner_agent.agent_id = "agent-owner"
+    owner_agent.name = "Owner"
+
+    async def _by_api_key(key: str):
+        if key == "owner-key":
+            return owner_agent
+        return None
+
+    async def _get_agent(agent_id: str):
+        if agent_id == "agent-owner":
+            return owner_agent
+        raise AgentNotFoundException(agent_id)
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+    svc.get_agent = AsyncMock(side_effect=_get_agent)
+    svc.search_agents = AsyncMock(return_value=[])
+    svc.unregister_agent = AsyncMock(return_value=True)
+    svc.is_alive = AsyncMock(return_value=True)
+    svc.batch_alive = AsyncMock(return_value={"agent-owner"})
+    return svc
+
+
+@pytest.fixture
+def stub_subnet_service():
+    svc = AsyncMock()
+    subnet = _make_subnet()
+
+    async def _get_subnet(subnet_id: str):
+        if subnet_id == "subnet-1":
+            return subnet
+        raise SubnetNotFoundException(subnet_id)
+
+    svc.get_subnet = AsyncMock(side_effect=_get_subnet)
+    svc.delete_subnet = AsyncMock(return_value=True)
+    svc.list_public_subnets = AsyncMock(return_value=[subnet])
+    svc.list_subnets = AsyncMock(return_value=[])
+    svc.get_subnet_children = AsyncMock(return_value=[])
+    return svc
+
+
+@pytest.fixture(autouse=True)
+def wire(stub_agent_service, stub_subnet_service):
+    app.dependency_overrides[get_agent_service] = lambda: stub_agent_service
+    app.dependency_overrides[get_subnet_service] = lambda: stub_subnet_service
+    yield
+    app.dependency_overrides.pop(get_agent_service, None)
+    app.dependency_overrides.pop(get_subnet_service, None)
+
+
+# ---------------------------------------------------------------------------
+# Helper — stub require_permission("acn:write") for agent DELETE tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_require_permission(sub: str, permissions: list[str] | None = None):
+    """Return a dependency factory that patches ``require_permission``."""
+
+    async def _impl(*args, **kwargs):
+        return {"sub": sub, "type": "user", "permissions": permissions or ["acn:write"]}
+
+    return _impl
+
+
+# ---------------------------------------------------------------------------
+# DELETE /subnets/{subnet_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSubnetConfirmGuard:
+    def test_missing_confirm_returns_400(self):
+        """No ``?confirm`` → 400 INVALID_REQUEST, subnet untouched."""
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 400, r.text
+        body = r.json()
+        assert body["error_code"] == "invalid_request"
+        assert "confirm=true" in body["details"].get("hint", "").lower()
+
+    def test_confirm_false_returns_400(self):
+        """``?confirm=false`` is not accepted."""
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/subnets/subnet-1?confirm=false",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 400, r.text
+        assert r.json()["error_code"] == "invalid_request"
+
+    def test_confirm_true_deletes_subnet(self, stub_subnet_service):
+        """``?confirm=true`` proceeds to delete and returns 200."""
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/subnets/subnet-1?confirm=true",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"status": "deleted", "subnet_id": "subnet-1"}
+        stub_subnet_service.delete_subnet.assert_awaited_once_with("subnet-1", "agent-owner")
+
+    def test_missing_confirm_does_not_call_service(self, stub_subnet_service):
+        """Service must never be called when confirm is absent."""
+        with TestClient(app) as client:
+            client.delete(
+                "/api/v1/subnets/subnet-1",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        stub_subnet_service.delete_subnet.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /agents/{agent_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAgentConfirmGuard:
+    def test_missing_confirm_returns_400(self, monkeypatch):
+        """No ``?confirm`` → 400 INVALID_REQUEST, agent untouched."""
+        from acn.routes import registry as reg_module
+
+        monkeypatch.setattr(
+            reg_module,
+            "require_permission",
+            lambda _perm: _fake_require_permission("agent-owner"),
+        )
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-owner",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 400, r.text
+        body = r.json()
+        assert body["error_code"] == "invalid_request"
+        assert "confirm=true" in body["details"].get("hint", "").lower()
+
+    def test_confirm_false_returns_400(self, monkeypatch):
+        from acn.routes import registry as reg_module
+
+        monkeypatch.setattr(
+            reg_module,
+            "require_permission",
+            lambda _perm: _fake_require_permission("agent-owner"),
+        )
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-owner?confirm=false",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 400, r.text
+        assert r.json()["error_code"] == "invalid_request"
+
+    def test_confirm_true_unregisters_agent(self, monkeypatch, stub_agent_service):
+        """``?confirm=true`` proceeds to unregister and returns 200."""
+        from acn.routes import registry as reg_module
+
+        monkeypatch.setattr(
+            reg_module,
+            "require_permission",
+            lambda _perm: _fake_require_permission("agent-owner"),
+        )
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-owner?confirm=true",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"status": "unregistered", "agent_id": "agent-owner"}
+        # Verify the service was reached (exact token_owner depends on auth mode)
+        stub_agent_service.unregister_agent.assert_awaited_once()
+
+    def test_missing_confirm_does_not_call_service(self, monkeypatch, stub_agent_service):
+        """Service must never be called when confirm is absent."""
+        from acn.routes import registry as reg_module
+
+        monkeypatch.setattr(
+            reg_module,
+            "require_permission",
+            lambda _perm: _fake_require_permission("agent-owner"),
+        )
+        with TestClient(app) as client:
+            client.delete(
+                "/api/v1/agents/agent-owner",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+
+        stub_agent_service.unregister_agent.assert_not_awaited()

--- a/tests/routes/test_registry_error_schema.py
+++ b/tests/routes/test_registry_error_schema.py
@@ -249,7 +249,7 @@ class TestRegistryFlatErrorSchemaUnregisterPath:
 
         with TestClient(app) as client:
             r = client.delete(
-                "/api/v1/agents/agent-target",
+                "/api/v1/agents/agent-target?confirm=true",
                 headers={"Authorization": "Bearer dev-mode-any-token"},
             )
 
@@ -408,7 +408,7 @@ class TestRegistryFlatErrorSchemaCrossModule:
 
         with TestClient(app) as client:
             r = client.delete(
-                "/api/v1/agents/agent-target",
+                "/api/v1/agents/agent-target?confirm=true",
                 headers={"Authorization": "Bearer dev-mode-any-token"},
             )
 

--- a/tests/routes/test_subnets_error_schema.py
+++ b/tests/routes/test_subnets_error_schema.py
@@ -524,7 +524,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
 
         with TestClient(app) as client:
             r = client.delete(
-                "/api/v1/subnets/subnet-1",
+                "/api/v1/subnets/subnet-1?confirm=true",
                 headers={"Authorization": "Bearer owner-key"},
             )
 
@@ -585,7 +585,7 @@ class TestSubnetsCatchAllDefence:
 
         with TestClient(app) as client:
             r = client.delete(
-                "/api/v1/subnets/subnet-1",
+                "/api/v1/subnets/subnet-1?confirm=true",
                 headers={"Authorization": "Bearer owner-key"},
             )
 


### PR DESCRIPTION
## Summary (ACL V6 Scope A — B8)

Closes part of #114.

### Problem

`DELETE /api/v1/subnets/{subnet_id}` and `DELETE /api/v1/agents/{agent_id}` had no guard against accidental calls. A typo in a script, a misfire from a UI, or a replayed HTTP request could silently delete production resources with no confirmation step.

### Change

Both endpoints now require `?confirm=true`:

| Call | Result |
|---|---|
| `DELETE /subnets/x` (no confirm) | `400 INVALID_REQUEST` — service never reached |
| `DELETE /subnets/x?confirm=false` | `400 INVALID_REQUEST` |
| `DELETE /subnets/x?confirm=true` | Proceeds, writes audit event |
| `DELETE /agents/x` (no confirm) | `400 INVALID_REQUEST` — service never reached |
| `DELETE /agents/x?confirm=true` | Proceeds, writes audit event |

The 400 body includes a `hint` field: `"Add ?confirm=true to confirm this destructive operation."`.

### Audit logging

On successful deletion, both routes now emit a `fire_and_forget_event` with `details.confirmed=true` — previously only a `structlog` INFO line existed for agent unregister and no explicit audit event was written for the subnet delete path.

### Files changed

- `acn/routes/subnets.py` — `delete_subnet`: adds `confirm` guard + monitoring import + audit event
- `acn/routes/registry.py` — `unregister_agent`: adds `confirm` guard + explicit audit event
- `tests/routes/test_delete_confirm_b8.py` (new) — 8 tests covering missing/false/true confirm for both endpoints

### Test results

```
8 passed
```

Made with [Cursor](https://cursor.com)