### PR TITLE
fix(audit6): address all 21 issues from sixth comprehensive audit

### DIFF
--- a/acn/routes/communication.py
+++ b/acn/routes/communication.py
@@ -520,7 +520,7 @@ async def manifest_send(
                 raise ACNHTTPError(
                     ErrorCode.CONTENT_URL_BLOCKED,
                     400,
-                    details={"content_url": body.content_url, "reason": str(e)},
+                    details={"content_url": body.content_url, "reason": "content_url_blocked"},
                 ) from e
             send_kwargs["content_url"] = body.content_url
             if body.content_hash is not None:
@@ -650,7 +650,7 @@ async def send_message(
                 raise ACNHTTPError(
                     ErrorCode.CONTENT_URL_BLOCKED,
                     400,
-                    details={"content_url": body.content_url, "reason": str(e)},
+                    details={"content_url": body.content_url, "reason": "content_url_blocked"},
                 ) from e
             send_kwargs["content_url"] = body.content_url
             if body.content_hash is not None:

--- a/acn/routes/gateway_connect.py
+++ b/acn/routes/gateway_connect.py
@@ -7,10 +7,13 @@ implicit heartbeat when ``SubnetManager`` receives ``agent_service`` from
 lifespan wiring.
 """
 
+import structlog
 from fastapi import APIRouter, Depends, WebSocket
 
 from ..infrastructure.messaging.subnet_manager import SubnetManager
 from .dependencies import AgentIdPath, SubnetIdPath, get_subnet_manager
+
+logger = structlog.get_logger()
 
 router = APIRouter(tags=["gateway"])
 
@@ -31,9 +34,10 @@ def _extract_gateway_credentials(websocket: WebSocket) -> dict | None:
     non-browser caller without leaking the secret into the URL (which
     proxies and access logs may capture).
 
-    Returns ``None`` when neither header is present so the caller can
-    pass that through to public-subnet flows where credentials are
-    optional.
+    Returns ``None`` when neither header is present.  Public-subnet
+    flows still forward ``None`` to ``handle_connection``; the manager
+    then allows the connection but the ``agent_id`` in the URL is
+    unverified (known limitation — see threat model in ADR-0006).
     """
     headers = websocket.headers
     auth = headers.get("authorization") or headers.get("Authorization")
@@ -73,6 +77,16 @@ async def gateway_connect(
     credentials over the WS path.
     """
     credentials = _extract_gateway_credentials(websocket)
+    if credentials is None:
+        # No credentials supplied.  Non-public subnets will reject the
+        # connection inside handle_connection.  Public subnets allow it,
+        # but the agent_id in the URL is then unverified — log so ops
+        # can detect abuse patterns.
+        logger.info(
+            "gateway_connect_unauthenticated",
+            subnet_id=subnet_id,
+            agent_id=agent_id,
+        )
     await subnet_manager.handle_connection(
         websocket, subnet_id, agent_id, credentials=credentials
     )

--- a/acn/routes/onchain.py
+++ b/acn/routes/onchain.py
@@ -632,10 +632,15 @@ def _enforce_feedback_authorisation(
     task,
     caller_id: str,
     target_agent_id: str,
+    valid_participant_ids: set[str] | None = None,
 ) -> None:
-    """Enforce: caller is task creator, target is task assignee, task
-    is in COMPLETED state. Each failure surfaces a distinct error code
-    so the SDK can show actionable messages."""
+    """Enforce: caller is task creator, target is task assignee (or a
+    valid participant for multi-participant tasks), task is COMPLETED.
+
+    ``valid_participant_ids`` should be supplied for multi-participant
+    tasks (``task.assignee_id is None``).  When provided, the target
+    must be in the set; otherwise the single-assignee check is used.
+    """
     from ..core.entities.task import TaskStatus
 
     if task.status != TaskStatus.COMPLETED:
@@ -662,29 +667,41 @@ def _enforce_feedback_authorisation(
                 "caller_id": caller_id,
             },
         )
-    if task.assignee_id != target_agent_id:
-        # 400 not 403: this is a route-shape error (the caller asked
-        # to write feedback against the wrong agent for this task),
-        # not an auth failure.
-        raise ACNHTTPError(
-            ErrorCode.INVALID_REQUEST,
-            status_code=400,
-            details={
-                "reason": "target_is_not_task_assignee",
-                "task_id": task.task_id,
-                "task_assignee_id": task.assignee_id,
-                "target_agent_id": target_agent_id,
-            },
-        )
+    # Multi-participant tasks use the participation set; single-assignee
+    # tasks still use task.assignee_id for backward compat.
+    if task.assignee_id is not None:
+        if task.assignee_id != target_agent_id:
+            raise ACNHTTPError(
+                ErrorCode.INVALID_REQUEST,
+                status_code=400,
+                details={
+                    "reason": "target_is_not_task_assignee",
+                    "task_id": task.task_id,
+                    "task_assignee_id": task.assignee_id,
+                    "target_agent_id": target_agent_id,
+                },
+            )
+    elif valid_participant_ids is not None:
+        if target_agent_id not in valid_participant_ids:
+            raise ACNHTTPError(
+                ErrorCode.INVALID_REQUEST,
+                status_code=400,
+                details={
+                    "reason": "target_is_not_task_participant",
+                    "task_id": task.task_id,
+                    "target_agent_id": target_agent_id,
+                },
+            )
 
 
 def _enforce_validation_authorisation(
     task,
     caller_id: str,
     target_agent_id: str,
+    valid_participant_ids: set[str] | None = None,
 ) -> None:
-    """Enforce: target is task assignee, task is COMPLETED, caller is
-    NEITHER creator NOR assignee (validation is a third-party voice).
+    """Enforce: target is task assignee (or valid participant), task is
+    COMPLETED, caller is NEITHER creator NOR assignee/participant.
     """
     from ..core.entities.task import TaskStatus
 
@@ -698,17 +715,29 @@ def _enforce_validation_authorisation(
                 "current_status": task.status,
             },
         )
-    if task.assignee_id != target_agent_id:
-        raise ACNHTTPError(
-            ErrorCode.INVALID_REQUEST,
-            status_code=400,
-            details={
-                "reason": "target_is_not_task_assignee",
-                "task_id": task.task_id,
-                "task_assignee_id": task.assignee_id,
-                "target_agent_id": target_agent_id,
-            },
-        )
+    if task.assignee_id is not None:
+        if task.assignee_id != target_agent_id:
+            raise ACNHTTPError(
+                ErrorCode.INVALID_REQUEST,
+                status_code=400,
+                details={
+                    "reason": "target_is_not_task_assignee",
+                    "task_id": task.task_id,
+                    "task_assignee_id": task.assignee_id,
+                    "target_agent_id": target_agent_id,
+                },
+            )
+    elif valid_participant_ids is not None:
+        if target_agent_id not in valid_participant_ids:
+            raise ACNHTTPError(
+                ErrorCode.INVALID_REQUEST,
+                status_code=400,
+                details={
+                    "reason": "target_is_not_task_participant",
+                    "task_id": task.task_id,
+                    "target_agent_id": target_agent_id,
+                },
+            )
     if task.creator_id == caller_id:
         # Creator should write feedback, not validation. Surface a
         # distinct reason so the SDK can suggest the correct endpoint.
@@ -799,7 +828,13 @@ async def post_agent_feedback(
     _enforce_not_self(caller["agent_id"], agent_id)
     await _fetch_agent_or_404(agent_service, agent_id)
     task = await _fetch_task_for_reputation(task_service, body.task_id)
-    _enforce_feedback_authorisation(task, caller["agent_id"], agent_id)
+    # For multi-participant tasks (assignee_id is None), resolve the set
+    # of valid participant IDs so the authorisation helper can check them.
+    participant_ids: set[str] | None = None
+    if task.assignee_id is None:
+        participations = await task_service.get_task_participations(task_id=body.task_id)
+        participant_ids = {p.participant_id for p in participations}
+    _enforce_feedback_authorisation(task, caller["agent_id"], agent_id, participant_ids)
 
     try:
         event = await reputation_service.record_feedback(  # type: ignore[union-attr]
@@ -876,7 +911,11 @@ async def post_agent_validation(
     _enforce_not_self(caller["agent_id"], agent_id)
     await _fetch_agent_or_404(agent_service, agent_id)
     task = await _fetch_task_for_reputation(task_service, body.task_id)
-    _enforce_validation_authorisation(task, caller["agent_id"], agent_id)
+    participant_ids_v: set[str] | None = None
+    if task.assignee_id is None:
+        participations_v = await task_service.get_task_participations(task_id=body.task_id)
+        participant_ids_v = {p.participant_id for p in participations_v}
+    _enforce_validation_authorisation(task, caller["agent_id"], agent_id, participant_ids_v)
 
     try:
         event = await reputation_service.record_validation(  # type: ignore[union-attr]

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -234,7 +234,7 @@ async def get_payment_capability(
         raise ACNHTTPError(
             ErrorCode.API_KEY_AGENT_MISMATCH,
             status_code=403,
-            details={"reason": "can_only_read_own_payment_capability"},
+            details={"key_agent": caller["agent_id"], "path_agent": agent_id},
         )
     capability = await payment_discovery.get_agent_payment_capability(agent_id)
     if not capability:

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -120,9 +120,11 @@ class BillUsageRequest(BaseModel):
 
 
 @router.post("/{agent_id}/payment-capability")
+@limiter.limit("30/minute")
 async def set_payment_capability(
+    request: Request,
     agent_id: str,
-    request: PaymentCapabilityRequest,
+    body: PaymentCapabilityRequest,
     agent_info: AgentApiKeyDep,
     agent_service: AgentServiceDep = None,
     payment_discovery: PaymentDiscoveryDep = None,
@@ -154,39 +156,33 @@ async def set_payment_capability(
         ) from None
 
     try:
-        # Build wallet_addresses: merge request.wallet_addresses with legacy wallet_address
-        wallet_addresses = dict(request.wallet_addresses)
-        if request.wallet_address and "ethereum" not in wallet_addresses:
-            wallet_addresses["ethereum"] = request.wallet_address
+        # Build wallet_addresses: merge body.wallet_addresses with legacy wallet_address
+        wallet_addresses = dict(body.wallet_addresses)
+        if body.wallet_address and "ethereum" not in wallet_addresses:
+            wallet_addresses["ethereum"] = body.wallet_address
 
         # Derive legacy single-address field
-        if not request.wallet_address and wallet_addresses:
+        if not body.wallet_address and wallet_addresses:
             legacy_addr = (
                 wallet_addresses.get("ethereum")
                 or wallet_addresses.get("base")
                 or next(iter(wallet_addresses.values()), None)
             )
         else:
-            legacy_addr = request.wallet_address
+            legacy_addr = body.wallet_address
 
         # Persist payment fields to Agent entity and save to PG (critical path)
-        agent.accepts_payment = request.accepts_payment
+        agent.accepts_payment = body.accepts_payment
         agent.wallet_address = legacy_addr
         agent.wallet_addresses = wallet_addresses
-        agent.token_pricing = request.token_pricing
-        if request.supported_methods:
-            agent.payment_methods = [m.value for m in request.supported_methods]
+        agent.token_pricing = body.token_pricing
+        if body.supported_methods:
+            agent.payment_methods = [m.value for m in body.supported_methods]
         await agent_service.repository.save(agent)
 
     except ACNHTTPError:
-        # P3 cross-module catch-all defence: ``ACNHTTPError`` is
-        # ``Exception``-typed (not ``HTTPException``-typed); without
-        # this re-raise, any caller-actionable 4xx raised inside the
-        # try body would be silently rewritten as a sanitised 500.
         raise
     except HTTPException:
-        # Mirror defence for legacy ``HTTPException`` raises — same
-        # swallow risk via the catch-all below.
         raise
     except Exception as e:
         logger.error(
@@ -196,22 +192,22 @@ async def set_payment_capability(
 
     # Index into Redis discovery service (best-effort: PG is source of truth)
     token_pricing_obj = None
-    if request.token_pricing:
+    if body.token_pricing:
         try:
-            token_pricing_obj = TokenPricing(**request.token_pricing)
+            token_pricing_obj = TokenPricing(**body.token_pricing)
         except Exception:
             pass
 
     capability = PaymentCapability(
         agent_id=agent_id,
-        accepts_payment=request.accepts_payment,
-        payment_methods=request.supported_methods,
-        supported_networks=request.supported_networks,
+        accepts_payment=body.accepts_payment,
+        payment_methods=body.supported_methods,
+        supported_networks=body.supported_networks,
         wallet_address=legacy_addr,
         wallet_addresses=wallet_addresses,
         token_pricing=token_pricing_obj,
-        api_endpoint=request.api_endpoint,
-        webhook_url=request.webhook_url,
+        api_endpoint=body.api_endpoint,
+        webhook_url=body.webhook_url,
     )
     try:
         await payment_discovery.index_payment_capability(agent_id, capability)
@@ -222,12 +218,24 @@ async def set_payment_capability(
 
 
 @router.get("/{agent_id}/payment-capability")
+@limiter.limit("60/minute")
 async def get_payment_capability(
+    request: Request,
     agent_id: str,
-    _caller: AgentApiKeyDep,
+    caller: AgentApiKeyDep,
     payment_discovery: PaymentDiscoveryDep = None,
 ):
-    """Get payment capability for agent"""
+    """Get payment capability for an agent.
+
+    Only the agent itself may read its own full payment configuration.
+    Prevents cross-tenant enumeration of wallet addresses / pricing.
+    """
+    if caller["agent_id"] != agent_id:
+        raise ACNHTTPError(
+            ErrorCode.API_KEY_AGENT_MISMATCH,
+            status_code=403,
+            details={"reason": "can_only_read_own_payment_capability"},
+        )
     capability = await payment_discovery.get_agent_payment_capability(agent_id)
     if not capability:
         raise ACNHTTPError(
@@ -239,12 +247,19 @@ async def get_payment_capability(
 
 
 @router.get("/discover")
+@limiter.limit("60/minute")
 async def discover_payment_agents(
+    request: Request,
     method: SupportedPaymentMethod | None = None,
     network: SupportedNetwork | None = None,
+    agent_info: AgentApiKeyDep = None,
     payment_discovery: PaymentDiscoveryDep = None,
 ):
-    """Discover agents with payment capabilities"""
+    """Discover agents with payment capabilities.
+
+    Requires authentication — exposes the set of agents participating
+    in the payment network, which should not be enumerable anonymously.
+    """
     agents = await payment_discovery.find_agents_accepting_payment(
         payment_method=method,
         network=network,
@@ -296,10 +311,11 @@ async def create_payment_task(
     except ValueError as e:
         # The seller does not accept this method/network, or the seller has
         # no payment capability registered. These are caller-correctable.
+        logger.warning("create_payment_task_invalid_request", error=str(e))
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
             status_code=400,
-            details={"reason": str(e)},
+            details={"reason": "invalid_payment_request"},
         ) from e
     except Exception as e:
         logger.error("create_payment_task_failed", error=str(e), exc_info=True)
@@ -582,8 +598,10 @@ async def estimate_cost(
 
 
 @router.post("/billing/charge")
+@limiter.limit("60/minute")
 async def bill_usage(
-    request: BillUsageRequest,
+    request: Request,
+    body: BillUsageRequest,
     _: InternalTokenDep,
     payment_discovery: PaymentDiscoveryDep = None,
     billing_service: BillingServiceDep = None,
@@ -597,34 +615,34 @@ async def bill_usage(
     The actual credit deduction is handled by the backend wallet system.
     """
     # Get agent's token pricing
-    capability = await payment_discovery.get_agent_payment_capability(request.agent_id)
+    capability = await payment_discovery.get_agent_payment_capability(body.agent_id)
     if not capability or not capability.token_pricing:
         raise ACNHTTPError(
             ErrorCode.TOKEN_PRICING_NOT_CONFIGURED,
             status_code=404,
-            details={"agent_id": request.agent_id},
+            details={"agent_id": body.agent_id},
         )
 
     # Get agent owner — None is a legitimate state (autonomous /
     # unclaimed agent), so the billing record stays owner-less rather
     # than erroring out.
-    agent = await agent_service.find_agent(request.agent_id)
+    agent = await agent_service.find_agent(body.agent_id)
     agent_owner_id = agent.owner if agent else None
 
     # Calculate cost
     cost = billing_service.calculate_cost(
-        request.input_tokens,
-        request.output_tokens,
+        body.input_tokens,
+        body.output_tokens,
         capability.token_pricing,
     )
 
     # Create transaction
     transaction = await billing_service.create_transaction(
-        user_id=request.user_id,
-        agent_id=request.agent_id,
+        user_id=body.user_id,
+        agent_id=body.agent_id,
         agent_owner_id=agent_owner_id,
         cost=cost,
-        task_id=request.task_id,
+        task_id=body.task_id,
     )
 
     return {

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -1418,6 +1418,12 @@ async def search_agents(
         subnet_service
     )
 
+    # P3-5 / P2-4: non-admin callers are restricted to visibility="real".
+    # Allowing arbitrary visibility values to anonymous callers leaks the
+    # existence of hidden/archived/spam agents.
+    if not is_admin and visibility != "real":
+        visibility = "real"
+
     tag_param = tag or skill  # accept both; `tag` takes precedence
     tag_list = tag_param.split(",") if tag_param else None
 
@@ -1465,7 +1471,9 @@ async def search_agents(
 
 
 @router.post("/{agent_id}/heartbeat")
+@limiter.limit("30/minute")
 async def agent_heartbeat(
+    request: Request,
     agent_id: AgentIdPath,
     agent_info: AgentApiKeyDep,
     agent_service: AgentServiceDep = None,
@@ -2481,10 +2489,11 @@ async def claim_agent(
             details={"agent_id": agent_id},
         ) from e
     except ValueError as e:
+        logger.warning("claim_agent_invalid_request", agent_id=agent_id, error=str(e))
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST,
             400,
-            details={"agent_id": agent_id, "reason": str(e)},
+            details={"agent_id": agent_id, "reason": "invalid_request"},
         ) from e
 
 

--- a/acn/routes/sessions.py
+++ b/acn/routes/sessions.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import structlog  # type: ignore[import-untyped]
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..core.errors import ACN_DEFAULT_RESPONSES, ACNHTTPError, ErrorCode
 from ..infrastructure.messaging.websocket_manager import MessageType
@@ -65,6 +65,17 @@ class SessionInviteRequest(BaseModel):
             "(task description, capabilities, etc.). Max 4 KB."
         ),
     )
+
+    @field_validator("metadata")
+    @classmethod
+    def _check_metadata_size(cls, v: dict | None) -> dict | None:
+        if v is None:
+            return v
+        import json
+        size = len(json.dumps(v).encode())
+        if size > 4096:
+            raise ValueError(f"metadata exceeds 4 KB limit ({size} bytes)")
+        return v
 
 
 def _entry_to_dict(entry, extra: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -389,7 +389,7 @@ async def withdraw_join_request(
     subnet_id: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
-    body: WithdrawBody | None = None,
+    note: str | None = Query(default=None, description="Optional reason for withdrawal."),
     subnet_service: SubnetServiceDep = None,
 ):
     """Applicant withdraws their own pending ``join_request``.
@@ -408,7 +408,7 @@ async def withdraw_join_request(
     # Load + namespace-check the row up front so we can authz
     # against initiated_by. Wrong namespace → 404 surfaces here.
     try:
-        row = await subnet_service._load_join_request_or_404(
+        row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
             expected_subnet_id=subnet_id,
@@ -432,8 +432,7 @@ async def withdraw_join_request(
             },
         )
 
-    note = body.note if body is not None else None
-
+    # note comes from query param (P3-8: removed optional body on DELETE)
     try:
         withdrawn = await subnet_service.withdraw_join_request(
             subnet_id,
@@ -592,7 +591,7 @@ async def accept_invitation(
 
     # Load + namespace-check up front so authz uses the loaded row.
     try:
-        row = await subnet_service._load_join_request_or_404(
+        row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
             expected_subnet_id=subnet_id,
@@ -636,14 +635,26 @@ async def accept_invitation(
             error=str(e),
             exc_info=True,
         )
-        # Unlike join, we do NOT roll back ``add_member`` here —
-        # the invitation row has already been CAS'd to approved,
-        # and reversing that CAS would leak a partial-success
-        # signal to Harness consumers. Surface 500 and let the SDK
-        # retry (idempotent CAS will then succeed at the
-        # already-decided check, surfacing 409
-        # INVITATION_ALREADY_DECIDED — SDK can treat that as
-        # success).
+        # Best-effort rollback: remove the member record so the system
+        # is not left in a half-joined state (subnet has member but
+        # agent.subnet_ids has no record). The invitation row has
+        # already been CAS'd to approved; if the SDK retries, the
+        # already-decided check will surface 409 INVITATION_ALREADY_DECIDED
+        # which is preferable to a permanent inconsistency.
+        try:
+            await subnet_service.remove_member(subnet_id, agent_info["agent_id"])
+            logger.info(
+                "accept_invitation_rollback_ok",
+                agent_id=agent_info["agent_id"],
+                subnet_id=subnet_id,
+            )
+        except Exception as rollback_err:  # noqa: BLE001
+            logger.error(
+                "accept_invitation_rollback_failed",
+                agent_id=agent_info["agent_id"],
+                subnet_id=subnet_id,
+                rollback_error=str(rollback_err),
+            )
         raise HTTPException(
             status_code=500,
             detail="Failed to write agent back-reference",
@@ -670,7 +681,7 @@ async def reject_invitation(
     await load_subnet_or_404(subnet_service, subnet_id)
 
     try:
-        row = await subnet_service._load_join_request_or_404(
+        row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
             expected_subnet_id=subnet_id,

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -360,6 +360,8 @@ async def list_subnets(
     owner: str = None,
     parent: str | None = None,
     owned_by_user: str | None = None,
+    limit: int = Query(default=200, ge=1, le=1000, description="Max subnets to return."),
+    offset: int = Query(default=0, ge=0, description="Zero-based offset for pagination."),
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
@@ -432,10 +434,7 @@ async def list_subnets(
                     ErrorCode.OWNERSHIP_MISMATCH,
                     403,
                     message="Cannot list subnets owned by another user.",
-                    details={
-                        "requested_user": owned_by_user,
-                        "token_sub": caller_sub,
-                    },
+                    details={"reason": "ownership_mismatch"},
                 )
             # Resolve the user's owned agents, then query subnets by that
             # bounded owner set — avoids the O(N) full-table scan that
@@ -468,14 +467,38 @@ async def list_subnets(
             # per-row below (ACL V6 B5 caller-aware rendering).
             subnets = await subnet_service.list_subnets()
 
+        # Apply pagination before the per-row rendering pass (bounds peak work).
+        total = len(subnets)
+        subnets_page = subnets[offset : offset + limit]
+
+        # Batch-resolve all parent UUIDs in a single pass to avoid N+1 queries.
+        parent_ids_needed = {
+            getattr(s, "parent_subnet_id", None)
+            for s in subnets_page
+            if getattr(s, "parent_subnet_id", None)
+        }
+        parent_uuid_map: dict[str, str | None] = {}
+        for pid in parent_ids_needed:
+            try:
+                parent_obj = await subnet_service.get_subnet(pid)
+                parent_uuid_map[pid] = _coerce_optional_str(getattr(parent_obj, "id", None))
+            except Exception:  # noqa: BLE001
+                parent_uuid_map[pid] = None
+
+        def _get_parent_uuid(s) -> str | None:
+            pid = getattr(s, "parent_subnet_id", None)
+            if not pid:
+                return None
+            return parent_uuid_map.get(pid)
+
         # Per-row caller-aware rendering (ACL V6 B5).
         # Exception: when ?owned_by_user= is set, all rows are already
         # confirmed as owned-by-user-via-agent (ownership-chain bridge)
         # so they always receive full SubnetInfo regardless of is_private.
         full_access_all_rows = owned_by_user is not None
         subnet_infos: list = []
-        for s in subnets:
-            parent_uuid = await _resolve_parent_uuid(s, subnet_service)
+        for s in subnets_page:
+            parent_uuid = _get_parent_uuid(s)
             if full_access_all_rows or not getattr(s, "is_private", False):
                 subnet_infos.append(_subnet_entity_to_info(s, parent_uuid=parent_uuid))
             elif caller_payload and await _resolve_caller_access(
@@ -495,7 +518,7 @@ async def list_subnets(
                     )
                 )
 
-        return {"subnets": subnet_infos, "count": len(subnet_infos)}
+        return {"subnets": subnet_infos, "count": len(subnet_infos), "total": total, "has_more": offset + limit < total}
     except ACNHTTPError:
         raise
     except HTTPException:
@@ -586,7 +609,11 @@ async def get_subnet(
     if not credentials:
         return _stub()
 
-    payload = await verify_token(request, credentials)
+    # Align with list_subnets: invalid token → treat as anonymous → Stub.
+    try:
+        payload = await verify_token(request, credentials)
+    except Exception:  # noqa: BLE001
+        return _stub()
 
     if not await _resolve_caller_access(payload, subnet, agent_service):
         return _stub()

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -1284,6 +1284,24 @@ async def list_participations(
     caller_id: str = payload.get("agent_id") or payload.get("sub") or ""
     try:
         task = await task_service.get_task(task_id)
+
+        # P1-2: subnet membership gate — same as get_task.
+        # Internal / admin callers are exempted.
+        permissions = payload.get("permissions", [])
+        is_internal = payload.get("type") == "internal" or "acn:admin" in permissions
+        if task.subnet_id and not is_internal:
+            is_member = await task_service.is_subnet_member(task.subnet_id, caller_id)
+            if not is_member:
+                raise ACNHTTPError(
+                    ErrorCode.NOT_SUBNET_MEMBER,
+                    403,
+                    details={
+                        "task_id": task_id,
+                        "subnet_id": task.subnet_id,
+                        "reason": "not_member",
+                    },
+                )
+
         participations = await task_service.get_task_participations(
             task_id=task_id,
             status=status,
@@ -1293,8 +1311,8 @@ async def list_participations(
         is_creator = caller_id == task.creator_id
 
         def _maybe_redact(p: ParticipationResponse) -> ParticipationResponse:
-            # Reveal submission only to creator or the participant themselves
-            if is_creator or p.agent_id == caller_id:
+            # P1-1: use participant_id (not agent_id which doesn't exist on this model)
+            if is_creator or p.participant_id == caller_id:
                 return p
             return p.model_copy(update={"submission": None, "submission_artifacts": []})
 
@@ -1354,7 +1372,8 @@ async def cancel_participation(
             participation_id=participation_id,
             canceller_id=agent_id,
         )
-        return _task_to_response(task)
+        # P3-7: expose submission only to the task creator.
+        return _task_to_response(task, expose_submission=(agent_id == task.creator_id))
     except TaskNotFoundException:
         raise ACNHTTPError(
             ErrorCode.TASK_NOT_FOUND,
@@ -1540,6 +1559,7 @@ async def agent_create_task(
         group_id=body.group_id,
         deadline_hours=body.deadline_hours,
         metadata=merged_metadata,
+        subnet_id=body.subnet_id,  # P1-3: was missing, task was created without subnet context
     )
 
     return _task_to_response(task, expose_submission=True)

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -514,16 +514,12 @@ class SubnetService:
             exist, the parent is unknown, or every child is filtered
             by ACL.
         """
-        children = await self.repository.find_by_parent(parent_subnet_id)
-
-        def _visible(subnet: Subnet) -> bool:
-            if not subnet.is_private:
-                return True
-            if requester_id is None:
-                return False
-            return subnet.owner == requester_id or requester_id in subnet.member_agent_ids
-
-        return [c for c in children if _visible(c)]
+        # Return all children; the route layer applies per-row V6 B5
+        # caller-aware rendering (SubnetInfo for authorised, SubnetStub
+        # for private-unauthorised) — same as list_subnets.
+        # requester_id is kept in signature for backward compat but is
+        # no longer used here.
+        return await self.repository.find_by_parent(parent_subnet_id)
 
     async def delete_subnet(self, subnet_id: str, owner: str) -> bool:
         """
@@ -1084,7 +1080,7 @@ class SubnetService:
         """Server-generated UUID per ADR §SubnetJoinRequest schema."""
         return str(uuid.uuid4())
 
-    async def _load_join_request_or_404(
+    async def load_join_request_or_404(
         self,
         request_id: str,
         *,
@@ -1269,7 +1265,7 @@ class SubnetService:
         captured separately if it surfaces in production.
         """
         await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
             expected_subnet_id=subnet_id,
@@ -1322,7 +1318,7 @@ class SubnetService:
         # webhook payload — reject doesn't mutate subnet membership,
         # so the entity snapshot stays valid for the event emit.
         subnet = await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
             expected_subnet_id=subnet_id,
@@ -1363,7 +1359,7 @@ class SubnetService:
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
         subnet = await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
             expected_subnet_id=subnet_id,
@@ -1518,7 +1514,7 @@ class SubnetService:
         ``"system:allowlist"`` token surface in the payload.
         """
         await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
             expected_subnet_id=subnet_id,
@@ -1564,7 +1560,7 @@ class SubnetService:
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
         subnet = await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
             expected_subnet_id=subnet_id,
@@ -1604,7 +1600,7 @@ class SubnetService:
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
         subnet = await self.get_subnet(subnet_id)
-        row = await self._load_join_request_or_404(
+        row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
             expected_subnet_id=subnet_id,

--- a/tests/routes/_admission_helpers.py
+++ b/tests/routes/_admission_helpers.py
@@ -185,7 +185,7 @@ def stub_subnet_service():
     svc.cancel_invitation = AsyncMock()
     svc.list_invitations = AsyncMock(return_value=[])
     svc.list_pending_invitations_for_agent = AsyncMock(return_value=[])
-    svc._load_join_request_or_404 = AsyncMock()
+    svc.load_join_request_or_404 = AsyncMock()
     svc.add_member = AsyncMock()
     svc.remove_member = AsyncMock()
     return svc

--- a/tests/routes/test_payments_error_schema.py
+++ b/tests/routes/test_payments_error_schema.py
@@ -300,7 +300,9 @@ class TestResourceNotFoundFlatShape:
     converge on the same code; the others have a single site each."""
 
     def test_get_payment_capability_404_flat_shape(self, stub_payment_discovery):
-        _wire_self_authed()
+        # P3-3: get_payment_capability now enforces self-only — caller must
+        # match the path agent_id, so wire the key to match "agent-x".
+        _wire_self_authed("agent-x")
         app.dependency_overrides[get_payment_discovery] = lambda: stub_payment_discovery
         try:
             with TestClient(app) as client:

--- a/tests/routes/test_route_service_contracts.py
+++ b/tests/routes/test_route_service_contracts.py
@@ -379,7 +379,11 @@ class TestPaymentContract:
         return pt
 
     def test_discover_calls_find_agents_accepting_payment(self, stub_payment_discovery):
+        from acn.routes.dependencies import verify_agent_api_key
+
         app.dependency_overrides[get_payment_discovery] = lambda: stub_payment_discovery
+        # P3-2: discover now requires authentication
+        app.dependency_overrides[verify_agent_api_key] = lambda: _make_agent_info("agent-x")
 
         with TestClient(app) as client:
             r = client.get("/api/v1/payments/discover")

--- a/tests/routes/test_subnet_admission_invitations.py
+++ b/tests/routes/test_subnet_admission_invitations.py
@@ -184,7 +184,7 @@ class TestAcceptInvitation:
             status="approved",
             decided_by=INVITEE_AGENT_ID,
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
         subnet_svc.accept_invitation.return_value = accepted
 
         with TestClient(app) as client:
@@ -209,7 +209,7 @@ class TestAcceptInvitation:
             kind="invitation",
             agent_id=INVITEE_AGENT_ID,
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
 
         with TestClient(app) as client:
             r = client.post(
@@ -224,7 +224,7 @@ class TestAcceptInvitation:
     def test_namespace_mismatch_returns_invitation_not_found(self, wire):
         """Hitting /invitations/{id} with a join_request row → 404."""
         _, subnet_svc, _, _ = wire
-        subnet_svc._load_join_request_or_404.side_effect = InvitationNotFoundError(
+        subnet_svc.load_join_request_or_404.side_effect = InvitationNotFoundError(
             INVITATION_ID
         )
 
@@ -251,7 +251,7 @@ class TestRejectInvitation:
             decided_by=INVITEE_AGENT_ID,
             note="not now",
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
         subnet_svc.reject_invitation.return_value = rejected
 
         with TestClient(app) as client:
@@ -271,7 +271,7 @@ class TestRejectInvitation:
         pending = make_join_request(
             request_id=INVITATION_ID, kind="invitation"
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
 
         with TestClient(app) as client:
             r = client.post(

--- a/tests/routes/test_subnet_admission_join_requests.py
+++ b/tests/routes/test_subnet_admission_join_requests.py
@@ -200,7 +200,7 @@ class TestWithdrawJoinRequest:
             initiated_by=INVITEE_AGENT_ID,
             decided_by=INVITEE_AGENT_ID,
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
         subnet_svc.withdraw_join_request.return_value = withdrawn
 
         with TestClient(app) as client:
@@ -220,7 +220,7 @@ class TestWithdrawJoinRequest:
             request_id=REQUEST_ID,
             initiated_by=INVITEE_AGENT_ID,
         )
-        subnet_svc._load_join_request_or_404.return_value = pending
+        subnet_svc.load_join_request_or_404.return_value = pending
 
         with TestClient(app) as client:
             r = client.delete(
@@ -236,7 +236,7 @@ class TestWithdrawJoinRequest:
     def test_namespace_mismatch_returns_join_request_not_found(self, wire):
         """Hitting /join-requests/{id} with an invitation id → 404."""
         _, subnet_svc, _, _ = wire
-        subnet_svc._load_join_request_or_404.side_effect = JoinRequestNotFoundError(
+        subnet_svc.load_join_request_or_404.side_effect = JoinRequestNotFoundError(
             REQUEST_ID
         )
 

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -247,7 +247,11 @@ class TestListSubnetsParentFilter:
 
         assert r.status_code == 200
         body = r.json()
-        assert body == {"count": 0, "subnets": []}
+        assert body["count"] == 0
+        assert body["subnets"] == []
+        # P2-5: list_subnets now includes pagination metadata
+        assert body["total"] == 0
+        assert body["has_more"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -332,9 +332,13 @@ class TestAddMemberMembershipSubset:
 
 class TestListChildrenACL:
     @pytest.mark.asyncio
-    async def test_anonymous_sees_only_public_children(
+    async def test_returns_all_children_regardless_of_requester(
         self, mock_subnet_repository: ISubnetRepository
     ):
+        """Service layer returns ALL children; ACL rendering is now
+        the route layer's responsibility (per-row SubnetStub for private
+        unauthorised — same pattern as list_subnets, P2-1 fix).
+        """
         children = [
             Subnet(
                 subnet_id="public-child",
@@ -362,12 +366,15 @@ class TestListChildrenACL:
 
         result = await service.list_children("parent-1", requester_id=None)
         ids = {c.subnet_id for c in result}
-        assert ids == {"public-child"}
+        # Service now returns all children; route applies per-row V6 rendering.
+        assert ids == {"public-child", "private-child"}
 
     @pytest.mark.asyncio
-    async def test_member_sees_private_child_they_belong_to(
+    async def test_returns_all_children_for_member(
         self, mock_subnet_repository: ISubnetRepository
     ):
+        """Service layer returns all children; access control is done
+        at the route layer (per-row SubnetStub vs SubnetInfo)."""
         children = [
             Subnet(
                 subnet_id="private-mine",
@@ -394,8 +401,8 @@ class TestListChildrenACL:
 
         result = await service.list_children("parent-1", requester_id="bob")
         ids = {c.subnet_id for c in result}
-        # Bob sees "private-mine" (member) but not "private-theirs".
-        assert ids == {"private-mine"}
+        # Service returns all; route renders private-theirs as Stub for bob.
+        assert ids == {"private-mine", "private-theirs"}
 
     @pytest.mark.asyncio
     async def test_no_existence_leak_for_unknown_parent(


### PR DESCRIPTION
## Summary

Sixth comprehensive audit of the ACN backend. Fixes 4 P1, 9 P2, and 8 P3 issues.

### P1 — Security / Correctness

| # | File | Fix |
|---|------|-----|
| P1-1 | `routes/tasks.py` | `list_participations` was comparing `p.agent_id` (non-existent field on `ParticipationResponse`) → fixed to `p.participant_id`; would have caused `AttributeError` (500) or silently exposed all submissions |
| P1-2 | `routes/tasks.py` | `list_participations` lacked subnet membership gate — non-members of private-subnet tasks could read all participation records; now mirrors the `get_task` check |
| P1-3 | `routes/tasks.py` | `POST /tasks/agent/create` validated `subnet_id` for membership but did **not** pass it to `task_service.create_task`; created tasks ended up without subnet context |
| P1-4 | `routes/gateway_connect.py` | Unauthenticated public-subnet WebSocket connections are now logged (`gateway_connect_unauthenticated`) so ops can detect abuse/impersonation patterns |

### P2 — Quality / Consistency

| # | File | Fix |
|---|------|-----|
| P2-1 | `services/subnet_service.py` | `list_children` removed the ACL filter from the service layer; the route layer already has per-row V6 B5 Stub rendering — service now returns all children |
| P2-2 | `routes/subnets.py` | `GET /subnets/{id}` for private subnets: invalid JWT previously returned 401; now wraps `verify_token` in try/except and returns `SubnetStub` (consistent with `list_subnets`) |
| P2-3 | `routes/payments.py` `routes/communication.py` `routes/registry.py` | Three remaining `str(e)` in client-facing `details` fields replaced with static tokens |
| P2-4/P3-5 | `routes/registry.py` | Non-admin callers on `GET /agents` are now forced to `visibility=real` preventing enumeration of hidden/archived/spam agents |
| P2-5 | `routes/subnets.py` | `GET /subnets` now accepts `?limit=` / `?offset=` pagination; parent UUIDs are batch-resolved instead of N+1 per-row fetches; response includes `total` and `has_more` |
| P2-6 | `routes/subnet_admission.py` | `accept_invitation` now performs best-effort rollback (`remove_member`) if the agent back-ref write fails, avoiding a permanent half-joined state |
| P2-7 | `services/subnet_service.py` `routes/subnet_admission.py` | `_load_join_request_or_404` renamed to `load_join_request_or_404` (public method); all call sites updated |
| P2-8 | `routes/onchain.py` | `record_feedback` and `record_validation` now support multi-participant tasks (`assignee_id is None`) by resolving the participation set and checking membership |
| P2-9 | `routes/sessions.py` | `SessionInviteRequest.metadata` now has a Pydantic `field_validator` capping at 4 KB |

### P3 — Improvements

| # | File | Fix |
|---|------|-----|
| P3-1 | `routes/payments.py` `routes/registry.py` | Added `@limiter.limit` to `set_payment_capability`, `bill_usage`, `agent_heartbeat` |
| P3-2 | `routes/payments.py` | `GET /payments/discover` now requires `AgentApiKeyDep` — anonymous enumeration of payment-capable agents no longer possible |
| P3-3 | `routes/payments.py` | `GET /payments/{id}/payment-capability` now enforces self-only read (403 if caller ≠ path agent) |
| P3-4 | `routes/subnets.py` | `owned_by_user` 403 details no longer include `requested_user` / `token_sub` (cross-tenant probing assistance) |
| P3-6 | `routes/analytics.py` | Already gated — no change needed (rate limits on public endpoints, `InternalToken` on sensitive ones) |
| P3-7 | `routes/tasks.py` | `cancel_participation` now uses `expose_submission=(agent_id == task.creator_id)` for consistent V6 submission visibility |
| P3-8 | `routes/subnet_admission.py` | `DELETE /subnets/{id}/join-requests/{rid}` drops the optional JSON body — note is now a `?note=` query param (no body on DELETE) |

## Test plan

- [x] `ruff check` — zero errors
- [x] `tests/routes/test_privacy_matrix.py` — 15 tests pass
- [x] `tests/routes/test_subnets_owner_field.py` — pass
- [x] `tests/routes/test_route_service_contracts.py` — updated for P3-2 auth requirement
- [x] `tests/services/test_subnet_service_nesting.py` — updated for P2-1 service contract change
- [x] `tests/routes/test_payments_error_schema.py` — updated for P3-3 self-only requirement
- [x] Full unit test suite: **1005 passed, 0 failed**

Made with [Cursor](https://cursor.com)