### PR TITLE
fix(security): audit hardening — 5 high-priority findings

### DIFF
--- a/acn/auth/middleware.py
+++ b/acn/auth/middleware.py
@@ -27,6 +27,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from jose.exceptions import ExpiredSignatureError
 
+from ..core.errors import ACNHTTPError, ErrorCode
 from ..monitoring import record_auth_failure
 
 logger = structlog.get_logger()
@@ -265,9 +266,11 @@ async def _verify_jwt(token: str, request: Request | None = None) -> dict:
                 path=path,
                 method=method,
             )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Unable to find appropriate signing key.",
+            raise ACNHTTPError(
+                ErrorCode.AUTHENTICATION_REQUIRED,
+                401,
+                message="Unable to find appropriate signing key.",
+                headers={"WWW-Authenticate": "Bearer"},
             )
 
         bare_domain = settings.auth0_domain.removeprefix("https://").removeprefix("http://").rstrip("/")
@@ -288,9 +291,11 @@ async def _verify_jwt(token: str, request: Request | None = None) -> dict:
             path=path,
             method=method,
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token has expired.",
+        raise ACNHTTPError(
+            ErrorCode.AUTHENTICATION_REQUIRED,
+            401,
+            message="Token has expired.",
+            headers={"WWW-Authenticate": "Bearer"},
         ) from None
     except JWTError as e:
         logger.warning("jwt_verification_failed", error=str(e))
@@ -301,10 +306,14 @@ async def _verify_jwt(token: str, request: Request | None = None) -> dict:
             method=method,
             extra={"jwt_error": type(e).__name__},
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token.",
+        raise ACNHTTPError(
+            ErrorCode.AUTHENTICATION_REQUIRED,
+            401,
+            message="Invalid token.",
+            headers={"WWW-Authenticate": "Bearer"},
         ) from e
+    except ACNHTTPError:
+        raise
     except HTTPException:
         raise
     except Exception as e:
@@ -374,9 +383,10 @@ async def verify_token(
             path=path,
             method=method,
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authorization header required.",
+        raise ACNHTTPError(
+            ErrorCode.AUTHENTICATION_REQUIRED,
+            401,
+            message="Authorization header required.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -405,9 +415,10 @@ async def verify_token(
             path=path,
             method=method,
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid API key.",
+        raise ACNHTTPError(
+            ErrorCode.AUTHENTICATION_REQUIRED,
+            401,
+            message="Invalid API key.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -441,9 +452,10 @@ def require_permission(permission: str):
                 method=method,
                 extra={"permission": permission},
             )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Missing required permission: {permission}",
+            raise ACNHTTPError(
+                ErrorCode.MISSING_PERMISSION,
+                403,
+                message=f"Missing required permission: {permission}",
             )
         return payload
 
@@ -512,9 +524,10 @@ def require_internal_or_permission(permission: str):
                 method=method,
                 extra={"permission": permission},
             )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Missing required permission: {permission}",
+            raise ACNHTTPError(
+                ErrorCode.MISSING_PERMISSION,
+                403,
+                message=f"Missing required permission: {permission}",
             )
         return payload
 

--- a/acn/config.py
+++ b/acn/config.py
@@ -5,9 +5,18 @@ Settings for ACN service
 """
 
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _read_pkg_version() -> str:
+    try:
+        return _pkg_version("acn")
+    except PackageNotFoundError:
+        return "unknown"
 
 # Hosts allowed when ``dev_mode=True``. Deliberately *excludes* ``0.0.0.0``
 # even though dev-mode docker-compose often binds it — letting dev_mode
@@ -23,7 +32,7 @@ class Settings(BaseSettings):
 
     # Service
     service_name: str = "ACN"
-    service_version: str = "0.7.1"
+    service_version: str = _read_pkg_version()
     host: str = "0.0.0.0"
     port: int = 8000
 

--- a/acn/core/errors.py
+++ b/acn/core/errors.py
@@ -338,6 +338,7 @@ class ErrorCode(StrEnum):
     # in section 4 of ``docs/features/acn-error-schema.md``.
     INSUFFICIENT_BALANCE = "insufficient_balance"
     RESOURCE_CONFLICT = "resource_conflict"
+    AGENT_HAS_OWNED_SUBNETS = "agent_has_owned_subnets"
 
 
 _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
@@ -482,6 +483,10 @@ _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
     ),
     ErrorCode.RESOURCE_CONFLICT: (
         "The request conflicts with the current state of the resource."
+    ),
+    ErrorCode.AGENT_HAS_OWNED_SUBNETS: (
+        "The agent cannot be deleted because it still owns one or more subnets. "
+        "Transfer ownership or delete the subnets first."
     ),
     # ===== ADR-0004 Slice 2.3 — subnet admission =====
     ErrorCode.SUBNET_NOT_OWNER: (

--- a/acn/infrastructure/messaging/subnet_manager.py
+++ b/acn/infrastructure/messaging/subnet_manager.py
@@ -576,6 +576,22 @@ class SubnetManager:
         if data.get("type") != GatewayMessageType.REGISTER:
             raise ValueError(f"Expected REGISTER, got {data.get('type')}")
 
+        # Impersonation guard: if an agent with this ID already exists in the
+        # registry and was NOT registered via the gateway protocol, reject the
+        # connection. This prevents a WS client from clobbering a REST-registered
+        # agent's record by connecting with the same agent_id over the public
+        # WebSocket endpoint.  Gateway reconnections (same agent reconnecting
+        # after a disconnect) are allowed: their metadata carries
+        # ``"connection_type": "gateway"``.
+        existing = await self.agent_service.repository.find_by_id(connection.agent_id)
+        if existing is not None:
+            existing_conn_type = (existing.metadata or {}).get("connection_type")
+            if existing_conn_type != "gateway":
+                raise ValueError(
+                    f"agent_id '{connection.agent_id}' is already registered via "
+                    f"a non-gateway protocol; choose a different agent_id"
+                )
+
         # Build agent info with gateway endpoint
         agent_data = data.get("agent_info", {})
         gateway_endpoint = (

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -211,6 +211,7 @@ async def set_payment_capability(
 @router.get("/{agent_id}/payment-capability")
 async def get_payment_capability(
     agent_id: str,
+    _caller: AgentApiKeyDep,
     payment_discovery: PaymentDiscoveryDep = None,
 ):
     """Get payment capability for agent"""
@@ -509,6 +510,7 @@ async def set_token_pricing(
 @router.get("/{agent_id}/token-pricing")
 async def get_token_pricing(
     agent_id: str,
+    _caller: AgentApiKeyDep,
     payment_discovery: PaymentDiscoveryDep = None,
 ):
     """Get token-based pricing for an agent"""
@@ -537,6 +539,7 @@ async def get_token_pricing(
 async def estimate_cost(
     request: Request,
     body: EstimateCostRequest,
+    _caller: AgentApiKeyDep,
     payment_discovery: PaymentDiscoveryDep = None,
 ):
     """

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -2235,6 +2235,7 @@ async def unregister_agent(
     agent_id: AgentIdPath,
     payload: dict = Depends(require_permission("acn:write")),
     agent_service: AgentServiceDep = None,
+    subnet_service: SubnetServiceDep = None,
     confirm: bool = Query(
         default=False,
         description=(
@@ -2247,6 +2248,9 @@ async def unregister_agent(
     """Unregister an agent.
 
     **Destructive operation** — requires ``?confirm=true``.
+
+    ADR-0006: rejected when the agent still owns one or more subnets —
+    transfer or delete the subnets first (``reason="has-owned-subnets"``).
 
     Clean Architecture: Route → AgentService → Repository
     """
@@ -2261,6 +2265,22 @@ async def unregister_agent(
         )
 
     token_owner: str = payload.get("sub", "")
+
+    # ADR-0006 invariant: an agent that still owns subnets cannot be deleted.
+    # Transfer or delete the subnets first so the registry never holds
+    # subnets with no reachable owner.
+    if subnet_service is not None:
+        owned = await subnet_service.list_subnets(owner=agent_id)
+        if owned:
+            raise ACNHTTPError(
+                ErrorCode.AGENT_HAS_OWNED_SUBNETS,
+                409,
+                details={
+                    "agent_id": agent_id,
+                    "owned_subnet_ids": [s.subnet_id for s in owned],
+                    "hint": "Delete or transfer ownership of these subnets before removing the agent.",
+                },
+            )
 
     try:
         # AgentService handles authorization check

--- a/tests/auth/test_middleware_production_dual_protocol.py
+++ b/tests/auth/test_middleware_production_dual_protocol.py
@@ -33,6 +33,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from acn.auth import middleware as mw
 from acn.core.entities import Agent
+from acn.core.errors import ACNHTTPError, ErrorCode
 
 
 def _make_agent(agent_id: str = "agent-uuid-prod") -> Agent:
@@ -133,11 +134,12 @@ class TestVerifyTokenApiKeyPath:
         revoked API key)."""
         _patch_agent_service(monkeypatch, returns=None)
 
-        with pytest.raises(HTTPException) as excinfo:
+        with pytest.raises(ACNHTTPError) as excinfo:
             await mw.verify_token(_stub_request(), _bearer("acn_revoked"))
 
         assert excinfo.value.status_code == 401
-        assert "Invalid API key" in excinfo.value.detail
+        assert excinfo.value.code == ErrorCode.AUTHENTICATION_REQUIRED
+        assert "Invalid API key" in excinfo.value.message
 
     @pytest.mark.asyncio
     async def test_api_key_path_does_not_invoke_jwt_verification(
@@ -217,11 +219,12 @@ class TestVerifyTokenJwtPath:
 class TestVerifyTokenMissingCredentials:
     @pytest.mark.asyncio
     async def test_no_credentials_raises_401_bearer_missing(self):
-        with pytest.raises(HTTPException) as excinfo:
+        with pytest.raises(ACNHTTPError) as excinfo:
             await mw.verify_token(_stub_request(), None)
 
         assert excinfo.value.status_code == 401
-        assert "Authorization header required" in excinfo.value.detail
+        assert excinfo.value.code == ErrorCode.AUTHENTICATION_REQUIRED
+        assert "Authorization header required" in excinfo.value.message
         assert excinfo.value.headers == {"WWW-Authenticate": "Bearer"}
 
 
@@ -266,10 +269,11 @@ class TestRequireInternalOrPermissionProduction:
         )
         checker = mw.require_internal_or_permission("acn:write")
 
-        with pytest.raises(HTTPException) as excinfo:
+        with pytest.raises(ACNHTTPError) as excinfo:
             await checker(_stub_request(), _bearer("eyJ.fake"), None)
 
         assert excinfo.value.status_code == 403
+        assert excinfo.value.code == ErrorCode.MISSING_PERMISSION
 
     @pytest.mark.asyncio
     async def test_api_key_propagates_through_verify_token(self, monkeypatch):
@@ -295,7 +299,8 @@ class TestRequireInternalOrPermissionProduction:
         _patch_agent_service(monkeypatch, returns=_make_agent("agent-rip-admin"))
         checker = mw.require_internal_or_permission("acn:admin")
 
-        with pytest.raises(HTTPException) as excinfo:
+        with pytest.raises(ACNHTTPError) as excinfo:
             await checker(_stub_request(), _bearer("acn_x"), None)
 
         assert excinfo.value.status_code == 403
+        assert excinfo.value.code == ErrorCode.MISSING_PERMISSION

--- a/tests/infrastructure/test_subnet_manager_register.py
+++ b/tests/infrastructure/test_subnet_manager_register.py
@@ -89,6 +89,12 @@ def _make_manager() -> tuple[SubnetManager, AsyncMock]:
     # ``.save(Agent(...))``; the AsyncMock attribute access auto-creates
     # ``.repository.save`` as another AsyncMock, which is exactly what
     # the assertions below want.
+    #
+    # ``find_by_id`` must return ``None`` to model a brand-new agent that
+    # does not yet exist in the registry. The impersonation guard added in
+    # ``_handle_registration`` checks the repository before writing; a
+    # truthy AsyncMock default would trip it for every new registration.
+    agent_service.repository.find_by_id = AsyncMock(return_value=None)
     manager = SubnetManager(
         agent_service=agent_service,
         redis_client=AsyncMock(),

--- a/tests/routes/test_payments_error_schema.py
+++ b/tests/routes/test_payments_error_schema.py
@@ -300,9 +300,13 @@ class TestResourceNotFoundFlatShape:
     converge on the same code; the others have a single site each."""
 
     def test_get_payment_capability_404_flat_shape(self, stub_payment_discovery):
+        _wire_self_authed()
         app.dependency_overrides[get_payment_discovery] = lambda: stub_payment_discovery
-        with TestClient(app) as client:
-            r = client.get("/api/v1/payments/agent-x/payment-capability")
+        try:
+            with TestClient(app) as client:
+                r = client.get("/api/v1/payments/agent-x/payment-capability")
+        finally:
+            app.dependency_overrides.pop(verify_agent_api_key, None)
         assert r.status_code == 404
         body = r.json()
         _assert_flat_shape(body)
@@ -321,9 +325,13 @@ class TestResourceNotFoundFlatShape:
         assert body["details"] == {"task_id": "task-ghost"}
 
     def test_get_token_pricing_404_flat_shape(self, stub_payment_discovery):
+        _wire_self_authed()
         app.dependency_overrides[get_payment_discovery] = lambda: stub_payment_discovery
-        with TestClient(app) as client:
-            r = client.get("/api/v1/payments/agent-x/token-pricing")
+        try:
+            with TestClient(app) as client:
+                r = client.get("/api/v1/payments/agent-x/token-pricing")
+        finally:
+            app.dependency_overrides.pop(verify_agent_api_key, None)
         assert r.status_code == 404
         body = r.json()
         _assert_flat_shape(body)
@@ -331,16 +339,20 @@ class TestResourceNotFoundFlatShape:
         assert body["details"] == {"agent_id": "agent-x"}
 
     def test_estimate_cost_404_flat_shape(self, stub_payment_discovery):
+        _wire_self_authed()
         app.dependency_overrides[get_payment_discovery] = lambda: stub_payment_discovery
-        with TestClient(app) as client:
-            r = client.post(
-                "/api/v1/payments/billing/estimate",
-                json={
-                    "agent_id": "agent-x",
-                    "estimated_input_tokens": 100,
-                    "estimated_output_tokens": 50,
-                },
-            )
+        try:
+            with TestClient(app) as client:
+                r = client.post(
+                    "/api/v1/payments/billing/estimate",
+                    json={
+                        "agent_id": "agent-x",
+                        "estimated_input_tokens": 100,
+                        "estimated_output_tokens": 50,
+                    },
+                )
+        finally:
+            app.dependency_overrides.pop(verify_agent_api_key, None)
         assert r.status_code == 404
         body = r.json()
         _assert_flat_shape(body)


### PR DESCRIPTION
## Summary

Full-codebase audit (v0.11.0) identified 5 high-priority issues. This PR addresses all of them.

### 1. `service_version` hardcoded as `"0.7.1"` (config.py)
`/health`, `/`, and the A2A server card were reporting v0.7.1 while the package is v0.11.0.
**Fix**: read from `importlib.metadata.version("acn")` at startup; falls back to `"unknown"` if the package isn't installed.

### 2. `DELETE /agents/{id}` allowed deleting subnet-owning agents (ADR-0006)
The ADR documented this invariant as "not yet enforced in the route layer". Deleting an agent that owns subnets left orphan subnets with no reachable owner.
**Fix**: route now calls `subnet_service.list_subnets(owner=agent_id)` before delegation; returns `409 AGENT_HAS_OWNED_SUBNETS` if non-empty. New `ErrorCode.AGENT_HAS_OWNED_SUBNETS` added to catalog.

### 3. `GET /payment-capability`, `GET /token-pricing`, `POST /billing/estimate` unauthenticated
Wallet addresses and per-agent token pricing were readable without any auth.
**Fix**: added `AgentApiKeyDep` to all three handlers.

### 4. Gateway WebSocket agent impersonation
On public subnets any WS client could connect with an arbitrary `agent_id`, overwriting the REST-registered record for that agent.
**Fix**: `_handle_registration` checks the repository before writing; if the claimed `agent_id` already exists with `connection_type != "gateway"` the connection is closed with a descriptive error.

### 5. `auth/middleware.py` 4xx responses bypassed the flat error schema
`verify_token` and `require_permission` raised `HTTPException` instead of `ACNHTTPError`, producing a `{"detail": "..."}` body that differs from every other protected endpoint.
**Fix**: migrated 5 raise sites to `ACNHTTPError(AUTHENTICATION_REQUIRED / MISSING_PERMISSION, 4xx)`. The 503 (Auth0 not configured) and 500 (unexpected auth error) paths remain `HTTPException` per the 5xx sanitisation policy documented in `core/errors.py`.

## Test changes
- `tests/auth/test_middleware_production_dual_protocol.py`: 4 tests updated from `pytest.raises(HTTPException)` to `pytest.raises(ACNHTTPError)` with `.code` assertions.
- `tests/routes/test_payments_error_schema.py`: 3 tests updated with `_wire_self_authed()` so they reach the 404 handler instead of the new 401 gate.

## Test plan
- [ ] All 56 affected tests pass locally
- [ ] CI green

Made with [Cursor](https://cursor.com)