### PR TITLE
fix: fifth audit hardening — rate-limit gaps, str(e) leak, billing TOCTOU

### DIFF
--- a/acn/routes/agent_subnets.py
+++ b/acn/routes/agent_subnets.py
@@ -15,7 +15,7 @@ owns only the URL + OpenAPI metadata.
 from __future__ import annotations
 
 import structlog  # type: ignore[import-untyped]
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from ..core.errors import ACN_DEFAULT_RESPONSES
 from ._subnet_membership import (
@@ -31,6 +31,7 @@ from .dependencies import (  # type: ignore[import-untyped]
     SubnetIdPath,
     SubnetServiceDep,
     WebhookServiceDep,
+    limiter,
 )
 
 logger = structlog.get_logger()
@@ -43,7 +44,9 @@ router = APIRouter(
 
 
 @router.post("/{agent_id}/subnets/{subnet_id}")
+@limiter.limit("30/minute")
 async def join_subnet(
+    request: Request,
     agent_id: AgentIdPath,
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,
@@ -74,7 +77,9 @@ async def join_subnet(
 
 
 @router.delete("/{agent_id}/subnets/{subnet_id}")
+@limiter.limit("30/minute")
 async def leave_subnet(
+    request: Request,
     agent_id: AgentIdPath,
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,

--- a/acn/routes/gateway_connect.py
+++ b/acn/routes/gateway_connect.py
@@ -15,6 +15,44 @@ from .dependencies import AgentIdPath, SubnetIdPath, get_subnet_manager
 router = APIRouter(tags=["gateway"])
 
 
+def _extract_gateway_credentials(websocket: WebSocket) -> dict | None:
+    """Build the ``credentials`` dict for non-public subnets from the WS handshake.
+
+    ``SubnetManager.validate_credentials`` accepts:
+
+    - ``{"token": "..."}``      — bearer scheme.
+    - ``{"api_key": "..."}``    — apiKey scheme.
+    - ``{"access_token": "..."}`` — OAuth scheme.
+
+    Browser ``new WebSocket()`` cannot set arbitrary headers, but proxies,
+    server-side clients (``httpx_ws``, ``websockets``, ``aiohttp``), and
+    SDKs all can. Supporting both ``Authorization: Bearer …`` and the
+    ``X-Api-Key`` header keeps the WS gateway accessible from every
+    non-browser caller without leaking the secret into the URL (which
+    proxies and access logs may capture).
+
+    Returns ``None`` when neither header is present so the caller can
+    pass that through to public-subnet flows where credentials are
+    optional.
+    """
+    headers = websocket.headers
+    auth = headers.get("authorization") or headers.get("Authorization")
+    if auth:
+        auth = auth.strip()
+        if auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+            if token:
+                return {"token": token}
+
+    api_key = headers.get("x-api-key") or headers.get("X-Api-Key")
+    if api_key:
+        api_key = api_key.strip()
+        if api_key:
+            return {"api_key": api_key}
+
+    return None
+
+
 @router.websocket("/gateway/connect/{subnet_id}/{agent_id}")
 async def gateway_connect(
     websocket: WebSocket,
@@ -26,5 +64,15 @@ async def gateway_connect(
 
     Mirrors the usage block in ``SubnetManager`` documentation; callers
     must send a REGISTER JSON frame immediately after connection.
+
+    Non-public subnets require credentials in the WebSocket handshake;
+    we accept ``Authorization: Bearer …`` (bearer scheme) or
+    ``X-Api-Key: …`` (apiKey scheme). Without this hand-off,
+    non-public subnets reject every connection at
+    ``validate_credentials`` because no caller can ever supply
+    credentials over the WS path.
     """
-    await subnet_manager.handle_connection(websocket, subnet_id, agent_id)
+    credentials = _extract_gateway_credentials(websocket)
+    await subnet_manager.handle_connection(
+        websocket, subnet_id, agent_id, credentials=credentials
+    )

--- a/acn/routes/onchain.py
+++ b/acn/routes/onchain.py
@@ -817,10 +817,14 @@ async def post_agent_feedback(
         # Service-layer validation (defense in depth — route-layer
         # checks above should catch the same things, but service
         # might catch corner cases like very-long evidence_uri).
+        # ``reason`` is a static token; raw ``str(e)`` may include
+        # internal field hints we don't want to surface externally
+        # (the full message is preserved in the chained ``from e``
+        # logger output for operators).
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
             status_code=400,
-            details={"reason": str(e)},
+            details={"reason": "invalid_request"},
         ) from e
 
     return _event_to_response(event)
@@ -885,10 +889,13 @@ async def post_agent_validation(
             task_metadata=None,
         )
     except ValueError as e:
+        # ``reason`` is a static token (matches ``record_feedback``
+        # error shape); the full message stays on the server side
+        # via the chained ``from e`` for operator triage.
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
             status_code=400,
-            details={"reason": str(e)},
+            details={"reason": "invalid_request"},
         ) from e
 
     return _event_to_response(event)

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 from typing import Literal
 
 import structlog  # type: ignore[import-untyped]
-from fastapi import APIRouter, HTTPException, Query, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -83,6 +83,7 @@ from .dependencies import (
     RequestIdPath,
     SubnetIdPath,
     SubnetServiceDep,
+    limiter,
 )
 
 logger = structlog.get_logger()
@@ -162,7 +163,9 @@ class CancelInvitationBody(_OptionalNoteBody):
 
 
 @router.post("/subnets/{subnet_id}/allowlist", status_code=201)
+@limiter.limit("30/minute")
 async def add_to_allowlist(
+    request: Request,
     subnet_id: SubnetIdPath,
     body: AllowlistAddBody,
     agent_info: AgentApiKeyDep,
@@ -215,7 +218,9 @@ async def add_to_allowlist(
     status_code=204,
     responses={**ACN_DEFAULT_RESPONSES, 204: {"description": "Entry removed"}},
 )
+@limiter.limit("30/minute")
 async def remove_from_allowlist(
+    request: Request,
     subnet_id: SubnetIdPath,
     agent_id: AgentIdPath,
     agent_info: AgentApiKeyDep,
@@ -256,7 +261,9 @@ async def remove_from_allowlist(
 
 
 @router.get("/subnets/{subnet_id}/allowlist")
+@limiter.limit("60/minute")
 async def list_allowlist(
+    request: Request,
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
@@ -303,7 +310,9 @@ async def list_allowlist(
 
 
 @router.post("/subnets/{subnet_id}/join-requests/{request_id}/approve")
+@limiter.limit("30/minute")
 async def approve_join_request(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -340,7 +349,9 @@ async def approve_join_request(
 
 
 @router.post("/subnets/{subnet_id}/join-requests/{request_id}/reject")
+@limiter.limit("30/minute")
 async def reject_join_request(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -372,7 +383,9 @@ async def reject_join_request(
 
 
 @router.delete("/subnets/{subnet_id}/join-requests/{request_id}")
+@limiter.limit("30/minute")
 async def withdraw_join_request(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -435,7 +448,9 @@ async def withdraw_join_request(
 
 
 @router.get("/subnets/{subnet_id}/join-requests")
+@limiter.limit("60/minute")
 async def list_join_requests(
+    request: Request,
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
@@ -495,7 +510,9 @@ async def list_join_requests(
 
 
 @router.post("/subnets/{subnet_id}/invitations")
+@limiter.limit("30/minute")
 async def send_invitation(
+    request: Request,
     subnet_id: SubnetIdPath,
     body: InviteBody,
     agent_info: AgentApiKeyDep,
@@ -547,7 +564,9 @@ async def send_invitation(
 
 
 @router.post("/subnets/{subnet_id}/invitations/{request_id}/accept")
+@limiter.limit("30/minute")
 async def accept_invitation(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -634,7 +653,9 @@ async def accept_invitation(
 
 
 @router.post("/subnets/{subnet_id}/invitations/{request_id}/reject")
+@limiter.limit("30/minute")
 async def reject_invitation(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -674,7 +695,9 @@ async def reject_invitation(
 
 
 @router.delete("/subnets/{subnet_id}/invitations/{request_id}")
+@limiter.limit("30/minute")
 async def cancel_invitation(
+    request: Request,
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
@@ -709,7 +732,9 @@ async def cancel_invitation(
 
 
 @router.get("/subnets/{subnet_id}/invitations")
+@limiter.limit("60/minute")
 async def list_invitations(
+    request: Request,
     subnet_id: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
@@ -745,7 +770,9 @@ async def list_invitations(
 
 
 @router.get("/agents/{agent_id}/subnet-invitations")
+@limiter.limit("60/minute")
 async def list_agent_pending_invitations(
+    request: Request,
     agent_id: AgentIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,

--- a/acn/services/billing_service.py
+++ b/acn/services/billing_service.py
@@ -341,6 +341,22 @@ class BillingService:
         2. Add earnings to agent owner
         3. Record network fee
 
+        Concurrency safety
+        ------------------
+        The status read + dedution + status write sequence is a
+        textbook TOCTOU: two concurrent callers (e.g. retried RPC,
+        racing schedulers) could both observe ``PENDING`` and both
+        deduct credits, double-charging the user. We bracket the
+        whole sequence in a Redis SET-NX-EX lock keyed on the
+        transaction id so only one caller proceeds; the other gets
+        ``ValueError("Transaction is currently being processed")``.
+        Lock TTL is 30s (well above the deduction p99) so a
+        crashed worker doesn't leave the row permanently locked.
+        After acquiring the lock we re-read the transaction status
+        — the lock prevents two concurrent processors, and the
+        re-read prevents reprocessing if a previous run finished
+        between the caller's status read and our lock acquisition.
+
         Args:
             transaction_id: ID of transaction to process
             deduct_credits_callback: async func(user_id, amount) to deduct credits
@@ -349,48 +365,70 @@ class BillingService:
         Returns:
             Updated transaction
         """
-        transaction = await self.get_transaction(transaction_id)
-        if not transaction:
-            raise ValueError(f"Transaction not found: {transaction_id}")
-
-        if transaction.status != BillingTransactionStatus.PENDING:
-            raise ValueError(f"Transaction not pending: {transaction.status}")
+        lock_key = f"{self._prefix}lock:tx:{transaction_id}"
+        # SET NX EX → only one caller acquires the lock at a time.
+        # Returns True on acquire, None/False otherwise (per redis-py
+        # contract for SET with nx=True).
+        acquired = await self.redis.set(lock_key, "1", nx=True, ex=30)
+        if not acquired:
+            raise ValueError(
+                f"Transaction is currently being processed: {transaction_id}"
+            )
 
         try:
-            # 1. Deduct credits from user
-            await deduct_credits_callback(
-                transaction.user_id,
-                transaction.cost.total_credits,
-            )
+            transaction = await self.get_transaction(transaction_id)
+            if not transaction:
+                raise ValueError(f"Transaction not found: {transaction_id}")
 
-            # 2. Add earnings to agent owner (if known)
-            if transaction.agent_owner_id:
-                await add_earnings_callback(
-                    transaction.agent_owner_id,
-                    transaction.cost.agent_income_credits,
+            # Re-check under the lock. If a previous processor finished
+            # before we acquired the lock the transaction will already
+            # be COMPLETED/FAILED — rejecting here prevents double
+            # charging on a stale ``process_transaction`` retry.
+            if transaction.status != BillingTransactionStatus.PENDING:
+                raise ValueError(f"Transaction not pending: {transaction.status}")
+
+            try:
+                # 1. Deduct credits from user
+                await deduct_credits_callback(
+                    transaction.user_id,
+                    transaction.cost.total_credits,
                 )
 
-            # 3. Record network fee (internal accounting)
-            await self._record_network_fee(
-                transaction.transaction_id,
-                transaction.cost.network_fee_credits,
-            )
+                # 2. Add earnings to agent owner (if known)
+                if transaction.agent_owner_id:
+                    await add_earnings_callback(
+                        transaction.agent_owner_id,
+                        transaction.cost.agent_income_credits,
+                    )
 
-            # Mark as completed
-            transaction.status = BillingTransactionStatus.COMPLETED
-            transaction.completed_at = datetime.now(UTC)
+                # 3. Record network fee (internal accounting)
+                await self._record_network_fee(
+                    transaction.transaction_id,
+                    transaction.cost.network_fee_credits,
+                )
 
-        except Exception as e:
-            # Mark as failed
-            transaction.status = BillingTransactionStatus.FAILED
-            transaction.error_message = str(e)
+                # Mark as completed
+                transaction.status = BillingTransactionStatus.COMPLETED
+                transaction.completed_at = datetime.now(UTC)
 
-        await self._save_transaction(transaction)
+            except Exception as e:
+                # Mark as failed
+                transaction.status = BillingTransactionStatus.FAILED
+                transaction.error_message = str(e)
 
-        # Send webhook notification
-        await self._send_billing_webhook(transaction)
+            await self._save_transaction(transaction)
 
-        return transaction
+            # Send webhook notification
+            await self._send_billing_webhook(transaction)
+
+            return transaction
+        finally:
+            # Best-effort lock release — failure here just leaves the
+            # 30s TTL to expire naturally, which is safe.
+            try:
+                await self.redis.delete(lock_key)
+            except Exception:  # noqa: BLE001
+                pass
 
     async def refund_transaction(
         self,


### PR DESCRIPTION
## Summary

Fifth comprehensive audit identified five issues across rate limiting, error message hygiene, billing concurrency, and a WS gateway functional gap. All fixed in this PR.

| Pri | Fix | Files |
|-----|-----|-------|
| P1-A | `onchain.py` reputation `ValueError` catches now emit static `invalid_request` token instead of raw `str(e)` (matches audit4 contract). | `acn/routes/onchain.py` |
| P1-B | All 12 `subnet_admission.py` endpoints (allowlist, join-requests, invitations, agent-side invitations list) gain `@limiter.limit` — `30/minute` for writes, `60/minute` for reads. | `acn/routes/subnet_admission.py` |
| P1-C | Canonical `join_subnet` / `leave_subnet` on `/api/v1/agents/{a}/subnets/{s}` get the same `30/minute` already enforced on the legacy mirror. | `acn/routes/agent_subnets.py` |
| P2-D | `BillingService.process_transaction` had a TOCTOU between status read and deduction — two concurrent callers could double-charge. Now bracketed by a Redis `SET NX EX 30` lock keyed on `transaction_id`; status is re-checked under the lock. | `acn/services/billing_service.py` |
| P3-E | `gateway_connect` was calling `handle_connection` without `credentials`, so non-public subnets rejected every WS. Now extracts bearer / api-key from the WS handshake headers and forwards them. | `acn/routes/gateway_connect.py` |

## Why these matter

- **TOCTOU double-charge** is a financial-correctness issue; user-visible the moment two clients race or a retried RPC fires.
- **Rate-limit gaps** on subnet admission flows let any authenticated agent spam owner approval mailboxes / cycle invites unbounded.
- **`str(e)` leakage** in reputation routes can echo internal field hints back to callers; we already cleaned every other route in audit4.
- **WS credentials gap** is a functional bug — non-public subnets simply could not be joined over WS.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/routes/test_agent_subnets.py tests/routes/test_subnet_admission_*.py` — 77/77 passed
- [x] `pytest tests/routes/test_onchain_reputation_routes.py tests/routes/test_onchain_error_schema.py tests/routes/test_gateway_connect_registered.py tests/services/test_billing_fallback_bounds.py` — 43/43 passed
- [x] `pytest tests/infrastructure/` — 284/284 passed
- [x] `pytest tests/services/` — 512/512 passed
- [ ] CI green

## Concurrency design notes (P2-D)

The lock is intentionally a SET-NX-EX rather than a status-flip CAS so the fix works for both billing backends (PG repository and Redis fallback) without changing the `IBillingRepository` interface. Lock TTL of 30s is generous (the deduction callbacks are sync round-trips); a crashed worker leaves the lock for at most that long. The contract change is one additional `ValueError` shape — `"Transaction is currently being processed: {id}"` — which callers should treat the same as the existing "not pending" error (don't retry into another deduction).

Made with [Cursor](https://cursor.com)