### PR TITLE
fix(cli): show ACN error_code+message instead of [object Object]

### DIFF
--- a/clients/cli/src/api.ts
+++ b/clients/cli/src/api.ts
@@ -11,6 +11,21 @@ export class AcnApiError extends Error {
   }
 }
 
+/** Extract a human-readable detail string from an API error body.
+ *  ACN API shape: { error_code, message, ... }
+ *  Fallback: { detail } (older/third-party), raw string, or JSON dump. */
+function extractDetail(body: unknown): string {
+  if (typeof body !== 'object' || body === null) return String(body);
+  const b = body as Record<string, unknown>;
+  if (typeof b['message'] === 'string') {
+    return typeof b['error_code'] === 'string'
+      ? `${b['error_code']}: ${b['message']}`
+      : b['message'];
+  }
+  if (typeof b['detail'] === 'string') return b['detail'];
+  return JSON.stringify(b);
+}
+
 export async function acnFetch<T>(
   path: string,
   options: RequestInit & { params?: Record<string, string | number | boolean | undefined> } = {}
@@ -39,11 +54,7 @@ export async function acnFetch<T>(
   if (!res.ok) {
     let body: unknown;
     try { body = await res.json(); } catch { body = await res.text(); }
-    const detail =
-      typeof body === 'object' && body !== null && 'detail' in body
-        ? String((body as { detail: unknown }).detail)
-        : String(body);
-    throw new AcnApiError(res.status, body, `HTTP ${res.status}: ${detail}`);
+    throw new AcnApiError(res.status, body, `HTTP ${res.status}: ${extractDetail(body)}`);
   }
 
   if (res.status === 204 || res.headers.get('content-length') === '0') {


### PR DESCRIPTION
## Summary

- `api.ts` was only checking for a `detail` field, but ACN API returns `{ error_code, message }`.  Any 4xx/5xx error rendered as `Error: HTTP 404: [object Object]`.
- Add `extractDetail()` helper: prefers `error_code: message` (ACN format), falls back to `detail` (legacy), then `JSON.stringify` as last resort.

## Behaviour change

| | Before | After |
|---|---|---|
| `acn agents get nonexistent` | `Error: HTTP 404: [object Object]` | `Error: HTTP 404: agent_not_found: The requested agent could not be found.` |
| `--json` mode | `{"error":"HTTP 404: [object Object]"}` | `{"error":"HTTP 404: agent_not_found: The requested agent could not be found."}` |

## Test plan

- [x] All 45 existing unit tests pass (`npm test`)
- [x] Manual smoke test against `api.acnlabs.dev` — 404, 401 errors now show clean messages

Made with [Cursor](https://cursor.com)