### PR TITLE
fix: third audit hardening — P0/P1/P2 across 8 files

### DIFF
--- a/acn/infrastructure/messaging/subnet_manager.py
+++ b/acn/infrastructure/messaging/subnet_manager.py
@@ -416,9 +416,12 @@ class SubnetManager:
                     return True
 
             elif scheme.type == "apiKey":
-                # Validate API key
+                # Validate API key using constant-time comparison to prevent
+                # timing side-channel attacks (mirrors the bearer branch above).
                 api_key = credentials.get("api_key") or credentials.get("apiKey")
-                if api_key and api_key == subnet.generated_token:
+                if api_key and subnet.generated_token and secrets.compare_digest(
+                    api_key, subnet.generated_token
+                ):
                     return True
 
             elif scheme.type in ("openIdConnect", "oauth2"):
@@ -546,7 +549,10 @@ class SubnetManager:
             logger.info(f"Agent disconnected: {subnet_id}/{agent_id}")
         except Exception as e:
             logger.error(f"Connection error for {subnet_id}/{agent_id}: {e}")
-            await self._send_error(websocket, str(e))
+            # Send a generic error code to the client — do not echo internal
+            # exception details over the WebSocket frame (they may contain
+            # internal hostnames, SQL errors, or agent_id enumeration hints).
+            await self._send_error(websocket, "connection_error")
         finally:
             await self._disconnect(subnet_id, agent_id)
 
@@ -750,17 +756,19 @@ class SubnetManager:
             if not future.done():
                 future.set_exception(ConnectionError(f"Agent disconnected: {reason}"))
 
-        # Unregister from ACN. We bypass ``AgentService.unregister_agent``
-        # here because that method enforces owner-based authorization
-        # (caller must match ``agent.owner``) and the gateway has no
-        # owner context — the connection is identified by its WS
-        # session, not a user identity. Going straight to the
-        # repository preserves the legacy "best-effort cleanup"
-        # contract.
+        # On disconnect, mark the agent as offline (clear alive key + inbox)
+        # but keep the agent record so the agent can reconnect later without
+        # re-choosing an agent_id. Full deletion happens only via the REST
+        # DELETE /agents/{id} endpoint, which runs the full
+        # unregister_agent() service path (subnet cleanup, payment index,
+        # follow-graph). Calling repository.delete() here would:
+        #   (a) bypass the service-layer cleanup gates, and
+        #   (b) in PG mode, leave Redis alive/inbox/payment indexes stale.
         try:
-            await self.agent_service.repository.delete(agent_id)
+            await self.redis.delete(f"acn:agents:{agent_id}:alive")
+            await self.redis.delete(f"acn:inbox:{agent_id}")
         except Exception as e:
-            logger.warning(f"Failed to unregister {agent_id}: {e}")
+            logger.warning(f"Failed to clear agent offline state {agent_id}: {e}")
 
         # Close WebSocket
         try:

--- a/acn/infrastructure/persistence/postgres/agent_repository.py
+++ b/acn/infrastructure/persistence/postgres/agent_repository.py
@@ -231,11 +231,33 @@ class PostgresAgentRepository(IAgentRepository):
 
     async def delete(self, agent_id: str) -> bool:
         async with self._session_factory() as session:
+            # Load before delete so we can clear Redis indexes that key on
+            # the agent's api_key hash and other fields.
+            row = await session.get(AgentModel, agent_id)
             result = await session.execute(
                 delete(AgentModel).where(AgentModel.agent_id == agent_id)
             )
             await session.commit()
-            return result.rowcount > 0
+            deleted = result.rowcount > 0
+
+        if deleted:
+            # Mirror the Redis cleanup performed by RedisAgentRepository.delete
+            # so that alive checks, inbox, and API-key lookups all invalidate
+            # immediately rather than waiting for TTL expiry.
+            await self._redis.delete(f"acn:agents:{agent_id}:alive")
+            await self._redis.delete(f"acn:inbox:{agent_id}")
+            if row is not None:
+                meta = row.agent_metadata or {}
+                api_key_hash = meta.get("api_key_hash") or (row.agent_metadata or {}).get("api_key")
+                if api_key_hash:
+                    await self._redis.delete(f"acn:agents:by_api_key:{api_key_hash}")
+                if row.owner:
+                    await self._redis.srem(f"acn:agents:by_owner:{row.owner}", agent_id)
+                await self._redis.srem("acn:agents:unclaimed", agent_id)
+                for subnet_id in (row.subnet_ids or []):
+                    await self._redis.srem(f"acn:subnets:{subnet_id}:agents", agent_id)
+
+        return deleted
 
     async def exists(self, agent_id: str) -> bool:
         async with self._session_factory() as session:

--- a/acn/routes/analytics.py
+++ b/acn/routes/analytics.py
@@ -134,6 +134,26 @@ async def list_activities(
     - agent_id: Filter by single agent (optional, requires auth)
     - agent_ids: Filter by multiple agents, comma-separated (optional, requires auth)
     """
+    # Enforce auth when filtering by task_id or user_id: these filters can reveal
+    # private task titles / user associations via the activity description field,
+    # bypassing the Task ACL contract enforced on GET /tasks endpoints.
+    if task_id or user_id:
+        if not authorization or not authorization.startswith("Bearer "):
+            raise ACNHTTPError(
+                ErrorCode.AUTHENTICATION_REQUIRED,
+                status_code=401,
+                details={"reason": "auth_required_for_task_or_user_filter"},
+            )
+        api_key = authorization[7:]
+        agent_service = get_agent_service()
+        authed_agent = await agent_service.get_agent_by_api_key(api_key)
+        if not authed_agent:
+            raise ACNHTTPError(
+                ErrorCode.AUTHENTICATION_REQUIRED,
+                status_code=401,
+                details={"reason": "invalid_api_key"},
+            )
+
     # Enforce auth when filtering by specific agent identity to prevent enumeration
     if agent_id or agent_ids:
         if not authorization or not authorization.startswith("Bearer "):

--- a/acn/routes/communication.py
+++ b/acn/routes/communication.py
@@ -841,7 +841,7 @@ async def send_message(
             to_agent=body.target_agent,
             status="error",
         )
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Message delivery failed") from e
 
 
 @router.post("/broadcast")
@@ -878,6 +878,21 @@ async def broadcast_message(
                 "from_agent": body.from_agent,
             },
         )
+
+    # Safety guard: broadcasting to the entire network (no target_subnet and
+    # no target_tags) is an O(N) fan-out that can saturate outbound connections
+    # and exhaust Redis/HTTP resources. Require at least one scoping selector
+    # so callers must explicitly opt in to the set they want to reach.
+    if not body.target_subnet and not body.target_tags:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            422,
+            message="Broadcast requires at least one selector: target_subnet or target_tags.",
+            details={
+                "hint": "Set target_subnet to a subnet_id or target_tags to a non-empty list.",
+            },
+        )
+
     try:
         message = _payload_to_a2a_message(body.message)
 
@@ -970,7 +985,7 @@ async def broadcast_message(
             "broadcast_sent",
             labels={"type": "broadcast", "status": "error"},
         )
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Broadcast failed") from e
 
 
 @router.post("/broadcast-by-tag")
@@ -1062,7 +1077,7 @@ async def broadcast_by_tag(
 
     except Exception as e:
         logger.error("tag_broadcast_failed", error=str(e))
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Tag broadcast failed") from e
 
 
 @router.get("/history/{agent_id}")
@@ -1121,7 +1136,7 @@ async def get_message_history(
 
     except Exception as e:
         logger.error("inbox_retrieve_failed", error=str(e))
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve inbox") from e
 
 
 class AckInboxRequest(BaseModel):
@@ -1176,7 +1191,7 @@ async def ack_message_history(
 
     except Exception as e:
         logger.error("inbox_ack_failed", error=str(e))
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to acknowledge message") from e
 
 
 @router.post("/retry-dlq")
@@ -1199,7 +1214,7 @@ async def retry_dead_letter_queue(
 
     except Exception as e:
         logger.error("dlq_retry_failed", error=str(e))
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retry dead-letter message") from e
 
 
 # ---------------------------------------------------------------------------
@@ -1362,4 +1377,4 @@ async def internal_send_message(
             to_agent=body.target_agent,
             status="error",
         )
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Message delivery failed") from e

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -297,7 +297,10 @@ def _validate_resolved_a2a_endpoint(endpoint: str) -> None:
     try:
         validate_endpoint_url(endpoint, allow_loopback=settings.dev_mode)
     except SSRFViolation as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+        logger.warning("endpoint_validation_rejected", endpoint=endpoint, reason=str(e))
+        raise HTTPException(
+            status_code=400, detail="The provided endpoint URL is not allowed."
+        ) from e
 
 
 async def _resolve_registration_endpoint(
@@ -330,9 +333,10 @@ async def _resolve_registration_endpoint(
             response.raise_for_status()
             fetched_card = response.json()
     except (httpx.HTTPError, ValueError, SSRFViolation) as e:
+        logger.warning("agent_card_fetch_failed", url=agent_card_url, reason=str(e))
         raise HTTPException(
             status_code=400,
-            detail=f"Unable to fetch A2A Agent Card: {e}",
+            detail="Unable to fetch the A2A Agent Card from the provided URL.",
         ) from e
 
     direct_endpoint = _extract_jsonrpc_endpoint_from_agent_card(fetched_card)
@@ -1587,7 +1591,9 @@ async def get_agent_card(
 
 
 @router.get("/{agent_id}/.well-known/agent-registration.json")
+@limiter.limit("60/minute")
 async def get_agent_registration_file(
+    request: Request,
     agent_id: AgentIdPath,
     agent_service: AgentServiceDep = None,
     cfg: Settings = Depends(get_settings),
@@ -2338,7 +2344,7 @@ async def unregister_agent(
         raise ACNHTTPError(
             ErrorCode.OWNERSHIP_MISMATCH,
             403,
-            details={"agent_id": agent_id, "reason": str(e)},
+            details={"agent_id": agent_id, "reason": "owner_mismatch"},
         ) from e
 
 

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -476,20 +476,29 @@ class AgentService:
 
         logger.info("unregister_agent", agent_id=agent_id)
         deleted = await self.repository.delete(agent_id)
-        # Best-effort follow-graph cleanup AFTER successful deletion so a
-        # cleanup failure cannot leave the agent itself half-deleted.
-        # Stale follow entries are cosmetic (lists ignore dangling ids
-        # via the existence check in ``_resolve_agents_with_counts``)
-        # so we do not unwind the agent delete on a cleanup error.
-        if deleted and self.follow_service is not None:
-            try:
-                await self.follow_service.cleanup_agent(agent_id)  # type: ignore[union-attr]
-            except Exception as e:  # noqa: BLE001 — best-effort
-                logger.warning(
-                    "follow_cleanup_failed_on_unregister",
-                    agent_id=agent_id,
-                    error=str(e),
-                )
+        if deleted:
+            # Best-effort follow-graph cleanup; stale follow entries are
+            # cosmetic so we do not unwind the delete on cleanup error.
+            if self.follow_service is not None:
+                try:
+                    await self.follow_service.cleanup_agent(agent_id)  # type: ignore[union-attr]
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "follow_cleanup_failed_on_unregister",
+                        agent_id=agent_id,
+                        error=str(e),
+                    )
+            # Remove from payment discovery index so the agent no longer
+            # appears in /payments/discover after deletion.
+            if self.payment_discovery is not None:
+                try:
+                    await self.payment_discovery.remove_payment_capability(agent_id)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "payment_discovery_cleanup_failed_on_unregister",
+                        agent_id=agent_id,
+                        error=str(e),
+                    )
         return deleted
 
     async def update_heartbeat(self, agent_id: str) -> Agent:

--- a/tests/routes/test_broadcast_service_convergence.py
+++ b/tests/routes/test_broadcast_service_convergence.py
@@ -255,6 +255,9 @@ class TestBroadcastRouteUsesBroadcastService:
                             "from_agent": "agent-a",
                             "message": {"text": "x"},
                             "strategy": strategy_input,
+                            # Provide a selector so the broadcast guard passes;
+                            # the stub service never actually fans out.
+                            "target_tags": ["test"],
                         },
                     )
                     assert r.status_code == 200, (

--- a/tests/routes/test_registry_error_schema.py
+++ b/tests/routes/test_registry_error_schema.py
@@ -422,7 +422,7 @@ class TestRegistryFlatErrorSchemaCrossModule:
         assert body["error_code"] == "ownership_mismatch"
         assert body["details"] == {
             "agent_id": "agent-target",
-            "reason": "Only the owner can unregister this agent.",
+            "reason": "owner_mismatch",
         }
 
     def test_bulk_delete_no_filter_returns_invalid_request(


### PR DESCRIPTION
## Summary

### P0 — 生产事故级
- **广播无选择器 422**：`POST /broadcast` 在 `target_subnet` 与 `target_tags` 均为空时现返回 `422 INVALID_REQUEST`，阻止对全网 O(N) fan-out。之前任意 agent（10/min 限额内）可触发 `find_all()` + 并发外呼全体 agent。
- **网关断连不删 repository**：`_disconnect` 停止调用 `repository.delete(agent_id)`，改为仅清 Redis `alive` + `inbox` key，让 agent 记录在重连时复用。之前：(a) 绕过 service 层所有清理门控；(b) PG 模式下只删 PG 行，Redis 残留至 TTL 到期。

### P1 — 安全/一致性
- **活动流 `task_id`/`user_id` 加鉴权**：`GET /analytics/activities?task_id=` 现需 API Key，防止通过活动描述（"Accepted task: {title}"）绕过 Task ACL 获取私有 task 标题。
- **`PostgresAgentRepository.delete` 同步清 Redis**：删除 PG 行后立即清 `alive` / `inbox` / `api_key` 索引 / `owner` + `subnet` 集合，与 `RedisAgentRepository` 对称，不再依赖 TTL 过期。
- **`unregister_agent` 清理 payment discovery**：删除成功后调用 `payment_discovery.remove_payment_capability(agent_id)`，`/payments/discover` 不再返回已删除 agent。
- **注册路径 4xx 脱敏**：SSRF/fetch 错误详情改为固定文案（`"The provided endpoint URL is not allowed."` / `"Unable to fetch the A2A Agent Card from the provided URL."`），真实原因写 structlog。

### P2 — 质量
- **communication.py**：全部 7 处 `detail=str(e)` 改为操作名静态消息。
- **agent-registration.json 限流**：加 `@limiter.limit("60/minute")`，与 agent-card.json 对齐。
- **subnet apiKey `compare_digest`**：`validate_credentials` 的 apiKey 分支改用常量时间比较。
- **网关错误帧脱敏**：WS 连接异常改发 `"connection_error"` 固定码，不再透传 `str(e)`。
- **`PermissionError` 进 403 details 改固定值**：`"reason": str(e)` → `"reason": "owner_mismatch"`。

## Test plan
- [ ] 全量 unit 套件通过（CI）
- [ ] `tests/routes/test_task_acl_scope_b.py` pass
- [ ] `tests/infrastructure/test_subnet_manager_register.py` pass

Made with [Cursor](https://cursor.com)