### PR TITLE
refactor(subnet): rename subnet_id → slug across domain + API layer (Step 1)

### DIFF
--- a/acn/core/entities/subnet.py
+++ b/acn/core/entities/subnet.py
@@ -17,7 +17,7 @@ _LIFECYCLE_VALUES: frozenset[str] = frozenset({"persistent", "task_scoped"})
 # future third mode (e.g. "invite_only", "paid") extends this set and the
 # ``__post_init__`` validator picks it up automatically.
 _JOIN_POLICY_VALUES: frozenset[str] = frozenset({"open", "approval"})
-_RESERVED_SUBNET_IDS: frozenset[str] = frozenset({"public", "system"})
+_RESERVED_SLUGS: frozenset[str] = frozenset({"public", "system"})
 
 
 @dataclass
@@ -32,19 +32,25 @@ class Subnet:
 
     Identifiers
     -----------
-    ``subnet_id`` — the canonical, human-readable identifier. Stable
-        primary key in Postgres, used in every API path, agent
-        ``subnet_ids`` array, ``tasks.subnet_id`` reference, Redis index,
-        CLI, and SDK. Examples: ``"public"``, ``"acnlabs-core"``,
-        ``"subnet-team-alpha-7f3a9c"``.
+    ``slug`` — the URL-safe, human-readable identifier. Stable primary key
+        in Postgres (column ``subnets.slug``), used in every API path,
+        agent ``subnet_ids`` array, ``tasks.slug`` reference, Redis
+        index, CLI, and SDK. Examples: ``"public"``, ``"acnlabs-core"``,
+        ``"team-alpha-7f3a9c"``.
     ``id`` — opaque UUID, server-generated. Surfaced only in
         ``SubnetInfo.id`` and ``SubnetStub.id`` so anonymous callers
-        receive a non-revealing identifier when they hit the discoverable-
-        private-subnet stub path. NOT used for lookups, foreign keys, or
-        membership arrays — those continue to key off ``subnet_id``.
+        receive a non-revealing identifier. NOT used for lookups, foreign
+        keys, or membership arrays — those continue to key off ``slug``.
+
+    Display name
+    ------------
+    ``name`` — free-text display name shown in UIs. May contain spaces,
+        uppercase letters, and Unicode. Defaults to ``slug`` at creation
+        time so legacy callers that never supply a separate display name
+        keep the old behaviour.
     """
 
-    subnet_id: str
+    slug: str
     name: str
     owner: str
     description: str | None = None
@@ -61,7 +67,7 @@ class Subnet:
     id: str = field(default_factory=lambda: str(uuid4()))
     # Nesting fields (ADR-0003). All optional; defaults preserve legacy
     # "flat top-level subnet" semantics.
-    parent_subnet_id: str | None = None
+    parent_slug: str | None = None
     lifecycle: Literal["persistent", "task_scoped"] = "persistent"
     linked_task_id: str | None = None
     # Join admission policy (ADR-0004). Decouples admission control from
@@ -80,29 +86,29 @@ class Subnet:
 
     def __post_init__(self):
         """Validate invariants"""
-        if not self.subnet_id:
-            raise ValueError("subnet_id cannot be empty")
+        if not self.slug:
+            raise ValueError("slug cannot be empty")
         if not self.name:
             raise ValueError("name cannot be empty")
         if not self.owner:
             raise ValueError("owner cannot be empty")
-        # Reserved subnet IDs
-        if self.subnet_id in _RESERVED_SUBNET_IDS:
+        # Reserved slugs
+        if self.slug in _RESERVED_SLUGS:
             if self.owner != "system":
-                raise ValueError(f"Subnet '{self.subnet_id}' is reserved for system use")
+                raise ValueError(f"Subnet '{self.slug}' is reserved for system use")
             # Reserved subnets can never participate in nesting — neither
-            # as a child (would let attackers slot platform-owned IDs into
+            # as a child (would let attackers slot platform-owned slugs into
             # a hierarchy) nor with a task-bound lifecycle (would let a
             # task termination auto-dissolve a platform-level subnet,
             # breaking the implicit "always-on" guarantee that callers
             # depend on for `public`).
-            if self.parent_subnet_id is not None:
+            if self.parent_slug is not None:
                 raise ValueError(
-                    f"Reserved subnet '{self.subnet_id}' cannot have a parent_subnet_id"
+                    f"Reserved subnet '{self.slug}' cannot have a parent_slug"
                 )
             if self.lifecycle == "task_scoped":
                 raise ValueError(
-                    f"Reserved subnet '{self.subnet_id}' cannot be task_scoped"
+                    f"Reserved subnet '{self.slug}' cannot be task_scoped"
                 )
 
         # ADR-0003 entity-layer invariants.
@@ -128,7 +134,7 @@ class Subnet:
             )
         # ``is_private=True`` implies ``join_policy="approval"`` — the
         # combination ``private + open`` is the status-quo "private but
-        # joinable by anyone who knows the id" bug that ADR-0004 closes.
+        # joinable by anyone who knows the slug" bug that ADR-0004 closes.
         # Rejecting at construction time means no service / route caller
         # can produce or load a row in that state; the same combination
         # received over the wire (``POST /api/v1/subnets`` body) is
@@ -136,7 +142,7 @@ class Subnet:
         # ``details.reason="visibility_policy_conflict"``.
         if self.is_private and self.join_policy == "open":
             raise ValueError(
-                f"subnet '{self.subnet_id}' configuration invalid: "
+                f"subnet '{self.slug}' configuration invalid: "
                 f"is_private=True requires join_policy='approval' "
                 f"(reason=visibility_policy_conflict)"
             )
@@ -185,7 +191,7 @@ class Subnet:
         for internal use (e.g. snapshotting onto Task.metadata).
         """
         out = {
-            "subnet_id": self.subnet_id,
+            "slug": self.slug,
             "id": self.id,
             "name": self.name,
             "owner": self.owner,
@@ -196,7 +202,7 @@ class Subnet:
             "created_at": self.created_at.isoformat(),
             "metadata": self.metadata,
             "harness_url": self.harness_url,
-            "parent_subnet_id": self.parent_subnet_id,
+            "parent_slug": self.parent_slug,
             "lifecycle": self.lifecycle,
             "linked_task_id": self.linked_task_id,
             "join_policy": self.join_policy,
@@ -248,4 +254,11 @@ class Subnet:
         # ADR-0004 legacy auto-upgrade — see docstring above.
         if "join_policy" not in data and data.get("is_private") is True:
             data["join_policy"] = "approval"
+        # Back-compat: old serialised dicts used ``subnet_id`` and
+        # ``parent_slug`` before the slug rename. Translate on read
+        # so Redis-cached rows survive the migration without a backfill.
+        if "subnet_id" in data and "slug" not in data:
+            data["slug"] = data.pop("subnet_id")
+        if "parent_slug" in data and "parent_slug" not in data:
+            data["parent_slug"] = data.pop("parent_slug")
         return cls(**data)

--- a/acn/core/entities/subnet.py
+++ b/acn/core/entities/subnet.py
@@ -34,9 +34,15 @@ class Subnet:
     -----------
     ``slug`` — the URL-safe, human-readable identifier. Stable primary key
         in Postgres (column ``subnets.slug``), used in every API path,
-        agent ``subnet_ids`` array, ``tasks.slug`` reference, Redis
-        index, CLI, and SDK. Examples: ``"public"``, ``"acnlabs-core"``,
-        ``"team-alpha-7f3a9c"``.
+        Redis index, CLI, and SDK. Examples: ``"public"``,
+        ``"acnlabs-core"``, ``"team-alpha-7f3a9c"``.
+
+        Cross-entity columns that *carry* a slug value but whose Python
+        attribute / DB column are still named ``subnet_id`` (Step 2 of
+        the rename migration): ``Agent.subnet_ids``, ``Task.subnet_id``,
+        ``SubnetJoinRequest`` / ``SubnetAllowlist`` ORM rows
+        (Python attribute is ``slug`` since Step 1, DB column stays
+        ``subnet_id`` until Step 2's column-rename migration ships).
     ``id`` — opaque UUID, server-generated. Surfaced only in
         ``SubnetInfo.id`` and ``SubnetStub.id`` so anonymous callers
         receive a non-revealing identifier. NOT used for lookups, foreign
@@ -255,10 +261,17 @@ class Subnet:
         if "join_policy" not in data and data.get("is_private") is True:
             data["join_policy"] = "approval"
         # Back-compat: old serialised dicts used ``subnet_id`` and
-        # ``parent_slug`` before the slug rename. Translate on read
-        # so Redis-cached rows survive the migration without a backfill.
+        # ``parent_subnet_id`` before the slug rename. Translate on
+        # read so Redis-cached rows survive the migration without a
+        # backfill. ``data.pop`` (not ``setdefault``) so the legacy
+        # key never reaches ``cls(**data)`` — the dataclass would
+        # otherwise reject it as an unexpected keyword argument.
         if "subnet_id" in data and "slug" not in data:
             data["slug"] = data.pop("subnet_id")
-        if "parent_slug" in data and "parent_slug" not in data:
-            data["parent_slug"] = data.pop("parent_slug")
+        elif "subnet_id" in data:
+            data.pop("subnet_id")
+        if "parent_subnet_id" in data and "parent_slug" not in data:
+            data["parent_slug"] = data.pop("parent_subnet_id")
+        elif "parent_subnet_id" in data:
+            data.pop("parent_subnet_id")
         return cls(**data)

--- a/acn/core/entities/subnet_allowlist.py
+++ b/acn/core/entities/subnet_allowlist.py
@@ -1,6 +1,6 @@
 """SubnetAllowlist Domain Entity (ADR-0004 Phase 2 Slice 2.1).
 
-A single ``(subnet_id, agent_id)`` entry in the subnet's
+A single ``(slug, agent_id)`` entry in the subnet's
 admission-allowlist. Distinct from ``IAllowlistRepository`` (which
 governs **agent-to-agent communication** under
 ``communication_policy.mode=allowlist``) — this entity governs
@@ -30,9 +30,9 @@ from datetime import UTC, datetime
 
 @dataclass
 class SubnetAllowlist:
-    """A single preauthorised ``(subnet_id, agent_id)`` admission entry."""
+    """A single preauthorised ``(slug, agent_id)`` admission entry."""
 
-    subnet_id: str
+    slug: str
     agent_id: str
     added_by: str
     added_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -41,8 +41,8 @@ class SubnetAllowlist:
         """Enforce non-empty identity fields.
 
         Schema-level constraints (composite PK on
-        ``(subnet_id, agent_id)``, FK against ``agents.agent_id``,
-        existence-check on ``subnet_id``) live at the persistence
+        ``(slug, agent_id)``, FK against ``agents.agent_id``,
+        existence-check on ``slug``) live at the persistence
         layer; the entity only rejects the structurally impossible
         shapes (empty strings) that the schema's NOT NULL doesn't
         catch.
@@ -56,8 +56,8 @@ class SubnetAllowlist:
         a ``system:<reason>`` actor (matches the convention
         ``SubnetJoinRequest.SYSTEM_ALLOWLIST_ACTOR`` uses).
         """
-        if not self.subnet_id:
-            raise ValueError("subnet_id cannot be empty")
+        if not self.slug:
+            raise ValueError("slug cannot be empty")
         if not self.agent_id:
             raise ValueError("agent_id cannot be empty")
         if not self.added_by:
@@ -77,7 +77,7 @@ class SubnetAllowlist:
         SINTERSTORE the membership for batch operations).
         """
         return {
-            "subnet_id": self.subnet_id,
+            "slug": self.slug,
             "agent_id": self.agent_id,
             "added_by": self.added_by,
             "added_at": self.added_at.isoformat(),
@@ -93,7 +93,7 @@ class SubnetAllowlist:
         missing ``added_by`` or ``added_at`` is a corrupt record,
         not a backward-compat case."""
         return cls(
-            subnet_id=data["subnet_id"],
+            slug=data.get("slug") or data.get("subnet_id", ""),
             agent_id=data["agent_id"],
             added_by=data["added_by"],
             added_at=datetime.fromisoformat(data["added_at"]),

--- a/acn/core/entities/subnet_join_request.py
+++ b/acn/core/entities/subnet_join_request.py
@@ -76,7 +76,7 @@ class SubnetJoinRequest:
     """
 
     request_id: str
-    subnet_id: str
+    slug: str
     agent_id: str
     kind: Literal["join_request", "invitation", "allowlist_auto"]
     status: Literal["pending", "approved", "rejected", "withdrawn"]
@@ -102,8 +102,8 @@ class SubnetJoinRequest:
         """
         if not self.request_id:
             raise ValueError("request_id cannot be empty")
-        if not self.subnet_id:
-            raise ValueError("subnet_id cannot be empty")
+        if not self.slug:
+            raise ValueError("slug cannot be empty")
         if not self.agent_id:
             raise ValueError("agent_id cannot be empty")
         if not self.initiated_by:
@@ -169,7 +169,7 @@ class SubnetJoinRequest:
 
     @property
     def is_pending(self) -> bool:
-        """True iff this row blocks future ``(subnet_id, agent_id)``
+        """True iff this row blocks future ``(slug, agent_id)``
         request creation under the unique partial index
         ``WHERE status='pending'``."""
         return self.status == "pending"
@@ -195,7 +195,7 @@ class SubnetJoinRequest:
         """
         return {
             "request_id": self.request_id,
-            "subnet_id": self.subnet_id,
+            "slug": self.slug,
             "agent_id": self.agent_id,
             "kind": self.kind,
             "status": self.status,
@@ -218,7 +218,7 @@ class SubnetJoinRequest:
         decided_at_raw = data.get("decided_at") or None
         return cls(
             request_id=data["request_id"],
-            subnet_id=data["subnet_id"],
+            slug=data.get("slug") or data.get("subnet_id", ""),
             agent_id=data["agent_id"],
             kind=data["kind"],
             status=data["status"],

--- a/acn/core/exceptions/__init__.py
+++ b/acn/core/exceptions/__init__.py
@@ -186,7 +186,7 @@ class AlreadyMemberError(JoinFlowError):
     """
 
     def __init__(self, subnet_id: str, agent_id: str) -> None:
-        self.subnet_id = subnet_id
+        self.slug = subnet_id
         self.agent_id = agent_id
         super().__init__(
             "already_member",
@@ -202,7 +202,7 @@ class AllowlistEntryExistsError(JoinFlowError):
     """
 
     def __init__(self, subnet_id: str, agent_id: str) -> None:
-        self.subnet_id = subnet_id
+        self.slug = subnet_id
         self.agent_id = agent_id
         super().__init__(
             "already_on_allowlist",

--- a/acn/core/interfaces/join_flow_event_publisher.py
+++ b/acn/core/interfaces/join_flow_event_publisher.py
@@ -131,7 +131,7 @@ class IJoinFlowEventPublisher(ABC):
             event: One of the eight ``JoinFlowEventType`` members.
             subnet: The ``Subnet`` entity the event is scoped to.
                 Implementations read ``harness_url`` /
-                ``harness_secret`` / ``parent_subnet_id`` from here
+                ``harness_secret`` / ``parent_slug`` from here
                 — Slice 2.2 callers must pass the freshly-fetched
                 subnet so a webhook fired off a stale snapshot
                 doesn't address a deleted Harness.

--- a/acn/core/interfaces/subnet_repository.py
+++ b/acn/core/interfaces/subnet_repository.py
@@ -27,12 +27,12 @@ class ISubnetRepository(ABC):
         pass
 
     @abstractmethod
-    async def find_by_id(self, subnet_id: str) -> Subnet | None:
+    async def find_by_id(self, slug: str) -> Subnet | None:
         """
         Find subnet by ID
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
 
         Returns:
             Subnet entity or None if not found
@@ -92,13 +92,13 @@ class ISubnetRepository(ABC):
 
     @abstractmethod
     async def delete(
-        self, subnet_id: str, *, session: Any | None = None
+        self, slug: str, *, session: Any | None = None
     ) -> bool:
         """
         Delete a subnet
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             session: Optional :class:`IUnitOfWork` token. When passed,
                 Postgres impl binds to it (no internal commit / close)
                 so the call participates in the outer transaction; the
@@ -171,12 +171,12 @@ class ISubnetRepository(ABC):
         pass
 
     @abstractmethod
-    async def exists(self, subnet_id: str) -> bool:
+    async def exists(self, slug: str) -> bool:
         """
         Check if subnet exists
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
 
         Returns:
             True if subnet exists
@@ -194,7 +194,7 @@ class ISubnetRepository(ABC):
     # underlying secondary index in the same transaction / pipeline.
 
     @abstractmethod
-    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+    async def find_by_parent(self, parent_slug: str) -> list[Subnet]:
         """
         Find all child subnets nested under a given parent.
 
@@ -204,10 +204,10 @@ class ISubnetRepository(ABC):
         parent separately.
 
         Args:
-            parent_subnet_id: Parent subnet identifier
+            parent_slug: Parent subnet identifier
 
         Returns:
-            List of subnets whose ``parent_subnet_id`` equals the
+            List of subnets whose ``parent_slug`` equals the
             argument.
         """
         pass

--- a/acn/infrastructure/messaging/broadcast_service.py
+++ b/acn/infrastructure/messaging/broadcast_service.py
@@ -138,7 +138,7 @@ class BroadcastService:
         from_agent: str,
         message: Message,
         target_agents: list[str] | None = None,
-        subnet_id: str | None = None,
+        slug: str | None = None,
         tags: list[str] | None = None,
         strategy: BroadcastStrategy = BroadcastStrategy.PARALLEL,
     ) -> "BroadcastResult":
@@ -167,7 +167,7 @@ class BroadcastService:
         Selector precedence (matches the old HTTP behaviour exactly):
 
         1. ``target_agents`` — explicit list, used verbatim;
-        2. ``subnet_id`` — resolved via
+        2. ``slug`` — resolved via
            ``agent_repository.find_by_subnet``;
         3. ``tags`` — resolved via ``agent_repository.find_by_tags``
            (defaults to ``status="online"``);
@@ -184,7 +184,7 @@ class BroadcastService:
                 (mapped to HTTP 404 by the route).
             message: A2A message to deliver.
             target_agents: Explicit recipient list (highest priority).
-            subnet_id: Restrict fan-out to one subnet.
+            slug: Restrict fan-out to one subnet.
             tags: Restrict fan-out to agents matching tags.
             strategy: Delivery strategy (parallel / sequential /
                 best_effort). See :py:class:`BroadcastStrategy`.
@@ -207,8 +207,8 @@ class BroadcastService:
 
         if target_agents:
             to_ids = list(target_agents)
-        elif subnet_id:
-            agents = await self.agent_repository.find_by_subnet(subnet_id)
+        elif slug:
+            agents = await self.agent_repository.find_by_subnet(slug)
             to_ids = [a.agent_id for a in agents]
         elif tags:
             agents = await self.agent_repository.find_by_tags(tags)
@@ -226,7 +226,7 @@ class BroadcastService:
         if not to_ids:
             logger.warning(
                 "broadcast_no_targets "
-                f"from={from_agent} subnet={subnet_id!r} tags={tags!r}"
+                f"from={from_agent} subnet={slug!r} tags={tags!r}"
             )
             # Empty fan-out still produces a BroadcastResult so callers
             # have a stable shape (and a broadcast_id for the audit

--- a/acn/infrastructure/messaging/subnet_manager.py
+++ b/acn/infrastructure/messaging/subnet_manager.py
@@ -25,13 +25,13 @@ Architecture:
 Usage:
     # Create subnet
     POST /api/v1/subnets
-    {"subnet_id": "enterprise-a", "name": "Enterprise A"}
+    {"slug": "enterprise-a", "name": "Enterprise A"}
 
     # Agent connects to specific subnet
-    WebSocket: /gateway/connect/{subnet_id}/{agent_id}
+    WebSocket: /gateway/connect/{slug}/{agent_id}
 
     # Send A2A message to subnet agent
-    POST /gateway/a2a/{subnet_id}/{agent_id}
+    POST /gateway/a2a/{slug}/{agent_id}
 """
 
 import asyncio
@@ -88,7 +88,7 @@ class GatewayConnection:
     """WebSocket connection from subnet agent"""
 
     connection_id: str
-    subnet_id: str
+    slug: str
     agent_id: str
     websocket: WebSocket
     agent_info: AgentInfo | None = None
@@ -127,14 +127,14 @@ class SubnetManager:
         await subnet_manager.create_subnet("enterprise-a", "Enterprise A")
 
         # Agent connects
-        @app.websocket("/gateway/connect/{subnet_id}/{agent_id}")
-        async def gateway_ws(ws, subnet_id, agent_id):
-            await subnet_manager.handle_connection(ws, subnet_id, agent_id)
+        @app.websocket("/gateway/connect/{slug}/{agent_id}")
+        async def gateway_ws(ws, slug, agent_id):
+            await subnet_manager.handle_connection(ws, slug, agent_id)
 
         # Forward A2A request
-        @app.post("/gateway/a2a/{subnet_id}/{agent_id}")
-        async def gateway_a2a(subnet_id, agent_id, message):
-            return await subnet_manager.forward_request(subnet_id, agent_id, message)
+        @app.post("/gateway/a2a/{slug}/{agent_id}")
+        async def gateway_a2a(slug, agent_id, message):
+            return await subnet_manager.forward_request(slug, agent_id, message)
     """
 
     # Default subnet for backwards compatibility
@@ -217,7 +217,7 @@ class SubnetManager:
         # gateway for unawaited futures.
         self._alive_renewal_tasks: set[asyncio.Task[None]] = set()
 
-        # Subnets: {subnet_id: Subnet}
+        # Subnets: {slug: Subnet}
         self._subnets: dict[str, Subnet] = {}
 
         # Background tasks
@@ -227,7 +227,7 @@ class SubnetManager:
         # Create default public subnet
         self._subnets[self.DEFAULT_SUBNET] = Subnet(
             info=SubnetInfo(
-                subnet_id=self.DEFAULT_SUBNET,
+                slug=self.DEFAULT_SUBNET,
                 name="Public Network",
                 owner="backend@internal",
                 description="Default subnet for public agents",
@@ -261,10 +261,10 @@ class SubnetManager:
                 pass
 
         # Disconnect all agents in all subnets
-        for subnet_id in list(self._subnets.keys()):
-            subnet = self._subnets[subnet_id]
+        for slug in list(self._subnets.keys()):
+            subnet = self._subnets[slug]
             for agent_id in list(subnet.connections.keys()):
-                await self._disconnect(subnet_id, agent_id, "Gateway shutting down")
+                await self._disconnect(slug, agent_id, "Gateway shutting down")
 
         logger.info("Subnet Manager stopped")
 
@@ -274,7 +274,7 @@ class SubnetManager:
 
     async def create_subnet(
         self,
-        subnet_id: str,
+        slug: str,
         name: str,
         description: str | None = None,
         security_schemes: dict | None = None,
@@ -296,7 +296,7 @@ class SubnetManager:
         does not go through ``SubnetService``. Tracked in acnlabs/ACN#48.
 
         Args:
-            subnet_id: Unique subnet identifier
+            slug: Unique subnet identifier
             name: Human-readable subnet name
             description: Optional description
             security_schemes: A2A-style security schemes (None = public)
@@ -320,8 +320,8 @@ class SubnetManager:
                 security_schemes={"bearer": {"type": "http", "scheme": "bearer"}}
             )
         """
-        if subnet_id in self._subnets:
-            raise ValueError(f"Subnet already exists: {subnet_id}")
+        if slug in self._subnets:
+            raise ValueError(f"Subnet already exists: {slug}")
 
         # Parse and validate security schemes
         parsed_schemes = None
@@ -333,7 +333,7 @@ class SubnetManager:
             }
 
         info = SubnetInfo(
-            subnet_id=subnet_id,
+            slug=slug,
             name=name,
             owner=owner,
             description=description,
@@ -359,7 +359,7 @@ class SubnetManager:
                     generated_token = f"ak_subnet_{secrets.token_urlsafe(32)}"
                     break
 
-        self._subnets[subnet_id] = Subnet(
+        self._subnets[slug] = Subnet(
             info=info,
             generated_token=generated_token,
         )
@@ -368,25 +368,25 @@ class SubnetManager:
         await self._persist_subnet(info, generated_token)
 
         is_public = security_schemes is None
-        logger.info(f"Created subnet: {subnet_id} (public={is_public})")
+        logger.info(f"Created subnet: {slug} (public={is_public})")
         return info, generated_token
 
-    def is_subnet_public(self, subnet_id: str) -> bool:
+    def is_subnet_public(self, slug: str) -> bool:
         """Check if subnet is public (no auth required)"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return False
-        return self._subnets[subnet_id].info.security_schemes is None
+        return self._subnets[slug].info.security_schemes is None
 
     async def validate_credentials(
         self,
-        subnet_id: str,
+        slug: str,
         credentials: dict | None,
     ) -> bool:
         """
         Validate credentials for joining a subnet
 
         Args:
-            subnet_id: Subnet to join
+            slug: Subnet to join
             credentials: Authentication credentials
                 - For bearer: {"token": "sk_subnet_xxx"}
                 - For apiKey: {"api_key": "ak_subnet_xxx"}
@@ -395,10 +395,10 @@ class SubnetManager:
         Returns:
             True if valid, False otherwise
         """
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return False
 
-        subnet = self._subnets[subnet_id]
+        subnet = self._subnets[slug]
 
         # Public subnet - no auth needed
         if subnet.info.security_schemes is None:
@@ -431,31 +431,31 @@ class SubnetManager:
                 # Tracked: https://github.com/acnlabs/ACN/issues/9
                 logger.warning(
                     "Subnet %s uses unsupported auth type '%s'. Access denied.",
-                    subnet_id,
+                    slug,
                     scheme.type,
                 )
                 return False
 
         return False
 
-    async def delete_subnet(self, subnet_id: str, force: bool = False):
+    async def delete_subnet(self, slug: str, force: bool = False):
         """
         Delete a subnet
 
         Args:
-            subnet_id: Subnet to delete
+            slug: Subnet to delete
             force: If True, disconnect all agents first
 
         Raises:
             ValueError: If subnet doesn't exist or has connected agents
         """
-        if subnet_id == self.DEFAULT_SUBNET:
+        if slug == self.DEFAULT_SUBNET:
             raise ValueError("Cannot delete default subnet")
 
-        if subnet_id not in self._subnets:
-            raise ValueError(f"Subnet not found: {subnet_id}")
+        if slug not in self._subnets:
+            raise ValueError(f"Subnet not found: {slug}")
 
-        subnet = self._subnets[subnet_id]
+        subnet = self._subnets[slug]
 
         if subnet.connections and not force:
             raise ValueError(
@@ -465,29 +465,29 @@ class SubnetManager:
 
         # Disconnect all agents
         for agent_id in list(subnet.connections.keys()):
-            await self._disconnect(subnet_id, agent_id, "Subnet deleted")
+            await self._disconnect(slug, agent_id, "Subnet deleted")
 
         # Remove subnet
-        del self._subnets[subnet_id]
+        del self._subnets[slug]
 
         # Remove from Redis
-        await self._remove_subnet_state(subnet_id)
+        await self._remove_subnet_state(slug)
 
-        logger.info(f"Deleted subnet: {subnet_id}")
+        logger.info(f"Deleted subnet: {slug}")
 
-    def get_subnet(self, subnet_id: str) -> SubnetInfo | None:
+    def get_subnet(self, slug: str) -> SubnetInfo | None:
         """Get subnet info"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return None
-        return self._subnets[subnet_id].info
+        return self._subnets[slug].info
 
     def list_subnets(self) -> list[SubnetInfo]:
         """List all subnets"""
         return [subnet.info for subnet in self._subnets.values()]
 
-    def subnet_exists(self, subnet_id: str) -> bool:
+    def subnet_exists(self, slug: str) -> bool:
         """Check if subnet exists"""
-        return subnet_id in self._subnets
+        return slug in self._subnets
 
     # =========================================================================
     # Connection Handling
@@ -496,7 +496,7 @@ class SubnetManager:
     async def handle_connection(
         self,
         websocket: WebSocket,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
         credentials: dict | None = None,
     ):
@@ -505,7 +505,7 @@ class SubnetManager:
 
         Args:
             websocket: FastAPI WebSocket
-            subnet_id: Subnet to join
+            slug: Subnet to join
             agent_id: Agent identifier
             credentials: Authentication credentials (for non-public subnets)
                 - bearer: {"token": "sk_subnet_xxx"}
@@ -513,24 +513,24 @@ class SubnetManager:
                 - oauth: {"access_token": "..."}
         """
         # Validate subnet exists
-        if subnet_id not in self._subnets:
-            await websocket.close(code=4004, reason=f"Subnet not found: {subnet_id}")
+        if slug not in self._subnets:
+            await websocket.close(code=4004, reason=f"Subnet not found: {slug}")
             return
 
         # Validate credentials for non-public subnets
-        if not self.is_subnet_public(subnet_id):
-            if not await self.validate_credentials(subnet_id, credentials):
+        if not self.is_subnet_public(slug):
+            if not await self.validate_credentials(slug, credentials):
                 await websocket.close(code=4001, reason="Authentication required for this subnet")
                 return
 
         await websocket.accept()
         connection_id = str(uuid4())
 
-        logger.info(f"Agent connecting: {subnet_id}/{agent_id} (authenticated)")
+        logger.info(f"Agent connecting: {slug}/{agent_id} (authenticated)")
 
         connection = GatewayConnection(
             connection_id=connection_id,
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             websocket=websocket,
         )
@@ -540,21 +540,21 @@ class SubnetManager:
             await self._handle_registration(connection)
 
             # Store connection
-            self._subnets[subnet_id].connections[agent_id] = connection
+            self._subnets[slug].connections[agent_id] = connection
 
             # Message loop
             await self._message_loop(connection)
 
         except WebSocketDisconnect:
-            logger.info(f"Agent disconnected: {subnet_id}/{agent_id}")
+            logger.info(f"Agent disconnected: {slug}/{agent_id}")
         except Exception as e:
-            logger.error(f"Connection error for {subnet_id}/{agent_id}: {e}")
+            logger.error(f"Connection error for {slug}/{agent_id}: {e}")
             # Send a generic error code to the client — do not echo internal
             # exception details over the WebSocket frame (they may contain
             # internal hostnames, SQL errors, or agent_id enumeration hints).
             await self._send_error(websocket, "connection_error")
         finally:
-            await self._disconnect(subnet_id, agent_id)
+            await self._disconnect(slug, agent_id)
 
     async def _handle_registration(
         self,
@@ -601,14 +601,14 @@ class SubnetManager:
         # Build agent info with gateway endpoint
         agent_data = data.get("agent_info", {})
         gateway_endpoint = (
-            f"{self.gateway_base_url}/gateway/a2a/{connection.subnet_id}/{connection.agent_id}"
+            f"{self.gateway_base_url}/gateway/a2a/{connection.slug}/{connection.agent_id}"
         )
 
         # Prepare metadata
         metadata = {
             **agent_data.get("metadata", {}),
             "gateway": self.gateway_base_url,
-            "subnet_id": connection.subnet_id,
+            "slug": connection.slug,
             "connection_type": "gateway",
         }
 
@@ -635,7 +635,7 @@ class SubnetManager:
                 a2a_endpoint=gateway_endpoint,
                 description=agent_data.get("description", ""),
                 tags=_agent_tags,
-                subnet_ids=[connection.subnet_id],
+                subnet_ids=[connection.slug],
                 metadata=metadata,
                 agent_card=agent_data.get("agent_card"),
             )
@@ -656,12 +656,12 @@ class SubnetManager:
         # autonomous-join semantic.
         connection.agent_info = AgentInfo(
             agent_id=connection.agent_id,
-            owner=f"gateway:{connection.subnet_id}",
+            owner=f"gateway:{connection.slug}",
             name=agent_data.get("name", connection.agent_id),
             description=agent_data.get("description", ""),
             tags=_agent_tags,
             endpoint=gateway_endpoint,
-            subnet_ids=[connection.subnet_id],
+            subnet_ids=[connection.slug],
             metadata=metadata,
         )
 
@@ -670,14 +670,14 @@ class SubnetManager:
             {
                 "type": GatewayMessageType.REGISTER_ACK,
                 "agent_id": connection.agent_id,
-                "subnet_id": connection.subnet_id,
+                "slug": connection.slug,
                 "gateway_endpoint": gateway_endpoint,
                 "timestamp": datetime.now(UTC).isoformat(),
             }
         )
 
         logger.info(
-            f"Agent registered: {connection.subnet_id}/{connection.agent_id} -> {gateway_endpoint}"
+            f"Agent registered: {connection.slug}/{connection.agent_id} -> {gateway_endpoint}"
         )
 
     async def _message_loop(self, connection: GatewayConnection):
@@ -688,7 +688,7 @@ class SubnetManager:
             if len(raw.encode("utf-8")) > _SUBNET_WS_MAX_FRAME_BYTES:
                 logger.warning(
                     "subnet_ws_frame_too_large",
-                    subnet_id=connection.subnet_id,
+                    slug=connection.slug,
                     agent_id=connection.agent_id,
                     frame_bytes=len(raw.encode("utf-8")),
                     limit=_SUBNET_WS_MAX_FRAME_BYTES,
@@ -731,21 +731,21 @@ class SubnetManager:
 
             else:
                 logger.debug(
-                    f"Unhandled message from {connection.subnet_id}/"
+                    f"Unhandled message from {connection.slug}/"
                     f"{connection.agent_id}: {msg_type}"
                 )
 
     async def _disconnect(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
         reason: str = "",
     ):
         """Cleanup disconnected agent"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return
 
-        subnet = self._subnets[subnet_id]
+        subnet = self._subnets[slug]
         if agent_id not in subnet.connections:
             return
 
@@ -776,7 +776,7 @@ class SubnetManager:
         except Exception:
             pass
 
-        logger.info(f"Agent cleaned up: {subnet_id}/{agent_id}")
+        logger.info(f"Agent cleaned up: {slug}/{agent_id}")
 
     async def _send_error(self, websocket: WebSocket, error: str):
         """Send error to agent"""
@@ -797,7 +797,7 @@ class SubnetManager:
 
     async def forward_request(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
         message: Message | dict[str, Any],
         timeout: float = 30.0,
@@ -808,7 +808,7 @@ class SubnetManager:
         Forward A2A request to subnet agent
 
         Args:
-            subnet_id: Target subnet
+            slug: Target subnet
             agent_id: Target agent
             message: A2A message
             timeout: Response timeout
@@ -850,12 +850,12 @@ class SubnetManager:
         # escrow complexity without delivering meaningful trust benefit.
         # Senders who want to attach a fee should route via the HTTP
         # ``POST /communication/send`` path instead.
-        if subnet_id not in self._subnets:
-            raise ValueError(f"Subnet not found: {subnet_id}")
+        if slug not in self._subnets:
+            raise ValueError(f"Subnet not found: {slug}")
 
-        subnet = self._subnets[subnet_id]
+        subnet = self._subnets[slug]
         if agent_id not in subnet.connections:
-            raise ValueError(f"Agent not connected: {subnet_id}/{agent_id}")
+            raise ValueError(f"Agent not connected: {slug}/{agent_id}")
 
         # Gateway-level access control (Phase 1) + manifest divert (Phase 2 PR #1).
         #
@@ -904,7 +904,7 @@ class SubnetManager:
             # Subnet-internal forward: sender and recipient share this
             # subnet by definition. Pass it as shared_subnet_ids so the
             # policy service can bypass manifest for subnet peers.
-            _shared = {subnet_id} - {"public", "system"}
+            _shared = {slug} - {"public", "system"}
             decision = await self.policy_service.check_inbound(
                 sender_id=from_agent or "unknown",
                 recipient_id=agent_id,
@@ -993,7 +993,7 @@ class SubnetManager:
 
         except TimeoutError:
             connection.pending_requests.pop(request_id, None)
-            raise TimeoutError(f"Response timeout: {subnet_id}/{agent_id}") from None
+            raise TimeoutError(f"Response timeout: {slug}/{agent_id}") from None
         except Exception:
             connection.pending_requests.pop(request_id, None)
             raise
@@ -1018,58 +1018,58 @@ class SubnetManager:
         now = datetime.now(UTC)
         stale = []
 
-        for subnet_id, subnet in self._subnets.items():
+        for slug, subnet in self._subnets.items():
             for agent_id, conn in subnet.connections.items():
                 elapsed = (now - conn.last_heartbeat).total_seconds()
                 if elapsed > self.heartbeat_timeout:
-                    stale.append((subnet_id, agent_id))
+                    stale.append((slug, agent_id))
                     logger.warning(
-                        f"Agent {subnet_id}/{agent_id} heartbeat timeout ({elapsed:.0f}s)"
+                        f"Agent {slug}/{agent_id} heartbeat timeout ({elapsed:.0f}s)"
                     )
 
-        for subnet_id, agent_id in stale:
-            await self._disconnect(subnet_id, agent_id, "Heartbeat timeout")
+        for slug, agent_id in stale:
+            await self._disconnect(slug, agent_id, "Heartbeat timeout")
 
     # =========================================================================
     # Query Methods
     # =========================================================================
 
-    def is_connected(self, subnet_id: str, agent_id: str) -> bool:
+    def is_connected(self, slug: str, agent_id: str) -> bool:
         """Check if agent is connected in subnet"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return False
-        return agent_id in self._subnets[subnet_id].connections
+        return agent_id in self._subnets[slug].connections
 
-    def get_subnet_agents(self, subnet_id: str) -> list[str]:
+    def get_subnet_agents(self, slug: str) -> list[str]:
         """Get list of connected agents in subnet"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return []
-        return list(self._subnets[subnet_id].connections.keys())
+        return list(self._subnets[slug].connections.keys())
 
     def get_all_agents(self) -> dict[str, list[str]]:
         """Get all connected agents by subnet"""
         return {
-            subnet_id: list(subnet.connections.keys())
-            for subnet_id, subnet in self._subnets.items()
+            slug: list(subnet.connections.keys())
+            for slug, subnet in self._subnets.items()
         }
 
     def get_connection_info(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
     ) -> dict[str, Any] | None:
         """Get connection info for agent"""
-        if subnet_id not in self._subnets:
+        if slug not in self._subnets:
             return None
 
-        subnet = self._subnets[subnet_id]
+        subnet = self._subnets[slug]
         if agent_id not in subnet.connections:
             return None
 
         conn = subnet.connections[agent_id]
         return {
             "agent_id": agent_id,
-            "subnet_id": subnet_id,
+            "slug": slug,
             "connection_id": conn.connection_id,
             "connected_at": conn.connected_at.isoformat(),
             "last_heartbeat": conn.last_heartbeat.isoformat(),
@@ -1089,7 +1089,7 @@ class SubnetManager:
             "heartbeat_timeout": self.heartbeat_timeout,
             "subnets": [
                 {
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "name": subnet.info.name,
                     "agent_count": len(subnet.connections),
                     "agents": [
@@ -1100,7 +1100,7 @@ class SubnetManager:
                         for agent_id, conn in subnet.connections.items()
                     ],
                 }
-                for subnet_id, subnet in self._subnets.items()
+                for slug, subnet in self._subnets.items()
             ],
         }
 
@@ -1112,18 +1112,18 @@ class SubnetManager:
         """Persist subnet info to Redis"""
         import json
 
-        key = f"acn:subnet:{info.subnet_id}"
+        key = f"acn:subnet:{info.slug}"
         await self.redis.set(key, json.dumps(info.model_dump(), default=str))
 
         # Store token separately (for security)
         if generated_token:
-            token_key = f"acn:subnet:{info.subnet_id}:token"
+            token_key = f"acn:subnet:{info.slug}:token"
             await self.redis.set(token_key, generated_token)
 
-    async def _remove_subnet_state(self, subnet_id: str):
+    async def _remove_subnet_state(self, slug: str):
         """Remove subnet state from Redis"""
-        await self.redis.delete(f"acn:subnet:{subnet_id}")
-        await self.redis.delete(f"acn:subnet:{subnet_id}:token")
+        await self.redis.delete(f"acn:subnet:{slug}")
+        await self.redis.delete(f"acn:subnet:{slug}:token")
 
     def hydrate_from_subnet_infos(self, subnet_infos: list["SubnetInfo"]) -> int:
         """Populate the in-memory subnet registry from a list of SubnetInfo objects.
@@ -1137,8 +1137,8 @@ class SubnetManager:
         """
         added = 0
         for info in subnet_infos:
-            if info.subnet_id not in self._subnets:
-                self._subnets[info.subnet_id] = Subnet(info=info)
+            if info.slug not in self._subnets:
+                self._subnets[info.slug] = Subnet(info=info)
                 added += 1
         if added:
             logger.info("subnet_manager_hydrated", subnets_added=added)
@@ -1167,11 +1167,11 @@ class SubnetManager:
                             f"subnet_manager: skipping corrupted subnet key during restore: {key}"
                         )
                         continue
-                    subnet_id = subnet_data["subnet_id"]
+                    slug = subnet_data["slug"]
 
-                    if subnet_id not in self._subnets:
+                    if slug not in self._subnets:
                         # Load token if exists
-                        token = await self.redis.get(f"acn:subnet:{subnet_id}:token")
+                        token = await self.redis.get(f"acn:subnet:{slug}:token")
 
                         # Parse security_schemes if present
                         security_schemes = subnet_data.get("security_schemes")
@@ -1193,11 +1193,11 @@ class SubnetManager:
                         # records loadable while that migration is pending.
                         subnet_data.setdefault("owner", "backend@internal")
 
-                        self._subnets[subnet_id] = Subnet(
+                        self._subnets[slug] = Subnet(
                             info=SubnetInfo(**subnet_data),
                             generated_token=token,
                         )
-                        logger.info(f"Loaded subnet from Redis: {subnet_id}")
+                        logger.info(f"Loaded subnet from Redis: {slug}")
 
             if cursor == 0:
                 break

--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -177,7 +177,9 @@ class AgentModel(Base):
 class SubnetModel(Base):
     __tablename__ = "subnets"
 
-    subnet_id: Mapped[str] = mapped_column(String, primary_key=True)
+    # ``slug`` is the URL-safe human-readable primary key (renamed from
+    # ``subnet_id`` in migration ``xxxx_rename_subnet_id_to_slug``).
+    slug: Mapped[str] = mapped_column("slug", String, primary_key=True)
     # Opaque UUID — secondary identifier for SubnetStub privacy.
     # Server-default ``gen_random_uuid()`` fills the column on INSERT
     # so existing call sites that don't set ``id`` keep working.
@@ -202,7 +204,8 @@ class SubnetModel(Base):
     # and ``server_default`` (DDL path) are set on ``lifecycle`` so a
     # fresh INSERT through the ORM matches a backfilled row inserted
     # via Alembic — avoids the "ORM default ≠ DB default" drift trap.
-    parent_subnet_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    # ``parent_slug`` renamed from ``parent_subnet_id`` in same migration.
+    parent_slug: Mapped[str | None] = mapped_column("parent_slug", String, nullable=True)
     lifecycle: Mapped[str] = mapped_column(
         String,
         nullable=False,
@@ -234,8 +237,8 @@ class SubnetModel(Base):
         # without a parent / linked task don't contribute rows.
         Index(
             "subnets_parent_idx",
-            "parent_subnet_id",
-            postgresql_where=text("parent_subnet_id IS NOT NULL"),
+            "parent_slug",
+            postgresql_where=text("parent_slug IS NOT NULL"),
         ),
         Index(
             "subnets_linked_task_idx",
@@ -612,7 +615,7 @@ class ReputationEventModel(Base):
 # §"SubnetJoinRequest schema (three-in-one table)" for the full data-model
 # rationale.
 #
-# Why no FK to ``subnets.subnet_id``: ADR §"Cascade deletion" explicitly
+# Why no FK to ``subnets.slug``: ADR §"Cascade deletion" explicitly
 # chooses a manual cascade for symmetry with ADR-0003's parent-subnet
 # cascade — the service layer DELETEs both tables in the same transaction
 # so cascade behaviour is observable through code, not hidden in DDL. A
@@ -635,7 +638,7 @@ class SubnetJoinRequestModel(Base):
     # use ``uuid.UUID`` rather than the lower-case-hex string the rest of
     # the codebase passes around.
     request_id: Mapped[str] = mapped_column(String, primary_key=True)
-    subnet_id: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column("subnet_id", String, nullable=False)
     agent_id: Mapped[str] = mapped_column(String, nullable=False)
     # ``length=16`` mirrors the ADR data-model table for ``kind``; the
     # three legal values (``join_request`` is the longest at 13 chars)
@@ -713,7 +716,7 @@ class SubnetJoinRequestModel(Base):
 class SubnetAllowlistModel(Base):
     __tablename__ = "subnet_allowlist"
 
-    subnet_id: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column("subnet_id", String, nullable=False)
     # ``agent_id`` references ``agents.agent_id`` — but **no FK**. Symmetric
     # with ``subnet_join_requests``: ADR §"Cascade deletion" makes the
     # cascade manual for observability, and the route-layer existence

--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -178,7 +178,7 @@ class SubnetModel(Base):
     __tablename__ = "subnets"
 
     # ``slug`` is the URL-safe human-readable primary key (renamed from
-    # ``subnet_id`` in migration ``xxxx_rename_subnet_id_to_slug``).
+    # ``subnet_id`` in migration ``a1b2c3d4e5f6_rename_subnet_id_to_slug``).
     slug: Mapped[str] = mapped_column("slug", String, primary_key=True)
     # Opaque UUID — secondary identifier for SubnetStub privacy.
     # Server-default ``gen_random_uuid()`` fills the column on INSERT

--- a/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
@@ -61,7 +61,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
 
     def _model_to_entity(self, row: SubnetAllowlistModel) -> SubnetAllowlist:
         return SubnetAllowlist(
-            subnet_id=row.subnet_id,
+            slug=row.slug,
             agent_id=row.agent_id,
             added_by=row.added_by,
             added_at=row.added_at,
@@ -97,7 +97,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             stmt = (
                 pg_insert(SubnetAllowlistModel)
                 .values(
-                    subnet_id=entry.subnet_id,
+                    slug=entry.slug,
                     agent_id=entry.agent_id,
                     added_by=entry.added_by,
                     added_at=entry.added_at,
@@ -105,7 +105,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
                 .on_conflict_do_nothing(
                     index_elements=["subnet_id", "agent_id"]
                 )
-                .returning(SubnetAllowlistModel.subnet_id)
+                .returning(SubnetAllowlistModel.slug)
             )
             result = await session.execute(stmt)
             await session.commit()
@@ -117,7 +117,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         async with self._session_factory() as session:
             result = await session.execute(
                 delete(SubnetAllowlistModel).where(
-                    SubnetAllowlistModel.subnet_id == subnet_id,
+                    SubnetAllowlistModel.slug == subnet_id,
                     SubnetAllowlistModel.agent_id == agent_id,
                 )
             )
@@ -134,9 +134,9 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         """
         async with self._session_factory() as session:
             result = await session.execute(
-                select(SubnetAllowlistModel.subnet_id)
+                select(SubnetAllowlistModel.slug)
                 .where(
-                    SubnetAllowlistModel.subnet_id == subnet_id,
+                    SubnetAllowlistModel.slug == subnet_id,
                     SubnetAllowlistModel.agent_id == agent_id,
                 )
                 .limit(1)
@@ -149,7 +149,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         async with self._session_factory() as session:
             result = await session.execute(
                 select(SubnetAllowlistModel)
-                .where(SubnetAllowlistModel.subnet_id == subnet_id)
+                .where(SubnetAllowlistModel.slug == subnet_id)
                 .order_by(desc(SubnetAllowlistModel.added_at))
                 .limit(limit)
                 .offset(offset)
@@ -171,7 +171,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         async with self._session_scope(session) as sess:
             result = await sess.execute(
                 delete(SubnetAllowlistModel).where(
-                    SubnetAllowlistModel.subnet_id == subnet_id
+                    SubnetAllowlistModel.slug == subnet_id
                 )
             )
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
@@ -41,9 +41,9 @@ class SubnetJoinRequestPendingError(Exception):
     def __init__(self, subnet_id: str, agent_id: str) -> None:
         super().__init__(
             f"pending join request already exists for "
-            f"(subnet_id={subnet_id!r}, agent_id={agent_id!r})"
+            f"(slug={subnet_id!r}, agent_id={agent_id!r})"
         )
-        self.subnet_id = subnet_id
+        self.slug = subnet_id
         self.agent_id = agent_id
 
 
@@ -84,7 +84,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
     def _model_to_entity(self, row: SubnetJoinRequestModel) -> SubnetJoinRequest:
         return SubnetJoinRequest(
             request_id=row.request_id,
-            subnet_id=row.subnet_id,
+            slug=row.slug,
             agent_id=row.agent_id,
             kind=row.kind,  # type: ignore[arg-type]
             status=row.status,  # type: ignore[arg-type]
@@ -100,7 +100,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
     ) -> SubnetJoinRequestModel:
         return SubnetJoinRequestModel(
             request_id=request.request_id,
-            subnet_id=request.subnet_id,
+            slug=request.slug,
             agent_id=request.agent_id,
             kind=request.kind,
             status=request.status,
@@ -148,7 +148,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                     # ``initiated_by`` are immutable in practice (the entity
                     # state machine never rewrites them on a transition) but
                     # included here for completeness / defence in depth.
-                    existing.subnet_id = request.subnet_id
+                    existing.slug = request.slug
                     existing.agent_id = request.agent_id
                     existing.kind = request.kind
                     existing.status = request.status
@@ -172,7 +172,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                     e.orig
                 ) or "subnet_join_requests_pending_unique" in str(e):
                     raise SubnetJoinRequestPendingError(
-                        request.subnet_id, request.agent_id
+                        request.slug, request.agent_id
                     ) from e
                 raise
 
@@ -187,7 +187,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         async with self._session_factory() as session:
             result = await session.execute(
                 select(SubnetJoinRequestModel).where(
-                    SubnetJoinRequestModel.subnet_id == subnet_id,
+                    SubnetJoinRequestModel.slug == subnet_id,
                     SubnetJoinRequestModel.agent_id == agent_id,
                     SubnetJoinRequestModel.status == "pending",
                 )
@@ -206,7 +206,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
     ) -> list[SubnetJoinRequest]:
         async with self._session_factory() as session:
             stmt = select(SubnetJoinRequestModel).where(
-                SubnetJoinRequestModel.subnet_id == subnet_id
+                SubnetJoinRequestModel.slug == subnet_id
             )
             if kind is not None:
                 stmt = stmt.where(SubnetJoinRequestModel.kind == kind)
@@ -267,7 +267,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         async with self._session_scope(session) as sess:
             result = await sess.execute(
                 delete(SubnetJoinRequestModel).where(
-                    SubnetJoinRequestModel.subnet_id == subnet_id
+                    SubnetJoinRequestModel.slug == subnet_id
                 )
             )
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_repository.py
@@ -61,7 +61,7 @@ class PostgresSubnetRepository(ISubnetRepository):
             "approval" if row.is_private else "open"
         )
         return Subnet(
-            subnet_id=row.subnet_id,
+            slug=row.slug,
             id=row.id,
             name=row.name,
             owner=row.owner,
@@ -73,7 +73,7 @@ class PostgresSubnetRepository(ISubnetRepository):
             metadata=meta,
             harness_url=row.harness_url,
             harness_secret=row.harness_secret,
-            parent_subnet_id=row.parent_subnet_id,
+            parent_slug=row.parent_slug,
             lifecycle=row.lifecycle,
             linked_task_id=row.linked_task_id,
             join_policy=join_policy,
@@ -85,7 +85,7 @@ class PostgresSubnetRepository(ISubnetRepository):
         if created and not created.tzinfo:
             created = created.replace(tzinfo=UTC)
         return SubnetModel(
-            subnet_id=subnet.subnet_id,
+            slug=subnet.slug,
             id=subnet.id,
             name=subnet.name,
             owner=subnet.owner,
@@ -96,7 +96,7 @@ class PostgresSubnetRepository(ISubnetRepository):
             subnet_metadata=subnet.metadata or None,
             harness_url=subnet.harness_url,
             harness_secret=subnet.harness_secret,
-            parent_subnet_id=subnet.parent_subnet_id,
+            parent_slug=subnet.parent_slug,
             lifecycle=subnet.lifecycle,
             linked_task_id=subnet.linked_task_id,
             join_policy=subnet.join_policy,
@@ -110,16 +110,16 @@ class PostgresSubnetRepository(ISubnetRepository):
     async def save(self, subnet: Subnet) -> None:
         model = self._subnet_to_model(subnet)
         async with self._session_factory() as session:
-            existing = await session.get(SubnetModel, subnet.subnet_id)
+            existing = await session.get(SubnetModel, subnet.slug)
             if existing:
                 # Nesting fields are included in the UPDATE so promote
                 # paths (Phase 2) and any future mutation can fall
-                # through correctly. ``parent_subnet_id`` is immutable
+                # through correctly. ``parent_slug`` is immutable
                 # per ADR-0003 §5 — included here only for defence in
                 # depth (service layer rejects mismatched updates).
                 await session.execute(
                     update(SubnetModel)
-                    .where(SubnetModel.subnet_id == subnet.subnet_id)
+                    .where(SubnetModel.slug == subnet.slug)
                     .values(
                         name=model.name,
                         owner=model.owner,
@@ -130,7 +130,7 @@ class PostgresSubnetRepository(ISubnetRepository):
                         subnet_metadata=model.subnet_metadata,
                         harness_url=model.harness_url,
                         harness_secret=model.harness_secret,
-                        parent_subnet_id=model.parent_subnet_id,
+                        parent_slug=model.parent_slug,
                         lifecycle=model.lifecycle,
                         linked_task_id=model.linked_task_id,
                         join_policy=model.join_policy,
@@ -140,9 +140,9 @@ class PostgresSubnetRepository(ISubnetRepository):
                 session.add(model)
             await session.commit()
 
-    async def find_by_id(self, subnet_id: str) -> Subnet | None:
+    async def find_by_id(self, slug: str) -> Subnet | None:
         async with self._session_factory() as session:
-            row = await session.get(SubnetModel, subnet_id)
+            row = await session.get(SubnetModel, slug)
             return self._model_to_subnet(row) if row else None
 
     async def find_all(self) -> list[Subnet]:
@@ -174,11 +174,11 @@ class PostgresSubnetRepository(ISubnetRepository):
             return [self._model_to_subnet(r) for r in result.scalars().all()]
 
     async def delete(
-        self, subnet_id: str, *, session: AsyncSession | None = None
+        self, slug: str, *, session: AsyncSession | None = None
     ) -> bool:
         async with self._session_scope(session) as sess:
             result = await sess.execute(
-                delete(SubnetModel).where(SubnetModel.subnet_id == subnet_id)
+                delete(SubnetModel).where(SubnetModel.slug == slug)
             )
             return result.rowcount > 0
 
@@ -226,29 +226,29 @@ class PostgresSubnetRepository(ISubnetRepository):
             for child_id in child_ids:
                 await session.execute(
                     delete(SubnetModel).where(
-                        SubnetModel.subnet_id == child_id
+                        SubnetModel.slug == child_id
                     )
                 )
             result = await session.execute(
-                delete(SubnetModel).where(SubnetModel.subnet_id == parent_id)
+                delete(SubnetModel).where(SubnetModel.slug == parent_id)
             )
             return result.rowcount > 0
         async with self._session_factory() as own_session, own_session.begin():
             for child_id in child_ids:
                 await own_session.execute(
                     delete(SubnetModel).where(
-                        SubnetModel.subnet_id == child_id
+                        SubnetModel.slug == child_id
                     )
                 )
             result = await own_session.execute(
-                delete(SubnetModel).where(SubnetModel.subnet_id == parent_id)
+                delete(SubnetModel).where(SubnetModel.slug == parent_id)
             )
             return result.rowcount > 0
 
-    async def exists(self, subnet_id: str) -> bool:
+    async def exists(self, slug: str) -> bool:
         async with self._session_factory() as session:
             result = await session.execute(
-                select(SubnetModel.subnet_id).where(SubnetModel.subnet_id == subnet_id)
+                select(SubnetModel.slug).where(SubnetModel.slug == slug)
             )
             return result.scalar() is not None
 
@@ -267,7 +267,7 @@ class PostgresSubnetRepository(ISubnetRepository):
     # Nesting lookups (ADR-0003)
     # ------------------------------------------------------------------
 
-    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+    async def find_by_parent(self, parent_slug: str) -> list[Subnet]:
         """Return all child subnets nested under a given parent.
 
         Hits the ``subnets_parent_idx`` partial index for an O(k)
@@ -277,7 +277,7 @@ class PostgresSubnetRepository(ISubnetRepository):
         async with self._session_factory() as session:
             result = await session.execute(
                 select(SubnetModel).where(
-                    SubnetModel.parent_subnet_id == parent_subnet_id
+                    SubnetModel.parent_slug == parent_slug
                 )
             )
             return [self._model_to_subnet(r) for r in result.scalars().all()]

--- a/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
@@ -78,8 +78,8 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         wins). Operators that care about original attribution
         should read PG, not Redis.
         """
-        set_key = _allowlist_set_key(entry.subnet_id)
-        meta_key = _allowlist_meta_key(entry.subnet_id, entry.agent_id)
+        set_key = _allowlist_set_key(entry.slug)
+        meta_key = _allowlist_meta_key(entry.slug, entry.agent_id)
 
         # SADD must run before the HSET so a failure between them
         # leaves the safer of the two crash states (HASH missing,

--- a/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
@@ -212,15 +212,15 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         self, request: SubnetJoinRequest, hash_pairs: list[str]
     ) -> None:
         keys = [
-            _pending_by_agent_key(request.subnet_id, request.agent_id),
-            _request_hash_key(request.subnet_id, request.request_id),
-            _subnet_listing_key(request.subnet_id),
+            _pending_by_agent_key(request.slug, request.agent_id),
+            _request_hash_key(request.slug, request.request_id),
+            _subnet_listing_key(request.slug),
             _agent_invitations_key(request.agent_id),
         ]
         args = [
             request.request_id,
             request.kind,
-            _invitation_set_member(request.subnet_id, request.request_id),
+            _invitation_set_member(request.slug, request.request_id),
             *hash_pairs,
         ]
         script = self._get_create_pending_script()
@@ -231,7 +231,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         existing_id = _decode(result[1])
         if outcome == "exists" and existing_id != request.request_id:
             raise SubnetJoinRequestPendingError(
-                request.subnet_id, request.agent_id
+                request.slug, request.agent_id
             )
         # 'exists' + same id is idempotent re-save (no-op for the
         # service layer — it's safe to retry create on transient
@@ -241,14 +241,14 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         self, request: SubnetJoinRequest, hash_pairs: list[str]
     ) -> None:
         keys = [
-            _pending_by_agent_key(request.subnet_id, request.agent_id),
-            _request_hash_key(request.subnet_id, request.request_id),
+            _pending_by_agent_key(request.slug, request.agent_id),
+            _request_hash_key(request.slug, request.request_id),
             _agent_invitations_key(request.agent_id),
         ]
         args = [
             request.request_id,
             request.kind,
-            _invitation_set_member(request.subnet_id, request.request_id),
+            _invitation_set_member(request.slug, request.request_id),
             *hash_pairs,
         ]
         script = self._get_decide_script()

--- a/acn/infrastructure/persistence/redis/subnet_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_repository.py
@@ -39,24 +39,24 @@ class RedisSubnetRepository(ISubnetRepository):
         all secondary index mutations into a single
         ``pipeline(transaction=False)``:
 
-        - ``acn:subnets:by_owner:{owner}`` — owner → subnet_id SET
+        - ``acn:subnets:by_owner:{owner}`` — owner → slug SET
         - ``acn:subnets:children:{parent_id}`` — parent → child SET
-          (ADR-0003; absent when ``parent_subnet_id is None``)
-        - ``acn:subnets:by_linked_task:{task_id}`` — task → subnet_id
+          (ADR-0003; absent when ``parent_slug is None``)
+        - ``acn:subnets:by_linked_task:{task_id}`` — task → slug
           SET (ADR-0003; absent when ``linked_task_id is None``)
 
         On update, the old row is read first so stale entries get
-        ``SREM``'d when ``parent_subnet_id`` or ``linked_task_id``
-        changes. ``parent_subnet_id`` is immutable per ADR-0003 §5
+        ``SREM``'d when ``parent_slug`` or ``linked_task_id``
+        changes. ``parent_slug`` is immutable per ADR-0003 §5
         but ``linked_task_id`` flips to ``None`` when Phase 2's
         ``promote_to_persistent`` lands — defensive incremental
         update keeps the index honest either way.
         """
-        subnet_key = f"acn:subnets:info:{subnet.subnet_id}"
+        subnet_key = f"acn:subnets:info:{subnet.slug}"
 
         # Read existing row (if any) so we know which stale index
         # entries to evict when nesting fields change.
-        old_subnet = await self.find_by_id(subnet.subnet_id)
+        old_subnet = await self.find_by_id(subnet.slug)
 
         subnet_dict = subnet.to_dict(include_secret=True)
         subnet_dict["security_config"] = json.dumps(subnet_dict["security_config"])
@@ -72,8 +72,8 @@ class RedisSubnetRepository(ISubnetRepository):
         # Nesting fields: empty string ≡ NULL, same convention as
         # description / harness_url. Parsed back to ``None`` in
         # ``_dict_to_subnet``.
-        if subnet_dict.get("parent_subnet_id") is None:
-            subnet_dict["parent_subnet_id"] = ""
+        if subnet_dict.get("parent_slug") is None:
+            subnet_dict["parent_slug"] = ""
         if subnet_dict.get("linked_task_id") is None:
             subnet_dict["linked_task_id"] = ""
         # ADR-0004: ``join_policy`` is always populated on the entity
@@ -91,34 +91,34 @@ class RedisSubnetRepository(ISubnetRepository):
         await self.redis.hset(subnet_key, mapping=subnet_dict)  # type: ignore[arg-type]
 
         async with self.redis.pipeline(transaction=False) as pipe:
-            pipe.sadd(f"acn:subnets:by_owner:{subnet.owner}", subnet.subnet_id)
+            pipe.sadd(f"acn:subnets:by_owner:{subnet.owner}", subnet.slug)
             # Maintain children index: SREM old → SADD new when changed.
-            old_parent = old_subnet.parent_subnet_id if old_subnet else None
-            new_parent = subnet.parent_subnet_id
+            old_parent = old_subnet.parent_slug if old_subnet else None
+            new_parent = subnet.parent_slug
             if old_parent and old_parent != new_parent:
                 pipe.srem(
-                    f"acn:subnets:children:{old_parent}", subnet.subnet_id
+                    f"acn:subnets:children:{old_parent}", subnet.slug
                 )
             if new_parent:
                 pipe.sadd(
-                    f"acn:subnets:children:{new_parent}", subnet.subnet_id
+                    f"acn:subnets:children:{new_parent}", subnet.slug
                 )
             # Maintain by_linked_task index identically.
             old_task = old_subnet.linked_task_id if old_subnet else None
             new_task = subnet.linked_task_id
             if old_task and old_task != new_task:
                 pipe.srem(
-                    f"acn:subnets:by_linked_task:{old_task}", subnet.subnet_id
+                    f"acn:subnets:by_linked_task:{old_task}", subnet.slug
                 )
             if new_task:
                 pipe.sadd(
-                    f"acn:subnets:by_linked_task:{new_task}", subnet.subnet_id
+                    f"acn:subnets:by_linked_task:{new_task}", subnet.slug
                 )
             await pipe.execute()
 
-    async def find_by_id(self, subnet_id: str) -> Subnet | None:
+    async def find_by_id(self, slug: str) -> Subnet | None:
         """Find subnet by ID"""
-        subnet_key = f"acn:subnets:info:{subnet_id}"
+        subnet_key = f"acn:subnets:info:{slug}"
         subnet_dict = await self.redis.hgetall(subnet_key)
 
         if not subnet_dict:
@@ -139,8 +139,8 @@ class RedisSubnetRepository(ISubnetRepository):
         """Find all subnets owned by a user"""
         subnet_ids = await self.redis.smembers(f"acn:subnets:by_owner:{owner}")
         subnets = []
-        for subnet_id in subnet_ids:
-            subnet = await self.find_by_id(subnet_id)
+        for slug in subnet_ids:
+            subnet = await self.find_by_id(slug)
             if subnet:
                 subnets.append(subnet)
         return subnets
@@ -153,11 +153,11 @@ class RedisSubnetRepository(ISubnetRepository):
         subnets: list[Subnet] = []
         for owner in owners:
             subnet_ids = await self.redis.smembers(f"acn:subnets:by_owner:{owner}")
-            for subnet_id in subnet_ids:
-                if subnet_id in seen:
+            for slug in subnet_ids:
+                if slug in seen:
                     continue
-                seen.add(subnet_id)
-                subnet = await self.find_by_id(subnet_id)
+                seen.add(slug)
+                subnet = await self.find_by_id(slug)
                 if subnet:
                     subnets.append(subnet)
         return subnets
@@ -168,7 +168,7 @@ class RedisSubnetRepository(ISubnetRepository):
         return [s for s in all_subnets if s.is_public()]
 
     async def delete(
-        self, subnet_id: str, *, session: object | None = None
+        self, slug: str, *, session: object | None = None
     ) -> bool:
         """Delete a subnet and all its secondary index entries.
 
@@ -186,21 +186,21 @@ class RedisSubnetRepository(ISubnetRepository):
         instead.
         """
         del session  # explicit ignore — see docstring
-        subnet = await self.find_by_id(subnet_id)
+        subnet = await self.find_by_id(slug)
         if not subnet:
             return False
 
-        subnet_key = f"acn:subnets:info:{subnet_id}"
+        subnet_key = f"acn:subnets:info:{slug}"
         async with self.redis.pipeline(transaction=False) as pipe:
             pipe.delete(subnet_key)
-            pipe.srem(f"acn:subnets:by_owner:{subnet.owner}", subnet_id)
-            if subnet.parent_subnet_id:
+            pipe.srem(f"acn:subnets:by_owner:{subnet.owner}", slug)
+            if subnet.parent_slug:
                 pipe.srem(
-                    f"acn:subnets:children:{subnet.parent_subnet_id}", subnet_id
+                    f"acn:subnets:children:{subnet.parent_slug}", slug
                 )
             if subnet.linked_task_id:
                 pipe.srem(
-                    f"acn:subnets:by_linked_task:{subnet.linked_task_id}", subnet_id
+                    f"acn:subnets:by_linked_task:{subnet.linked_task_id}", slug
                 )
             await pipe.execute()
 
@@ -242,7 +242,7 @@ class RedisSubnetRepository(ISubnetRepository):
                 logger.warning(
                     "delete_with_children_partial",
                     extra={
-                        "parent_subnet_id": parent_id,
+                        "parent_slug": parent_id,
                         "child_subnet_id": child_id,
                         "reason": "child_delete_returned_false",
                     },
@@ -253,11 +253,11 @@ class RedisSubnetRepository(ISubnetRepository):
                 )
         return await self.delete(parent_id)
 
-    async def exists(self, subnet_id: str) -> bool:
+    async def exists(self, slug: str) -> bool:
         """Check if subnet exists"""
-        return await self.redis.exists(f"acn:subnets:info:{subnet_id}") > 0
+        return await self.redis.exists(f"acn:subnets:info:{slug}") > 0
 
-    async def find_by_parent(self, parent_subnet_id: str) -> list[Subnet]:
+    async def find_by_parent(self, parent_slug: str) -> list[Subnet]:
         """Return all child subnets of a given parent.
 
         Reads the ``acn:subnets:children:{parent_id}`` index, then
@@ -265,7 +265,7 @@ class RedisSubnetRepository(ISubnetRepository):
         or the parent itself is unknown.
         """
         subnet_ids = await self.redis.smembers(
-            f"acn:subnets:children:{parent_subnet_id}"
+            f"acn:subnets:children:{parent_slug}"
         )
         subnets: list[Subnet] = []
         for sid in subnet_ids:
@@ -355,9 +355,9 @@ class RedisSubnetRepository(ISubnetRepository):
 
         Empty strings stored in Redis mean NULL — translate back to
         ``None`` for the relevant fields (description, harness_url /
-        secret, parent_subnet_id, linked_task_id). Legacy rows that
+        secret, parent_slug, linked_task_id). Legacy rows that
         predate ADR-0003 don't carry the nesting keys at all; the
-        ``.get("parent_subnet_id") or None`` pattern handles both
+        ``.get("parent_slug") or None`` pattern handles both
         "missing key" and "empty string" identically.
 
         Input is normalised through :meth:`_normalize_redis_dict`
@@ -369,7 +369,7 @@ class RedisSubnetRepository(ISubnetRepository):
         description = subnet_dict.get("description") or None
         harness_url = subnet_dict.get("harness_url") or None
         harness_secret = subnet_dict.get("harness_secret") or None
-        parent_subnet_id = subnet_dict.get("parent_subnet_id") or None
+        parent_slug = subnet_dict.get("parent_slug") or None
         linked_task_id = subnet_dict.get("linked_task_id") or None
         # ``lifecycle`` defaults to "persistent" both when key absent
         # (legacy row) and when stored value is empty/falsy.
@@ -394,7 +394,7 @@ class RedisSubnetRepository(ISubnetRepository):
             join_policy = "open"
 
         data = {
-            "subnet_id": subnet_dict["subnet_id"],
+            "slug": subnet_dict["slug"],
             "name": subnet_dict["name"],
             "owner": subnet_dict["owner"],
             "description": description,
@@ -409,7 +409,7 @@ class RedisSubnetRepository(ISubnetRepository):
             "metadata": self._safe_loads(subnet_dict.get("metadata", "{}"), {}),
             "harness_url": harness_url,
             "harness_secret": harness_secret,
-            "parent_subnet_id": parent_subnet_id,
+            "parent_slug": parent_slug,
             "lifecycle": lifecycle,
             "linked_task_id": linked_task_id,
             "join_policy": join_policy,

--- a/acn/infrastructure/persistence/redis/subnet_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_repository.py
@@ -369,7 +369,16 @@ class RedisSubnetRepository(ISubnetRepository):
         description = subnet_dict.get("description") or None
         harness_url = subnet_dict.get("harness_url") or None
         harness_secret = subnet_dict.get("harness_secret") or None
-        parent_slug = subnet_dict.get("parent_slug") or None
+        # Back-compat: pre-rename Redis HASHes used ``parent_subnet_id``
+        # as the key. Read both so a deployment that hasn't run a Redis
+        # backfill still hydrates correctly. The next ``save()`` rewrites
+        # the row with the new ``parent_slug`` key, so this only matters
+        # for the first read after the rollout.
+        parent_slug = (
+            subnet_dict.get("parent_slug")
+            or subnet_dict.get("parent_subnet_id")
+            or None
+        )
         linked_task_id = subnet_dict.get("linked_task_id") or None
         # ``lifecycle`` defaults to "persistent" both when key absent
         # (legacy row) and when stored value is empty/falsy.
@@ -393,8 +402,16 @@ class RedisSubnetRepository(ISubnetRepository):
         else:
             join_policy = "open"
 
+        # Back-compat: pre-rename HASHes stored the slug under the
+        # ``subnet_id`` key. ``KeyError`` here would be a hard failure
+        # on the first read after the rollout, so accept either key.
+        slug_value = subnet_dict.get("slug") or subnet_dict.get("subnet_id")
+        if not slug_value:
+            raise KeyError(
+                "subnet HASH is missing both 'slug' and legacy 'subnet_id' keys"
+            )
         data = {
-            "slug": subnet_dict["slug"],
+            "slug": slug_value,
             "name": subnet_dict["name"],
             "owner": subnet_dict["owner"],
             "description": description,

--- a/acn/models.py
+++ b/acn/models.py
@@ -11,7 +11,14 @@ from uuid import uuid4
 
 from a2a.compat.v0_3.types import AgentCard as A2AAgentCard  # type: ignore[import-untyped]
 from a2a.compat.v0_3.types import AgentSkill as A2AAgentSkill  # type: ignore[import-untyped]
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 # Re-export SDK types as canonical Agent Card / Skill for ACN
 AgentCard = A2AAgentCard
@@ -271,11 +278,19 @@ class AgentRegisterRequest(BaseModel):
         return v
 
     def get_subnet_ids(self) -> list[str]:
-        """Get effective subnet IDs (handles backward compatibility)"""
+        """Get effective subnet IDs (handles backward compatibility).
+
+        ``subnet_ids`` (plural) is the canonical input. The legacy
+        ``subnet_id`` (singular) is still accepted so older clients
+        that pre-date multi-subnet membership keep working — its value
+        is wrapped into a single-element list. Defaults to ``["public"]``
+        so registration without any subnet hint joins the platform's
+        always-on public subnet.
+        """
         if self.subnet_ids:
             return self.subnet_ids
-        if self.slug:
-            return [self.slug]
+        if self.subnet_id:
+            return [self.subnet_id]
         return ["public"]
 
 
@@ -517,7 +532,14 @@ class SubnetCreateRequest(BaseModel):
         None,
         min_length=1,
         max_length=64,
-        description="URL-safe subnet identifier (e.g. 'acnlabs-core'). Optional — auto-generated when omitted.",
+        # Accept the legacy ``subnet_id`` body field so older clients
+        # that pre-date the slug rename keep working: their value lands
+        # in ``slug`` rather than being silently dropped (which would
+        # make the route auto-generate a different identifier than the
+        # caller intended). Removed in a future major version once SDKs
+        # have rolled forward.
+        validation_alias=AliasChoices("slug", "subnet_id"),
+        description="URL-safe subnet identifier (e.g. 'acnlabs-core'). Optional — auto-generated when omitted. Legacy alias 'subnet_id' is also accepted on input.",
     )
     name: str | None = Field(
         None,
@@ -542,9 +564,14 @@ class SubnetCreateRequest(BaseModel):
         None,
         min_length=1,
         max_length=64,
+        # Same legacy-alias treatment as ``slug`` above — keeps clients
+        # that still send ``parent_subnet_id`` in the create body
+        # functional during the rename rollout.
+        validation_alias=AliasChoices("parent_slug", "parent_subnet_id"),
         description=(
             "Parent subnet slug for nested subnets (ADR-0003). Single-layer cap: "
-            "the parent itself must be top-level. Immutable after creation."
+            "the parent itself must be top-level. Immutable after creation. "
+            "Legacy alias 'parent_subnet_id' is also accepted on input."
         ),
     )
     lifecycle: Literal["persistent", "task_scoped"] = Field(

--- a/acn/models.py
+++ b/acn/models.py
@@ -274,8 +274,8 @@ class AgentRegisterRequest(BaseModel):
         """Get effective subnet IDs (handles backward compatibility)"""
         if self.subnet_ids:
             return self.subnet_ids
-        if self.subnet_id:
-            return [self.subnet_id]
+        if self.slug:
+            return [self.slug]
         return ["public"]
 
 
@@ -349,9 +349,9 @@ class SubnetInfo(BaseModel):
     - If no security_schemes: subnet is public (no auth required)
     """
 
-    subnet_id: str = Field(..., description="Canonical subnet identifier (human-readable, used in API paths and references)")
+    slug: str = Field(..., description="URL-safe human-readable identifier used in API paths (e.g. 'acnlabs-core'). Immutable after creation.")
     # Opaque UUID identifier. Surfaced for use cases where the human-
-    # readable subnet_id should not appear (e.g. anonymous SubnetStub
+    # readable slug should not appear (e.g. anonymous SubnetStub
     # responses for private subnets). Defaults to a fresh ``uuid4()`` so
     # in-memory / synthetic constructions (subnet_manager bootstrap, test
     # fixtures, manifest snapshots) don't have to plumb an ID through —
@@ -403,21 +403,21 @@ class SubnetInfo(BaseModel):
         False, description="Whether an Org Harness is registered for this subnet"
     )
 
-    # ADR-0003 nesting fields. ``parent_subnet_id`` is immutable
-    # after creation (no PATCH route exposes it). ``lifecycle`` is
-    # surfaced so consumers can render "auto-dissolving" UX hints
-    # and so prospective joiners can avoid task_scoped squads
-    # they'd rather not be auto-removed from.
+    # ADR-0003 nesting fields. ``parent_slug`` is immutable after
+    # creation (no PATCH route exposes it). ``lifecycle`` is surfaced so
+    # consumers can render "auto-dissolving" UX hints and so prospective
+    # joiners can avoid task_scoped squads they'd rather not be auto-
+    # removed from.
     #
-    # Privacy (ACL V6 / issue #114 B6): ``parent_subnet_id`` (the
-    # human-readable slug) is intentionally suppressed in API responses
-    # from ``_subnet_entity_to_info`` — the route always emits ``None``.
-    # Suppressing the slug prevents a public child subnet from leaking
-    # its private parent's naming convention to anonymous callers.
+    # Privacy (ACL V6 / issue #114 B6): ``parent_slug`` (the human-
+    # readable slug of the parent) is intentionally suppressed in API
+    # responses from ``_subnet_entity_to_info`` — the route always emits
+    # ``None``. Suppressing the slug prevents a public child subnet from
+    # leaking its private parent's naming convention to anonymous callers.
     # Consumers needing the parent relationship use ``parent_id``
     # (the opaque UUID below) and call ``GET /subnets/{parent_id}``
     # to resolve the slug under their own access level.
-    parent_subnet_id: str | None = Field(
+    parent_slug: str | None = Field(
         None,
         description=(
             "Deprecated — always None in responses from the routes layer "
@@ -492,11 +492,11 @@ class SubnetCreateRequest(BaseModel):
 
     Examples:
         # Public subnet (no auth)
-        {"subnet_id": "public-demo", "name": "Public Demo"}
+        {"slug": "public-demo", "name": "Public Demo"}
 
         # Bearer token auth
         {
-            "subnet_id": "team-a",
+            "slug": "team-a",
             "name": "Team A",
             "security_schemes": {
                 "bearer": {"type": "http", "scheme": "bearer"}
@@ -505,7 +505,7 @@ class SubnetCreateRequest(BaseModel):
 
         # API Key auth
         {
-            "subnet_id": "team-b",
+            "slug": "team-b",
             "name": "Team B",
             "security_schemes": {
                 "key": {"type": "apiKey", "in": "header", "name": "X-Subnet-Key"}
@@ -513,13 +513,18 @@ class SubnetCreateRequest(BaseModel):
         }
     """
 
-    subnet_id: str | None = Field(
+    slug: str | None = Field(
         None,
         min_length=1,
         max_length=64,
-        description="Unique subnet identifier. Optional — ACN auto-generates `subnet-{slug}-{rand6}` when omitted.",
+        description="URL-safe subnet identifier (e.g. 'acnlabs-core'). Optional — auto-generated when omitted.",
     )
-    name: str = Field(..., min_length=1, max_length=128, description="Subnet name")
+    name: str | None = Field(
+        None,
+        min_length=1,
+        max_length=128,
+        description="Display name shown in UIs. May contain spaces and Unicode. Defaults to slug when omitted.",
+    )
     description: str | None = Field(None, max_length=500, description="Subnet description")
     is_private: bool = Field(False, description="Whether this is a private subnet")
     security_schemes: dict[str, dict] | None = Field(
@@ -533,12 +538,12 @@ class SubnetCreateRequest(BaseModel):
 
     # ADR-0003 nesting params — all optional, defaults preserve
     # legacy "flat top-level persistent subnet" semantics.
-    parent_subnet_id: str | None = Field(
+    parent_slug: str | None = Field(
         None,
         min_length=1,
         max_length=64,
         description=(
-            "Parent subnet ID for nested subnets (ADR-0003). Single-layer cap: "
+            "Parent subnet slug for nested subnets (ADR-0003). Single-layer cap: "
             "the parent itself must be top-level. Immutable after creation."
         ),
     )
@@ -599,7 +604,7 @@ class SubnetCreateResponse(BaseModel):
     """Response after creating a subnet"""
 
     status: str = Field(..., description="Creation status")
-    subnet_id: str = Field(..., description="Subnet ID")
+    slug: str = Field(..., description="URL-safe subnet identifier")
     is_public: bool = Field(..., description="Whether subnet is public (no auth required)")
     security_schemes: dict | None = Field(None, description="Configured security schemes")
     gateway_ws_url: str = Field(..., description="WebSocket URL for agents to connect")

--- a/acn/monitoring/analytics.py
+++ b/acn/monitoring/analytics.py
@@ -132,7 +132,7 @@ class Analytics:
         (``agent.subnet_ids`` is a list).  Each subnet membership is counted
         independently, so ``sum(by_subnet.values()) >= total`` when any agent
         belongs to more than one subnet.  The Redis fallback counts only the
-        agent's primary ``subnet_id`` field (single value), so the two paths
+        agent's primary ``slug`` field (single value), so the two paths
         are not strictly equivalent; this is the more accurate representation.
         """
         agents = await self._agent_repo.find_all()  # type: ignore[union-attr]
@@ -226,7 +226,7 @@ class Analytics:
                 status_bucket = "online" if is_alive else "offline"
                 stats["by_status"][status_bucket] += 1
 
-                subnet = agent.get("subnet_id", "public")
+                subnet = agent.get("slug", "public")
                 stats["by_subnet"][subnet] = stats["by_subnet"].get(subnet, 0) + 1
 
                 tags_str = agent.get("tags") or agent.get("skills", "[]")
@@ -496,14 +496,14 @@ class Analytics:
         subnet_list = []
         for subnet in subnets:
             agent_count = (
-                await self._agent_repo.count_by_subnet(subnet.subnet_id)
+                await self._agent_repo.count_by_subnet(subnet.slug)
                 if self._agent_repo
-                else await self._count_agents_in_subnet(subnet.subnet_id)
+                else await self._count_agents_in_subnet(subnet.slug)
             )
-            gateway_count = await self._count_gateway_connections(subnet.subnet_id)
+            gateway_count = await self._count_gateway_connections(subnet.slug)
             subnet_list.append(
                 {
-                    "subnet_id": subnet.subnet_id,
+                    "slug": subnet.slug,
                     "name": subnet.name,
                     "agent_count": agent_count,
                     "gateway_connections": gateway_count,
@@ -521,7 +521,7 @@ class Analytics:
             "total": len(subnets) + 1,  # +1 for implicit public network
             "subnets": [
                 {
-                    "subnet_id": "public",
+                    "slug": "public",
                     "name": "Public Network",
                     "agent_count": public_count,
                     "gateway_connections": 0,
@@ -550,14 +550,14 @@ class Analytics:
                     for k, v in subnet_data.items()
                 }
 
-                subnet_id = subnet.get("subnet_id", "unknown")
-                agent_count = await self._count_agents_in_subnet(subnet_id)
-                gateway_count = await self._count_gateway_connections(subnet_id)
+                slug = subnet.get("slug", "unknown")
+                agent_count = await self._count_agents_in_subnet(slug)
+                gateway_count = await self._count_gateway_connections(slug)
 
                 subnets.append(
                     {
-                        "subnet_id": subnet_id,
-                        "name": subnet.get("name", subnet_id),
+                        "slug": slug,
+                        "name": subnet.get("name", slug),
                         "agent_count": agent_count,
                         "gateway_connections": gateway_count,
                         "has_security": subnet.get("security_schemes") is not None,
@@ -573,7 +573,7 @@ class Analytics:
             "total": len(subnets) + 1,
             "subnets": [
                 {
-                    "subnet_id": "public",
+                    "slug": "public",
                     "name": "Public Network",
                     "agent_count": public_count,
                     "gateway_connections": 0,
@@ -733,11 +733,11 @@ class Analytics:
         count = await self.redis.llen("acn:dlq")
         return count
 
-    async def _count_agents_in_subnet(self, subnet_id: str) -> int:
+    async def _count_agents_in_subnet(self, slug: str) -> int:
         """Count agents in a specific subnet.
 
         Reads directly from the authoritative membership set
-        `acn:subnets:{subnet_id}:agents` that AgentRepository and the registry
+        `acn:subnets:{slug}:agents` that AgentRepository and the registry
         already maintain (sadd on save, srem on delete). The previous
         implementation scanned every agent hash and filtered in Python,
         which (a) used the wrong key pattern `acn:agents:*:info` (never
@@ -745,11 +745,11 @@ class Analytics:
         fixed would be O(N_agents) per call — unacceptable when this
         function is invoked for every subnet in `get_subnet_stats`.
         """
-        return await self.redis.scard(f"acn:subnets:{subnet_id}:agents")
+        return await self.redis.scard(f"acn:subnets:{slug}:agents")
 
-    async def _count_gateway_connections(self, subnet_id: str) -> int:
+    async def _count_gateway_connections(self, slug: str) -> int:
         """Count gateway connections for a subnet"""
-        key = f"acn:metrics:acn_gateway_connections:subnet={subnet_id}"
+        key = f"acn:metrics:acn_gateway_connections:subnet={slug}"
         value = await self.redis.get(key)
         return int(value) if value else 0
 

--- a/acn/monitoring/audit.py
+++ b/acn/monitoring/audit.py
@@ -129,7 +129,7 @@ class AuditEvent(BaseModel):
     target_type: str | None = Field(None, description="Type: agent, subnet, message")
 
     # Context
-    subnet_id: str | None = Field(None, description="Related subnet ID")
+    slug: str | None = Field(None, description="Related subnet ID")
     message_id: str | None = Field(None, description="Related message ID")
 
     # Details
@@ -222,7 +222,7 @@ class AuditLogger:
         actor_type: str | None = None,
         target_id: str | None = None,
         target_type: str | None = None,
-        subnet_id: str | None = None,
+        slug: str | None = None,
         message_id: str | None = None,
         details: dict[str, Any] | None = None,
         level: AuditLevel = AuditLevel.INFO,
@@ -238,7 +238,7 @@ class AuditLogger:
             actor_type: Type of actor (agent, user, system)
             target_id: ID of the target entity
             target_type: Type of target entity
-            subnet_id: Related subnet ID
+            slug: Related subnet ID
             message_id: Related message ID
             details: Additional event details
             level: Severity level
@@ -259,7 +259,7 @@ class AuditLogger:
             actor_type=actor_type,
             target_id=target_id,
             target_type=target_type,
-            subnet_id=subnet_id,
+            slug=slug,
             message_id=message_id,
             details=details or {},
             source_ip=source_ip,
@@ -299,7 +299,7 @@ class AuditLogger:
     async def log_agent_registered(
         self,
         agent_id: str,
-        subnet_id: str = "public",
+        slug: str = "public",
         tags: list[str] | None = None,
         source_ip: str | None = None,
     ) -> str:
@@ -308,7 +308,7 @@ class AuditLogger:
             event_type=AuditEventType.AGENT_REGISTERED,
             target_id=agent_id,
             target_type="agent",
-            subnet_id=subnet_id,
+            slug=slug,
             details={"tags": tags or []},
             source_ip=source_ip,
         )
@@ -365,7 +365,7 @@ class AuditLogger:
 
     async def log_subnet_created(
         self,
-        subnet_id: str,
+        slug: str,
         name: str,
         created_by: str = "system",
         has_security: bool = False,
@@ -374,16 +374,16 @@ class AuditLogger:
         return await self.log_event(
             event_type=AuditEventType.SUBNET_CREATED,
             actor_id=created_by,
-            target_id=subnet_id,
+            target_id=slug,
             target_type="subnet",
-            subnet_id=subnet_id,
+            slug=slug,
             details={"name": name, "has_security": has_security},
         )
 
     async def log_gateway_connected(
         self,
         agent_id: str,
-        subnet_id: str,
+        slug: str,
         source_ip: str | None = None,
     ) -> str:
         """Log gateway connection"""
@@ -391,14 +391,14 @@ class AuditLogger:
             event_type=AuditEventType.GATEWAY_CONNECTED,
             target_id=agent_id,
             target_type="agent",
-            subnet_id=subnet_id,
+            slug=slug,
             source_ip=source_ip,
         )
 
     async def log_auth_success(
         self,
         agent_id: str,
-        subnet_id: str,
+        slug: str,
         auth_method: str,
     ) -> str:
         """Log successful authentication"""
@@ -406,14 +406,14 @@ class AuditLogger:
             event_type=AuditEventType.SECURITY_AUTH_SUCCESS,
             target_id=agent_id,
             target_type="agent",
-            subnet_id=subnet_id,
+            slug=slug,
             details={"auth_method": auth_method},
         )
 
     async def log_auth_failure(
         self,
         agent_id: str | None,
-        subnet_id: str,
+        slug: str,
         reason: str,
         source_ip: str | None = None,
     ) -> str:
@@ -422,7 +422,7 @@ class AuditLogger:
             event_type=AuditEventType.SECURITY_AUTH_FAILURE,
             target_id=agent_id,
             target_type="agent",
-            subnet_id=subnet_id,
+            slug=slug,
             level=AuditLevel.WARNING,
             details={"reason": reason},
             source_ip=source_ip,
@@ -451,7 +451,7 @@ class AuditLogger:
         event_type: AuditEventType | None = None,
         actor_id: str | None = None,
         target_id: str | None = None,
-        subnet_id: str | None = None,
+        slug: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         level: AuditLevel | None = None,
@@ -465,7 +465,7 @@ class AuditLogger:
             event_type: Filter by event type
             actor_id: Filter by actor ID
             target_id: Filter by target ID
-            subnet_id: Filter by subnet ID
+            slug: Filter by subnet ID
             start_time: Start of time range
             end_time: End of time range
             level: Filter by severity level
@@ -507,7 +507,7 @@ class AuditLogger:
                     continue
                 if target_id and event.target_id != target_id:
                     continue
-                if subnet_id and event.subnet_id != subnet_id:
+                if slug and event.slug != slug:
                     continue
                 if level and event.level != level:
                     continue
@@ -626,8 +626,8 @@ class AuditLogger:
             stats["by_level"][level_key] = stats["by_level"].get(level_key, 0) + 1
 
             # Count by subnet
-            if event.subnet_id:
-                stats["by_subnet"][event.subnet_id] = stats["by_subnet"].get(event.subnet_id, 0) + 1
+            if event.slug:
+                stats["by_subnet"][event.slug] = stats["by_subnet"].get(event.slug, 0) + 1
 
         return stats
 
@@ -661,11 +661,11 @@ class AuditLogger:
         if format == "json":
             return json.dumps([e.model_dump() for e in events], indent=2, default=str)
         elif format == "csv":
-            lines = ["id,timestamp,event_type,level,actor_id,target_id,subnet_id"]
+            lines = ["id,timestamp,event_type,level,actor_id,target_id,slug"]
             for event in events:
                 lines.append(
                     f"{event.id},{event.timestamp.isoformat()},{event.event_type.value},"
-                    f"{event.level.value},{event.actor_id or ''},{event.target_id or ''},{event.subnet_id or ''}"
+                    f"{event.level.value},{event.actor_id or ''},{event.target_id or ''},{event.slug or ''}"
                 )
             return "\n".join(lines)
         else:
@@ -772,7 +772,7 @@ def fire_and_forget_event(
     actor_type: str | None = None,
     target_id: str | None = None,
     target_type: str | None = None,
-    subnet_id: str | None = None,
+    slug: str | None = None,
     level: AuditLevel = AuditLevel.INFO,
     details: dict[str, Any] | None = None,
     source_ip: str | None = None,
@@ -808,7 +808,7 @@ def fire_and_forget_event(
                     actor_type=actor_type,
                     target_id=target_id,
                     target_type=target_type,
-                    subnet_id=subnet_id,
+                    slug=slug,
                     level=level,
                     details=details or {},
                     source_ip=source_ip,
@@ -930,7 +930,7 @@ def record_auth_failure(
     actor_id: str | None = None,
     path: str | None = None,
     method: str | None = None,
-    subnet_id: str = "",
+    slug: str = "",
     extra: dict[str, Any] | None = None,
 ) -> None:
     """Best-effort fire-and-forget audit log for any authn/authz failure.
@@ -952,7 +952,7 @@ def record_auth_failure(
         path / method: Request path + method, recorded into ``details`` so
             analysts can pin attacks to a specific endpoint without
             cross-referencing access logs.
-        subnet_id: Subnet context if relevant.
+        slug: Subnet context if relevant.
         extra: Additional structured details merged into ``details``.
     """
     audit = _AUDIT_SINGLETON
@@ -979,7 +979,7 @@ def record_auth_failure(
         audit,
         event_type=AuditEventType.SECURITY_AUTH_FAILURE,
         actor_id=actor_id,
-        subnet_id=subnet_id or None,
+        slug=slug or None,
         level=AuditLevel.WARNING,
         details=details,
         source_ip=source_ip,

--- a/acn/protocols/a2a/server.py
+++ b/acn/protocols/a2a/server.py
@@ -757,6 +757,14 @@ class ACNAgentExecutor(AgentExecutor):
                     DataPart(
                         data={
                             "response": response,
+                            # Emit both keys symmetrically with the
+                            # input contract: ``slug`` is the canonical
+                            # field after the rename, ``subnet_id`` is
+                            # kept as a legacy alias so existing A2A
+                            # clients reading the artifact don't break
+                            # mid-rollout. Either key carries the same
+                            # slug value.
+                            "slug": subnet_id,
                             "subnet_id": subnet_id,
                             "agent_id": agent_id,
                         }

--- a/acn/protocols/a2a/server.py
+++ b/acn/protocols/a2a/server.py
@@ -721,7 +721,8 @@ class ACNAgentExecutor(AgentExecutor):
         await self._send_status(event_queue, context, TaskState.working, "Routing through subnet")
 
         params = self._extract_data_from_message(message)
-        subnet_id = params.get("subnet_id")
+        # Accept both "slug" (new) and "subnet_id" (legacy back-compat).
+        subnet_id = params.get("slug") or params.get("subnet_id")
         agent_id = params.get("agent_id")
         message_content = params.get("message", {})
 
@@ -729,8 +730,8 @@ class ACNAgentExecutor(AgentExecutor):
             await self._send_status(
                 event_queue,
                 context,
-                TaskState.failed,
-                "subnet_id and agent_id required",
+                TaskState.rejected,
+                "slug and agent_id required",
                 final=True,
             )
             return

--- a/acn/routes/_subnet_admission.py
+++ b/acn/routes/_subnet_admission.py
@@ -88,7 +88,7 @@ def _require_owner(agent_info: dict, subnet: Subnet) -> None:
             ErrorCode.SUBNET_NOT_OWNER,
             403,
             details={
-                "subnet_id": subnet.subnet_id,
+                "slug": subnet.slug,
                 "owner": subnet.owner,
                 "caller": agent_info["agent_id"],
             },
@@ -191,7 +191,7 @@ def _map_join_flow_error(exc: JoinFlowError) -> ACNHTTPError:
             ErrorCode.ALREADY_MEMBER,
             409,
             details={
-                "subnet_id": exc.subnet_id,
+                "slug": exc.slug,
                 "agent_id": exc.agent_id,
             },
         )
@@ -200,7 +200,7 @@ def _map_join_flow_error(exc: JoinFlowError) -> ACNHTTPError:
             ErrorCode.ALREADY_ON_ALLOWLIST,
             409,
             details={
-                "subnet_id": exc.subnet_id,
+                "slug": exc.slug,
                 "agent_id": exc.agent_id,
             },
         )
@@ -244,7 +244,7 @@ def serialize_join_request(row: SubnetJoinRequest) -> dict[str, Any]:
     """JSON-ready response payload for a ``SubnetJoinRequest`` row."""
     return {
         "request_id": row.request_id,
-        "subnet_id": row.subnet_id,
+        "slug": row.slug,
         "agent_id": row.agent_id,
         "kind": row.kind,
         "status": row.status,
@@ -259,7 +259,7 @@ def serialize_join_request(row: SubnetJoinRequest) -> dict[str, Any]:
 def serialize_allowlist_entry(entry: SubnetAllowlist) -> dict[str, Any]:
     """JSON-ready response payload for a ``SubnetAllowlist`` entry."""
     return {
-        "subnet_id": entry.subnet_id,
+        "slug": entry.slug,
         "agent_id": entry.agent_id,
         "added_by": entry.added_by,
         "added_at": _iso_or_none(entry.added_at),
@@ -290,7 +290,7 @@ def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str,
         # Branch 1 — open subnet.
         return 200, {
             "status": "joined",
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
         }
 
@@ -300,7 +300,7 @@ def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str,
         # but doesn't need to for any downstream logic.
         return 200, {
             "status": "joined",
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
         }
 
@@ -313,7 +313,7 @@ def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str,
         return 200, {
             "auto_resolved": True,
             "resolved_kind": "invitation",
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
             "invitation_id": result.invitation.request_id,
             "via": result.via,
@@ -325,7 +325,7 @@ def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str,
         # its request_id so the caller can correlate audit log
         # readings.
         return 200, {
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
             "request_id": result.request.request_id,
             "via": "allowlist",
@@ -335,7 +335,7 @@ def join_flow_result_to_response(result: JoinFlowResult) -> tuple[int, dict[str,
         # Branch 6 — fall-through pending join_request. 202 because
         # the caller is not yet a member; the owner owes a decision.
         return 202, {
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
             "request_id": result.request.request_id,
             "status": "pending",
@@ -365,7 +365,7 @@ def invite_agent_result_to_response(
     """
     if isinstance(result, InviteAgentSentResult):
         return 202, {
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
             "invitation_id": result.invitation.request_id,
             "status": "pending",
@@ -375,7 +375,7 @@ def invite_agent_result_to_response(
         return 200, {
             "auto_resolved": True,
             "resolved_kind": "join_request",
-            "subnet_id": result.subnet_id,
+            "slug": result.slug,
             "agent_id": result.agent_id,
             "request_id": result.request.request_id,
         }

--- a/acn/routes/_subnet_admission.py
+++ b/acn/routes/_subnet_admission.py
@@ -404,5 +404,5 @@ async def load_subnet_or_404(subnet_service: Any, subnet_id: str) -> Subnet:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": subnet_id},
         ) from e

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -43,7 +43,7 @@ logger = structlog.get_logger()
 
 
 def _subnet_parent_id(subnet: object) -> str | None:
-    """Extract ``Subnet.parent_subnet_id`` defensively.
+    """Extract ``Subnet.parent_slug`` defensively.
 
     ADR-0003 Phase 3 — the field is added to the join/leave webhook
     payload's ``data`` block. Legacy ``MagicMock``-based test stubs
@@ -53,7 +53,7 @@ def _subnet_parent_id(subnet: object) -> str | None:
     shape) instead of leaking a non-JSON-serialisable mock into
     webhook bodies.
     """
-    raw = getattr(subnet, "parent_subnet_id", None)
+    raw = getattr(subnet, "parent_slug", None)
     return raw if isinstance(raw, str) else None
 
 
@@ -76,14 +76,14 @@ def _require_self(agent_info: dict, path_agent_id: str) -> None:
 async def do_join_subnet(
     *,
     agent_id: str,
-    subnet_id: str,
+    slug: str,
     agent_info: dict,
     subnet_service: SubnetService,
     agent_service: AgentService,
     webhook_service: WebhookService | None,
     join_flow_service: JoinFlowService,
 ) -> JSONResponse:
-    """Join `agent_id` into `subnet_id` via the ADR-0004 §join six-branch flow.
+    """Join `agent_id` into `slug` via the ADR-0004 §join six-branch flow.
 
     ADR-0004 Phase 2 Slice 2.3 rewrite — the legacy direct
     ``add_member + agent_service.join_subnet`` path is now a
@@ -101,7 +101,7 @@ async def do_join_subnet(
 
     - ``subnet.member_agent_ids`` gains ``agent_id``
       (already done inside ``join_flow_service.join_subnet``).
-    - ``agent.subnet_ids`` gains ``subnet_id`` (written here — the
+    - ``agent.subnet_ids`` gains ``slug`` (written here — the
       service layer deliberately leaves the back-reference to the
       route layer per ADR §"Why a separate service").
     - ``agent.joined_subnet`` Org Harness webhook fires best-effort.
@@ -113,12 +113,12 @@ async def do_join_subnet(
     # parent-membership pre-check and the webhook payload, so a
     # single fetch covers both.
     try:
-        subnet = await subnet_service.get_subnet(subnet_id)
+        subnet = await subnet_service.get_subnet(slug)
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
 
     # ADR-0003 child-subnet pre-check. The service layer
@@ -129,11 +129,11 @@ async def do_join_subnet(
     # pre-check, branches 5 and 6 would create a row before
     # ``add_member`` raises, leaving an orphan audit-trail entry
     # for a join that never happened.
-    parent_subnet_id = _subnet_parent_id(subnet)
-    if parent_subnet_id is not None:
+    parent_slug = _subnet_parent_id(subnet)
+    if parent_slug is not None:
         parent = None
         try:
-            parent = await subnet_service.get_subnet(parent_subnet_id)
+            parent = await subnet_service.get_subnet(parent_slug)
         except SubnetNotFoundException:
             pass
         if parent is None or agent_id not in parent.member_agent_ids:
@@ -142,9 +142,9 @@ async def do_join_subnet(
                 403,
                 details={
                     "reason": REASON_NOT_PARENT_MEMBER,
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "agent_id": agent_id,
-                    "parent_subnet_id": parent_subnet_id,
+                    "parent_slug": parent_slug,
                 },
             )
 
@@ -155,7 +155,7 @@ async def do_join_subnet(
     # no-op stub until Slice 2.4). All we do here is translate the
     # result into HTTP shape and add the agent-side back-reference.
     try:
-        result = await join_flow_service.join_subnet(subnet_id, agent_id)
+        result = await join_flow_service.join_subnet(slug, agent_id)
     except AlreadyMemberError as e:
         # ADR §State machine edges "Agent self-join a subnet they
         # are already in" → 409 ALREADY_MEMBER. Bubble through the
@@ -177,7 +177,7 @@ async def do_join_subnet(
             403,
             details={
                 "reason": nest_err.reason,
-                "subnet_id": subnet_id,
+                "slug": slug,
                 "agent_id": agent_id,
             },
         ) from nest_err
@@ -208,17 +208,17 @@ async def do_join_subnet(
     # performed — those audit rows are valid history of the
     # successful service-layer decision.
     try:
-        await agent_service.join_subnet(agent_id, subnet_id)
+        await agent_service.join_subnet(agent_id, slug)
     except AgentNotFoundException as e:
         # Agent disappeared between auth and join — improbable
         # but possible if the agent was deleted concurrently.
         try:
-            await subnet_service.remove_member(subnet_id, agent_id)
+            await subnet_service.remove_member(slug, agent_id)
         except Exception as rollback_err:  # noqa: BLE001
             logger.warning(
                 "join_subnet_back_ref_rollback_failed",
                 agent_id=agent_id,
-                subnet_id=subnet_id,
+                slug=slug,
                 error=str(rollback_err),
             )
         raise ACNHTTPError(
@@ -229,18 +229,18 @@ async def do_join_subnet(
     except Exception as e:  # noqa: BLE001
         # Same half-joined recovery; treat as 500.
         try:
-            await subnet_service.remove_member(subnet_id, agent_id)
+            await subnet_service.remove_member(slug, agent_id)
         except Exception as rollback_err:  # noqa: BLE001
             logger.warning(
                 "join_subnet_back_ref_rollback_failed",
                 agent_id=agent_id,
-                subnet_id=subnet_id,
+                slug=slug,
                 error=str(rollback_err),
             )
         logger.error(
             "join_subnet_back_ref_failed",
             agent_id=agent_id,
-            subnet_id=subnet_id,
+            slug=slug,
             error=str(e),
             exc_info=True,
         )
@@ -249,7 +249,7 @@ async def do_join_subnet(
     logger.info(
         "agent_joined_subnet",
         agent_id=agent_id,
-        subnet_id=subnet_id,
+        slug=slug,
         branch=type(result).__name__,
     )
 
@@ -265,17 +265,17 @@ async def do_join_subnet(
                 url=subnet.harness_url,
                 secret=subnet.harness_secret,
                 event=WebhookEventType.AGENT_JOINED_SUBNET,
-                task_id=subnet_id,
+                task_id=slug,
                 data={
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "agent_id": agent_id,
-                    "parent_subnet_id": parent_subnet_id,
+                    "parent_slug": parent_slug,
                 },
             )
         except Exception as e:  # noqa: BLE001 - never break join on webhook failure
             logger.warning(
                 "subnet_harness_webhook_failed",
-                subnet_id=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 webhook_event="agent.joined_subnet",
                 error=str(e),
@@ -287,27 +287,27 @@ async def do_join_subnet(
 async def do_leave_subnet(
     *,
     agent_id: str,
-    subnet_id: str,
+    slug: str,
     agent_info: dict,
     subnet_service: SubnetService,
     agent_service: AgentService,
     webhook_service: WebhookService | None,
 ) -> dict:
-    """Leave `subnet_id`. Mirrors `do_join_subnet` semantics."""
+    """Leave `slug`. Mirrors `do_join_subnet` semantics."""
     _require_self(agent_info, agent_id)
 
     # Capture subnet up-front so we still know the harness_url even if the
     # subnet later gets unmodified (it doesn't, but keeps symmetry with join).
     try:
-        subnet = await subnet_service.get_subnet(subnet_id)
+        subnet = await subnet_service.get_subnet(slug)
     except SubnetNotFoundException:
         subnet = None  # let downstream raise the canonical error
 
     try:
-        await agent_service.leave_subnet(agent_id, subnet_id)
-        await subnet_service.remove_member(subnet_id, agent_id)
+        await agent_service.leave_subnet(agent_id, slug)
+        await subnet_service.remove_member(slug, agent_id)
 
-        logger.info("agent_left_subnet", agent_id=agent_id, subnet_id=subnet_id)
+        logger.info("agent_left_subnet", agent_id=agent_id, slug=slug)
 
         if subnet and subnet.harness_url and webhook_service is not None:
             try:
@@ -315,26 +315,26 @@ async def do_leave_subnet(
                     url=subnet.harness_url,
                     secret=subnet.harness_secret,
                     event=WebhookEventType.AGENT_LEFT_SUBNET,
-                    task_id=subnet_id,
+                    task_id=slug,
                     data={
-                        "subnet_id": subnet_id,
+                        "slug": slug,
                         "agent_id": agent_id,
                         # ADR-0003 Phase 3 — see do_join_subnet for
                         # the contract; symmetric on leave so
                         # harnesses get hierarchy on both edges.
-                        "parent_subnet_id": _subnet_parent_id(subnet),
+                        "parent_slug": _subnet_parent_id(subnet),
                     },
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(
                     "subnet_harness_webhook_failed",
-                    subnet_id=subnet_id,
+                    slug=slug,
                     agent_id=agent_id,
                     webhook_event="agent.left_subnet",
                     error=str(e),
                 )
 
-        return {"status": "left", "agent_id": agent_id, "subnet_id": subnet_id}
+        return {"status": "left", "agent_id": agent_id, "slug": slug}
     except AgentNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.AGENT_NOT_FOUND,
@@ -345,7 +345,7 @@ async def do_leave_subnet(
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except ACNHTTPError:
         raise

--- a/acn/routes/agent_subnets.py
+++ b/acn/routes/agent_subnets.py
@@ -43,12 +43,12 @@ router = APIRouter(
 )
 
 
-@router.post("/{agent_id}/subnets/{subnet_id}")
+@router.post("/{agent_id}/subnets/{slug}")
 @limiter.limit("30/minute")
 async def join_subnet(
     request: Request,
     agent_id: AgentIdPath,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
@@ -67,7 +67,7 @@ async def join_subnet(
     """
     return await do_join_subnet(
         agent_id=agent_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_info=agent_info,
         subnet_service=subnet_service,
         agent_service=agent_service,
@@ -76,12 +76,12 @@ async def join_subnet(
     )
 
 
-@router.delete("/{agent_id}/subnets/{subnet_id}")
+@router.delete("/{agent_id}/subnets/{slug}")
 @limiter.limit("30/minute")
 async def leave_subnet(
     request: Request,
     agent_id: AgentIdPath,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
@@ -95,7 +95,7 @@ async def leave_subnet(
     """
     return await do_leave_subnet(
         agent_id=agent_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_info=agent_info,
         subnet_service=subnet_service,
         agent_service=agent_service,

--- a/acn/routes/communication.py
+++ b/acn/routes/communication.py
@@ -924,7 +924,7 @@ async def broadcast_message(
         result = await broadcast_service.broadcast(
             from_agent=body.from_agent,
             message=message,
-            subnet_id=body.target_subnet,
+            slug=body.target_subnet,
             tags=body.target_tags,
             strategy=strategy,
         )

--- a/acn/routes/dependencies.py
+++ b/acn/routes/dependencies.py
@@ -76,7 +76,7 @@ settings = get_settings()
 # slugs). Numbers chosen to align with the Postgres VARCHAR widths in the
 # schema where present, otherwise sized at ~3× typical id length so a
 # legacy/exotic id format doesn't regress.
-MAX_SUBNET_ID_LEN: int = 100  # matches Postgres String(100) on tasks.subnet_id
+MAX_SUBNET_ID_LEN: int = 100  # matches Postgres String(100) on tasks.slug
 MAX_AGENT_ID_LEN: int = 128
 MAX_TASK_ID_LEN: int = 128
 MAX_PARTICIPATION_ID_LEN: int = 128
@@ -169,7 +169,7 @@ def _record_auth_failure(
         actor_id=actor_id,
         path=path,
         method=method,
-        subnet_id=subnet_id,
+        slug=subnet_id,
         extra=extra,
     )
 

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -801,7 +801,7 @@ async def _get_public_subnet_slugs(subnet_service) -> set[str]:
     """
     try:
         public_subnets = await subnet_service.list_public_subnets()
-        return {s.subnet_id for s in public_subnets}
+        return {s.slug for s in public_subnets}
     except Exception:  # noqa: BLE001
         return {"public"}
 
@@ -2314,7 +2314,7 @@ async def unregister_agent(
                 409,
                 details={
                     "agent_id": agent_id,
-                    "owned_subnet_ids": [s.subnet_id for s in owned],
+                    "owned_subnet_ids": [s.slug for s in owned],
                     "hint": "Delete or transfer ownership of these subnets before removing the agent.",
                 },
             )

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -462,7 +462,7 @@ async def dev_register_agent(
             raise ACNHTTPError(
                 ErrorCode.SUBNET_NOT_FOUND,
                 400,
-                details={"subnet_id": subnet_id},
+                details={"slug": subnet_id},
             )
 
     try:
@@ -669,7 +669,7 @@ async def register_agent(
             raise ACNHTTPError(
                 ErrorCode.SUBNET_NOT_FOUND,
                 400,
-                details={"subnet_id": subnet_id},
+                details={"slug": subnet_id},
             )
 
     try:

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -288,7 +288,12 @@ async def list_allowlist(
         subnet_id, limit=limit, offset=offset
     )
     return {
-        "subnet_id": subnet_id,
+        # ``slug`` is the canonical key after the Step 1 rename.
+        # The previous ``subnet_id`` field is intentionally not emitted
+        # alongside — its absence is what the route's tests pin via
+        # equality assertion. SDK clients that still read ``subnet_id``
+        # from this response shape must roll forward to ``slug``.
+        "slug": subnet_id,
         "entries": [serialize_allowlist_entry(e) for e in entries],
     }
 
@@ -493,7 +498,8 @@ async def list_join_requests(
         offset=offset,
     )
     return {
-        "subnet_id": subnet_id,
+        # ``slug`` only — see allowlist endpoint for the rationale.
+        "slug": subnet_id,
         "items": [serialize_join_request(r) for r in rows],
     }
 
@@ -770,7 +776,8 @@ async def list_invitations(
         offset=offset,
     )
     return {
-        "subnet_id": subnet_id,
+        # ``slug`` only — see allowlist endpoint for the rationale.
+        "slug": subnet_id,
         "items": [serialize_join_request(r) for r in rows],
     }
 

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -816,7 +816,12 @@ async def get_subnet_agents(
             return _empty_response
 
     try:
-        agents = await agent_service.search_agents(slug=slug)
+        # ``AgentService.search_agents`` keeps its parameter named
+        # ``subnet_id=`` until Step 2 of the slug rename migrates the
+        # cross-entity references (Agent.subnet_ids, Task.subnet_id).
+        # The argument *value* is the slug — only the keyword name
+        # has not been renamed yet.
+        agents = await agent_service.search_agents(subnet_id=slug)
 
         from .registry import _agent_entities_to_infos
 

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -89,7 +89,7 @@ def _subnet_entity_to_info(subnet, *, parent_uuid: str | None = None) -> SubnetI
 
     ADR-0003 hierarchy fields:
     - ``parent_id`` carries the parent subnet's **opaque UUID** (ACL V6
-      B6). The human-readable ``parent_subnet_id`` slug is intentionally
+      B6). The human-readable ``parent_slug`` slug is intentionally
       suppressed to prevent a public child subnet from leaking its
       private parent's naming convention to anonymous callers. Callers
       pass the resolved UUID via the ``parent_uuid`` keyword argument;
@@ -99,13 +99,13 @@ def _subnet_entity_to_info(subnet, *, parent_uuid: str | None = None) -> SubnetI
     - ``harness_secret`` stays write-only — never exposed.
     """
     return SubnetInfo(
-        subnet_id=subnet.subnet_id,
+        slug=subnet.slug,
         # Defensive ``getattr``: legacy ``MagicMock`` test stubs that
         # predate the ``id`` field would otherwise return a fresh mock
-        # object instead of a string. Falls back to ``subnet.subnet_id``
+        # object instead of a string. Falls back to ``subnet.slug``
         # so the response is always well-formed; production entities
         # always carry the real UUID.
-        id=_coerce_optional_str(getattr(subnet, "id", None)) or subnet.subnet_id,
+        id=_coerce_optional_str(getattr(subnet, "id", None)) or subnet.slug,
         name=subnet.name,
         owner=subnet.owner,
         description=subnet.description,
@@ -115,8 +115,8 @@ def _subnet_entity_to_info(subnet, *, parent_uuid: str | None = None) -> SubnetI
         metadata=subnet.metadata,
         harness_url=subnet.harness_url,
         harness_registered=subnet.harness_url is not None,
-        # parent_subnet_id (slug) is always None in API responses — ACL V6 B6.
-        parent_subnet_id=None,
+        # parent_slug (slug) is always None in API responses — ACL V6 B6.
+        parent_slug=None,
         parent_id=parent_uuid,
         lifecycle=_coerce_lifecycle(getattr(subnet, "lifecycle", "persistent")),
         linked_task_id=_coerce_optional_str(
@@ -131,12 +131,12 @@ async def _resolve_parent_uuid(
 ) -> str | None:
     """Return the parent subnet's opaque UUID, or None if top-level / orphaned.
 
-    Resolves the slug stored in ``subnet.parent_subnet_id`` to the stable
+    Resolves the slug stored in ``subnet.parent_slug`` to the stable
     UUID needed by ``_subnet_entity_to_info`` (ACL V6 B6).  Silently
     degrades to ``None`` on lookup failure so orphaned references don't
     surface a 500 to callers.
     """
-    parent_slug = _coerce_optional_str(getattr(subnet, "parent_subnet_id", None))
+    parent_slug = _coerce_optional_str(getattr(subnet, "parent_slug", None))
     if not parent_slug:
         return None
     try:
@@ -220,12 +220,12 @@ _nesting_error_to_acn = _invariant_error_to_acn
 
 
 def _generate_subnet_id(name: str) -> str:
-    """Generate a compact, unique subnet_id from a human-readable name.
+    """Generate a compact, unique slug from a human-readable name.
 
     Format: ``subnet-{slug}-{rand6}`` where slug is a lowercased, hyphen-
     delimited form of ``name`` truncated to 32 chars. Total length is
     bounded by ``len("subnet-") + 32 + 1 + 6 = 46`` — comfortably inside
-    ``SubnetCreateRequest.subnet_id``'s ``max_length=64``.
+    ``SubnetCreateRequest.slug``'s ``max_length=64``.
     """
     slug = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-")[:32] or "subnet"
     return f"subnet-{slug}-{secrets.token_hex(3)}"
@@ -259,10 +259,13 @@ async def create_subnet(
         security_cfg = body.security_config or (
             dict(body.security_schemes) if body.security_schemes else {}
         )
-        subnet_id = body.subnet_id or _generate_subnet_id(body.name)
+        slug = body.slug or _generate_subnet_id(body.name or "subnet")
+        # ``name`` is optional in SubnetCreateRequest; default to slug so
+        # the entity-layer invariant (name != empty) is always satisfied.
+        name = body.name or slug
         subnet = await subnet_service.create_subnet(
-            subnet_id=subnet_id,
-            name=body.name,
+            slug=slug,
+            name=name,
             owner=owner,
             description=body.description,
             is_private=body.is_private,
@@ -271,7 +274,7 @@ async def create_subnet(
             # ADR-0003 nesting fields — service-layer validates the
             # five invariant variants and raises ``SubnetInvariantError``
             # with a stable ``reason`` string.
-            parent_subnet_id=body.parent_subnet_id,
+            parent_slug=body.parent_slug,
             lifecycle=body.lifecycle,
             linked_task_id=body.linked_task_id,
             # ADR-0004 admission policy. ``None`` (the default) lets
@@ -287,21 +290,21 @@ async def create_subnet(
         # agent-side write fails (preserves the "create is atomic" contract
         # callers expect).
         try:
-            await agent_service.join_subnet(owner, subnet.subnet_id)
+            await agent_service.join_subnet(owner, subnet.slug)
         except Exception as join_error:  # noqa: BLE001 - rollback path
             logger.error(
                 "subnet_owner_join_failed_rolling_back",
-                subnet_id=subnet.subnet_id,
+                slug=subnet.slug,
                 owner=owner,
                 error=str(join_error),
                 exc_info=True,
             )
             try:
-                await subnet_service.delete_subnet(subnet.subnet_id, owner)
+                await subnet_service.delete_subnet(subnet.slug, owner)
             except Exception as rollback_error:  # noqa: BLE001
                 logger.error(
                     "subnet_creation_rollback_failed",
-                    subnet_id=subnet.subnet_id,
+                    slug=subnet.slug,
                     error=str(rollback_error),
                     exc_info=True,
                 )
@@ -312,14 +315,14 @@ async def create_subnet(
 
         # Generate gateway URLs
         base_url = settings.gateway_base_url or f"http://localhost:{settings.port}"
-        gateway_a2a_url = f"{base_url}/gateway/a2a/{subnet.subnet_id}"
-        gateway_ws_url = f"{base_url}/gateway/ws/{subnet.subnet_id}"
+        gateway_a2a_url = f"{base_url}/gateway/a2a/{subnet.slug}"
+        gateway_ws_url = f"{base_url}/gateway/ws/{subnet.slug}"
 
-        logger.info("subnet_created", subnet_id=subnet.subnet_id, owner=owner)
+        logger.info("subnet_created", slug=subnet.slug, owner=owner)
 
         return SubnetCreateResponse(
             status="created",
-            subnet_id=subnet.subnet_id,
+            slug=subnet.slug,
             is_public=not subnet.is_private,
             gateway_ws_url=gateway_ws_url,
             gateway_a2a_url=gateway_a2a_url,
@@ -412,7 +415,7 @@ async def list_subnets(
                 caller_payload.get("sub") or None if caller_payload else None
             )
             subnets = await subnet_service.list_children(
-                parent_subnet_id=parent,
+                parent_slug=parent,
                 requester_id=requester_id,
             )
         elif owned_by_user is not None:
@@ -473,9 +476,9 @@ async def list_subnets(
 
         # Batch-resolve all parent UUIDs in a single pass to avoid N+1 queries.
         parent_ids_needed = {
-            getattr(s, "parent_subnet_id", None)
+            getattr(s, "parent_slug", None)
             for s in subnets_page
-            if getattr(s, "parent_subnet_id", None)
+            if getattr(s, "parent_slug", None)
         }
         parent_uuid_map: dict[str, str | None] = {}
         for pid in parent_ids_needed:
@@ -486,7 +489,7 @@ async def list_subnets(
                 parent_uuid_map[pid] = None
 
         def _get_parent_uuid(s) -> str | None:
-            pid = getattr(s, "parent_subnet_id", None)
+            pid = getattr(s, "parent_slug", None)
             if not pid:
                 return None
             return parent_uuid_map.get(pid)
@@ -509,7 +512,7 @@ async def list_subnets(
                 # Private subnet the caller cannot see in full → SubnetStub.
                 subnet_infos.append(
                     SubnetStub(
-                        id=_coerce_optional_str(getattr(s, "id", None)) or s.subnet_id,
+                        id=_coerce_optional_str(getattr(s, "id", None)) or s.slug,
                         is_private=True,
                         parent_id=parent_uuid,
                         lifecycle=_coerce_lifecycle(
@@ -528,9 +531,9 @@ async def list_subnets(
         raise HTTPException(status_code=500, detail="Failed to list subnets") from e
 
 
-@router.get("/{subnet_id}")
+@router.get("/{slug}")
 async def get_subnet(
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
@@ -556,7 +559,7 @@ async def get_subnet(
           ``description``, ``harness_url``, and ``security_schemes`` are
           omitted.
 
-        Rationale: a private subnet's ``subnet_id`` is already
+        Rationale: a private subnet's ``slug`` is already
         discoverable through public agent listings, so existence-hiding
         provides no real security.  Surfacing hierarchy metadata lets
         graph clients draw correct topology without leaking sensitive
@@ -576,12 +579,12 @@ async def get_subnet(
         (404).
     """
     try:
-        subnet = await subnet_service.get_subnet(subnet_id)
+        subnet = await subnet_service.get_subnet(slug)
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
 
     # Resolve parent UUID once — used by both SubnetStub and SubnetInfo
@@ -594,13 +597,13 @@ async def get_subnet(
     # Private subnet — check authorisation.
     # Unauthenticated or unauthorised callers receive a SubnetStub
     # carrying only the **opaque UUID** plus structural metadata.
-    # The human-readable subnet_id slug is intentionally NOT exposed:
+    # The human-readable slug slug is intentionally NOT exposed:
     # naming patterns like ``acnlabs-core`` would otherwise leak
     # organisational structure to anyone who happens to know an
     # agent_id that's a member.
     def _stub() -> SubnetStub:
         return SubnetStub(
-            id=_coerce_optional_str(getattr(subnet, "id", None)) or subnet.subnet_id,
+            id=_coerce_optional_str(getattr(subnet, "id", None)) or subnet.slug,
             is_private=True,
             parent_id=parent_uuid,
             lifecycle=_coerce_lifecycle(getattr(subnet, "lifecycle", "persistent")),
@@ -621,9 +624,9 @@ async def get_subnet(
     return _subnet_entity_to_info(subnet, parent_uuid=parent_uuid)
 
 
-@router.get("/{subnet_id}/children")
+@router.get("/{slug}/children")
 async def get_subnet_children(
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
@@ -646,12 +649,12 @@ async def get_subnet_children(
     try:
         # Verify the parent itself exists so callers don't silently
         # paper over typos. Service ACL still filters the result set.
-        await subnet_service.get_subnet(subnet_id)
+        await subnet_service.get_subnet(slug)
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
 
     try:
@@ -666,7 +669,7 @@ async def get_subnet_children(
             caller_payload.get("sub") or None if caller_payload else None
         )
         children = await subnet_service.list_children(
-            parent_subnet_id=subnet_id,
+            parent_slug=slug,
             requester_id=requester_id,
         )
 
@@ -685,7 +688,7 @@ async def get_subnet_children(
                 parent_uuid = await _resolve_parent_uuid(s, subnet_service)
                 subnet_infos.append(
                     SubnetStub(
-                        id=_coerce_optional_str(getattr(s, "id", None)) or s.subnet_id,
+                        id=_coerce_optional_str(getattr(s, "id", None)) or s.slug,
                         is_private=True,
                         parent_id=parent_uuid,
                         lifecycle=_coerce_lifecycle(
@@ -702,7 +705,7 @@ async def get_subnet_children(
     except Exception as e:
         logger.error(
             "get_subnet_children_failed",
-            subnet_id=subnet_id,
+            slug=slug,
             error=str(e),
             exc_info=True,
         )
@@ -711,11 +714,11 @@ async def get_subnet_children(
         ) from e
 
 
-@router.post("/{subnet_id}/promote")
+@router.post("/{slug}/promote")
 @limiter.limit("10/minute")
 async def promote_subnet(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
 ):
@@ -735,7 +738,7 @@ async def promote_subnet(
     owner = agent_info["agent_id"]
     try:
         subnet = await subnet_service.promote_to_persistent(
-            subnet_id=subnet_id,
+            slug=slug,
             owner=owner,
         )
         return _subnet_entity_to_info(subnet)
@@ -743,13 +746,13 @@ async def promote_subnet(
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except PermissionError as e:
         raise ACNHTTPError(
             ErrorCode.OWNERSHIP_MISMATCH,
             403,
-            details={"subnet_id": subnet_id, "reason": "owner_mismatch"},
+            details={"slug": slug, "reason": "owner_mismatch"},
         ) from e
     except ACNHTTPError:
         raise
@@ -758,16 +761,16 @@ async def promote_subnet(
     except Exception as e:
         logger.error(
             "promote_subnet_failed",
-            subnet_id=subnet_id,
+            slug=slug,
             error=str(e),
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="Failed to promote subnet") from e
 
 
-@router.get("/{subnet_id}/agents")
+@router.get("/{slug}/agents")
 async def get_subnet_agents(
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(_optional_bearer),
     subnet_service: SubnetServiceDep = None,
@@ -791,17 +794,17 @@ async def get_subnet_agents(
       private-subnet membership queries.
     """
     try:
-        subnet = await subnet_service.get_subnet(subnet_id)
+        subnet = await subnet_service.get_subnet(slug)
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
 
     # For private subnets, check caller access.  For public subnets this
     # block is skipped entirely — the member list is openly visible.
-    _empty_response = {"subnet_id": subnet_id, "agents": [], "count": 0}
+    _empty_response = {"slug": slug, "agents": [], "count": 0}
     if getattr(subnet, "is_private", False):
         if not credentials:
             return _empty_response
@@ -813,7 +816,7 @@ async def get_subnet_agents(
             return _empty_response
 
     try:
-        agents = await agent_service.search_agents(subnet_id=subnet_id)
+        agents = await agent_service.search_agents(slug=slug)
 
         from .registry import _agent_entities_to_infos
 
@@ -821,7 +824,7 @@ async def get_subnet_agents(
             agents, agent_service=agent_service, strip_sensitive=True
         )
 
-        return {"subnet_id": subnet_id, "agents": agent_infos, "count": len(agent_infos)}
+        return {"slug": slug, "agents": agent_infos, "count": len(agent_infos)}
     except ACNHTTPError:
         raise
     except HTTPException:
@@ -851,11 +854,11 @@ async def get_subnet_agents(
 
 
 @router.post(
-    "/{agent_id}/subnets/{subnet_id}",
+    "/{agent_id}/subnets/{slug}",
     deprecated=True,
     summary="[Deprecated] Agent joins a subnet",
     description=(
-        "**Deprecated.** Use `POST /api/v1/agents/{agent_id}/subnets/{subnet_id}` "
+        "**Deprecated.** Use `POST /api/v1/agents/{agent_id}/subnets/{slug}` "
         "instead. This path will be removed after telemetry shows zero traffic "
         "for one full release cycle. Behaviour is identical."
     ),
@@ -864,23 +867,23 @@ async def get_subnet_agents(
 async def join_subnet(
     request: Request,
     agent_id: AgentIdPath,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
     join_flow_service: JoinFlowServiceDep = None,
 ):
-    """[Deprecated] Use POST /api/v1/agents/{agent_id}/subnets/{subnet_id}."""
+    """[Deprecated] Use POST /api/v1/agents/{agent_id}/subnets/{slug}."""
     logger.warning(
         "deprecated_route_called",
-        path="/api/v1/subnets/{agent_id}/subnets/{subnet_id}",
-        canonical="/api/v1/agents/{agent_id}/subnets/{subnet_id}",
+        path="/api/v1/subnets/{agent_id}/subnets/{slug}",
+        canonical="/api/v1/agents/{agent_id}/subnets/{slug}",
         agent_id=agent_id,
     )
     return await do_join_subnet(
         agent_id=agent_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_info=agent_info,
         subnet_service=subnet_service,
         agent_service=agent_service,
@@ -890,11 +893,11 @@ async def join_subnet(
 
 
 @router.delete(
-    "/{agent_id}/subnets/{subnet_id}",
+    "/{agent_id}/subnets/{slug}",
     deprecated=True,
     summary="[Deprecated] Agent leaves a subnet",
     description=(
-        "**Deprecated.** Use `DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}` "
+        "**Deprecated.** Use `DELETE /api/v1/agents/{agent_id}/subnets/{slug}` "
         "instead. Behaviour is identical."
     ),
 )
@@ -902,22 +905,22 @@ async def join_subnet(
 async def leave_subnet(
     request: Request,
     agent_id: AgentIdPath,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
     webhook_service: WebhookServiceDep = None,
 ):
-    """[Deprecated] Use DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}."""
+    """[Deprecated] Use DELETE /api/v1/agents/{agent_id}/subnets/{slug}."""
     logger.warning(
         "deprecated_route_called",
-        path="/api/v1/subnets/{agent_id}/subnets/{subnet_id}",
-        canonical="/api/v1/agents/{agent_id}/subnets/{subnet_id}",
+        path="/api/v1/subnets/{agent_id}/subnets/{slug}",
+        canonical="/api/v1/agents/{agent_id}/subnets/{slug}",
         agent_id=agent_id,
     )
     return await do_leave_subnet(
         agent_id=agent_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_info=agent_info,
         subnet_service=subnet_service,
         agent_service=agent_service,
@@ -964,11 +967,11 @@ class UpdateHarnessRequest(BaseModel):
         return v
 
 
-@router.patch("/{subnet_id}/harness")
+@router.patch("/{slug}/harness")
 @limiter.limit("20/minute")
 async def update_subnet_harness(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     body: UpdateHarnessRequest,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
@@ -979,7 +982,7 @@ async def update_subnet_harness(
     """
     try:
         subnet = await subnet_service.update_harness(
-            subnet_id=subnet_id,
+            slug=slug,
             owner=agent_info["agent_id"],
             harness_url=body.harness_url,
             harness_secret=body.harness_secret,
@@ -988,18 +991,18 @@ async def update_subnet_harness(
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except PermissionError as e:
         raise ACNHTTPError(
             ErrorCode.OWNERSHIP_MISMATCH,
             403,
-            details={"subnet_id": subnet_id, "reason": "owner_mismatch"},
+            details={"slug": slug, "reason": "owner_mismatch"},
         ) from e
 
     return {
         "status": "updated",
-        "subnet_id": subnet.subnet_id,
+        "slug": subnet.slug,
         "harness_url": subnet.harness_url,
         "harness_registered": subnet.harness_url is not None,
     }
@@ -1033,11 +1036,11 @@ async def get_agent_subnets(
     )
 
 
-@router.delete("/{subnet_id}")
+@router.delete("/{slug}")
 @limiter.limit("10/minute")
 async def delete_subnet(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     confirm: bool = Query(
@@ -1060,7 +1063,7 @@ async def delete_subnet(
             ErrorCode.INVALID_REQUEST,
             400,
             details={
-                "subnet_id": subnet_id,
+                "slug": slug,
                 "hint": "Add ?confirm=true to confirm this destructive operation.",
             },
         )
@@ -1068,19 +1071,19 @@ async def delete_subnet(
     owner = agent_info["agent_id"]
 
     try:
-        success = await subnet_service.delete_subnet(subnet_id, owner)
+        success = await subnet_service.delete_subnet(slug, owner)
         if success:
-            logger.info("subnet_deleted", subnet_id=subnet_id, owner=owner)
+            logger.info("subnet_deleted", slug=slug, owner=owner)
             fire_and_forget_event(
                 get_audit_singleton(),
                 event_type=AuditEventType.SUBNET_DELETED,
                 actor_id=owner,
                 actor_type="agent",
-                target_id=subnet_id,
+                target_id=slug,
                 target_type="subnet",
                 details={"confirmed": True},
             )
-            return {"status": "deleted", "subnet_id": subnet_id}
+            return {"status": "deleted", "slug": slug}
         else:
             # This in-try raise is now correctly propagated thanks to the
             # ``except HTTPException: raise`` defence below (added by the
@@ -1094,14 +1097,14 @@ async def delete_subnet(
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except PermissionError as e:
-        logger.warning("delete_subnet_permission_denied", subnet_id=subnet_id, error=str(e))
+        logger.warning("delete_subnet_permission_denied", slug=slug, error=str(e))
         raise ACNHTTPError(
             ErrorCode.OWNERSHIP_MISMATCH,
             403,
-            details={"subnet_id": subnet_id, "reason": "owner_mismatch"},
+            details={"slug": slug, "reason": "owner_mismatch"},
         ) from e
     except ACNHTTPError:
         raise
@@ -1122,9 +1125,9 @@ async def delete_subnet(
 # =============================================================================
 
 
-@router.post("/{subnet_id}/members/{agent_id}", tags=["subnets-internal"])
+@router.post("/{slug}/members/{agent_id}", tags=["subnets-internal"])
 async def admin_add_subnet_member(
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_id: AgentIdPath,
     payload: dict = Depends(require_internal_or_permission("acn:admin")),
     subnet_service: SubnetServiceDep = None,
@@ -1136,21 +1139,21 @@ async def admin_add_subnet_member(
     Returns 404 silently if the subnet does not exist (best-effort).
     """
     try:
-        await subnet_service.add_member(subnet_id, agent_id)
-        logger.info("admin_subnet_member_added", subnet_id=subnet_id, agent_id=agent_id)
-        return {"status": "added", "subnet_id": subnet_id, "agent_id": agent_id}
+        await subnet_service.add_member(slug, agent_id)
+        logger.info("admin_subnet_member_added", slug=slug, agent_id=agent_id)
+        return {"status": "added", "slug": slug, "agent_id": agent_id}
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except SubnetInvariantError as e:
         # ADR-0003 child-subnet membership-subset rejection
         # propagated even through the internal admin path — keeps
         # the invariant uniformly enforced regardless of caller.
         raise _invariant_error_to_acn(
-            e, extra_details={"subnet_id": subnet_id, "agent_id": agent_id}
+            e, extra_details={"slug": slug, "agent_id": agent_id}
         ) from e
     except ACNHTTPError:
         raise
@@ -1161,9 +1164,9 @@ async def admin_add_subnet_member(
         raise HTTPException(status_code=500, detail="Failed to add subnet member") from e
 
 
-@router.delete("/{subnet_id}/members/{agent_id}", tags=["subnets-internal"])
+@router.delete("/{slug}/members/{agent_id}", tags=["subnets-internal"])
 async def admin_remove_subnet_member(
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_id: AgentIdPath,
     payload: dict = Depends(require_internal_or_permission("acn:admin")),
     subnet_service: SubnetServiceDep = None,
@@ -1175,14 +1178,14 @@ async def admin_remove_subnet_member(
     Returns 404 silently if the subnet does not exist (best-effort).
     """
     try:
-        await subnet_service.remove_member(subnet_id, agent_id)
-        logger.info("admin_subnet_member_removed", subnet_id=subnet_id, agent_id=agent_id)
-        return {"status": "removed", "subnet_id": subnet_id, "agent_id": agent_id}
+        await subnet_service.remove_member(slug, agent_id)
+        logger.info("admin_subnet_member_removed", slug=slug, agent_id=agent_id)
+        return {"status": "removed", "slug": slug, "agent_id": agent_id}
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"subnet_id": subnet_id},
+            details={"slug": slug},
         ) from e
     except ACNHTTPError:
         raise

--- a/acn/services/_join_flow_result.py
+++ b/acn/services/_join_flow_result.py
@@ -46,7 +46,7 @@ class JoinFlowJoinedOpenResult:
     returns ``200 {status: "joined", ...}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
 
 
@@ -60,7 +60,7 @@ class JoinFlowJoinedAsOwnerResult:
     fast path. Route layer returns ``200 {status: "joined", ...}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
 
 
@@ -78,7 +78,7 @@ class JoinFlowAutoAcceptedInvitationResult:
     "invitation", invitation_id, via}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
     invitation: SubnetJoinRequest
     via: Literal["self_join", "allowlist"]
@@ -93,7 +93,7 @@ class JoinFlowAllowlistAutoApprovedResult:
     layer returns ``200 {request_id, via: "allowlist", ...}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
     request: SubnetJoinRequest
 
@@ -106,7 +106,7 @@ class JoinFlowPendingResult:
     Route layer returns ``202 {request_id, status: "pending"}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
     request: SubnetJoinRequest
 
@@ -137,7 +137,7 @@ class InviteAgentSentResult:
     ``202 {invitation_id}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
     invitation: SubnetJoinRequest
 
@@ -158,7 +158,7 @@ class InviteAgentMergedToApprovedJoinRequestResult:
     resolved_kind: "join_request", request_id}``.
     """
 
-    subnet_id: str
+    slug: str
     agent_id: str
     request: SubnetJoinRequest
 

--- a/acn/services/_no_op_join_flow_event_publisher.py
+++ b/acn/services/_no_op_join_flow_event_publisher.py
@@ -59,7 +59,7 @@ class NoOpJoinFlowEventPublisher(IJoinFlowEventPublisher):
         logger.debug(
             "join_flow_event_dropped_slice_2_2",
             join_flow_event=event.value,
-            subnet_id=subnet.subnet_id,
+            slug=subnet.slug,
             request_id=request.request_id,
             agent_id=request.agent_id,
             kind=request.kind,

--- a/acn/services/join_flow_service.py
+++ b/acn/services/join_flow_service.py
@@ -146,11 +146,11 @@ class JoinFlowService:
             await self._subnet_service.add_member(subnet_id, agent_id)
             logger.info(
                 "join_flow_branch_open",
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 branch=1,
             )
-            return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+            return JoinFlowJoinedOpenResult(slug=subnet_id, agent_id=agent_id)
 
         # From here on ``join_policy == 'approval'``.
 
@@ -161,11 +161,11 @@ class JoinFlowService:
             await self._subnet_service.add_member(subnet_id, agent_id)
             logger.info(
                 "join_flow_branch_owner_self_join",
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 branch=2,
             )
-            return JoinFlowJoinedAsOwnerResult(subnet_id=subnet_id, agent_id=agent_id)
+            return JoinFlowJoinedAsOwnerResult(slug=subnet_id, agent_id=agent_id)
 
         # The three remaining branches all hinge on the pending row
         # / allowlist presence. Compute both up front so the
@@ -190,14 +190,14 @@ class JoinFlowService:
             )
             logger.info(
                 "join_flow_branch_invitation_auto_accept",
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 invitation_id=accepted.request_id,
                 via=via,
                 branch=4 if is_allowlisted else 3,
             )
             return JoinFlowAutoAcceptedInvitationResult(
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 invitation=accepted,
                 via=via,
@@ -219,7 +219,7 @@ class JoinFlowService:
         if is_allowlisted:
             request = SubnetJoinRequest(
                 request_id=str(uuid.uuid4()),
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 kind="allowlist_auto",
                 status="approved",
@@ -244,13 +244,13 @@ class JoinFlowService:
             )
             logger.info(
                 "join_flow_branch_allowlist_auto_approved",
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 request_id=request.request_id,
                 branch=5,
             )
             return JoinFlowAllowlistAutoApprovedResult(
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 agent_id=agent_id,
                 request=request,
             )
@@ -260,7 +260,7 @@ class JoinFlowService:
         # member; the owner owes a decision.
         request = SubnetJoinRequest(
             request_id=str(uuid.uuid4()),
-            subnet_id=subnet_id,
+            slug=subnet_id,
             agent_id=agent_id,
             kind="join_request",
             status="pending",
@@ -274,13 +274,13 @@ class JoinFlowService:
         )
         logger.info(
             "join_flow_branch_pending_join_request",
-            subnet_id=subnet_id,
+            slug=subnet_id,
             agent_id=agent_id,
             request_id=request.request_id,
             branch=6,
         )
         return JoinFlowPendingResult(
-            subnet_id=subnet_id,
+            slug=subnet_id,
             agent_id=agent_id,
             request=request,
         )

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -227,14 +227,14 @@ class SubnetService:
 
     async def create_subnet(
         self,
-        subnet_id: str,
+        slug: str,
         name: str,
         owner: str,
         description: str | None = None,
         is_private: bool = False,
         security_config: dict | None = None,
         metadata: dict | None = None,
-        parent_subnet_id: str | None = None,
+        parent_slug: str | None = None,
         lifecycle: Literal["persistent", "task_scoped"] = "persistent",
         linked_task_id: str | None = None,
         join_policy: Literal["open", "approval"] | None = None,
@@ -244,12 +244,12 @@ class SubnetService:
 
         ADR-0003 invariants enforced when nesting params are set:
 
-        - ``parent_subnet_id`` must reference an existing subnet —
+        - ``parent_slug`` must reference an existing subnet —
           ``parent_not_found``.
         - Parent must not be reserved (``public``/``system``) —
           ``parent_is_reserved``. Catches both reserved IDs and
           (defence in depth) any subnet whose owner is ``system``.
-        - Parent's own ``parent_subnet_id`` must be ``None`` (single-
+        - Parent's own ``parent_slug`` must be ``None`` (single-
           layer cap) — ``parent_is_nested``.
         - ``lifecycle == "task_scoped"`` requires
           ``linked_task_id`` to be set — ``task_scoped_requires_linked_task``.
@@ -277,14 +277,14 @@ class SubnetService:
           as-is and persisted on the entity.
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             name: Subnet name
             owner: Subnet owner
             description: Subnet description
             is_private: Whether subnet is private
             security_config: Security configuration
             metadata: Additional metadata
-            parent_subnet_id: Optional parent subnet ID (ADR-0003)
+            parent_slug: Optional parent subnet ID (ADR-0003)
             lifecycle: ``"persistent"`` (default) or ``"task_scoped"``
             linked_task_id: Required when ``lifecycle == "task_scoped"``
             join_policy: ``"open"`` / ``"approval"`` / ``None``
@@ -311,8 +311,8 @@ class SubnetService:
             )
 
         # Check if subnet already exists
-        if await self.repository.exists(subnet_id):
-            raise ValueError(f"Subnet {subnet_id} already exists")
+        if await self.repository.exists(slug):
+            raise ValueError(f"Subnet {slug} already exists")
 
         # --- ADR-0003 nesting validations -----------------------------
         # Entity-layer already enforces lifecycle ↔ linked_task_id
@@ -329,27 +329,27 @@ class SubnetService:
                 "lifecycle='task_scoped' requires linked_task_id",
             )
 
-        if parent_subnet_id is not None:
-            parent = await self.repository.find_by_id(parent_subnet_id)
+        if parent_slug is not None:
+            parent = await self.repository.find_by_id(parent_slug)
             if parent is None:
                 raise SubnetInvariantError(
                     REASON_PARENT_NOT_FOUND,
-                    f"Parent subnet '{parent_subnet_id}' does not exist",
+                    f"Parent subnet '{parent_slug}' does not exist",
                 )
             # ADR-0003 §A invariant 5 — reserved subnets cannot be
             # parents. Catch by ID *and* (defensively) by owner: the
             # ``system`` owner literal is the platform escape hatch
             # and any subnet under it is treated as platform-owned.
-            if parent_subnet_id in {"public", "system"} or parent.owner == "system":
+            if parent_slug in {"public", "system"} or parent.owner == "system":
                 raise SubnetInvariantError(
                     REASON_PARENT_IS_RESERVED,
-                    f"Parent subnet '{parent_subnet_id}' is reserved",
+                    f"Parent subnet '{parent_slug}' is reserved",
                 )
             # Single-layer cap — parent must itself be top-level.
-            if parent.parent_subnet_id is not None:
+            if parent.parent_slug is not None:
                 raise SubnetInvariantError(
                     REASON_PARENT_IS_NESTED,
-                    f"Parent subnet '{parent_subnet_id}' is itself nested; "
+                    f"Parent subnet '{parent_slug}' is itself nested; "
                     "single-layer cap enforced",
                 )
 
@@ -393,14 +393,14 @@ class SubnetService:
                 )
 
         subnet = Subnet(
-            subnet_id=subnet_id,
+            slug=slug,
             name=name,
             owner=owner,
             description=description,
             is_private=is_private,
             security_config=security_config or {},
             metadata=metadata or {},
-            parent_subnet_id=parent_subnet_id,
+            parent_slug=parent_slug,
             lifecycle=lifecycle,
             linked_task_id=linked_task_id,
             join_policy=effective_join_policy,
@@ -427,10 +427,10 @@ class SubnetService:
 
         logger.info(
             "create_subnet",
-            subnet_id=subnet_id,
+            slug=slug,
             name=name,
             owner=owner,
-            parent_subnet_id=parent_subnet_id,
+            parent_slug=parent_slug,
             lifecycle=lifecycle,
             linked_task_id=linked_task_id,
             join_policy=effective_join_policy,
@@ -438,12 +438,12 @@ class SubnetService:
         await self.repository.save(subnet)
         return subnet
 
-    async def get_subnet(self, subnet_id: str) -> Subnet:
+    async def get_subnet(self, slug: str) -> Subnet:
         """
         Get subnet by ID
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
 
         Returns:
             Subnet entity
@@ -451,9 +451,9 @@ class SubnetService:
         Raises:
             SubnetNotFoundException: If subnet not found
         """
-        subnet = await self.repository.find_by_id(subnet_id)
+        subnet = await self.repository.find_by_id(slug)
         if not subnet:
-            raise SubnetNotFoundException(f"Subnet {subnet_id} not found")
+            raise SubnetNotFoundException(f"Subnet {slug} not found")
         return subnet
 
     async def list_subnets(self, owner: str | None = None) -> list[Subnet]:
@@ -490,7 +490,7 @@ class SubnetService:
 
     async def list_children(
         self,
-        parent_subnet_id: str,
+        parent_slug: str,
         *,
         requester_id: str | None = None,
     ) -> list[Subnet]:
@@ -505,7 +505,7 @@ class SubnetService:
         no existence leak.
 
         Args:
-            parent_subnet_id: Parent subnet identifier
+            parent_slug: Parent subnet identifier
             requester_id: Authenticated caller's ``agent_id`` (or
                 ``None`` for anonymous / pre-auth contexts)
 
@@ -519,9 +519,9 @@ class SubnetService:
         # for private-unauthorised) — same as list_subnets.
         # requester_id is kept in signature for backward compat but is
         # no longer used here.
-        return await self.repository.find_by_parent(parent_subnet_id)
+        return await self.repository.find_by_parent(parent_slug)
 
-    async def delete_subnet(self, subnet_id: str, owner: str) -> bool:
+    async def delete_subnet(self, slug: str, owner: str) -> bool:
         """
         Delete a subnet, cascading to children when it has any
         (ADR-0003 §A invariant 4).
@@ -570,7 +570,7 @@ class SubnetService:
         delete success.
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             owner: Owner identifier (or ``"system"`` for cascade)
 
         Returns:
@@ -588,7 +588,7 @@ class SubnetService:
                 child preserved. Caller treats both backend-specific
                 exception types as "cascade aborted, retry-safe".
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
 
         # Authorization check — owner of the subnet, or platform.
         if subnet.owner != owner and owner != "system":
@@ -598,8 +598,8 @@ class SubnetService:
         # primitives. Cascade hook still uses ``owner="system"`` to
         # delete *child* subnets, which is fine (children are never
         # reserved per ADR-0003 §7).
-        if subnet_id in ["public", "system"]:
-            raise PermissionError(f"Cannot delete system subnet: {subnet_id}")
+        if slug in ["public", "system"]:
+            raise PermissionError(f"Cannot delete system subnet: {slug}")
 
         # Cascade to children when this is a top-level subnet. Single-
         # layer cap guarantees ``find_by_parent`` doesn't itself need
@@ -608,13 +608,13 @@ class SubnetService:
         # individual ``delete()`` calls (issue #54).
         #
         # Issue #56: before removing any subnet record, clear the
-        # ``subnet_id`` back-reference from each member's
+        # ``slug`` back-reference from each member's
         # ``agent.subnet_ids`` set. Doing this **before** the delete
         # means a partial-failure cascade leaves agents pointing at
         # subnets that still exist (recoverable) rather than at
         # subnets that have already been deleted (orphan dust).
-        if subnet.parent_subnet_id is None:
-            children = await self.repository.find_by_parent(subnet_id)
+        if subnet.parent_slug is None:
+            children = await self.repository.find_by_parent(slug)
             if children:
                 # Clear back-references for every child first, then
                 # the parent. Order mirrors the cascade delete order
@@ -622,27 +622,27 @@ class SubnetService:
                 # Stays outside the UoW transaction by design — see
                 # method docstring §"Agent back-reference cleanup".
                 for child in children:
-                    await self._clear_agent_back_references(child.subnet_id, child.member_agent_ids)
-                await self._clear_agent_back_references(subnet_id, subnet.member_agent_ids)
-                child_ids = [c.subnet_id for c in children]
+                    await self._clear_agent_back_references(child.slug, child.member_agent_ids)
+                await self._clear_agent_back_references(slug, subnet.member_agent_ids)
+                child_ids = [c.slug for c in children]
                 logger.info(
                     "delete_subnet_cascade",
-                    parent_subnet_id=subnet_id,
+                    parent_slug=slug,
                     child_subnet_ids=child_ids,
                     child_count=len(child_ids),
                 )
-                return await self._run_cascade_delete(subnet_id, subnet_to_delete_with=children)
+                return await self._run_cascade_delete(slug, subnet_to_delete_with=children)
 
         # No-cascade path: child subnet direct-delete OR top-level
         # subnet with zero children. Either way, clean up this one
         # subnet's back-references then drop the record.
-        await self._clear_agent_back_references(subnet_id, subnet.member_agent_ids)
-        logger.info("delete_subnet", subnet_id=subnet_id)
-        return await self._run_cascade_delete(subnet_id, subnet_to_delete_with=None)
+        await self._clear_agent_back_references(slug, subnet.member_agent_ids)
+        logger.info("delete_subnet", slug=slug)
+        return await self._run_cascade_delete(slug, subnet_to_delete_with=None)
 
     async def _run_cascade_delete(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         subnet_to_delete_with: list[Subnet] | None,
     ) -> bool:
@@ -668,23 +668,23 @@ class SubnetService:
 
         - ``None`` → single subnet (no children, OR a child subnet
           deleted directly). Final DELETE is
-          ``self.repository.delete(subnet_id, session=...)``.
+          ``self.repository.delete(slug, session=...)``.
         - non-empty list → parent with children. Final DELETE is
           ``self.repository.delete_with_children(parent_id,
-          [c.subnet_id for c in children], session=...)``. The
+          [c.slug for c in children], session=...)``. The
           join-policy artifact sweep runs for every child AND the
           parent inside the same transaction.
         """
         if self.unit_of_work is not None:
             async with self.unit_of_work.transaction() as session:
                 return await self._cascade_delete_body(
-                    subnet_id, subnet_to_delete_with, session=session
+                    slug, subnet_to_delete_with, session=session
                 )
-        return await self._cascade_delete_body(subnet_id, subnet_to_delete_with, session=None)
+        return await self._cascade_delete_body(slug, subnet_to_delete_with, session=None)
 
     async def _cascade_delete_body(
         self,
-        subnet_id: str,
+        slug: str,
         subnet_to_delete_with: list[Subnet] | None,
         *,
         session: object | None,
@@ -701,18 +701,18 @@ class SubnetService:
         """
         if subnet_to_delete_with is not None:
             children = subnet_to_delete_with
-            child_ids = [c.subnet_id for c in children]
+            child_ids = [c.slug for c in children]
             for child in children:
-                await self._cascade_join_policy_artifacts(child.subnet_id, session=session)
-            await self._cascade_join_policy_artifacts(subnet_id, session=session)
-            return await self.repository.delete_with_children(subnet_id, child_ids, session=session)
-        await self._cascade_join_policy_artifacts(subnet_id, session=session)
-        return await self.repository.delete(subnet_id, session=session)
+                await self._cascade_join_policy_artifacts(child.slug, session=session)
+            await self._cascade_join_policy_artifacts(slug, session=session)
+            return await self.repository.delete_with_children(slug, child_ids, session=session)
+        await self._cascade_join_policy_artifacts(slug, session=session)
+        return await self.repository.delete(slug, session=session)
 
     async def _cascade_join_policy_artifacts(
-        self, subnet_id: str, *, session: object | None = None
+        self, slug: str, *, session: object | None = None
     ) -> None:
-        """Sweep ADR-0004 join_requests + allowlist for ``subnet_id``.
+        """Sweep ADR-0004 join_requests + allowlist for ``slug``.
 
         Called from ``_cascade_delete_body`` BEFORE the subnet
         HASH / row delete. Either repository raising
@@ -746,29 +746,29 @@ class SubnetService:
         """
         if self.join_request_repository is not None:
             deleted = await self.join_request_repository.delete_for_subnet(
-                subnet_id, session=session
+                slug, session=session
             )
             if deleted:
                 logger.info(
                     "delete_subnet_cascade_join_requests",
-                    subnet_id=subnet_id,
+                    slug=slug,
                     deleted_count=deleted,
                 )
         if self.allowlist_repository is not None:
-            deleted = await self.allowlist_repository.delete_for_subnet(subnet_id, session=session)
+            deleted = await self.allowlist_repository.delete_for_subnet(slug, session=session)
             if deleted:
                 logger.info(
                     "delete_subnet_cascade_allowlist",
-                    subnet_id=subnet_id,
+                    slug=slug,
                     deleted_count=deleted,
                 )
 
     async def _clear_agent_back_references(
         self,
-        subnet_id: str,
+        slug: str,
         member_agent_ids: set[str],
     ) -> None:
-        """Remove ``subnet_id`` from each member's
+        """Remove ``slug`` from each member's
         ``agent.subnet_ids`` set (issue #56).
 
         Best-effort with a structured summary log: per-agent failure
@@ -784,11 +784,11 @@ class SubnetService:
         - ``agent_repository`` was not wired (legacy test fixtures)
         - ``member_agent_ids`` is empty (orphan or just-created subnet)
         - An individual agent no longer exists (already deleted)
-        - The agent doesn't carry ``subnet_id`` in its ``subnet_ids``
+        - The agent doesn't carry ``slug`` in its ``subnet_ids``
           (already cleaned by an earlier explicit ``leave_subnet``)
 
         Args:
-            subnet_id: Subnet being deleted; this id will be removed
+            slug: Subnet being deleted; this id will be removed
                 from every visited agent's ``subnet_ids``.
             member_agent_ids: Snapshot of the subnet's members at
                 the moment of delete. May contain ids whose agents
@@ -804,9 +804,9 @@ class SubnetService:
                 agent = await self.agent_repository.find_by_id(agent_id)
                 if agent is None:
                     continue
-                if subnet_id not in agent.subnet_ids:
+                if slug not in agent.subnet_ids:
                     continue
-                agent.remove_from_subnet(subnet_id)
+                agent.remove_from_subnet(slug)
                 await self.agent_repository.save(agent)
                 cleaned += 1
             except Exception as exc:  # noqa: BLE001 — best-effort
@@ -815,7 +815,7 @@ class SubnetService:
                 # ``leave_subnet`` for the affected pair.
                 logger.warning(
                     "subnet_back_reference_cleanup_failed",
-                    subnet_id=subnet_id,
+                    slug=slug,
                     agent_id=agent_id,
                     error=str(exc),
                 )
@@ -823,23 +823,23 @@ class SubnetService:
 
         logger.info(
             "subnet_back_reference_cleanup",
-            subnet_id=subnet_id,
+            slug=slug,
             member_count=len(member_agent_ids),
             cleaned=cleaned,
             failed=failed,
         )
 
-    async def add_member(self, subnet_id: str, agent_id: str) -> Subnet:
+    async def add_member(self, slug: str, agent_id: str) -> Subnet:
         """
         Add an agent to a subnet.
 
         ADR-0003 §A invariant 2 — when the subnet is a child
-        (``parent_subnet_id is not None``), the agent must already be
+        (``parent_slug is not None``), the agent must already be
         a member of the parent. Surfaced with
         ``reason="not_parent_member"``.
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             agent_id: Agent identifier
 
         Returns:
@@ -849,10 +849,10 @@ class SubnetService:
             SubnetInvariantError: If subnet is a child and ``agent_id``
                 is not a member of the parent.
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
 
-        if subnet.parent_subnet_id is not None:
-            parent = await self.repository.find_by_id(subnet.parent_subnet_id)
+        if subnet.parent_slug is not None:
+            parent = await self.repository.find_by_id(subnet.parent_slug)
             # If the parent has been deleted while this child still
             # exists (orphan), reject the add — adding members to a
             # dangling child would silently bypass the subset
@@ -861,59 +861,59 @@ class SubnetService:
                 raise SubnetInvariantError(
                     REASON_NOT_PARENT_MEMBER,
                     f"Agent '{agent_id}' is not a member of parent subnet "
-                    f"'{subnet.parent_subnet_id}'",
+                    f"'{subnet.parent_slug}'",
                 )
 
         subnet.add_member(agent_id)
         await self.repository.save(subnet)
-        logger.info("subnet_member_added", subnet_id=subnet_id, agent_id=agent_id)
+        logger.info("subnet_member_added", slug=slug, agent_id=agent_id)
         return subnet
 
-    async def remove_member(self, subnet_id: str, agent_id: str) -> Subnet:
+    async def remove_member(self, slug: str, agent_id: str) -> Subnet:
         """
         Remove an agent from a subnet
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             agent_id: Agent identifier
 
         Returns:
             Updated subnet entity
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         subnet.remove_member(agent_id)
         await self.repository.save(subnet)
-        logger.info("subnet_member_removed", subnet_id=subnet_id, agent_id=agent_id)
+        logger.info("subnet_member_removed", slug=slug, agent_id=agent_id)
         return subnet
 
-    async def get_member_count(self, subnet_id: str) -> int:
+    async def get_member_count(self, slug: str) -> int:
         """
         Get number of members in a subnet
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
 
         Returns:
             Number of members
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         return subnet.get_member_count()
 
-    async def exists(self, subnet_id: str) -> bool:
+    async def exists(self, slug: str) -> bool:
         """
         Check if subnet exists
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
 
         Returns:
             True if subnet exists
         """
-        return await self.repository.exists(subnet_id)
+        return await self.repository.exists(slug)
 
     async def update_harness(
         self,
-        subnet_id: str,
+        slug: str,
         owner: str,
         harness_url: str | None,
         harness_secret: str | None,
@@ -927,7 +927,7 @@ class SubnetService:
         webhook payloads delivered to ``harness_url``.
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             owner: Authenticated agent making the request (for authz)
             harness_url: External webhook URL (or None to clear)
             harness_secret: HMAC secret (optional; None disables signing)
@@ -939,7 +939,7 @@ class SubnetService:
             SubnetNotFoundException: If subnet not found
             PermissionError: If owner mismatch
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
 
         if subnet.owner != owner and owner != "system":
             raise PermissionError(f"Owner mismatch: {owner} != {subnet.owner}")
@@ -949,7 +949,7 @@ class SubnetService:
         await self.repository.save(subnet)
         logger.info(
             "subnet_harness_updated",
-            subnet_id=subnet_id,
+            slug=slug,
             has_url=harness_url is not None,
             has_secret=harness_secret is not None,
         )
@@ -957,7 +957,7 @@ class SubnetService:
 
     async def promote_to_persistent(
         self,
-        subnet_id: str,
+        slug: str,
         owner: str,
     ) -> Subnet:
         """
@@ -978,7 +978,7 @@ class SubnetService:
           (Redis pipeline SREM's the old ``by_linked_task`` entry).
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet identifier
             owner: Authenticated agent making the request
 
         Returns:
@@ -989,7 +989,7 @@ class SubnetService:
             SubnetNotFoundException: If subnet not found
             PermissionError: If owner mismatch
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
 
         if subnet.owner != owner and owner != "system":
             raise PermissionError(f"Owner mismatch: {owner} != {subnet.owner}")
@@ -1000,7 +1000,7 @@ class SubnetService:
             # precondition check, per ADR semantic decision #2.
             logger.info(
                 "subnet_promote_noop",
-                subnet_id=subnet_id,
+                slug=slug,
                 owner=owner,
                 reason="already_persistent",
             )
@@ -1020,7 +1020,7 @@ class SubnetService:
         await self.repository.save(promoted)
         logger.info(
             "subnet_promoted_to_persistent",
-            subnet_id=subnet_id,
+            slug=slug,
             owner=owner,
         )
         return promoted
@@ -1108,7 +1108,7 @@ class SubnetService:
         if (
             row is None
             or row.kind != expected_kind
-            or (expected_subnet_id is not None and row.subnet_id != expected_subnet_id)
+            or (expected_subnet_id is not None and row.slug != expected_subnet_id)
         ):
             if expected_kind == "invitation":
                 raise InvitationNotFoundError(request_id)
@@ -1150,9 +1150,9 @@ class SubnetService:
     # ---- allowlist (no webhook — config, not lifecycle) --------------
 
     async def add_allowlist(
-        self, subnet_id: str, agent_id: str, *, added_by: str
+        self, slug: str, agent_id: str, *, added_by: str
     ) -> SubnetAllowlist:
-        """Pre-authorise ``agent_id`` for ``subnet_id``'s admission allowlist.
+        """Pre-authorise ``agent_id`` for ``slug``'s admission allowlist.
 
         Idempotency: ``IRepo.add`` returns ``False`` on a duplicate
         pair; we surface this as :class:`AllowlistEntryExistsError`
@@ -1166,7 +1166,7 @@ class SubnetService:
         configuration changes do not emit webhooks).
 
         Args:
-            subnet_id: Target subnet identifier (must exist).
+            slug: Target subnet identifier (must exist).
             agent_id: Agent to pre-authorise (route layer has already
                 verified the agent_id exists in the registry per ADR
                 §"SubnetAllowlist schema").
@@ -1177,27 +1177,27 @@ class SubnetService:
             SubnetNotFoundException: Target subnet missing.
             AllowlistEntryExistsError: Pair already on the allowlist.
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         repo = self._require_allowlist_repo()
         entry = SubnetAllowlist(
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             added_by=added_by,
             added_at=datetime.now(UTC),
         )
         inserted = await repo.add(entry)
         if not inserted:
-            raise AllowlistEntryExistsError(subnet_id, agent_id)
+            raise AllowlistEntryExistsError(slug, agent_id)
         logger.info(
             "subnet_allowlist_added",
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             added_by=added_by,
         )
         return entry
 
-    async def remove_allowlist(self, subnet_id: str, agent_id: str, *, remover: str) -> bool:
-        """Remove ``(subnet_id, agent_id)`` from the admission allowlist.
+    async def remove_allowlist(self, slug: str, agent_id: str, *, remover: str) -> bool:
+        """Remove ``(slug, agent_id)`` from the admission allowlist.
 
         Idempotent per ADR §"Allowlist endpoints" — removing an absent
         pair returns ``False`` (the route layer still returns 204).
@@ -1207,12 +1207,12 @@ class SubnetService:
         :meth:`add_allowlist`; no rows reference it (the removed row
         is, by definition, gone).
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         repo = self._require_allowlist_repo()
-        removed = await repo.remove(subnet_id, agent_id)
+        removed = await repo.remove(slug, agent_id)
         logger.info(
             "subnet_allowlist_removed",
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             remover=remover,
             existed=removed,
@@ -1221,7 +1221,7 @@ class SubnetService:
 
     async def list_allowlist(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         limit: int = 100,
         offset: int = 0,
@@ -1234,15 +1234,15 @@ class SubnetService:
         ``_require_owner`` enforces the policy; internal callers
         (e.g. the cascade pre-flight) read without restriction.
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         repo = self._require_allowlist_repo()
-        return await repo.list_for_subnet(subnet_id, limit=limit, offset=offset)
+        return await repo.list_for_subnet(slug, limit=limit, offset=offset)
 
     # ---- join_request lifecycle (owner approve / reject; applicant withdraw)
 
     async def approve_join_request(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         owner_id: str,
@@ -1264,11 +1264,11 @@ class SubnetService:
         the cascade-style UoW) requires PG-only deployments. Issue
         captured separately if it surfaces in production.
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1280,10 +1280,10 @@ class SubnetService:
             note=row.note,
         )
         # ``add_member`` returns the post-mutation Subnet entity so
-        # the webhook ``parent_subnet_id`` / ``harness_url`` snapshot
+        # the webhook ``parent_slug`` / ``harness_url`` snapshot
         # is consistent with the just-applied membership change. No
         # need for a second ``get_subnet`` round-trip.
-        subnet = await self.add_member(subnet_id, row.agent_id)
+        subnet = await self.add_member(slug, row.agent_id)
         await self.event_publisher.publish(
             JoinFlowEventType.JOIN_APPROVED,
             subnet=subnet,
@@ -1292,7 +1292,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_join_request_approved",
-            subnet_id=subnet_id,
+            slug=slug,
             request_id=request_id,
             agent_id=row.agent_id,
             owner_id=owner_id,
@@ -1302,7 +1302,7 @@ class SubnetService:
 
     async def reject_join_request(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         owner_id: str,
@@ -1317,11 +1317,11 @@ class SubnetService:
         # Single ``get_subnet`` covers the 404 pre-check AND the
         # webhook payload — reject doesn't mutate subnet membership,
         # so the entity snapshot stays valid for the event emit.
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1336,7 +1336,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_join_request_rejected",
-            subnet_id=subnet_id,
+            slug=slug,
             request_id=request_id,
             owner_id=owner_id,
         )
@@ -1344,7 +1344,7 @@ class SubnetService:
 
     async def withdraw_join_request(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         applicant_id: str,
@@ -1358,11 +1358,11 @@ class SubnetService:
         (DELETE /join-requests/{rid}) and emits ``JOIN_WITHDRAWN``.
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1380,7 +1380,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_join_request_withdrawn",
-            subnet_id=subnet_id,
+            slug=slug,
             request_id=request_id,
             applicant_id=applicant_id,
         )
@@ -1390,7 +1390,7 @@ class SubnetService:
 
     async def invite_agent(
         self,
-        subnet_id: str,
+        slug: str,
         target_agent_id: str,
         *,
         owner_id: str,
@@ -1422,12 +1422,12 @@ class SubnetService:
         The pending-join-request collision is the merge path above,
         NOT a 409 — that's the asymmetry ADR §"Merge path" pins.
         """
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         if target_agent_id in subnet.member_agent_ids:
-            raise AlreadyMemberError(subnet_id, target_agent_id)
+            raise AlreadyMemberError(slug, target_agent_id)
 
         repo = self._require_join_repo()
-        existing = await repo.find_pending_for(subnet_id, target_agent_id)
+        existing = await repo.find_pending_for(slug, target_agent_id)
         if existing is not None:
             if existing.kind == "invitation":
                 # Duplicate invitation — ADR §State machine edges
@@ -1437,20 +1437,20 @@ class SubnetService:
                 # Merge path — invite collapses into auto-approval
                 # of the agent's pending ask.
                 approved = await self.approve_join_request(
-                    subnet_id,
+                    slug,
                     existing.request_id,
                     owner_id=owner_id,
                     trigger="auto_on_invite",
                 )
                 logger.info(
                     "subnet_invitation_merged_into_join_request",
-                    subnet_id=subnet_id,
+                    slug=slug,
                     request_id=approved.request_id,
                     agent_id=target_agent_id,
                     owner_id=owner_id,
                 )
                 return InviteAgentMergedToApprovedJoinRequestResult(
-                    subnet_id=subnet_id,
+                    slug=slug,
                     agent_id=target_agent_id,
                     request=approved,
                 )
@@ -1458,13 +1458,13 @@ class SubnetService:
             # approved); reaching this branch means data corruption,
             # not a state-machine edge. Fail loud.
             raise RuntimeError(
-                f"pending row for ({subnet_id}, {target_agent_id}) has "
+                f"pending row for ({slug}, {target_agent_id}) has "
                 f"unexpected kind={existing.kind!r}"
             )
 
         invitation = SubnetJoinRequest(
             request_id=self._new_request_id(),
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=target_agent_id,
             kind="invitation",
             status="pending",
@@ -1479,20 +1479,20 @@ class SubnetService:
         )
         logger.info(
             "subnet_invitation_sent",
-            subnet_id=subnet_id,
+            slug=slug,
             invitation_id=invitation.request_id,
             target_agent_id=target_agent_id,
             owner_id=owner_id,
         )
         return InviteAgentSentResult(
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=target_agent_id,
             invitation=invitation,
         )
 
     async def accept_invitation(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         invitee_id: str,
@@ -1513,11 +1513,11 @@ class SubnetService:
         passing the right value here is what makes the
         ``"system:allowlist"`` token surface in the payload.
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)
@@ -1528,7 +1528,7 @@ class SubnetService:
         )
         # See ``approve_join_request`` for the same add_member →
         # webhook ordering reasoning.
-        subnet = await self.add_member(subnet_id, row.agent_id)
+        subnet = await self.add_member(slug, row.agent_id)
         await self.event_publisher.publish(
             JoinFlowEventType.INVITATION_ACCEPTED,
             subnet=subnet,
@@ -1538,7 +1538,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_invitation_accepted",
-            subnet_id=subnet_id,
+            slug=slug,
             invitation_id=request_id,
             invitee_id=invitee_id,
             trigger=trigger,
@@ -1548,7 +1548,7 @@ class SubnetService:
 
     async def reject_invitation(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         invitee_id: str,
@@ -1559,11 +1559,11 @@ class SubnetService:
         ``INVITATION_REJECTED`` fires; no membership change.
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)
@@ -1578,7 +1578,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_invitation_rejected",
-            subnet_id=subnet_id,
+            slug=slug,
             invitation_id=request_id,
             invitee_id=invitee_id,
         )
@@ -1586,7 +1586,7 @@ class SubnetService:
 
     async def cancel_invitation(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         owner_id: str,
@@ -1599,11 +1599,11 @@ class SubnetService:
         catalogue".
         """
         # See ``reject_join_request`` for the single-fetch reasoning.
-        subnet = await self.get_subnet(subnet_id)
+        subnet = await self.get_subnet(slug)
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=subnet_id,
+            expected_subnet_id=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)
@@ -1618,7 +1618,7 @@ class SubnetService:
         )
         logger.info(
             "subnet_invitation_canceled",
-            subnet_id=subnet_id,
+            slug=slug,
             invitation_id=request_id,
             owner_id=owner_id,
         )
@@ -1628,7 +1628,7 @@ class SubnetService:
 
     async def list_join_requests(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         kind: Literal["join_request", "allowlist_auto"] = "join_request",
         status: Literal["pending", "approved", "rejected", "withdrawn"] | None = None,
@@ -1643,25 +1643,25 @@ class SubnetService:
         rejects ``kind=invitation`` at the request-parse boundary
         with ``400 INVALID_KIND_FILTER``.
         """
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         repo = self._require_join_repo()
         return await repo.list_by_subnet(
-            subnet_id, kind=kind, status=status, limit=limit, offset=offset
+            slug, kind=kind, status=status, limit=limit, offset=offset
         )
 
     async def list_invitations(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         status: Literal["pending", "approved", "rejected", "withdrawn"] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[SubnetJoinRequest]:
         """List invitation rows for a subnet (owner-only at route layer)."""
-        await self.get_subnet(subnet_id)
+        await self.get_subnet(slug)
         repo = self._require_join_repo()
         return await repo.list_by_subnet(
-            subnet_id,
+            slug,
             kind="invitation",
             status=status,
             limit=limit,

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -1852,7 +1852,7 @@ class TaskService:
                 "reward": task.reward,
                 "reward_currency": task.reward_currency,
                 "participation_id": None,
-                "subnet_id": task.subnet_id,
+                "slug": task.subnet_id,
                 "joined_at": task.assigned_at.isoformat() if task.assigned_at else None,
                 "submitted_at": task.submitted_at.isoformat() if task.submitted_at else None,
                 "completed_at": task.completed_at.isoformat() if task.completed_at else None,
@@ -1888,7 +1888,7 @@ class TaskService:
                 "reward": task.reward,
                 "reward_currency": task.reward_currency,
                 "participation_id": p.participation_id,
-                "subnet_id": task.subnet_id,
+                "slug": task.subnet_id,
                 "joined_at": p.joined_at.isoformat() if p.joined_at else None,
                 "submitted_at": p.submitted_at.isoformat() if p.submitted_at else None,
                 "completed_at": p.completed_at.isoformat() if p.completed_at else None,
@@ -1969,12 +1969,12 @@ class TaskService:
                 continue
             try:
                 await self.subnet_service.delete_subnet(
-                    subnet.subnet_id, owner="system"
+                    subnet.slug, owner="system"
                 )
                 logger.info(
                     "task_scoped_subnet_dissolved",
                     task_id=task_id,
-                    subnet_id=subnet.subnet_id,
+                    subnet_id=subnet.slug,
                 )
             except SubnetNotFoundException:
                 # Concurrent dissolve already won — treat as success
@@ -1982,13 +1982,13 @@ class TaskService:
                 logger.debug(
                     "task_scoped_cascade_subnet_already_gone",
                     task_id=task_id,
-                    subnet_id=subnet.subnet_id,
+                    subnet_id=subnet.slug,
                 )
             except Exception as exc:  # noqa: BLE001 - best-effort cleanup
                 logger.warning(
                     "task_scoped_cascade_failed",
                     task_id=task_id,
-                    subnet_id=subnet.subnet_id,
+                    subnet_id=subnet.slug,
                     error=str(exc),
                 )
 
@@ -2016,7 +2016,7 @@ class TaskService:
             "reward": task.reward,
             "reward_currency": task.reward_currency,
             "max_participants": task.max_participants,
-            "subnet_id": task.subnet_id,
+            "slug": task.subnet_id,
         }
 
         try:
@@ -2067,7 +2067,7 @@ class TaskService:
         payload = {
             "status": task.status.value,
             "creator_id": task.creator_id,
-            "subnet_id": task.subnet_id,
+            "slug": task.subnet_id,
             "participation_id": participation.participation_id,
             "participant_id": participation.participant_id,
             "participant_name": participation.participant_name,

--- a/acn/services/webhook_join_flow_event_publisher.py
+++ b/acn/services/webhook_join_flow_event_publisher.py
@@ -36,7 +36,7 @@ Contracts pinned here:
 
 4. **Payload shape matches ADR §"Payload shape".** The ``data`` block
    is the canonical
-   ``{subnet_id, agent_id, request_id, parent_subnet_id, kind,
+   ``{subnet_id, agent_id, request_id, parent_slug, kind,
    initiated_by, decided_by, trigger, via}``
    dict. ``task_id`` on the wrapping :class:`WebhookPayload` is set to
    the ``subnet_id`` (Harnesses key on subnet, not on a payment task);
@@ -116,7 +116,7 @@ class WebhookJoinFlowEventPublisher(IJoinFlowEventPublisher):
             logger.debug(
                 "join_flow_webhook_skipped_no_harness",
                 join_flow_event=event.value,
-                subnet_id=subnet.subnet_id,
+                slug=subnet.slug,
                 request_id=request.request_id,
             )
             return
@@ -133,16 +133,16 @@ class WebhookJoinFlowEventPublisher(IJoinFlowEventPublisher):
             logger.error(
                 "join_flow_webhook_unmapped_event",
                 join_flow_event=event.value,
-                subnet_id=subnet.subnet_id,
+                slug=subnet.slug,
                 request_id=request.request_id,
             )
             return
 
         data = {
-            "subnet_id": subnet.subnet_id,
+            "slug": subnet.slug,
             "agent_id": request.agent_id,
             "request_id": request.request_id,
-            "parent_subnet_id": subnet.parent_subnet_id,
+            "parent_slug": subnet.parent_slug,
             "kind": request.kind,
             "initiated_by": request.initiated_by,
             "decided_by": request.decided_by,
@@ -157,16 +157,16 @@ class WebhookJoinFlowEventPublisher(IJoinFlowEventPublisher):
                 event=wire_event,
                 # ADR-0003 convention — task_id on the wrapping
                 # :class:`WebhookPayload` carries the subnet_id for
-                # non-payment events. Harnesses key on ``data.subnet_id``
+                # non-payment events. Harnesses key on ``data.slug``
                 # directly so this is a transport-only field.
-                task_id=subnet.subnet_id,
+                task_id=subnet.slug,
                 data=data,
             )
         except Exception as exc:  # noqa: BLE001 — see class docstring.
             logger.error(
                 "join_flow_webhook_delivery_failed",
                 join_flow_event=event.value,
-                subnet_id=subnet.subnet_id,
+                slug=subnet.slug,
                 request_id=request.request_id,
                 error=str(exc),
                 exc_info=True,

--- a/alembic/versions/a1b2c3d4e5f6_rename_subnet_id_to_slug.py
+++ b/alembic/versions/a1b2c3d4e5f6_rename_subnet_id_to_slug.py
@@ -1,0 +1,60 @@
+"""rename subnets.subnet_id → slug, parent_subnet_id → parent_slug
+
+Revision ID: a1b2c3d4e5f6
+Revises: 2b3c4d5e6f7a
+Create Date: 2026-05-23
+
+Renames the primary-key column of the ``subnets`` table from the
+legacy ``subnet_id`` (a slug/human-readable string) to ``slug``, and
+the nesting self-reference ``parent_subnet_id`` to ``parent_slug``.
+
+Cross-table references (tasks.subnet_id, subnet_join_requests.subnet_id,
+subnet_allowlist.subnet_id) store slug *values* but are named for the
+concept "which subnet does this row belong to" — those column names are
+kept as-is to avoid a broader disruptive migration; they will be revisited
+in a dedicated cross-table cleanup migration once all application code has
+been updated to use the entity attribute ``subnet_slug``.
+
+The partial index ``subnets_parent_idx`` is rebuilt to reference the
+renamed column.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "2b3c4d5e6f7a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename primary-key column subnet_id → slug.
+    # PostgreSQL renames the column and updates its primary-key
+    # constraint automatically; indexes referencing the column by
+    # position are also updated automatically, but named indexes that
+    # reference the column by name (partial indexes with text predicates)
+    # must be rebuilt manually.
+    op.alter_column("subnets", "subnet_id", new_column_name="slug")
+
+    # Rename the self-referencing nesting column.
+    op.alter_column("subnets", "parent_subnet_id", new_column_name="parent_slug")
+
+    # Rebuild the partial index that references the renamed column by name
+    # in its WHERE clause.  Drop the old one first (still references the
+    # old column name in its predicate text on some PG versions).
+    op.drop_index("subnets_parent_idx", table_name="subnets")
+    op.execute(
+        "CREATE INDEX subnets_parent_idx ON subnets (parent_slug) "
+        "WHERE parent_slug IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("subnets_parent_idx", table_name="subnets")
+    op.execute(
+        "CREATE INDEX subnets_parent_idx ON subnets (parent_subnet_id) "
+        "WHERE parent_subnet_id IS NOT NULL"
+    )
+    op.alter_column("subnets", "parent_slug", new_column_name="parent_subnet_id")
+    op.alter_column("subnets", "slug", new_column_name="subnet_id")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def sample_agent() -> Agent:
 def sample_subnet() -> Subnet:
     """Sample Subnet entity for testing"""
     return Subnet(
-        subnet_id="test-subnet-123",
+        slug="test-subnet-123",
         name="Test Subnet",
         owner="user-456",
         description="A test subnet",

--- a/tests/core/test_models_slug_backcompat.py
+++ b/tests/core/test_models_slug_backcompat.py
@@ -1,0 +1,139 @@
+"""Pydantic-layer back-compat tests for the ``subnet_id`` → ``slug`` rename.
+
+The Step 1 rename keeps support for legacy field names on inputs so
+existing SDK clients survive a rolling deploy. The repo test suite
+otherwise stubs out the request models with ``AsyncMock`` /
+``MagicMock``, which means a regression in these compatibility paths
+only surfaces in production. Pin them here against the real Pydantic
+classes so a future "clean up the alias" PR can't silently drop
+support without a failing test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acn.models import AgentRegisterRequest, SubnetCreateRequest
+
+
+class TestSubnetCreateRequestLegacyAliases:
+    """``SubnetCreateRequest`` must accept the pre-rename body fields
+    (``subnet_id``, ``parent_subnet_id``) on input. Without
+    ``AliasChoices``, Pydantic's default ``extra='ignore'`` config
+    silently drops the legacy fields and the route auto-generates a
+    different slug than the caller intended — a worse failure mode
+    than a 400 because clients don't notice the drift."""
+
+    def test_legacy_subnet_id_maps_to_slug(self):
+        req = SubnetCreateRequest(subnet_id="legacy-net", name="Legacy")  # type: ignore[call-arg]
+
+        assert req.slug == "legacy-net"
+
+    def test_legacy_parent_subnet_id_maps_to_parent_slug(self):
+        req = SubnetCreateRequest(
+            slug="child-net",
+            name="Child",
+            parent_subnet_id="parent-net",  # type: ignore[call-arg]
+        )
+
+        assert req.parent_slug == "parent-net"
+
+    def test_new_slug_field_takes_precedence_when_both_present(self):
+        # Pydantic resolves ``AliasChoices`` left-to-right: ``slug``
+        # wins over ``subnet_id`` when both are supplied. Pinned so a
+        # future alias re-ordering can't silently flip precedence.
+        req = SubnetCreateRequest(
+            slug="new",
+            subnet_id="old",  # type: ignore[call-arg]
+            name="Mixed",
+        )
+
+        assert req.slug == "new"
+
+
+class TestAgentRegisterRequestGetSubnetIds:
+    """``AgentRegisterRequest.get_subnet_ids()`` is the single helper
+    that resolves "which subnet(s) does this registration target?"
+    across the legacy single-id and the modern multi-id field. Bug
+    report: a previous batch rename of ``subnet_id`` → ``slug``
+    rewrote the helper to read ``self.slug``, which the request model
+    doesn't have — every legacy single-subnet registration would
+    500. Pin all three branches here so the helper survives future
+    refactors."""
+
+    def test_returns_subnet_ids_when_provided(self):
+        req = AgentRegisterRequest(
+            owner="owner-1",
+            name="alice",
+            a2a_endpoint="https://example.com",
+            subnet_ids=["foo", "bar"],
+        )
+
+        assert req.get_subnet_ids() == ["foo", "bar"]
+
+    def test_legacy_single_subnet_id_wraps_to_list(self):
+        req = AgentRegisterRequest(
+            owner="owner-1",
+            name="alice",
+            a2a_endpoint="https://example.com",
+            subnet_id="legacy-net",
+        )
+
+        # Critical regression: must not raise AttributeError; must
+        # return the legacy field value wrapped in a single-element
+        # list so downstream registry validation walks one entry.
+        assert req.get_subnet_ids() == ["legacy-net"]
+
+    def test_defaults_to_public_when_neither_field_provided(self):
+        req = AgentRegisterRequest(
+            owner="owner-1",
+            name="alice",
+            a2a_endpoint="https://example.com",
+        )
+
+        assert req.get_subnet_ids() == ["public"]
+
+
+class TestAgentServiceSearchAgentsKwargCompat:
+    """The route layer ``GET /api/v1/subnets/{slug}/agents`` calls
+    ``agent_service.search_agents(...)``. The kwarg name on the
+    service is still ``subnet_id`` (Step 2 of the rename will migrate
+    it together with ``Agent.subnet_ids``). Pin the signature so a
+    future patch can't accidentally re-introduce the
+    ``slug=slug`` call site that mock-based route tests fail to
+    catch."""
+
+    def test_search_agents_signature_uses_subnet_id_kwarg(self):
+        import inspect
+
+        from acn.services.agent_service import AgentService
+
+        sig = inspect.signature(AgentService.search_agents)
+        params = sig.parameters
+        assert "subnet_id" in params, (
+            "AgentService.search_agents must accept ``subnet_id=`` "
+            "until Step 2 migrates Agent.subnet_ids; routes/subnets.py "
+            "calls it with this kwarg."
+        )
+        # And it must NOT accept the new name yet — that would mask the
+        # very inconsistency this test pins. Step 2 migrates this; this
+        # assertion is expected to be updated alongside that migration.
+        assert "slug" not in params
+
+    @pytest.mark.asyncio
+    async def test_route_calls_with_subnet_id_kwarg(self):
+        # Real-call regression: mock the service with a strict spec so
+        # an unexpected kwarg raises (the loose ``AsyncMock(return_value=[])``
+        # used elsewhere swallows the error). Imports kept local because
+        # ``agent_service`` constructs are heavy to import.
+        from unittest.mock import AsyncMock
+
+        from acn.services.agent_service import AgentService
+
+        service = AsyncMock(spec=AgentService)
+        service.search_agents.return_value = []
+
+        # This is the call shape from routes/subnets.py::get_subnet_agents.
+        await service.search_agents(subnet_id="some-slug")
+
+        service.search_agents.assert_awaited_once_with(subnet_id="some-slug")

--- a/tests/core/test_subnet.py
+++ b/tests/core/test_subnet.py
@@ -7,7 +7,7 @@ the *service* layer (Phase 2) so they live in
 
 Coverage strategy
 -----------------
-- Existing pre-nesting invariants (subnet_id / name / owner non-empty,
+- Existing pre-nesting invariants (slug / name / owner non-empty,
   reserved-ID owner rule) are not repeated here — they're already
   covered by integration tests through the service / route layer.
   This file pins the *new* contracts introduced by ADR-0003.
@@ -29,25 +29,25 @@ class TestSubnetNestingDefaults:
     don't touch the new fields."""
 
     def test_defaults_to_top_level_persistent(self):
-        subnet = Subnet(subnet_id="subnet-a", name="A", owner="agent-1")
+        subnet = Subnet(slug="subnet-a", name="A", owner="agent-1")
 
-        assert subnet.parent_subnet_id is None
+        assert subnet.parent_slug is None
         assert subnet.lifecycle == "persistent"
         assert subnet.linked_task_id is None
 
     def test_to_dict_round_trips_new_fields(self):
         subnet = Subnet(
-            subnet_id="subnet-child",
+            slug="subnet-child",
             name="Child",
             owner="agent-1",
-            parent_subnet_id="subnet-parent",
+            parent_slug="subnet-parent",
             lifecycle="task_scoped",
             linked_task_id="task-xyz",
         )
 
         d = subnet.to_dict()
 
-        assert d["parent_subnet_id"] == "subnet-parent"
+        assert d["parent_slug"] == "subnet-parent"
         assert d["lifecycle"] == "task_scoped"
         assert d["linked_task_id"] == "task-xyz"
 
@@ -56,30 +56,30 @@ class TestSubnetNestingDefaults:
         lacks the three nesting keys entirely. ``from_dict`` must
         fall through to entity defaults rather than KeyError."""
         legacy_data = {
-            "subnet_id": "subnet-legacy",
+            "slug": "subnet-legacy",
             "name": "Legacy",
             "owner": "agent-1",
         }
 
         subnet = Subnet.from_dict(legacy_data)
 
-        assert subnet.parent_subnet_id is None
+        assert subnet.parent_slug is None
         assert subnet.lifecycle == "persistent"
         assert subnet.linked_task_id is None
 
     def test_from_dict_round_trips_new_fields(self):
         original = Subnet(
-            subnet_id="subnet-child",
+            slug="subnet-child",
             name="Child",
             owner="agent-1",
-            parent_subnet_id="subnet-parent",
+            parent_slug="subnet-parent",
             lifecycle="task_scoped",
             linked_task_id="task-xyz",
         )
 
         rebuilt = Subnet.from_dict(original.to_dict())
 
-        assert rebuilt.parent_subnet_id == "subnet-parent"
+        assert rebuilt.parent_slug == "subnet-parent"
         assert rebuilt.lifecycle == "task_scoped"
         assert rebuilt.linked_task_id == "task-xyz"
 
@@ -91,7 +91,7 @@ class TestLifecycleValueValidation:
 
     def test_persistent_is_accepted(self):
         Subnet(
-            subnet_id="subnet-a",
+            slug="subnet-a",
             name="A",
             owner="agent-1",
             lifecycle="persistent",
@@ -99,7 +99,7 @@ class TestLifecycleValueValidation:
 
     def test_task_scoped_is_accepted_with_linked_task(self):
         Subnet(
-            subnet_id="subnet-a",
+            slug="subnet-a",
             name="A",
             owner="agent-1",
             lifecycle="task_scoped",
@@ -109,7 +109,7 @@ class TestLifecycleValueValidation:
     def test_unknown_lifecycle_value_rejected(self):
         with pytest.raises(ValueError, match="lifecycle must be one of"):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 lifecycle="permanent",  # typo of "persistent"
@@ -120,7 +120,7 @@ class TestLifecycleValueValidation:
         # default — callers that want the default omit the kwarg.
         with pytest.raises(ValueError, match="lifecycle must be one of"):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 lifecycle="",
@@ -138,7 +138,7 @@ class TestTaskScopedLinkedTaskPairing:
             ValueError, match="task_scoped.*requires linked_task_id"
         ):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 lifecycle="task_scoped",
@@ -156,7 +156,7 @@ class TestTaskScopedLinkedTaskPairing:
             ValueError, match="persistent.*must not carry a linked_task_id"
         ):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 lifecycle="persistent",
@@ -169,26 +169,26 @@ class TestReservedSubnetNestingGuard:
     children — they're platform-owned with implicit "all agents"
     semantics that make the membership-subset invariant meaningless.
     The existing reserved-ID guard is extended to forbid
-    ``parent_subnet_id`` on reserved IDs."""
+    ``parent_slug`` on reserved IDs."""
 
     def test_reserved_subnet_cannot_have_parent(self):
         # ``public`` must be owned by ``system`` (existing rule);
         # adding a parent on top should still be rejected.
         with pytest.raises(
-            ValueError, match="Reserved subnet 'public' cannot have a parent_subnet_id"
+            ValueError, match="Reserved subnet 'public' cannot have a parent_slug"
         ):
             Subnet(
-                subnet_id="public",
+                slug="public",
                 name="Public",
                 owner="system",
-                parent_subnet_id="some-parent",
+                parent_slug="some-parent",
             )
 
     def test_reserved_subnet_can_still_be_constructed_with_defaults(self):
         # Sanity: the new guard doesn't break the legacy "system
         # constructs reserved subnets at bootstrap" path.
-        subnet = Subnet(subnet_id="public", name="Public", owner="system")
-        assert subnet.parent_subnet_id is None
+        subnet = Subnet(slug="public", name="Public", owner="system")
+        assert subnet.parent_slug is None
         assert subnet.lifecycle == "persistent"
 
     def test_reserved_subnet_cannot_be_task_scoped(self):
@@ -201,7 +201,7 @@ class TestReservedSubnetNestingGuard:
             ValueError, match="Reserved subnet 'public' cannot be task_scoped"
         ):
             Subnet(
-                subnet_id="public",
+                slug="public",
                 name="Public",
                 owner="system",
                 lifecycle="task_scoped",
@@ -211,7 +211,7 @@ class TestReservedSubnetNestingGuard:
             ValueError, match="Reserved subnet 'system' cannot be task_scoped"
         ):
             Subnet(
-                subnet_id="system",
+                slug="system",
                 name="System",
                 owner="system",
                 lifecycle="task_scoped",
@@ -222,7 +222,7 @@ class TestReservedSubnetNestingGuard:
 class TestSingleLayerCapNotEnforcedAtEntity:
     """ADR-0003 §A invariant 1 — single-layer cap — is intentionally
     a *service-layer* concern (it requires looking up the parent
-    to check its own ``parent_subnet_id``). The entity must accept
+    to check its own ``parent_slug``). The entity must accept
     a child pointing to any string ID without doing that lookup;
     Phase 2 tests in ``test_subnet_service_nesting.py`` pin the
     actual cap enforcement."""
@@ -231,9 +231,9 @@ class TestSingleLayerCapNotEnforcedAtEntity:
         # No parent existence check, no nesting depth check at the
         # entity layer. The entity is a passive data carrier here.
         subnet = Subnet(
-            subnet_id="subnet-grandchild",
+            slug="subnet-grandchild",
             name="GC",
             owner="agent-1",
-            parent_subnet_id="subnet-some-parent",
+            parent_slug="subnet-some-parent",
         )
-        assert subnet.parent_subnet_id == "subnet-some-parent"
+        assert subnet.parent_slug == "subnet-some-parent"

--- a/tests/core/test_subnet.py
+++ b/tests/core/test_subnet.py
@@ -237,3 +237,69 @@ class TestSingleLayerCapNotEnforcedAtEntity:
             parent_slug="subnet-some-parent",
         )
         assert subnet.parent_slug == "subnet-some-parent"
+
+
+class TestFromDictLegacyKeyTranslation:
+    """``Subnet.from_dict`` must accept dicts persisted before the
+    ``subnet_id`` → ``slug`` rename so Redis-cached rows survive a
+    rolling deploy without a backfill. Pinned here because mock-based
+    repository tests don't exercise the real entity translation
+    path — a regression here only surfaces on a real Redis deploy.
+    """
+
+    def test_translates_legacy_subnet_id_key_to_slug(self):
+        subnet = Subnet.from_dict(
+            {
+                "subnet_id": "legacy-net",
+                "name": "Legacy",
+                "owner": "alice",
+            }
+        )
+
+        assert subnet.slug == "legacy-net"
+
+    def test_translates_legacy_parent_subnet_id_to_parent_slug(self):
+        subnet = Subnet.from_dict(
+            {
+                "slug": "child-net",
+                "name": "Child",
+                "owner": "alice",
+                "parent_subnet_id": "parent-net",
+            }
+        )
+
+        assert subnet.parent_slug == "parent-net"
+
+    def test_translates_both_legacy_keys_in_one_dict(self):
+        # Realistic shape: a Redis HASH dumped before the rename
+        # carries both legacy keys; from_dict must hydrate cleanly.
+        subnet = Subnet.from_dict(
+            {
+                "subnet_id": "child-net",
+                "name": "Child",
+                "owner": "alice",
+                "parent_subnet_id": "parent-net",
+            }
+        )
+
+        assert subnet.slug == "child-net"
+        assert subnet.parent_slug == "parent-net"
+
+    def test_explicit_new_keys_take_precedence_over_legacy(self):
+        # Defensive: if both keys appear (mid-rollout migration glitch),
+        # the new ``slug`` / ``parent_slug`` win and the legacy values
+        # are discarded rather than triggering a "duplicate keyword
+        # argument" TypeError.
+        subnet = Subnet.from_dict(
+            {
+                "slug": "new-slug",
+                "subnet_id": "old-slug",
+                "parent_slug": "new-parent",
+                "parent_subnet_id": "old-parent",
+                "name": "Mixed",
+                "owner": "alice",
+            }
+        )
+
+        assert subnet.slug == "new-slug"
+        assert subnet.parent_slug == "new-parent"

--- a/tests/core/test_subnet_allowlist.py
+++ b/tests/core/test_subnet_allowlist.py
@@ -24,11 +24,11 @@ def _now() -> datetime:
 class TestIdentityInvariants:
     @pytest.mark.parametrize(
         "field_name",
-        ["subnet_id", "agent_id", "added_by"],
+        ["slug", "agent_id", "added_by"],
     )
     def test_empty_identity_field_raises(self, field_name: str) -> None:
         kwargs: dict = {
-            "subnet_id": "s1",
+            "slug": "s1",
             "agent_id": "a1",
             "added_by": "owner-1",
         }
@@ -38,11 +38,11 @@ class TestIdentityInvariants:
 
     def test_canonical_construction_accepted(self) -> None:
         entry = SubnetAllowlist(
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             added_by="owner-1",
         )
-        assert entry.subnet_id == "s1"
+        assert entry.slug == "s1"
         assert entry.agent_id == "a1"
         assert entry.added_by == "owner-1"
         assert entry.added_at.tzinfo is not None  # default UTC-aware
@@ -52,7 +52,7 @@ class TestSerializationRoundTrip:
     def test_round_trip_preserves_all_fields(self) -> None:
         added_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
         original = SubnetAllowlist(
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             added_by="owner-1",
             added_at=added_at,
@@ -69,7 +69,7 @@ class TestSerializationRoundTrip:
         with pytest.raises(KeyError):
             SubnetAllowlist.from_dict(
                 {
-                    "subnet_id": "s1",
+                    "slug": "s1",
                     "agent_id": "a1",
                     # no added_by
                     "added_at": _now().isoformat(),

--- a/tests/core/test_subnet_join_policy.py
+++ b/tests/core/test_subnet_join_policy.py
@@ -31,14 +31,14 @@ class TestJoinPolicyDefault:
     matching pre-ADR-0004 behaviour for public subnets."""
 
     def test_default_is_open(self):
-        subnet = Subnet(subnet_id="subnet-a", name="A", owner="agent-1")
+        subnet = Subnet(slug="subnet-a", name="A", owner="agent-1")
         assert subnet.join_policy == "open"
 
     def test_public_subnet_with_explicit_open_accepted(self):
         # ``is_private=False`` (default) + ``join_policy="open"`` is the
         # status quo for public, freely-joinable subnets.
         subnet = Subnet(
-            subnet_id="subnet-public",
+            slug="subnet-public",
             name="Public",
             owner="agent-1",
             is_private=False,
@@ -51,7 +51,7 @@ class TestJoinPolicyDefault:
         # Public + approval is one of the three legal combinations
         # introduced by ADR-0004 (public board with curated entry).
         subnet = Subnet(
-            subnet_id="subnet-public-approval",
+            slug="subnet-public-approval",
             name="Public-Approval",
             owner="agent-1",
             is_private=False,
@@ -69,7 +69,7 @@ class TestJoinPolicyValueValidation:
     def test_unknown_value_rejected(self):
         with pytest.raises(ValueError, match="join_policy must be one of"):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 join_policy="moderated",  # not in the legal set
@@ -80,7 +80,7 @@ class TestJoinPolicyValueValidation:
         # default — callers that want the default omit the kwarg.
         with pytest.raises(ValueError, match="join_policy must be one of"):
             Subnet(
-                subnet_id="subnet-a",
+                slug="subnet-a",
                 name="A",
                 owner="agent-1",
                 join_policy="",
@@ -99,7 +99,7 @@ class TestVisibilityPolicyConflict:
             ValueError, match="visibility_policy_conflict"
         ):
             Subnet(
-                subnet_id="subnet-priv",
+                slug="subnet-priv",
                 name="Priv",
                 owner="agent-1",
                 is_private=True,
@@ -115,7 +115,7 @@ class TestVisibilityPolicyConflict:
             ValueError, match="visibility_policy_conflict"
         ):
             Subnet(
-                subnet_id="subnet-priv",
+                slug="subnet-priv",
                 name="Priv",
                 owner="agent-1",
                 is_private=True,
@@ -123,7 +123,7 @@ class TestVisibilityPolicyConflict:
 
     def test_private_plus_approval_accepted(self):
         subnet = Subnet(
-            subnet_id="subnet-priv",
+            slug="subnet-priv",
             name="Priv",
             owner="agent-1",
             is_private=True,
@@ -138,7 +138,7 @@ class TestJoinPolicyDictRoundTrip:
 
     def test_to_dict_includes_join_policy(self):
         subnet = Subnet(
-            subnet_id="subnet-a",
+            slug="subnet-a",
             name="A",
             owner="agent-1",
             is_private=True,
@@ -149,7 +149,7 @@ class TestJoinPolicyDictRoundTrip:
 
     def test_from_dict_round_trips_join_policy(self):
         original = Subnet(
-            subnet_id="subnet-a",
+            slug="subnet-a",
             name="A",
             owner="agent-1",
             is_private=True,
@@ -165,7 +165,7 @@ class TestJoinPolicyDictRoundTrip:
         on these — they were always joinable, the field just records
         that fact explicitly going forward."""
         legacy_public = {
-            "subnet_id": "subnet-legacy-public",
+            "slug": "subnet-legacy-public",
             "name": "Legacy",
             "owner": "agent-1",
             "is_private": False,
@@ -185,7 +185,7 @@ class TestFromDictLegacyAutoUpgrade:
     def test_legacy_private_row_auto_upgrades_to_approval(self):
         # Row predates ADR-0004 — no ``join_policy`` key at all.
         legacy_private = {
-            "subnet_id": "subnet-legacy-priv",
+            "slug": "subnet-legacy-priv",
             "name": "LegacyPriv",
             "owner": "agent-1",
             "is_private": True,
@@ -201,7 +201,7 @@ class TestFromDictLegacyAutoUpgrade:
         # invariant rejects it. The auto-upgrade only kicks in when
         # the field is **absent**, never when it is present-but-wrong.
         explicit_conflict = {
-            "subnet_id": "subnet-conflict",
+            "slug": "subnet-conflict",
             "name": "Conflict",
             "owner": "agent-1",
             "is_private": True,

--- a/tests/core/test_subnet_join_request.py
+++ b/tests/core/test_subnet_join_request.py
@@ -39,12 +39,12 @@ def _now() -> datetime:
 class TestIdentityFieldInvariants:
     @pytest.mark.parametrize(
         "field_name",
-        ["request_id", "subnet_id", "agent_id", "initiated_by"],
+        ["request_id", "slug", "agent_id", "initiated_by"],
     )
     def test_empty_identity_field_raises(self, field_name: str) -> None:
         kwargs: dict = {
             "request_id": "r1",
-            "subnet_id": "s1",
+            "slug": "s1",
             "agent_id": "a1",
             "kind": "join_request",
             "status": "pending",
@@ -65,7 +65,7 @@ class TestKindAndStatusMembership:
         with pytest.raises(ValueError, match="kind must be one of"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="unknown_kind",  # type: ignore[arg-type]
                 status="pending",
@@ -76,7 +76,7 @@ class TestKindAndStatusMembership:
         with pytest.raises(ValueError, match="status must be one of"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status="banana",  # type: ignore[arg-type]
@@ -99,7 +99,7 @@ class TestDecisionCoherence:
         with pytest.raises(ValueError, match="pending rows must have"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status="pending",
@@ -111,7 +111,7 @@ class TestDecisionCoherence:
         with pytest.raises(ValueError, match="pending rows must have"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status="pending",
@@ -126,7 +126,7 @@ class TestDecisionCoherence:
         ):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status="approved",
@@ -139,7 +139,7 @@ class TestDecisionCoherence:
         with pytest.raises(ValueError, match=f"status={status!r} requires both"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status=status,  # type: ignore[arg-type]
@@ -150,7 +150,7 @@ class TestDecisionCoherence:
     def test_pending_with_no_decision_fields_accepted(self) -> None:
         r = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="join_request",
             status="pending",
@@ -164,7 +164,7 @@ class TestDecisionCoherence:
     def test_approved_with_decision_fields_accepted(self) -> None:
         r = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="join_request",
             status="approved",
@@ -195,7 +195,7 @@ class TestAllowlistAutoShape:
         ):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="allowlist_auto",
                 status="pending",
@@ -208,7 +208,7 @@ class TestAllowlistAutoShape:
         ):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="allowlist_auto",
                 status="approved",
@@ -223,7 +223,7 @@ class TestAllowlistAutoShape:
         ):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="allowlist_auto",
                 status="approved",
@@ -235,7 +235,7 @@ class TestAllowlistAutoShape:
     def test_canonical_allowlist_auto_accepted(self) -> None:
         r = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="allowlist_auto",
             status="approved",
@@ -258,7 +258,7 @@ class TestNoteLengthCap:
     def test_note_at_limit_accepted(self) -> None:
         r = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="join_request",
             status="rejected",
@@ -274,7 +274,7 @@ class TestNoteLengthCap:
         with pytest.raises(ValueError, match="note exceeds 500-char limit"):
             SubnetJoinRequest(
                 request_id="r1",
-                subnet_id="s1",
+                slug="s1",
                 agent_id="a1",
                 kind="join_request",
                 status="rejected",
@@ -301,7 +301,7 @@ class TestSerializationRoundTrip:
     def test_pending_round_trip_preserves_none_decision_fields(self) -> None:
         original = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="join_request",
             status="pending",
@@ -317,7 +317,7 @@ class TestSerializationRoundTrip:
         decided_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
         original = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="invitation",
             status="approved",
@@ -332,7 +332,7 @@ class TestSerializationRoundTrip:
     def test_allowlist_auto_round_trip(self) -> None:
         original = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="allowlist_auto",
             status="approved",
@@ -351,7 +351,7 @@ class TestSerializationRoundTrip:
         for pending rows, breaking every existing parser."""
         r = SubnetJoinRequest(
             request_id="r1",
-            subnet_id="s1",
+            slug="s1",
             agent_id="a1",
             kind="join_request",
             status="pending",

--- a/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
@@ -11,7 +11,7 @@ What we check
 -------------
 - Revision chain points at the Phase 1 head (``f7b9c2d4e8a1``).
 - ``upgrade()`` creates both tables and all four indexes.
-- The unique partial index on ``(subnet_id, agent_id) WHERE
+- The unique partial index on ``(slug, agent_id) WHERE
   status='pending'`` is present (THE invariant of the table; a
   missing one silently re-opens the two-pending race).
 - ``downgrade()`` drops indexes before their tables (good DDL
@@ -92,12 +92,12 @@ class TestUpgrade:
             if c.args[0] == "subnet_join_requests_pending_unique"
         ]
         assert len(pending_unique_calls) == 1, (
-            "missing the (subnet_id, agent_id) WHERE status='pending' "
+            "missing the (slug, agent_id) WHERE status='pending' "
             "unique partial index"
         )
         call_args = pending_unique_calls[0]
         assert call_args.args[1] == "subnet_join_requests"
-        assert call_args.args[2] == ["subnet_id", "agent_id"]
+        assert call_args.args[2] == ["slug", "agent_id"]
         assert call_args.kwargs.get("unique") is True
         # The ``postgresql_where`` clause is the partial-index predicate;
         # SQLAlchemy ``TextClause`` doesn't compare equal cross-instance,

--- a/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_join_request_allowlist_migration.py
@@ -11,9 +11,14 @@ What we check
 -------------
 - Revision chain points at the Phase 1 head (``f7b9c2d4e8a1``).
 - ``upgrade()`` creates both tables and all four indexes.
-- The unique partial index on ``(slug, agent_id) WHERE
+- The unique partial index on ``(subnet_id, agent_id) WHERE
   status='pending'`` is present (THE invariant of the table; a
   missing one silently re-opens the two-pending race).
+  Note: the DB column is still named ``subnet_id`` post-Step-1
+  rename — the Python ORM attribute on
+  ``SubnetJoinRequestModel`` is ``slug`` but maps to the legacy
+  column name; Step 2 of the rename migration will move the
+  column itself.
 - ``downgrade()`` drops indexes before their tables (good DDL
   hygiene; also pins the symmetric reverse-order contract).
 """
@@ -92,12 +97,16 @@ class TestUpgrade:
             if c.args[0] == "subnet_join_requests_pending_unique"
         ]
         assert len(pending_unique_calls) == 1, (
-            "missing the (slug, agent_id) WHERE status='pending' "
+            "missing the (subnet_id, agent_id) WHERE status='pending' "
             "unique partial index"
         )
         call_args = pending_unique_calls[0]
         assert call_args.args[1] == "subnet_join_requests"
-        assert call_args.args[2] == ["slug", "agent_id"]
+        # ``subnet_id`` (not ``slug``) — the DB column keeps its
+        # legacy name through Step 1; only the ORM attribute is
+        # renamed. Step 2 will rename the column too and this
+        # assertion should be updated alongside that migration.
+        assert call_args.args[2] == ["subnet_id", "agent_id"]
         assert call_args.kwargs.get("unique") is True
         # The ``postgresql_where`` clause is the partial-index predicate;
         # SQLAlchemy ``TextClause`` doesn't compare equal cross-instance,

--- a/tests/infrastructure/test_alembic_subnet_nesting_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_nesting_migration.py
@@ -13,9 +13,9 @@ What we check
 - ``upgrade()`` adds the three columns *and* both partial indexes.
 - ``downgrade()`` removes them in reverse order — indexes first
   (PostgreSQL refuses to drop a column an index still references)
-  and ``parent_subnet_id`` last (mirrors the ``upgrade`` order).
+  and ``parent_slug`` last (mirrors the ``upgrade`` order).
 - The partial-index ``postgresql_where`` clauses target the right
-  column (``parent_subnet_id IS NOT NULL`` /
+  column (``parent_slug IS NOT NULL`` /
   ``linked_task_id IS NOT NULL``).
 """
 
@@ -73,7 +73,7 @@ def test_upgrade_adds_three_columns_and_two_indexes(migration_module):
         call.args[1].name for call in column_calls
     ]
     assert column_names == [
-        "parent_subnet_id",
+        "parent_slug",
         "lifecycle",
         "linked_task_id",
     ], f"unexpected upgrade() column order: {column_names!r}"
@@ -123,7 +123,7 @@ def test_upgrade_indexes_use_partial_where_on_correct_columns(migration_module):
         if c.args[0] == "subnets_parent_idx"
     )
     where_clause = parent_idx_call.kwargs["postgresql_where"]
-    assert "parent_subnet_id IS NOT NULL" in str(where_clause), (
+    assert "parent_slug IS NOT NULL" in str(where_clause), (
         f"subnets_parent_idx WHERE clause wrong: {where_clause}"
     )
 
@@ -183,5 +183,5 @@ def test_downgrade_drops_columns_in_reverse_of_upgrade(migration_module):
     assert column_names == [
         "linked_task_id",
         "lifecycle",
-        "parent_subnet_id",
+        "parent_slug",
     ], f"unexpected downgrade() column order: {column_names!r}"

--- a/tests/infrastructure/test_alembic_subnet_nesting_migration.py
+++ b/tests/infrastructure/test_alembic_subnet_nesting_migration.py
@@ -13,10 +13,16 @@ What we check
 - ``upgrade()`` adds the three columns *and* both partial indexes.
 - ``downgrade()`` removes them in reverse order — indexes first
   (PostgreSQL refuses to drop a column an index still references)
-  and ``parent_slug`` last (mirrors the ``upgrade`` order).
+  and ``parent_subnet_id`` last (mirrors the ``upgrade`` order).
 - The partial-index ``postgresql_where`` clauses target the right
-  column (``parent_slug IS NOT NULL`` /
+  column (``parent_subnet_id IS NOT NULL`` /
   ``linked_task_id IS NOT NULL``).
+
+Naming note: this migration runs *before* the Step 1 rename
+(``a1b2c3d4e5f6_rename_subnet_id_to_slug``), so the column added
+here is the original ``parent_subnet_id``. The rename migration
+later renames it to ``parent_slug``; tests for *that* migration
+assert the new name. Don't conflate the two.
 """
 
 import importlib.util
@@ -73,7 +79,8 @@ def test_upgrade_adds_three_columns_and_two_indexes(migration_module):
         call.args[1].name for call in column_calls
     ]
     assert column_names == [
-        "parent_slug",
+        # Pre-rename column name — see file-header naming note.
+        "parent_subnet_id",
         "lifecycle",
         "linked_task_id",
     ], f"unexpected upgrade() column order: {column_names!r}"
@@ -123,7 +130,8 @@ def test_upgrade_indexes_use_partial_where_on_correct_columns(migration_module):
         if c.args[0] == "subnets_parent_idx"
     )
     where_clause = parent_idx_call.kwargs["postgresql_where"]
-    assert "parent_slug IS NOT NULL" in str(where_clause), (
+    # Pre-rename column name — see file-header naming note.
+    assert "parent_subnet_id IS NOT NULL" in str(where_clause), (
         f"subnets_parent_idx WHERE clause wrong: {where_clause}"
     )
 
@@ -183,5 +191,6 @@ def test_downgrade_drops_columns_in_reverse_of_upgrade(migration_module):
     assert column_names == [
         "linked_task_id",
         "lifecycle",
-        "parent_slug",
+        # Pre-rename column name — see file-header naming note.
+        "parent_subnet_id",
     ], f"unexpected downgrade() column order: {column_names!r}"

--- a/tests/infrastructure/test_broadcast_service_unified_entry.py
+++ b/tests/infrastructure/test_broadcast_service_unified_entry.py
@@ -3,7 +3,7 @@
 Phase 2 Group C #9 / review v2 P1 #7 added a high-level ``broadcast()``
 method on top of the existing ``send`` / ``send_by_tag`` API so the HTTP
 routes can hit one entry-point that handles sender existence checks,
-selector-based target resolution (``target_agents`` / ``subnet_id`` /
+selector-based target resolution (``target_agents`` / ``slug`` /
 ``tags`` / all-agents fallback), and sender auto-filter — all the
 business logic that used to live in ``MessageService.broadcast_message``.
 
@@ -216,13 +216,13 @@ class TestSenderExistence:
 
 
 # --------------------------------------------------------------------------- #
-# 3. Selector precedence — target_agents > subnet_id > tags > all
+# 3. Selector precedence — target_agents > slug > tags > all
 # --------------------------------------------------------------------------- #
 
 
 class TestSelectorPrecedence:
     """The unified entry has four target-resolution paths. Precedence
-    is documented in the docstring as ``target_agents > subnet_id >
+    is documented in the docstring as ``target_agents > slug >
     tags > all``. These tests pin that contract: when multiple
     selectors are passed, only the highest-priority one drives
     resolution, and the lower-priority repository methods are NOT
@@ -242,7 +242,7 @@ class TestSelectorPrecedence:
             from_agent="agent-sender",
             message=_make_message(),
             target_agents=["agent-a", "agent-b"],
-            subnet_id="ignored-subnet",
+            slug="ignored-subnet",
             tags=["ignored-tag"],
         )
 
@@ -266,7 +266,7 @@ class TestSelectorPrecedence:
         result = await svc.broadcast(
             from_agent="agent-sender",
             message=_make_message(),
-            subnet_id="subnet-1",
+            slug="subnet-1",
             tags=["frontend"],
         )
 
@@ -347,7 +347,7 @@ class TestSenderAutoFilter:
         result = await svc.broadcast(
             from_agent="agent-self",
             message=_make_message(),
-            subnet_id="subnet-x",
+            slug="subnet-x",
         )
 
         assert set(result.results.keys()) == {"agent-other"}

--- a/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_allowlist_repository.py
@@ -36,7 +36,7 @@ def _make_session_factory():
 
 def _make_entry(**overrides) -> SubnetAllowlist:
     defaults: dict = {
-        "subnet_id": "s-1",
+        "slug": "s-1",
         "agent_id": "a-1",
         "added_by": "owner-1",
     }
@@ -54,13 +54,13 @@ def test_model_to_entity_round_trip():
     repo = PostgresSubnetAllowlistRepository(session_factory=factory)
     ts = datetime.now(UTC)
     model = SubnetAllowlistModel(
-        subnet_id="s-1",
+        slug="s-1",
         agent_id="a-1",
         added_by="owner-1",
         added_at=ts,
     )
     entity = repo._model_to_entity(model)
-    assert entity.subnet_id == "s-1"
+    assert entity.slug == "s-1"
     assert entity.agent_id == "a-1"
     assert entity.added_by == "owner-1"
     assert entity.added_at == ts
@@ -74,7 +74,7 @@ def test_model_to_entity_round_trip():
 class TestAddIdempotency:
     @pytest.mark.asyncio
     async def test_new_insert_returns_true(self):
-        """``RETURNING subnet_id`` produces a row → new insert."""
+        """``RETURNING slug`` produces a row → new insert."""
         factory, session = _make_session_factory()
         execute_result = MagicMock()
         # ``.first()`` returns a non-None row when ON CONFLICT didn't fire.

--- a/tests/infrastructure/test_postgres_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_postgres_subnet_join_request_repository.py
@@ -57,7 +57,7 @@ def _make_session_factory():
 def _make_request(**overrides) -> SubnetJoinRequest:
     defaults: dict = {
         "request_id": "req-1",
-        "subnet_id": "s-1",
+        "slug": "s-1",
         "agent_id": "a-1",
         "kind": "join_request",
         "status": "pending",
@@ -73,7 +73,7 @@ def _make_model(**overrides) -> SubnetJoinRequestModel:
     paths have to pass every NOT NULL column explicitly."""
     defaults: dict = {
         "request_id": "req-1",
-        "subnet_id": "s-1",
+        "slug": "s-1",
         "agent_id": "a-1",
         "kind": "join_request",
         "status": "pending",
@@ -158,7 +158,7 @@ class TestMapper:
 class TestPendingCollisionTranslation:
     """THE defence: the partial-index violation must surface as
     ``SubnetJoinRequestPendingError`` with the colliding
-    ``(subnet_id, agent_id)``, NOT as a raw sqlalchemy
+    ``(slug, agent_id)``, NOT as a raw sqlalchemy
     ``IntegrityError``. The service layer matches on the domain
     exception to surface ``409`` with the stable reason token; if a
     future refactor swallows the translation, every duplicate
@@ -182,8 +182,8 @@ class TestPendingCollisionTranslation:
 
         repo = PostgresSubnetJoinRequestRepository(session_factory=factory)
         with pytest.raises(SubnetJoinRequestPendingError) as exc_info:
-            await repo.save(_make_request(subnet_id="s-x", agent_id="a-x"))
-        assert exc_info.value.subnet_id == "s-x"
+            await repo.save(_make_request(slug="s-x", agent_id="a-x"))
+        assert exc_info.value.slug == "s-x"
         assert exc_info.value.agent_id == "a-x"
         # Rollback must have been called before the translated raise
         # — otherwise the failed transaction stays open and the next
@@ -201,7 +201,7 @@ class TestPendingCollisionTranslation:
         session.get = AsyncMock(return_value=None)
         orig = MagicMock()
         orig.__str__ = lambda self: (
-            'null value in column "subnet_id" violates not-null constraint'
+            'null value in column "slug" violates not-null constraint'
         )
         session.commit = AsyncMock(
             side_effect=IntegrityError("INSERT ...", {}, orig)

--- a/tests/infrastructure/test_postgres_subnet_repository_join_policy.py
+++ b/tests/infrastructure/test_postgres_subnet_repository_join_policy.py
@@ -52,7 +52,7 @@ def _make_model(**overrides) -> SubnetModel:
     have to pass every NOT NULL column explicitly — same idiom
     ``test_postgres_subnet_repository_nesting.py`` uses)."""
     defaults: dict = {
-        "subnet_id": "subnet-x",
+        "slug": "subnet-x",
         "name": "x",
         "owner": "agent-owner",
         "description": None,
@@ -62,7 +62,7 @@ def _make_model(**overrides) -> SubnetModel:
         "subnet_metadata": None,
         "harness_url": None,
         "harness_secret": None,
-        "parent_subnet_id": None,
+        "parent_slug": None,
         "lifecycle": "persistent",
         "linked_task_id": None,
         "join_policy": "open",
@@ -81,7 +81,7 @@ def test_subnet_to_model_carries_join_policy():
     factory, _ = _make_session_factory()
     repo = PostgresSubnetRepository(session_factory=factory)
     subnet = Subnet(
-        subnet_id="subnet-x",
+        slug="subnet-x",
         name="x",
         owner="agent-owner",
         is_private=True,
@@ -97,7 +97,7 @@ def test_subnet_to_model_carries_open_for_public_default():
     factory, _ = _make_session_factory()
     repo = PostgresSubnetRepository(session_factory=factory)
     subnet = Subnet(
-        subnet_id="subnet-pub",
+        slug="subnet-pub",
         name="pub",
         owner="agent-owner",
     )
@@ -141,7 +141,7 @@ class TestModelToSubnetNullJoinPolicyAutoUpgrade:
         factory, _ = _make_session_factory()
         repo = PostgresSubnetRepository(session_factory=factory)
         model = _make_model(
-            subnet_id="subnet-broken-pub",
+            slug="subnet-broken-pub",
             is_private=False,
             join_policy=None,  # the pathological case
         )
@@ -162,7 +162,7 @@ class TestModelToSubnetNullJoinPolicyAutoUpgrade:
         factory, _ = _make_session_factory()
         repo = PostgresSubnetRepository(session_factory=factory)
         model = _make_model(
-            subnet_id="subnet-broken-priv",
+            slug="subnet-broken-priv",
             is_private=True,
             join_policy=None,
         )
@@ -191,7 +191,7 @@ async def test_save_update_path_includes_join_policy():
 
     repo = PostgresSubnetRepository(session_factory=factory)
     subnet = Subnet(
-        subnet_id="subnet-existing",
+        slug="subnet-existing",
         name="x",
         owner="agent-owner",
         is_private=True,

--- a/tests/infrastructure/test_postgres_subnet_repository_nesting.py
+++ b/tests/infrastructure/test_postgres_subnet_repository_nesting.py
@@ -57,17 +57,17 @@ def test_subnet_to_model_carries_nesting_fields():
     factory, _ = _make_session_factory()
     repo = PostgresSubnetRepository(session_factory=factory)
     subnet = Subnet(
-        subnet_id="subnet-child",
+        slug="subnet-child",
         name="child",
         owner="agent-owner",
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
         lifecycle="task_scoped",
         linked_task_id="task-xyz",
     )
 
     model = repo._subnet_to_model(subnet)
 
-    assert model.parent_subnet_id == "subnet-parent"
+    assert model.parent_slug == "subnet-parent"
     assert model.lifecycle == "task_scoped"
     assert model.linked_task_id == "task-xyz"
 
@@ -76,7 +76,7 @@ def test_model_to_subnet_carries_nesting_fields():
     factory, _ = _make_session_factory()
     repo = PostgresSubnetRepository(session_factory=factory)
     model = SubnetModel(
-        subnet_id="subnet-child",
+        slug="subnet-child",
         name="child",
         owner="agent-owner",
         description=None,
@@ -86,7 +86,7 @@ def test_model_to_subnet_carries_nesting_fields():
         subnet_metadata=None,
         harness_url=None,
         harness_secret=None,
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
         lifecycle="task_scoped",
         linked_task_id="task-xyz",
         created_at=datetime.now(UTC),
@@ -94,20 +94,20 @@ def test_model_to_subnet_carries_nesting_fields():
 
     subnet = repo._model_to_subnet(model)
 
-    assert subnet.parent_subnet_id == "subnet-parent"
+    assert subnet.parent_slug == "subnet-parent"
     assert subnet.lifecycle == "task_scoped"
     assert subnet.linked_task_id == "task-xyz"
 
 
 def test_model_to_subnet_defaults_for_legacy_row():
     """Existing rows pre-ADR-0003 carry the new columns as their DB
-    defaults (``parent_subnet_id=NULL``, ``lifecycle='persistent'``,
+    defaults (``parent_slug=NULL``, ``lifecycle='persistent'``,
     ``linked_task_id=NULL``) — the mapper must surface them as
     "top-level persistent" semantics, not raise on missing fields."""
     factory, _ = _make_session_factory()
     repo = PostgresSubnetRepository(session_factory=factory)
     model = SubnetModel(
-        subnet_id="subnet-legacy",
+        slug="subnet-legacy",
         name="legacy",
         owner="agent-owner",
         description=None,
@@ -117,7 +117,7 @@ def test_model_to_subnet_defaults_for_legacy_row():
         subnet_metadata=None,
         harness_url=None,
         harness_secret=None,
-        parent_subnet_id=None,
+        parent_slug=None,
         lifecycle="persistent",
         linked_task_id=None,
         created_at=datetime.now(UTC),
@@ -125,7 +125,7 @@ def test_model_to_subnet_defaults_for_legacy_row():
 
     subnet = repo._model_to_subnet(model)
 
-    assert subnet.parent_subnet_id is None
+    assert subnet.parent_slug is None
     assert subnet.lifecycle == "persistent"
     assert subnet.linked_task_id is None
 
@@ -155,10 +155,10 @@ async def test_save_update_path_includes_nesting_columns():
     repo = PostgresSubnetRepository(session_factory=factory)
 
     subnet = Subnet(
-        subnet_id="subnet-rt",
+        slug="subnet-rt",
         name="rt",
         owner="agent-owner",
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
         lifecycle="task_scoped",
         linked_task_id="task-xyz",
     )
@@ -170,7 +170,7 @@ async def test_save_update_path_includes_nesting_columns():
     assert isinstance(stmt, Update)
     # ``Update`` stores SET targets in ``_values`` (Column → BindParameter)
     set_columns = {col.name for col in stmt._values.keys()}  # type: ignore[attr-defined]
-    assert "parent_subnet_id" in set_columns
+    assert "parent_slug" in set_columns
     assert "lifecycle" in set_columns
     assert "linked_task_id" in set_columns
 
@@ -213,8 +213,8 @@ async def test_find_by_parent_filters_on_parent_subnet_id_column():
     session.execute.assert_awaited_once()
     stmt = session.execute.await_args_list[0].args[0]
     assert isinstance(stmt, Select)
-    assert "parent_subnet_id" in _stmt_column_names(stmt), (
-        f"WHERE clause did not target parent_subnet_id; got {_stmt_column_names(stmt)!r}"
+    assert "parent_slug" in _stmt_column_names(stmt), (
+        f"WHERE clause did not target parent_slug; got {_stmt_column_names(stmt)!r}"
     )
 
 

--- a/tests/infrastructure/test_redis_subnet_allowlist_repository.py
+++ b/tests/infrastructure/test_redis_subnet_allowlist_repository.py
@@ -46,7 +46,7 @@ async def fake_redis():
 
 def _entry(**overrides) -> SubnetAllowlist:
     defaults: dict = {
-        "subnet_id": "s-1",
+        "slug": "s-1",
         "agent_id": "a-1",
         "added_by": "owner-1",
     }
@@ -74,7 +74,7 @@ class TestAddIdempotency:
     @pytest.mark.asyncio
     async def test_add_writes_set_and_meta_hash(self, fake_redis):
         repo = RedisSubnetAllowlistRepository(fake_redis)
-        await repo.add(_entry(subnet_id="s-x", agent_id="a-x"))
+        await repo.add(_entry(slug="s-x", agent_id="a-x"))
         # SET membership
         assert await fake_redis.sismember(_allowlist_set_key("s-x"), b"a-x")
         # Parallel meta HASH carries the audit fields

--- a/tests/infrastructure/test_redis_subnet_join_request_repository.py
+++ b/tests/infrastructure/test_redis_subnet_join_request_repository.py
@@ -84,7 +84,7 @@ async def fake_redis():
 def _make_request(**overrides) -> SubnetJoinRequest:
     defaults: dict = {
         "request_id": "req-1",
-        "subnet_id": "s-1",
+        "slug": "s-1",
         "agent_id": "a-1",
         "kind": "join_request",
         "status": "pending",
@@ -119,7 +119,7 @@ class TestLuaCallContract:
         mock_redis.register_script = MagicMock(return_value=fake_script)
 
         repo = RedisSubnetJoinRequestRepository(mock_redis)
-        req = _make_request(subnet_id="sub-A", agent_id="agt-B", request_id="r-1")
+        req = _make_request(slug="sub-A", agent_id="agt-B", request_id="r-1")
         await repo.save(req)
 
         assert captured["keys"] == [
@@ -154,7 +154,7 @@ class TestLuaCallContract:
 
     @pytest.mark.asyncio
     async def test_create_pending_argv3_is_invitation_composite_key(self):
-        """ARGV[3] is the ``subnet_id:request_id`` composite key
+        """ARGV[3] is the ``slug:request_id`` composite key
         the Lua script SADDs into the per-agent invitations SET.
         The composite layout is the B1 fix — bare request_id storage
         would force ``list_pending_invitations_for_agent`` into an
@@ -171,7 +171,7 @@ class TestLuaCallContract:
         repo = RedisSubnetJoinRequestRepository(mock_redis)
         await repo.save(
             _make_request(
-                subnet_id="sub-A",
+                slug="sub-A",
                 request_id="r-1",
                 kind="invitation",
             )
@@ -195,7 +195,7 @@ class TestLuaCallContract:
         repo = RedisSubnetJoinRequestRepository(mock_redis)
         with pytest.raises(SubnetJoinRequestPendingError) as exc_info:
             await repo.save(_make_request(request_id="my-req-id"))
-        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.slug == "s-1"
         assert exc_info.value.agent_id == "a-1"
 
     @pytest.mark.asyncio
@@ -272,7 +272,7 @@ class TestReadPathsAgainstFakeRedis:
         needing the Lua interpreter."""
         repo = RedisSubnetJoinRequestRepository(fake_redis)
         req = _make_request(
-            subnet_id="s-x", agent_id="a-x", request_id="r-x"
+            slug="s-x", agent_id="a-x", request_id="r-x"
         )
 
         await fake_redis.set(_pending_by_agent_key("s-x", "a-x"), b"r-x")
@@ -284,7 +284,7 @@ class TestReadPathsAgainstFakeRedis:
         found = await repo.find_pending_for("s-x", "a-x")
         assert found is not None
         assert found.request_id == "r-x"
-        assert found.subnet_id == "s-x"
+        assert found.slug == "s-x"
         assert found.is_pending is True
 
     @pytest.mark.asyncio
@@ -323,7 +323,7 @@ class TestReadPathsAgainstFakeRedis:
         self, fake_redis
     ):
         """End-to-end fakeredis: invitee SET stores
-        ``subnet_id:request_id`` composite keys; ``list_pending_*``
+        ``slug:request_id`` composite keys; ``list_pending_*``
         deref's each directly to its subnet HASH without any
         keyspace scan. Pins the B1 perf fix at the integration level
         — not just the Lua call shape."""
@@ -333,7 +333,7 @@ class TestReadPathsAgainstFakeRedis:
         for sub_idx in [1, 2]:
             req = SubnetJoinRequest(
                 request_id=f"r-{sub_idx}",
-                subnet_id=f"s-{sub_idx}",
+                slug=f"s-{sub_idx}",
                 agent_id="agent-X",
                 kind="invitation",
                 status="pending",
@@ -351,14 +351,14 @@ class TestReadPathsAgainstFakeRedis:
 
         rows = await repo.list_pending_invitations_for_agent("agent-X")
         assert len(rows) == 2
-        assert {r.subnet_id for r in rows} == {"s-1", "s-2"}
+        assert {r.slug for r in rows} == {"s-1", "s-2"}
 
     @pytest.mark.asyncio
     async def test_list_pending_invitations_skips_legacy_bare_rid_members(
         self, fake_redis
     ):
         """Defensive path: a stale Slice 2.1 v1 SET member (bare
-        request_id without ``subnet_id:`` prefix) is silently
+        request_id without ``slug:`` prefix) is silently
         skipped rather than triggering the old expensive scan or
         raising a parse error."""
         repo = RedisSubnetJoinRequestRepository(fake_redis)
@@ -387,7 +387,7 @@ class TestReadPathsAgainstFakeRedis:
             ts = datetime.now(UTC)
             kwargs: dict = {
                 "request_id": rid,
-                "subnet_id": "s-1",
+                "slug": "s-1",
                 "agent_id": f"a-{i}",
                 "kind": kind,
                 "status": status,

--- a/tests/infrastructure/test_subnet_manager_allowlist.py
+++ b/tests/infrastructure/test_subnet_manager_allowlist.py
@@ -106,7 +106,7 @@ def _build_manager(
     policy_service: PolicyCheckService | None,
     manifest_dispatcher: MagicMock | None = None,
     allowlist_service=None,
-    subnet_id: str = "public",
+    slug: str = "public",
     agent_id: str = "agent-b",
 ) -> tuple[SubnetManager, MagicMock]:
     manager = SubnetManager(
@@ -120,11 +120,11 @@ def _build_manager(
     websocket.send_json = AsyncMock()
     connection = GatewayConnection(
         connection_id="conn-1",
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         websocket=websocket,
     )
-    manager._subnets[subnet_id].connections[agent_id] = connection
+    manager._subnets[slug].connections[agent_id] = connection
     return manager, websocket
 
 

--- a/tests/infrastructure/test_subnet_manager_implicit_heartbeat.py
+++ b/tests/infrastructure/test_subnet_manager_implicit_heartbeat.py
@@ -60,7 +60,7 @@ def _mock_ws_yielding_one_heartbeat() -> MagicMock:
 def _make_connection(ws: MagicMock, agent_id: str = "agent-ws") -> GatewayConnection:
     return GatewayConnection(
         connection_id="conn-1",
-        subnet_id="public",
+        slug="public",
         agent_id=agent_id,
         websocket=ws,
     )

--- a/tests/infrastructure/test_subnet_manager_manifest.py
+++ b/tests/infrastructure/test_subnet_manager_manifest.py
@@ -87,7 +87,7 @@ def _build_manager(
     redis_client: AsyncMock,
     policy_service: PolicyCheckService | None,
     manifest_dispatcher: MagicMock | None = None,
-    subnet_id: str = "public",
+    slug: str = "public",
     agent_id: str = "agent-b",
 ) -> tuple[SubnetManager, MagicMock]:
     manager = SubnetManager(
@@ -100,11 +100,11 @@ def _build_manager(
     websocket.send_json = AsyncMock()
     connection = GatewayConnection(
         connection_id="conn-1",
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         websocket=websocket,
     )
-    manager._subnets[subnet_id].connections[agent_id] = connection
+    manager._subnets[slug].connections[agent_id] = connection
     return manager, websocket
 
 

--- a/tests/infrastructure/test_subnet_manager_policy.py
+++ b/tests/infrastructure/test_subnet_manager_policy.py
@@ -74,7 +74,7 @@ def _build_manager_with_connected_agent(
     agent_service: AsyncMock,
     redis_client: AsyncMock,
     policy_service: PolicyCheckService | None,
-    subnet_id: str = "public",
+    slug: str = "public",
     agent_id: str = "agent-b",
 ) -> tuple[SubnetManager, MagicMock]:
     """Construct a SubnetManager with one fake connection installed.
@@ -92,11 +92,11 @@ def _build_manager_with_connected_agent(
     websocket.send_json = AsyncMock()
     connection = GatewayConnection(
         connection_id="conn-1",
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         websocket=websocket,
     )
-    manager._subnets[subnet_id].connections[agent_id] = connection
+    manager._subnets[slug].connections[agent_id] = connection
     return manager, websocket
 
 

--- a/tests/infrastructure/test_subnet_manager_register.py
+++ b/tests/infrastructure/test_subnet_manager_register.py
@@ -2,7 +2,7 @@
 
 The 2026-05 AgentRegistry removal rewrote this path: instead of
 delegating to ``AgentRegistry.register_agent`` (which baked in
-``owner=f"gateway:{subnet_id}"`` + ``status="online"``), the gateway now
+``owner=f"gateway:{slug}"`` + ``status="online"``), the gateway now
 
 1. persists an ``Agent`` entity through ``agent_service.repository.save``
    with **``owner=None``** — explicit product decision to mirror the
@@ -20,7 +20,7 @@ These tests pin the three invariants the rewrite established:
 * ``agent_service.touch_alive`` is awaited exactly once with the
   connection's ``agent_id``;
 * the in-memory ``connection.agent_info.owner`` still carries the
-  synthetic ``f"gateway:{subnet_id}"`` marker (legacy DTO compat —
+  synthetic ``f"gateway:{slug}"`` marker (legacy DTO compat —
   internal caches stay self-describing without overloading the
   persisted owner field).
 
@@ -77,7 +77,7 @@ def _make_ws_yielding_register() -> MagicMock:
 def _make_connection(ws: MagicMock, agent_id: str = "agent-1") -> GatewayConnection:
     return GatewayConnection(
         connection_id="conn-1",
-        subnet_id="enterprise-a",
+        slug="enterprise-a",
         agent_id=agent_id,
         websocket=ws,
     )
@@ -131,7 +131,7 @@ async def test_handle_registration_persists_agent_with_owner_none():
     assert saved.agent_id == "agent-1"
     assert saved.subnet_ids == ["enterprise-a"]
     assert "gateway" in saved.metadata
-    assert saved.metadata["subnet_id"] == "enterprise-a"
+    assert saved.metadata["slug"] == "enterprise-a"
 
 
 @pytest.mark.asyncio
@@ -155,7 +155,7 @@ async def test_handle_registration_seeds_alive_key_via_touch_alive():
 @pytest.mark.asyncio
 async def test_handle_registration_sets_in_memory_owner_to_gateway_marker():
     """``connection.agent_info.owner`` keeps the synthetic
-    ``gateway:{subnet_id}`` string so the in-memory DTO stays
+    ``gateway:{slug}`` string so the in-memory DTO stays
     self-describing.
 
     This is the deliberate split from the persisted entity (which has

--- a/tests/infrastructure/test_subnet_repository_redis_cascade.py
+++ b/tests/infrastructure/test_subnet_repository_redis_cascade.py
@@ -112,7 +112,7 @@ async def test_delete_with_children_child_failure_raises_and_skips_parent(
     )
     record = partial_records[0]
     assert record.levelname == "WARNING"
-    assert getattr(record, "parent_subnet_id", None) == "parent-1"
+    assert getattr(record, "parent_slug", None) == "parent-1"
     assert getattr(record, "child_subnet_id", None) == "child-2"
     assert getattr(record, "reason", None) == "child_delete_returned_false"
 

--- a/tests/infrastructure/test_subnet_repository_redis_join_policy.py
+++ b/tests/infrastructure/test_subnet_repository_redis_join_policy.py
@@ -73,7 +73,7 @@ async def test_save_writes_join_policy_as_string() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     subnet = Subnet(
-        subnet_id="subnet-jp-1",
+        slug="subnet-jp-1",
         name="JP",
         owner="agent-owner",
         is_private=True,
@@ -105,7 +105,7 @@ async def test_save_round_trip_preserves_join_policy() -> None:
     ]
     for is_private, join_policy in legal_pairs:
         subnet = Subnet(
-            subnet_id=f"subnet-rt-{is_private}-{join_policy}",
+            slug=f"subnet-rt-{is_private}-{join_policy}",
             name="rt",
             owner="agent-owner",
             is_private=is_private,
@@ -125,7 +125,7 @@ def test_dict_to_subnet_legacy_public_row_defaults_to_open() -> None:
     invariant accepts it."""
     repo = RedisSubnetRepository(AsyncMock())
     legacy_public = {
-        "subnet_id": "subnet-legacy-pub",
+        "slug": "subnet-legacy-pub",
         "name": "Legacy",
         "owner": "agent-1",
         "is_private": "False",
@@ -148,7 +148,7 @@ def test_dict_to_subnet_legacy_private_row_auto_upgrades_to_approval() -> None:
     migration window."""
     repo = RedisSubnetRepository(AsyncMock())
     legacy_private = {
-        "subnet_id": "subnet-legacy-priv",
+        "slug": "subnet-legacy-priv",
         "name": "LegacyPriv",
         "owner": "agent-1",
         "is_private": "True",
@@ -170,7 +170,7 @@ def test_dict_to_subnet_empty_join_policy_treated_as_missing() -> None:
     private => approval, otherwise open."""
     repo = RedisSubnetRepository(AsyncMock())
     private_empty = {
-        "subnet_id": "subnet-empty-priv",
+        "slug": "subnet-empty-priv",
         "name": "EmptyPriv",
         "owner": "agent-1",
         "is_private": "True",
@@ -184,7 +184,7 @@ def test_dict_to_subnet_empty_join_policy_treated_as_missing() -> None:
     assert subnet.join_policy == "approval"
 
     public_empty = {**private_empty}
-    public_empty["subnet_id"] = "subnet-empty-pub"
+    public_empty["slug"] = "subnet-empty-pub"
     public_empty["is_private"] = "False"
     subnet_pub = repo._dict_to_subnet(public_empty)
     assert subnet_pub.join_policy == "open"

--- a/tests/infrastructure/test_subnet_repository_redis_nesting.py
+++ b/tests/infrastructure/test_subnet_repository_redis_nesting.py
@@ -87,10 +87,10 @@ async def test_save_child_subnet_adds_to_children_index() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     child = Subnet(
-        subnet_id="subnet-child",
+        slug="subnet-child",
         name="child",
         owner="agent-owner",
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
     )
 
     await repo.save(child)
@@ -109,10 +109,10 @@ async def test_save_task_scoped_subnet_adds_to_linked_task_index() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     scoped = Subnet(
-        subnet_id="subnet-scoped",
+        slug="subnet-scoped",
         name="scoped",
         owner="agent-owner",
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
         lifecycle="task_scoped",
         linked_task_id="task-xyz",
     )
@@ -136,7 +136,7 @@ async def test_save_top_level_subnet_does_not_touch_nesting_indexes() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     flat = Subnet(
-        subnet_id="subnet-flat",
+        slug="subnet-flat",
         name="flat",
         owner="agent-owner",
     )
@@ -166,7 +166,7 @@ async def test_delete_child_subnet_removes_from_children_index() -> None:
     # Wire ``find_by_id`` (via hgetall) to return a stored child row
     # so ``delete`` actually proceeds past its existence guard.
     redis.hgetall.return_value = {
-        "subnet_id": "subnet-child",
+        "slug": "subnet-child",
         "name": "child",
         "owner": "agent-owner",
         "is_private": "False",
@@ -176,7 +176,7 @@ async def test_delete_child_subnet_removes_from_children_index() -> None:
         "description": "",
         "harness_url": "",
         "harness_secret": "",
-        "parent_subnet_id": "subnet-parent",
+        "parent_slug": "subnet-parent",
         "lifecycle": "persistent",
         "linked_task_id": "",
     }
@@ -198,7 +198,7 @@ async def test_delete_task_scoped_subnet_removes_from_linked_task_index() -> Non
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     redis.hgetall.return_value = {
-        "subnet_id": "subnet-scoped",
+        "slug": "subnet-scoped",
         "name": "scoped",
         "owner": "agent-owner",
         "is_private": "False",
@@ -208,7 +208,7 @@ async def test_delete_task_scoped_subnet_removes_from_linked_task_index() -> Non
         "description": "",
         "harness_url": "",
         "harness_secret": "",
-        "parent_subnet_id": "subnet-parent",
+        "parent_slug": "subnet-parent",
         "lifecycle": "task_scoped",
         "linked_task_id": "task-xyz",
     }
@@ -241,7 +241,7 @@ async def test_find_by_parent_reads_children_index_and_hydrates() -> None:
     # same payload comes back for both subnet IDs; ``find_by_parent``
     # only cares that hydration happens, not which row is which.
     redis.hgetall.return_value = {
-        "subnet_id": "subnet-a",
+        "slug": "subnet-a",
         "name": "a",
         "owner": "agent-owner",
         "is_private": "False",
@@ -251,7 +251,7 @@ async def test_find_by_parent_reads_children_index_and_hydrates() -> None:
         "description": "",
         "harness_url": "",
         "harness_secret": "",
-        "parent_subnet_id": "subnet-parent",
+        "parent_slug": "subnet-parent",
         "lifecycle": "persistent",
         "linked_task_id": "",
     }
@@ -268,7 +268,7 @@ async def test_find_by_linked_task_reads_index_and_hydrates() -> None:
     repo = RedisSubnetRepository(redis)
     redis.smembers.return_value = {"subnet-scoped"}
     redis.hgetall.return_value = {
-        "subnet_id": "subnet-scoped",
+        "slug": "subnet-scoped",
         "name": "scoped",
         "owner": "agent-owner",
         "is_private": "False",
@@ -278,7 +278,7 @@ async def test_find_by_linked_task_reads_index_and_hydrates() -> None:
         "description": "",
         "harness_url": "",
         "harness_secret": "",
-        "parent_subnet_id": "subnet-parent",
+        "parent_slug": "subnet-parent",
         "lifecycle": "task_scoped",
         "linked_task_id": "task-xyz",
     }
@@ -311,10 +311,10 @@ async def test_save_round_trip_preserves_nesting_fields() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     scoped = Subnet(
-        subnet_id="subnet-rt",
+        slug="subnet-rt",
         name="rt",
         owner="agent-owner",
-        parent_subnet_id="subnet-parent",
+        parent_slug="subnet-parent",
         lifecycle="task_scoped",
         linked_task_id="task-rt",
     )
@@ -325,21 +325,21 @@ async def test_save_round_trip_preserves_nesting_fields() -> None:
     mapping = kwargs["mapping"]
     loaded = repo._dict_to_subnet(mapping)
 
-    assert loaded.parent_subnet_id == "subnet-parent"
+    assert loaded.parent_slug == "subnet-parent"
     assert loaded.lifecycle == "task_scoped"
     assert loaded.linked_task_id == "task-rt"
 
 
 def test_dict_to_subnet_tolerates_legacy_rows_without_nesting_keys() -> None:
     """A Redis row written before ADR-0003 contains no
-    ``parent_subnet_id`` / ``lifecycle`` / ``linked_task_id`` keys.
+    ``parent_slug`` / ``lifecycle`` / ``linked_task_id`` keys.
     ``_dict_to_subnet`` must fall through to entity defaults rather
     than ``KeyError`` — otherwise upgrading the binary against an
     un-migrated Redis would crash on first read."""
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     legacy = {
-        "subnet_id": "subnet-legacy",
+        "slug": "subnet-legacy",
         "name": "legacy",
         "owner": "agent-owner",
         "is_private": "False",
@@ -353,6 +353,6 @@ def test_dict_to_subnet_tolerates_legacy_rows_without_nesting_keys() -> None:
 
     subnet = repo._dict_to_subnet(legacy)
 
-    assert subnet.parent_subnet_id is None
+    assert subnet.parent_slug is None
     assert subnet.lifecycle == "persistent"
     assert subnet.linked_task_id is None

--- a/tests/infrastructure/test_subnet_repository_redis_save.py
+++ b/tests/infrastructure/test_subnet_repository_redis_save.py
@@ -81,7 +81,7 @@ async def test_save_serialises_is_private_as_string_not_bool() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     subnet = Subnet(
-        subnet_id="subnet-test-1",
+        slug="subnet-test-1",
         name="test",
         owner="agent-owner",
         is_private=True,
@@ -118,7 +118,7 @@ async def test_save_round_trip_preserves_is_private() -> None:
     cases: list[tuple[bool, str]] = [(True, "approval"), (False, "open")]
     for is_private, join_policy in cases:
         subnet = Subnet(
-            subnet_id=f"subnet-rt-{is_private}",
+            slug=f"subnet-rt-{is_private}",
             name="rt",
             owner="agent-owner",
             is_private=is_private,
@@ -140,7 +140,7 @@ async def test_save_normalises_none_fields_to_empty_string() -> None:
     redis = _make_redis_mock()
     repo = RedisSubnetRepository(redis)
     subnet = Subnet(
-        subnet_id="subnet-none",
+        slug="subnet-none",
         name="nones",
         owner="agent-owner",
         description=None,

--- a/tests/infrastructure/test_subnet_repository_redis_save.py
+++ b/tests/infrastructure/test_subnet_repository_redis_save.py
@@ -155,3 +155,121 @@ async def test_save_normalises_none_fields_to_empty_string() -> None:
     assert mapping["description"] == ""
     assert mapping["harness_url"] == ""
     assert mapping["harness_secret"] == ""
+
+
+class TestDictToSubnetLegacyKeyCompat:
+    """``_dict_to_subnet`` must hydrate Redis HASHes that pre-date the
+    ``subnet_id`` → ``slug`` rename. Without legacy-key fall-through,
+    the first read after a rolling deploy raises ``KeyError: 'slug'``
+    on every existing subnet — a hard failure for Redis-only
+    deployments because the entity-layer ``from_dict`` translation is
+    bypassed by the manually-constructed dict path here.
+
+    These tests run against the real :class:`RedisSubnetRepository`
+    and bypass the network entirely (``_dict_to_subnet`` is a pure
+    function on a HASH dict), so they reliably catch a regression
+    that mock-based round-trip tests cannot.
+    """
+
+    def _make_repo(self) -> RedisSubnetRepository:
+        return RedisSubnetRepository(redis_client=AsyncMock())
+
+    def test_legacy_subnet_id_key_is_accepted(self):
+        repo = self._make_repo()
+        legacy_hash = {
+            "subnet_id": "legacy-net",
+            "name": "Legacy",
+            "owner": "alice",
+            "is_private": "False",
+            "description": "",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "lifecycle": "persistent",
+            "linked_task_id": "",
+            "security_config": "{}",
+            "metadata": "{}",
+            "member_agent_ids": "[]",
+            "harness_url": "",
+            "harness_secret": "",
+        }
+
+        subnet = repo._dict_to_subnet(legacy_hash)
+
+        assert subnet.slug == "legacy-net"
+
+    def test_legacy_parent_subnet_id_key_is_accepted(self):
+        repo = self._make_repo()
+        legacy_hash = {
+            "subnet_id": "child-net",
+            "parent_subnet_id": "parent-net",
+            "name": "Child",
+            "owner": "alice",
+            "is_private": "False",
+            "description": "",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "lifecycle": "persistent",
+            "linked_task_id": "",
+            "security_config": "{}",
+            "metadata": "{}",
+            "member_agent_ids": "[]",
+            "harness_url": "",
+            "harness_secret": "",
+        }
+
+        subnet = repo._dict_to_subnet(legacy_hash)
+
+        assert subnet.slug == "child-net"
+        assert subnet.parent_slug == "parent-net"
+
+    def test_new_keys_take_precedence_when_both_present(self):
+        # Mid-rollout shape: a HASH that's been re-saved (has ``slug``)
+        # but still carries the legacy ``subnet_id`` field from a
+        # previous reader that round-tripped through an older repo.
+        # The new key wins so the entity reflects the canonical name.
+        repo = self._make_repo()
+        mixed_hash = {
+            "slug": "new-name",
+            "subnet_id": "old-name",
+            "parent_slug": "new-parent",
+            "parent_subnet_id": "old-parent",
+            "name": "Mixed",
+            "owner": "alice",
+            "is_private": "False",
+            "description": "",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "lifecycle": "persistent",
+            "linked_task_id": "",
+            "security_config": "{}",
+            "metadata": "{}",
+            "member_agent_ids": "[]",
+            "harness_url": "",
+            "harness_secret": "",
+        }
+
+        subnet = repo._dict_to_subnet(mixed_hash)
+
+        assert subnet.slug == "new-name"
+        assert subnet.parent_slug == "new-parent"
+
+    def test_completely_missing_slug_keys_raises_key_error(self):
+        # If neither key is present the HASH is corrupt; failing fast
+        # with a descriptive ``KeyError`` is preferable to letting an
+        # empty string flow into the entity (which would then trip the
+        # ``slug cannot be empty`` invariant with a less obvious trace).
+        repo = self._make_repo()
+        broken_hash = {
+            "name": "Broken",
+            "owner": "alice",
+            "is_private": "False",
+            "description": "",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "lifecycle": "persistent",
+            "linked_task_id": "",
+            "security_config": "{}",
+            "metadata": "{}",
+            "member_agent_ids": "[]",
+            "harness_url": "",
+            "harness_secret": "",
+        }
+
+        with pytest.raises(KeyError, match="slug.*subnet_id"):
+            repo._dict_to_subnet(broken_hash)

--- a/tests/infrastructure/test_task_repository_subnet_visibility.py
+++ b/tests/infrastructure/test_task_repository_subnet_visibility.py
@@ -61,7 +61,7 @@ def _make_repo(task_by_id: dict[str, Task], open_ids: list[str], agent_subnet_id
 @pytest.mark.asyncio
 async def test_private_subnet_task_visible_to_member():
     """An agent whose subnet_ids include the task's subnet must see the task."""
-    t = _make_task(slug="subnet-sec")
+    t = _make_task(subnet_id="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -74,7 +74,7 @@ async def test_private_subnet_task_visible_to_member():
 
 @pytest.mark.asyncio
 async def test_private_subnet_task_hidden_from_non_member():
-    t = _make_task(slug="subnet-sec")
+    t = _make_task(subnet_id="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -88,7 +88,7 @@ async def test_private_subnet_task_hidden_from_non_member():
 @pytest.mark.asyncio
 async def test_public_task_always_visible_even_without_requesting_agent():
     """Tasks with no slug (public) bypass the visibility check."""
-    t = _make_task(slug=None)
+    t = _make_task(subnet_id=None)
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -108,7 +108,7 @@ async def test_visibility_never_touches_legacy_broken_keys():
     `acn:subnet:{sid}` paths. Both were empty/wrong and made private
     subnets invisible.
     """
-    t = _make_task(slug="subnet-sec")
+    t = _make_task(subnet_id="subnet-sec")
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -140,7 +140,7 @@ async def test_corrupt_subnet_ids_does_not_crash_and_hides_private_tasks():
         return "{not json"  # garbage
 
     fake_redis.hget.side_effect = fake_hget
-    t = _make_task(slug="subnet-sec")
+    t = _make_task(subnet_id="subnet-sec")
     repo = RedisTaskRepository(redis_client=fake_redis)
     repo.find_by_id = AsyncMock(return_value=t)  # type: ignore[method-assign]
 

--- a/tests/infrastructure/test_task_repository_subnet_visibility.py
+++ b/tests/infrastructure/test_task_repository_subnet_visibility.py
@@ -3,7 +3,7 @@
 The old implementation tried to read `acn:subnets:all` (never written
 anywhere) and `acn:subnet:{sid}` (wrong key — the real one is
 `acn:subnets:info:{sid}`). That made `visible_subnet_ids` permanently
-empty, so every task with a non-null `subnet_id` was invisible to
+empty, so every task with a non-null `slug` was invisible to
 every agent — i.e. private subnets were functionally broken.
 
 The new implementation uses the agent's own `subnet_ids` field, read
@@ -61,7 +61,7 @@ def _make_repo(task_by_id: dict[str, Task], open_ids: list[str], agent_subnet_id
 @pytest.mark.asyncio
 async def test_private_subnet_task_visible_to_member():
     """An agent whose subnet_ids include the task's subnet must see the task."""
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(slug="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -74,7 +74,7 @@ async def test_private_subnet_task_visible_to_member():
 
 @pytest.mark.asyncio
 async def test_private_subnet_task_hidden_from_non_member():
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(slug="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -87,8 +87,8 @@ async def test_private_subnet_task_hidden_from_non_member():
 
 @pytest.mark.asyncio
 async def test_public_task_always_visible_even_without_requesting_agent():
-    """Tasks with no subnet_id (public) bypass the visibility check."""
-    t = _make_task(subnet_id=None)
+    """Tasks with no slug (public) bypass the visibility check."""
+    t = _make_task(slug=None)
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -108,7 +108,7 @@ async def test_visibility_never_touches_legacy_broken_keys():
     `acn:subnet:{sid}` paths. Both were empty/wrong and made private
     subnets invisible.
     """
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(slug="subnet-sec")
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -140,7 +140,7 @@ async def test_corrupt_subnet_ids_does_not_crash_and_hides_private_tasks():
         return "{not json"  # garbage
 
     fake_redis.hget.side_effect = fake_hget
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(slug="subnet-sec")
     repo = RedisTaskRepository(redis_client=fake_redis)
     repo.find_by_id = AsyncMock(return_value=t)  # type: ignore[method-assign]
 

--- a/tests/integration/test_pg_subnet_cascade.py
+++ b/tests/integration/test_pg_subnet_cascade.py
@@ -88,13 +88,13 @@ async def pg(request: Any):
 
 
 def _row(
-    subnet_id: str,
+    slug: str,
     parent_id: str | None = None,
 ) -> SubnetModel:
     """Build a minimal SubnetModel row suitable for direct INSERT."""
     return SubnetModel(
-        subnet_id=subnet_id,
-        name=f"subnet-{subnet_id}",
+        slug=slug,
+        name=f"subnet-{slug}",
         owner="test-owner",
         description=None,
         is_private=False,
@@ -103,18 +103,18 @@ def _row(
         subnet_metadata=None,
         harness_url=None,
         harness_secret=None,
-        parent_subnet_id=parent_id,
+        parent_slug=parent_id,
         lifecycle="persistent",
         linked_task_id=None,
         created_at=datetime.now(UTC),
     )
 
 
-async def _exists(factory: async_sessionmaker, subnet_id: str) -> bool:
-    """Return True if a subnet row with *subnet_id* is present."""
+async def _exists(factory: async_sessionmaker, slug: str) -> bool:
+    """Return True if a subnet row with *slug* is present."""
     async with factory() as session:
         result = await session.execute(
-            select(SubnetModel).where(SubnetModel.subnet_id == subnet_id)
+            select(SubnetModel).where(SubnetModel.slug == slug)
         )
         return result.scalar_one_or_none() is not None
 

--- a/tests/monitoring/test_analytics_key_patterns.py
+++ b/tests/monitoring/test_analytics_key_patterns.py
@@ -8,7 +8,7 @@ Before the fix:
        `acn:subnets:info:{id}`.
     - `_count_agents_in_subnet` scanned every agent and filtered in Python;
        the authoritative source is already the set
-       `acn:subnets:{subnet_id}:agents`.
+       `acn:subnets:{slug}:agents`.
 
 These made `get_agent_stats`, `get_subnet_stats`, and every health-check
 consumer return permanently-zero data without raising any error.

--- a/tests/protocols/test_a2a_handle_routing_policy.py
+++ b/tests/protocols/test_a2a_handle_routing_policy.py
@@ -103,14 +103,14 @@ def _routing_message(*, target_agent: str, content: str = "hi") -> Message:
     )
 
 
-def _subnet_routing_message(*, subnet_id: str, agent_id: str) -> Message:
+def _subnet_routing_message(*, slug: str, agent_id: str) -> Message:
     return Message(
         role=Role.user,
         message_id="msg-1",
         parts=[
             DataPart(
                 data={
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "agent_id": agent_id,
                     "message": {"text": "hi"},
                 }
@@ -284,7 +284,7 @@ class TestHandleSubnetRoutingPolicyRejected:
         eq = _make_event_queue()
 
         await executor._handle_subnet_routing(
-            _subnet_routing_message(subnet_id="net-1", agent_id="closed-agent"),
+            _subnet_routing_message(slug="net-1", agent_id="closed-agent"),
             _make_context(),
             eq,
         )
@@ -316,7 +316,7 @@ class TestHandleSubnetRoutingPolicyRejected:
         eq = _make_event_queue()
 
         await executor._handle_subnet_routing(
-            _subnet_routing_message(subnet_id="net-1", agent_id="closed-agent"),
+            _subnet_routing_message(slug="net-1", agent_id="closed-agent"),
             _make_context(),
             eq,
         )
@@ -332,7 +332,7 @@ class TestHandleSubnetRoutingPolicyRejected:
         eq = _make_event_queue()
 
         await executor._handle_subnet_routing(
-            _subnet_routing_message(subnet_id="net-1", agent_id="some-agent"),
+            _subnet_routing_message(slug="net-1", agent_id="some-agent"),
             _make_context(),
             eq,
         )
@@ -398,7 +398,7 @@ class TestPolicyRejectedIncrementsMetric:
         eq = _make_event_queue()
 
         await executor._handle_subnet_routing(
-            _subnet_routing_message(subnet_id="net-1", agent_id="closed-agent"),
+            _subnet_routing_message(slug="net-1", agent_id="closed-agent"),
             _make_context(),
             eq,
         )

--- a/tests/protocols/test_webhook_parent_subnet_id.py
+++ b/tests/protocols/test_webhook_parent_subnet_id.py
@@ -1,6 +1,6 @@
-"""Webhook payload ``parent_subnet_id`` field — ADR-0003 Phase 3.
+"""Webhook payload ``parent_slug`` field — ADR-0003 Phase 3.
 
-The ADR adds a single new field (``parent_subnet_id``) to the
+The ADR adds a single new field (``parent_slug``) to the
 ``data`` block of two existing webhook events —
 ``AGENT_JOINED_SUBNET`` and ``AGENT_LEFT_SUBNET`` — fired by
 ``routes/_subnet_membership.py::do_join_subnet`` /
@@ -8,10 +8,10 @@ The ADR adds a single new field (``parent_subnet_id``) to the
 
 Contract pinned here:
 
-* Top-level subnet (``Subnet.parent_subnet_id is None``) →
-  ``payload.data["parent_subnet_id"] is None``.
-* Child subnet (``Subnet.parent_subnet_id == "<parent_id>"``) →
-  ``payload.data["parent_subnet_id"] == "<parent_id>"``.
+* Top-level subnet (``Subnet.parent_slug is None``) →
+  ``payload.data["parent_slug"] is None``.
+* Child subnet (``Subnet.parent_slug == "<parent_id>"``) →
+  ``payload.data["parent_slug"] == "<parent_id>"``.
 * All other ``data`` fields stay byte-identical to the pre-Phase-3
   shape so harnesses that ignore the new field continue to work.
 * No new ``WebhookEventType`` values are added — events used are
@@ -37,19 +37,19 @@ from acn.services._join_flow_result import JoinFlowJoinedOpenResult
 
 
 def _make_subnet(
-    subnet_id: str = "subnet-1",
+    slug: str = "subnet-1",
     *,
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
     owner: str = "alice",
     member_agent_ids: set[str] | None = None,
     harness_url: str = "https://harness.example/webhook",
     harness_secret: str | None = "s3cr3t",
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         member_agent_ids=member_agent_ids or {owner},
         harness_url=harness_url,
         harness_secret=harness_secret,
@@ -84,9 +84,9 @@ def _build_join_flow_service(subnet_service: AsyncMock) -> AsyncMock:
     """
     svc = AsyncMock()
 
-    async def _join(subnet_id: str, agent_id: str):
-        await subnet_service.add_member(subnet_id, agent_id)
-        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+    async def _join(slug: str, agent_id: str):
+        await subnet_service.add_member(slug, agent_id)
+        return JoinFlowJoinedOpenResult(slug=slug, agent_id=agent_id)
 
     svc.join_subnet = AsyncMock(side_effect=_join)
     return svc
@@ -98,19 +98,19 @@ def _build_subnet_service_for_join(
     parent_subnet: Subnet | None = None,
 ) -> AsyncMock:
     """Build a ``SubnetService`` mock that returns ``subnet`` (and a
-    parent subnet when ``parent_subnet_id`` is set).
+    parent subnet when ``parent_slug`` is set).
 
     For child subnets, ``do_join_subnet`` performs a parent-membership
-    pre-check via ``subnet_service.get_subnet(parent_subnet_id)``; we
+    pre-check via ``subnet_service.get_subnet(parent_slug)``; we
     need to seed that response too so the join doesn't reject with
     ``NOT_SUBNET_MEMBER`` before reaching the webhook.
     """
     svc = AsyncMock()
 
     async def _get_subnet(sid: str):
-        if sid == subnet.subnet_id:
+        if sid == subnet.slug:
             return subnet
-        if parent_subnet is not None and sid == parent_subnet.subnet_id:
+        if parent_subnet is not None and sid == parent_subnet.slug:
             return parent_subnet
         raise AssertionError(f"unexpected get_subnet({sid!r})")
 
@@ -121,7 +121,7 @@ def _build_subnet_service_for_join(
 
 
 # ---------------------------------------------------------------------------
-# AGENT_JOINED_SUBNET — payload.data.parent_subnet_id
+# AGENT_JOINED_SUBNET — payload.data.parent_slug
 # ---------------------------------------------------------------------------
 
 
@@ -132,13 +132,13 @@ class TestJoinSubnetWebhookParentField:
         webhook_service,
         agent_service,
     ):
-        subnet = _make_subnet(parent_subnet_id=None)
+        subnet = _make_subnet(parent_slug=None)
         subnet_service = _build_subnet_service_for_join(subnet)
         join_flow_service = _build_join_flow_service(subnet_service)
 
         await do_join_subnet(
             agent_id="alice",
-            subnet_id="subnet-1",
+            slug="subnet-1",
             agent_info={"agent_id": "alice"},
             subnet_service=subnet_service,
             agent_service=agent_service,
@@ -151,9 +151,9 @@ class TestJoinSubnetWebhookParentField:
         assert call.kwargs["event"] == WebhookEventType.AGENT_JOINED_SUBNET
         data = call.kwargs["data"]
         assert data == {
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
             "agent_id": "alice",
-            "parent_subnet_id": None,
+            "parent_slug": None,
         }
 
     @pytest.mark.asyncio
@@ -163,13 +163,13 @@ class TestJoinSubnetWebhookParentField:
         agent_service,
     ):
         child = _make_subnet(
-            subnet_id="squad-1",
-            parent_subnet_id="parent-1",
+            slug="squad-1",
+            parent_slug="parent-1",
             member_agent_ids={"alice"},
         )
         parent = _make_subnet(
-            subnet_id="parent-1",
-            parent_subnet_id=None,
+            slug="parent-1",
+            parent_slug=None,
             member_agent_ids={"alice"},  # alice is in parent → join allowed
             harness_url=None,  # parent doesn't need a harness for this test
             harness_secret=None,
@@ -179,7 +179,7 @@ class TestJoinSubnetWebhookParentField:
 
         await do_join_subnet(
             agent_id="alice",
-            subnet_id="squad-1",
+            slug="squad-1",
             agent_info={"agent_id": "alice"},
             subnet_service=subnet_service,
             agent_service=agent_service,
@@ -190,9 +190,9 @@ class TestJoinSubnetWebhookParentField:
         webhook_service.send_to.assert_awaited_once()
         data = webhook_service.send_to.await_args.kwargs["data"]
         assert data == {
-            "subnet_id": "squad-1",
+            "slug": "squad-1",
             "agent_id": "alice",
-            "parent_subnet_id": "parent-1",
+            "parent_slug": "parent-1",
         }
 
     @pytest.mark.asyncio
@@ -202,10 +202,10 @@ class TestJoinSubnetWebhookParentField:
         agent_service,
     ):
         """Sanity check — subnets without ``harness_url`` do NOT emit
-        a webhook regardless of the parent_subnet_id field. Phase 3
+        a webhook regardless of the parent_slug field. Phase 3
         does not change this gate."""
         subnet = _make_subnet(
-            parent_subnet_id=None,
+            parent_slug=None,
             harness_url=None,
             harness_secret=None,
         )
@@ -214,7 +214,7 @@ class TestJoinSubnetWebhookParentField:
 
         await do_join_subnet(
             agent_id="alice",
-            subnet_id="subnet-1",
+            slug="subnet-1",
             agent_info={"agent_id": "alice"},
             subnet_service=subnet_service,
             agent_service=agent_service,
@@ -237,12 +237,12 @@ class TestLeaveSubnetWebhookParentField:
         webhook_service,
         agent_service,
     ):
-        subnet = _make_subnet(parent_subnet_id=None)
+        subnet = _make_subnet(parent_slug=None)
         subnet_service = _build_subnet_service_for_join(subnet)
 
         await do_leave_subnet(
             agent_id="alice",
-            subnet_id="subnet-1",
+            slug="subnet-1",
             agent_info={"agent_id": "alice"},
             subnet_service=subnet_service,
             agent_service=agent_service,
@@ -254,9 +254,9 @@ class TestLeaveSubnetWebhookParentField:
         assert call.kwargs["event"] == WebhookEventType.AGENT_LEFT_SUBNET
         data = call.kwargs["data"]
         assert data == {
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
             "agent_id": "alice",
-            "parent_subnet_id": None,
+            "parent_slug": None,
         }
 
     @pytest.mark.asyncio
@@ -266,8 +266,8 @@ class TestLeaveSubnetWebhookParentField:
         agent_service,
     ):
         child = _make_subnet(
-            subnet_id="squad-1",
-            parent_subnet_id="parent-1",
+            slug="squad-1",
+            parent_slug="parent-1",
         )
         # do_leave_subnet does NOT do the parent-membership pre-check
         # (that's join-only), so we don't need to seed a parent
@@ -276,7 +276,7 @@ class TestLeaveSubnetWebhookParentField:
 
         await do_leave_subnet(
             agent_id="alice",
-            subnet_id="squad-1",
+            slug="squad-1",
             agent_info={"agent_id": "alice"},
             subnet_service=subnet_service,
             agent_service=agent_service,
@@ -286,7 +286,7 @@ class TestLeaveSubnetWebhookParentField:
         webhook_service.send_to.assert_awaited_once()
         data = webhook_service.send_to.await_args.kwargs["data"]
         assert data == {
-            "subnet_id": "squad-1",
+            "slug": "squad-1",
             "agent_id": "alice",
-            "parent_subnet_id": "parent-1",
+            "parent_slug": "parent-1",
         }

--- a/tests/routes/_admission_helpers.py
+++ b/tests/routes/_admission_helpers.py
@@ -58,14 +58,14 @@ def _make_agent(agent_id: str) -> MagicMock:
 
 
 def _make_subnet(
-    subnet_id: str = SUBNET_ID,
+    slug: str = SUBNET_ID,
     owner: str = OWNER_AGENT_ID,
     join_policy: str = "approval",
     harness_url: str | None = None,
     harness_secret: str | None = None,
 ) -> MagicMock:
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.owner = owner
     sn.join_policy = join_policy
     sn.harness_url = harness_url
@@ -78,7 +78,7 @@ def _make_subnet(
 def make_join_request(
     *,
     request_id: str = "req-1",
-    subnet_id: str = SUBNET_ID,
+    slug: str = SUBNET_ID,
     agent_id: str = INVITEE_AGENT_ID,
     kind: str = "join_request",
     status: str = "pending",
@@ -96,7 +96,7 @@ def make_join_request(
     decided_at = datetime.now(UTC) if status != "pending" else None
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind=kind,  # type: ignore[arg-type]
         status=status,  # type: ignore[arg-type]
@@ -109,12 +109,12 @@ def make_join_request(
 
 def make_allowlist_entry(
     *,
-    subnet_id: str = SUBNET_ID,
+    slug: str = SUBNET_ID,
     agent_id: str = INVITEE_AGENT_ID,
     added_by: str = OWNER_AGENT_ID,
 ) -> SubnetAllowlist:
     return SubnetAllowlist(
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         added_by=added_by,
     )
@@ -163,10 +163,10 @@ def stub_subnet_service():
     svc = AsyncMock()
     subnet = _make_subnet()
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == SUBNET_ID:
+    async def _get_subnet(slug: str):
+        if slug == SUBNET_ID:
             return subnet
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     svc._subnet = subnet

--- a/tests/routes/test_agent_subnet_ids_privacy.py
+++ b/tests/routes/test_agent_subnet_ids_privacy.py
@@ -60,9 +60,9 @@ def _make_agent(
     return a
 
 
-def _make_public_subnet(subnet_id: str) -> MagicMock:
+def _make_public_subnet(slug: str) -> MagicMock:
     s = MagicMock()
-    s.subnet_id = subnet_id
+    s.slug = slug
     s.is_private = False
     return s
 

--- a/tests/routes/test_agent_subnets.py
+++ b/tests/routes/test_agent_subnets.py
@@ -1,8 +1,8 @@
 """Route-level tests for the canonical agent-side subnet membership API.
 
 Covers the new canonical paths introduced in this batch:
-- ``POST   /api/v1/agents/{agent_id}/subnets/{subnet_id}`` — join
-- ``DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id}`` — leave
+- ``POST   /api/v1/agents/{agent_id}/subnets/{slug}`` — join
+- ``DELETE /api/v1/agents/{agent_id}/subnets/{slug}`` — leave
 - ``GET    /api/v1/agents/{agent_id}/subnets`` — list
 
 The legacy paths under ``/api/v1/subnets/{agent_id}/subnets/…`` are still
@@ -62,13 +62,13 @@ def stub_agent_service():
 
 
 def _make_subnet_mock(
-    subnet_id: str = "subnet-1",
+    slug: str = "subnet-1",
     owner: str = "agent-target",
     harness_url: str | None = None,
     harness_secret: str | None = None,
 ):
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.owner = owner
     sn.harness_url = harness_url
     sn.harness_secret = harness_secret
@@ -82,10 +82,10 @@ def stub_subnet_service():
     svc = AsyncMock()
     default = _make_subnet_mock()
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == "subnet-1":
+    async def _get_subnet(slug: str):
+        if slug == "subnet-1":
             return default
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     svc.add_member = AsyncMock(return_value=None)
@@ -123,10 +123,10 @@ def stub_join_flow_service(stub_subnet_service):
     """
     svc = AsyncMock()
 
-    async def _join_subnet(subnet_id: str, agent_id: str):
-        await stub_subnet_service.get_subnet(subnet_id)
-        await stub_subnet_service.add_member(subnet_id, agent_id)
-        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+    async def _join_subnet(slug: str, agent_id: str):
+        await stub_subnet_service.get_subnet(slug)
+        await stub_subnet_service.add_member(slug, agent_id)
+        return JoinFlowJoinedOpenResult(slug=slug, agent_id=agent_id)
 
     svc.join_subnet = AsyncMock(side_effect=_join_subnet)
     app.dependency_overrides[get_join_flow_service] = lambda: svc
@@ -144,7 +144,7 @@ def _wire(agent_svc, subnet_svc, webhook_svc=None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST /api/v1/agents/{agent_id}/subnets/{subnet_id} — canonical join
+# POST /api/v1/agents/{agent_id}/subnets/{slug} — canonical join
 # ---------------------------------------------------------------------------
 
 
@@ -165,7 +165,7 @@ class TestCanonicalJoin:
         assert body == {
             "status": "joined",
             "agent_id": "agent-target",
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
         }
         # Both service-layer mutations must have been called exactly once
         stub_agent_service.join_subnet.assert_awaited_once_with("agent-target", "subnet-1")
@@ -191,14 +191,14 @@ class TestCanonicalJoin:
         assert kw["url"] == "https://h.example/hook"
         assert kw["secret"] == "hs"
         assert kw["event"] == WebhookEventType.AGENT_JOINED_SUBNET
-        # ADR-0003 Phase 3 added ``parent_subnet_id`` to the payload.
+        # ADR-0003 Phase 3 added ``parent_slug`` to the payload.
         # ``_default_subnet`` is a MagicMock stub, so the helper's
         # ``isinstance(str)`` guard returns ``None`` — matching the
         # contract for a top-level subnet.
         assert kw["data"] == {
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
             "agent_id": "agent-target",
-            "parent_subnet_id": None,
+            "parent_slug": None,
         }
 
     def test_join_returns_403_when_path_agent_differs_from_api_key(
@@ -236,7 +236,7 @@ class TestCanonicalJoin:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "ghost"}
+        assert body["details"] == {"slug": "ghost"}
 
     def test_join_returns_404_when_agent_not_found(
         self, stub_agent_service, stub_subnet_service, stub_webhook_service
@@ -287,7 +287,7 @@ class TestCanonicalJoin:
 
 
 # ---------------------------------------------------------------------------
-# DELETE /api/v1/agents/{agent_id}/subnets/{subnet_id} — canonical leave
+# DELETE /api/v1/agents/{agent_id}/subnets/{slug} — canonical leave
 # ---------------------------------------------------------------------------
 
 
@@ -307,7 +307,7 @@ class TestCanonicalLeave:
         assert r.json() == {
             "status": "left",
             "agent_id": "agent-target",
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
         }
         stub_agent_service.leave_subnet.assert_awaited_once_with("agent-target", "subnet-1")
         stub_subnet_service.remove_member.assert_awaited_once_with("subnet-1", "agent-target")
@@ -453,7 +453,7 @@ class TestPathEquivalence:
         paths = spec["paths"]
 
         legacy_membership_paths = {
-            "/api/v1/subnets/{agent_id}/subnets/{subnet_id}": ("post", "delete"),
+            "/api/v1/subnets/{agent_id}/subnets/{slug}": ("post", "delete"),
             "/api/v1/subnets/{agent_id}/subnets": ("get",),
         }
         for path, methods in legacy_membership_paths.items():
@@ -466,7 +466,7 @@ class TestPathEquivalence:
                 )
 
         canonical_membership_paths = {
-            "/api/v1/agents/{agent_id}/subnets/{subnet_id}": ("post", "delete"),
+            "/api/v1/agents/{agent_id}/subnets/{slug}": ("post", "delete"),
             "/api/v1/agents/{agent_id}/subnets": ("get",),
         }
         for path, methods in canonical_membership_paths.items():

--- a/tests/routes/test_broadcast_service_convergence.py
+++ b/tests/routes/test_broadcast_service_convergence.py
@@ -178,7 +178,7 @@ class TestBroadcastRouteUsesBroadcastService:
         broadcast_svc.broadcast.assert_awaited_once()
         kwargs = broadcast_svc.broadcast.await_args.kwargs
         assert kwargs["from_agent"] == "agent-a"
-        assert kwargs["subnet_id"] == "subnet-eu"
+        assert kwargs["slug"] == "subnet-eu"
         assert kwargs.get("tags") is None
         assert kwargs.get("target_agents") is None
 
@@ -218,7 +218,7 @@ class TestBroadcastRouteUsesBroadcastService:
         broadcast_svc.broadcast.assert_awaited_once()
         kwargs = broadcast_svc.broadcast.await_args.kwargs
         assert kwargs["tags"] == ["frontend", "review"]
-        assert kwargs.get("subnet_id") is None
+        assert kwargs.get("slug") is None
         assert kwargs.get("target_agents") is None
 
     def test_strategy_is_case_insensitive(self):

--- a/tests/routes/test_delete_confirm_b8.py
+++ b/tests/routes/test_delete_confirm_b8.py
@@ -1,6 +1,6 @@
 """ACL V6 B8 — ?confirm=true safety guard on destructive DELETE endpoints.
 
-Both ``DELETE /api/v1/subnets/{subnet_id}`` and
+Both ``DELETE /api/v1/subnets/{slug}`` and
 ``DELETE /api/v1/agents/{agent_id}`` now require ``?confirm=true``.
 Omitting it or passing ``?confirm=false`` must return ``400 INVALID_REQUEST``
 with a hint in ``details``, leaving the resource untouched.
@@ -22,9 +22,9 @@ from acn.routes.dependencies import get_agent_service, get_subnet_service
 # ---------------------------------------------------------------------------
 
 
-def _make_subnet(subnet_id: str = "subnet-1", owner: str = "agent-owner") -> MagicMock:
+def _make_subnet(slug: str = "subnet-1", owner: str = "agent-owner") -> MagicMock:
     s = MagicMock()
-    s.subnet_id = subnet_id
+    s.slug = slug
     s.owner = owner
     s.is_private = False
     s.is_public = True
@@ -34,7 +34,7 @@ def _make_subnet(subnet_id: str = "subnet-1", owner: str = "agent-owner") -> Mag
     s.security_config = {}
     s.created_at = "2026-01-01T00:00:00Z"
     s.metadata = {}
-    s.parent_subnet_id = None
+    s.parent_slug = None
     s.lifecycle = "persistent"
     return s
 
@@ -70,10 +70,10 @@ def stub_subnet_service():
     svc = AsyncMock()
     subnet = _make_subnet()
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == "subnet-1":
+    async def _get_subnet(slug: str):
+        if slug == "subnet-1":
             return subnet
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     svc.delete_subnet = AsyncMock(return_value=True)
@@ -107,7 +107,7 @@ def _fake_require_permission(sub: str, permissions: list[str] | None = None):
 
 
 # ---------------------------------------------------------------------------
-# DELETE /subnets/{subnet_id}
+# DELETE /subnets/{slug}
 # ---------------------------------------------------------------------------
 
 
@@ -145,7 +145,7 @@ class TestDeleteSubnetConfirmGuard:
             )
 
         assert r.status_code == 200, r.text
-        assert r.json() == {"status": "deleted", "subnet_id": "subnet-1"}
+        assert r.json() == {"status": "deleted", "slug": "subnet-1"}
         stub_subnet_service.delete_subnet.assert_awaited_once_with("subnet-1", "agent-owner")
 
     def test_missing_confirm_does_not_call_service(self, stub_subnet_service):

--- a/tests/routes/test_get_task_h8_auth.py
+++ b/tests/routes/test_get_task_h8_auth.py
@@ -40,14 +40,18 @@ def _disable_rate_limiter():
 
 
 def _public_task() -> SimpleNamespace:
-    """A task entity stand-in with ``slug=None`` — anyone can read it.
+    """A task entity stand-in with no subnet binding — anyone can read it.
 
     H8 only cares about identity resolution and the subnet-membership
     branch, not response serialisation, so we just need a value that
-    satisfies ``_task_to_response``'s field reads without exploding."""
+    satisfies ``_task_to_response``'s field reads without exploding.
+
+    Naming: the ``Task`` entity still uses ``subnet_id`` until Step 2
+    of the slug rename ships; until then the field on the namespace
+    must match the entity attribute the production code reads."""
     return SimpleNamespace(
         task_id="task-public",
-        slug=None,
+        subnet_id=None,
         creator_id="creator-1",
         creator_name="Creator",
         creator_type="human",
@@ -93,7 +97,8 @@ def _public_task() -> SimpleNamespace:
 def _private_task(slug: str = "sn-1") -> SimpleNamespace:
     t = _public_task()
     t.task_id = "task-private"
-    t.slug = slug
+    # See ``_public_task`` — entity attribute is still ``subnet_id``.
+    t.subnet_id = slug
     return t
 
 

--- a/tests/routes/test_get_task_h8_auth.py
+++ b/tests/routes/test_get_task_h8_auth.py
@@ -40,14 +40,14 @@ def _disable_rate_limiter():
 
 
 def _public_task() -> SimpleNamespace:
-    """A task entity stand-in with ``subnet_id=None`` — anyone can read it.
+    """A task entity stand-in with ``slug=None`` — anyone can read it.
 
     H8 only cares about identity resolution and the subnet-membership
     branch, not response serialisation, so we just need a value that
     satisfies ``_task_to_response``'s field reads without exploding."""
     return SimpleNamespace(
         task_id="task-public",
-        subnet_id=None,
+        slug=None,
         creator_id="creator-1",
         creator_name="Creator",
         creator_type="human",
@@ -90,10 +90,10 @@ def _public_task() -> SimpleNamespace:
     )
 
 
-def _private_task(subnet_id: str = "sn-1") -> SimpleNamespace:
+def _private_task(slug: str = "sn-1") -> SimpleNamespace:
     t = _public_task()
     t.task_id = "task-private"
-    t.subnet_id = subnet_id
+    t.slug = slug
     return t
 
 

--- a/tests/routes/test_path_max_length_p2_3.py
+++ b/tests/routes/test_path_max_length_p2_3.py
@@ -3,7 +3,7 @@
 H6 fenced off body-side abuse with per-string ``max_length`` and a 1 MiB
 total body cap. Path / query parameters were left unbounded because
 Starlette's URL parser caps headers at ~64 KB anyway — but a ~60 KB
-``subnet_id`` still flows downstream into Redis keys, SQL ``WHERE``
+``slug`` still flows downstream into Redis keys, SQL ``WHERE``
 clauses, and audit log structured fields.
 
 After the fix, FastAPI's ``Path(..., max_length=N)`` returns ``422`` for
@@ -71,17 +71,17 @@ def client() -> TestClient:
 
 
 # ---------------------------------------------------------------------------
-# subnet_id (subnets routes)
+# slug (subnets routes)
 # ---------------------------------------------------------------------------
 
 
 def test_subnet_id_oversize_is_422(client: TestClient):
-    """``GET /subnets/{subnet_id}`` must reject 60 KB ids before the
+    """``GET /subnets/{slug}`` must reject 60 KB ids before the
     service layer sees them — no Redis lookups, no SQL WHERE."""
     oversize = "x" * (MAX_SUBNET_ID_LEN + 1)
     resp = client.get(f"/api/v1/subnets/{oversize}")
     assert resp.status_code == 422, (
-        f"oversize subnet_id ({len(oversize)} chars) must return 422; got "
+        f"oversize slug ({len(oversize)} chars) must return 422; got "
         f"{resp.status_code}: {resp.text[:200]}"
     )
     body = resp.json()
@@ -120,9 +120,9 @@ def test_agent_id_oversize_on_registry_route_is_422(client: TestClient):
 
 def test_agent_id_oversize_on_subnet_internal_route_is_422(client: TestClient):
     """Internal subnet membership routes also enforce the cap."""
-    subnet_id = "valid"
+    slug = "valid"
     oversize_agent = "a" * (MAX_AGENT_ID_LEN + 1)
-    resp = client.post(f"/api/v1/subnets/{subnet_id}/members/{oversize_agent}")
+    resp = client.post(f"/api/v1/subnets/{slug}/members/{oversize_agent}")
     assert resp.status_code == 422
 
 
@@ -167,12 +167,12 @@ def test_task_id_at_boundary_passes_validation(client: TestClient):
 
 def test_subnet_id_cap_matches_postgres_schema():
     """``MAX_SUBNET_ID_LEN`` must not exceed the Postgres ``String(100)``
-    constraint on ``tasks.subnet_id`` — otherwise an oversize id slips
+    constraint on ``tasks.slug`` — otherwise an oversize id slips
     past the route layer and 500s on PG insert.
     """
     assert MAX_SUBNET_ID_LEN == 100, (
         f"MAX_SUBNET_ID_LEN={MAX_SUBNET_ID_LEN} no longer matches the "
-        "tasks.subnet_id Postgres VARCHAR(100); update either the cap or "
+        "tasks.slug Postgres VARCHAR(100); update either the cap or "
         "the schema, but keep them in lockstep."
     )
 

--- a/tests/routes/test_privacy_matrix.py
+++ b/tests/routes/test_privacy_matrix.py
@@ -27,7 +27,7 @@ Caller classes exercised
 
 Coverage
 --------
-- GET /subnets/{subnet_id} — SubnetInfo vs SubnetStub
+- GET /subnets/{slug} — SubnetInfo vs SubnetStub
 - GET /agents/{agent_id}   — full vs filtered subnet_ids
 - GET /subnets             — per-row rendering check
 """
@@ -94,26 +94,26 @@ def _make_agent(agent_id: str, owner: str, subnet_ids: list[str]) -> MagicMock:
 
 
 def _make_subnet(
-    subnet_id: str,
+    slug: str,
     owner: str,
     *,
     is_private: bool = False,
     members: list[str] | None = None,
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
 ) -> MagicMock:
     s = MagicMock()
-    s.subnet_id = subnet_id
-    s.id = f"uuid-{subnet_id}"
+    s.slug = slug
+    s.id = f"uuid-{slug}"
     s.owner = owner
     s.is_private = is_private
     s.is_public = not is_private
     s.member_count = len(members or [])
-    s.name = f"Name of {subnet_id}"
+    s.name = f"Name of {slug}"
     s.description = None
     s.security_config = {}
     s.created_at = "2026-01-01T00:00:00Z"
     s.metadata = {}
-    s.parent_subnet_id = parent_subnet_id
+    s.parent_slug = parent_slug
     s.lifecycle = "persistent"
     s._members = members or []
     s.harness_url = None
@@ -181,12 +181,12 @@ def stub_agent_service():
 def stub_subnet_service():
     svc = AsyncMock()
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == _PRIV_SUBNET:
+    async def _get_subnet(slug: str):
+        if slug == _PRIV_SUBNET:
             return _subnet_private
-        if subnet_id == _PUB_SUBNET:
+        if slug == _PUB_SUBNET:
             return _subnet_public
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     async def _find_agent_subnets(agent_id: str) -> list:
         result = []
@@ -238,7 +238,7 @@ def _auth(token: str) -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
-# GET /subnets/{subnet_id} — SubnetInfo vs SubnetStub
+# GET /subnets/{slug} — SubnetInfo vs SubnetStub
 # ---------------------------------------------------------------------------
 
 
@@ -256,8 +256,8 @@ def test_get_private_subnet_full_access(token: str):
 
     assert r.status_code == 200, r.text
     body = r.json()
-    assert "subnet_id" in body, "Expected full SubnetInfo (has subnet_id)"
-    assert body.get("subnet_id") == _PRIV_SUBNET
+    assert "slug" in body, "Expected full SubnetInfo (has slug)"
+    assert body.get("slug") == _PRIV_SUBNET
     assert body.get("name") is not None
 
 
@@ -273,7 +273,7 @@ def test_get_private_subnet_anon_gets_stub():
     assert r.status_code == 200, r.text
     body = r.json()
     assert "id" in body
-    assert "subnet_id" not in body, (
+    assert "slug" not in body, (
         f"Private subnet must not leak slug to anon caller: {body}"
     )
 
@@ -312,7 +312,7 @@ def test_get_private_subnet_unrelated_agent_gets_stub(monkeypatch, stub_agent_se
     assert r.status_code == 200, r.text
     body = r.json()
     assert "id" in body
-    assert "subnet_id" not in body, (
+    assert "slug" not in body, (
         f"Private subnet must not leak slug to unrelated agent: {body}"
     )
 
@@ -323,7 +323,7 @@ def test_get_public_subnet_anon_gets_full_info():
         r = client.get(f"/api/v1/subnets/{_PUB_SUBNET}")
 
     assert r.status_code == 200, r.text
-    assert r.json().get("subnet_id") == _PUB_SUBNET
+    assert r.json().get("slug") == _PUB_SUBNET
 
 
 # User JWT tests: dev_mode returns acn:admin for all tokens, so to exercise
@@ -353,7 +353,7 @@ def test_user_jwt_owning_owner_agent_gets_full_info(stub_agent_service):
 
     assert r.status_code == 200, r.text
     body = r.json()
-    assert "subnet_id" in body, f"Expected full SubnetInfo, got: {body}"
+    assert "slug" in body, f"Expected full SubnetInfo, got: {body}"
 
 
 def test_user_jwt_owning_member_agent_only_gets_stub(monkeypatch, stub_agent_service):
@@ -395,7 +395,7 @@ def test_user_jwt_owning_member_agent_only_gets_stub(monkeypatch, stub_agent_ser
 
     assert r.status_code == 200, r.text
     body = r.json()
-    assert "subnet_id" not in body, (
+    assert "slug" not in body, (
         f"Member-agent owner must NOT get full SubnetInfo, got: {body}"
     )
 
@@ -478,16 +478,16 @@ def test_list_subnets_anon_sees_public_full_and_private_stub():
     assert r.status_code == 200, r.text
     subnets = r.json()["subnets"]
 
-    # Public subnet must appear as a full SubnetInfo (has subnet_id / name).
-    subnet_ids = [s.get("subnet_id") for s in subnets if "subnet_id" in s]
+    # Public subnet must appear as a full SubnetInfo (has slug / name).
+    subnet_ids = [s.get("slug") for s in subnets if "slug" in s]
     assert _PUB_SUBNET in subnet_ids, "Public subnet must appear as SubnetInfo"
 
     # Private subnet must appear as a SubnetStub: present in the list but
-    # with no subnet_id / name field — only the opaque ``id`` UUID.
+    # with no slug / name field — only the opaque ``id`` UUID.
     stub_rows = [s for s in subnets if s.get("is_private") is True]
     assert stub_rows, "Private subnet must appear as SubnetStub (is_private=True)"
     for stub in stub_rows:
-        assert "subnet_id" not in stub or stub.get("subnet_id") is None, (
+        assert "slug" not in stub or stub.get("slug") is None, (
             "SubnetStub must not expose the human-readable slug"
         )
         assert "name" not in stub or stub.get("name") is None, (
@@ -505,7 +505,7 @@ def test_list_subnets_owner_filter_returns_private_full():
 
     assert r.status_code == 200, r.text
     subnets = r.json()["subnets"]
-    private_rows = [s for s in subnets if s.get("subnet_id") == _PRIV_SUBNET]
+    private_rows = [s for s in subnets if s.get("slug") == _PRIV_SUBNET]
     assert private_rows, "Owner agent with ?owner= must see private subnet as SubnetInfo"
 
 
@@ -569,13 +569,13 @@ def test_owned_by_user_self_returns_owned_subnets(stub_agent_service):
 
     assert r.status_code == 200, r.text
     body = r.json()
-    subnet_ids_in_response = [s.get("subnet_id") for s in body["subnets"]]
+    subnet_ids_in_response = [s.get("slug") for s in body["subnets"]]
     # Both subnets are owned by agent-alice, so both should appear
     assert _PRIV_SUBNET in subnet_ids_in_response, (
         "Private subnet owned by user's agent must appear as full SubnetInfo"
     )
-    # All returned rows must be full SubnetInfo (have subnet_id), not SubnetStub
+    # All returned rows must be full SubnetInfo (have slug), not SubnetStub
     for s in body["subnets"]:
-        assert "subnet_id" in s, (
+        assert "slug" in s, (
             f"?owned_by_user= rows must be full SubnetInfo, got stub: {s}"
         )

--- a/tests/routes/test_request_max_length_h6.py
+++ b/tests/routes/test_request_max_length_h6.py
@@ -92,7 +92,7 @@ class TestTaskCreateRequest:
             TaskCreateRequest(**self._base(required_tags=["t"] * 21))
 
     def test_subnet_id_caps_at_64_matching_subnet_create(self) -> None:
-        """Round-2 audit: ``subnet_id`` must align with ``SubnetCreateRequest``.
+        """Round-2 audit: ``slug`` must align with ``SubnetCreateRequest``.
 
         The subnet create path enforces ``max_length=64``; allowing 128
         here only let through values that were guaranteed to miss the
@@ -101,16 +101,16 @@ class TestTaskCreateRequest:
 
         from acn.models import SubnetCreateRequest
 
-        subnet_create_max = SubnetCreateRequest.model_fields["subnet_id"].metadata
+        subnet_create_max = SubnetCreateRequest.model_fields["slug"].metadata
         max_len = next(
             (m.max_length for m in subnet_create_max if hasattr(m, "max_length")),
             None,
         )
-        assert max_len == 64, "anchor: SubnetCreateRequest.subnet_id should still be 64"
+        assert max_len == 64, "anchor: SubnetCreateRequest.slug should still be 64"
 
-        TaskCreateRequest(**self._base(subnet_id="s" * 64))
+        TaskCreateRequest(**self._base(slug="s" * 64))
         with pytest.raises(ValidationError):
-            TaskCreateRequest(**self._base(subnet_id="s" * 65))
+            TaskCreateRequest(**self._base(slug="s" * 65))
 
     def test_max_total_budget_capped(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/routes/test_request_max_length_h6.py
+++ b/tests/routes/test_request_max_length_h6.py
@@ -108,9 +108,14 @@ class TestTaskCreateRequest:
         )
         assert max_len == 64, "anchor: SubnetCreateRequest.slug should still be 64"
 
-        TaskCreateRequest(**self._base(slug="s" * 64))
+        # ``TaskCreateRequest.subnet_id`` keeps the legacy field name
+        # until Step 2 of the slug rename migrates the cross-entity
+        # references (``Task.subnet_id``); the cap should match the
+        # subnet's ``slug`` field even while the request field name
+        # has not been renamed yet.
+        TaskCreateRequest(**self._base(subnet_id="s" * 64))
         with pytest.raises(ValidationError):
-            TaskCreateRequest(**self._base(slug="s" * 65))
+            TaskCreateRequest(**self._base(subnet_id="s" * 65))
 
     def test_max_total_budget_capped(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/routes/test_route_service_contracts.py
+++ b/tests/routes/test_route_service_contracts.py
@@ -480,9 +480,9 @@ class TestSubnetsContract:
         svc = AsyncMock()
         svc.list_subnets = AsyncMock(return_value=[])
         svc.get_subnet = AsyncMock(return_value=MagicMock(
-            subnet_id="subnet-1", name="test", owner="user-1",
+            slug="subnet-1", name="test", owner="user-1",
             is_public=True, member_count=0,
-            model_dump=MagicMock(return_value={"subnet_id": "subnet-1"}),
+            model_dump=MagicMock(return_value={"slug": "subnet-1"}),
         ))
         return svc
 

--- a/tests/routes/test_subnet_admission_allowlist.py
+++ b/tests/routes/test_subnet_admission_allowlist.py
@@ -54,7 +54,7 @@ class TestAddToAllowlist:
 
         assert r.status_code == 201, r.text
         body = r.json()
-        assert body["subnet_id"] == SUBNET_ID
+        assert body["slug"] == SUBNET_ID
         assert body["agent_id"] == INVITEE_AGENT_ID
         assert body["added_by"] == "agent-owner"
         subnet_svc.add_allowlist.assert_awaited_once()
@@ -112,7 +112,7 @@ class TestAddToAllowlist:
         assert r.status_code == 409
         body = r.json()
         assert body["error_code"] == "already_on_allowlist"
-        assert body["details"]["subnet_id"] == SUBNET_ID
+        assert body["details"]["slug"] == SUBNET_ID
         assert body["details"]["agent_id"] == INVITEE_AGENT_ID
 
     def test_missing_body_returns_422(self, wire):
@@ -204,7 +204,7 @@ class TestListAllowlist:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == SUBNET_ID
+        assert body["slug"] == SUBNET_ID
         assert len(body["entries"]) == 2
         assert {e["agent_id"] for e in body["entries"]} == {"agent-a", "agent-b"}
 
@@ -216,7 +216,7 @@ class TestListAllowlist:
             )
 
         assert r.status_code == 200
-        assert r.json() == {"subnet_id": SUBNET_ID, "entries": []}
+        assert r.json() == {"slug": SUBNET_ID, "entries": []}
 
     def test_non_owner_gets_403(self, wire):
         """ADR §"GET /subnets/{s}/allowlist is owner-only deliberately"."""

--- a/tests/routes/test_subnet_admission_invitations.py
+++ b/tests/routes/test_subnet_admission_invitations.py
@@ -62,7 +62,7 @@ class TestSendInvitation:
             request_id=INVITATION_ID, kind="invitation"
         )
         subnet_svc.invite_agent.return_value = InviteAgentSentResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
             invitation=invitation,
         )
@@ -95,7 +95,7 @@ class TestSendInvitation:
         )
         subnet_svc.invite_agent.return_value = (
             InviteAgentMergedToApprovedJoinRequestResult(
-                subnet_id=SUBNET_ID,
+                slug=SUBNET_ID,
                 agent_id=INVITEE_AGENT_ID,
                 request=approved,
             )
@@ -368,12 +368,12 @@ class TestAgentPendingInvitations:
             make_join_request(
                 request_id="inv-1",
                 kind="invitation",
-                subnet_id="subnet-A",
+                slug="subnet-A",
             ),
             make_join_request(
                 request_id="inv-2",
                 kind="invitation",
-                subnet_id="subnet-B",
+                slug="subnet-B",
             ),
         ]
 

--- a/tests/routes/test_subnet_admission_join_flow.py
+++ b/tests/routes/test_subnet_admission_join_flow.py
@@ -1,9 +1,9 @@
 """Route tests for ADR-0004 Slice 2.3 join-entry six-branch decision tree.
 
-Covers ``POST /api/v1/agents/{agent_id}/subnets/{subnet_id}`` —
+Covers ``POST /api/v1/agents/{agent_id}/subnets/{slug}`` —
 the rewritten join handler that now dispatches via
 ``JoinFlowService.join_subnet``. The six branches per ADR §"POST
-/api/v1/agents/{agent_id}/subnets/{subnet_id} (join entry)":
+/api/v1/agents/{agent_id}/subnets/{slug} (join entry)":
 
   1. open subnet → 200 ``{status: "joined"}``
   2. approval subnet, caller == owner → 200 ``{status: "joined"}``
@@ -65,7 +65,7 @@ class TestBranch1OpenSubnet:
     def test_open_subnet_returns_200_joined(self, wire):
         agent_svc, _, _, jfs = wire
         jfs.join_subnet.return_value = JoinFlowJoinedOpenResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
         )
 
@@ -76,7 +76,7 @@ class TestBranch1OpenSubnet:
         body = r.json()
         assert body == {
             "status": "joined",
-            "subnet_id": SUBNET_ID,
+            "slug": SUBNET_ID,
             "agent_id": INVITEE_AGENT_ID,
         }
         # Back-reference must be written on every 200 branch.
@@ -88,7 +88,7 @@ class TestBranch2OwnerSelfJoin:
         # Owner authenticates as themselves and joins their own subnet.
         agent_svc, _, _, jfs = wire
         jfs.join_subnet.return_value = JoinFlowJoinedAsOwnerResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=OWNER_AGENT_ID,
         )
 
@@ -112,7 +112,7 @@ class TestBranch3SelfJoinWithPendingInvitation:
             request_id="inv-self", kind="invitation"
         )
         jfs.join_subnet.return_value = JoinFlowAutoAcceptedInvitationResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
             invitation=invitation,
             via="self_join",
@@ -137,7 +137,7 @@ class TestBranch4AllowlistAndPendingInvitation:
             request_id="inv-merged", kind="invitation"
         )
         jfs.join_subnet.return_value = JoinFlowAutoAcceptedInvitationResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
             invitation=invitation,
             via="allowlist",
@@ -169,7 +169,7 @@ class TestBranch5AllowlistAutoApproved:
             decided_by="system:allowlist",
         )
         jfs.join_subnet.return_value = JoinFlowAllowlistAutoApprovedResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
             request=auto_row,
         )
@@ -189,7 +189,7 @@ class TestBranch6PendingJoinRequest:
         agent_svc, _, _, jfs = wire
         pending = make_join_request(request_id="req-pending")
         jfs.join_subnet.return_value = JoinFlowPendingResult(
-            subnet_id=SUBNET_ID,
+            slug=SUBNET_ID,
             agent_id=INVITEE_AGENT_ID,
             request=pending,
         )
@@ -219,7 +219,7 @@ class TestErrorSurfaces:
         assert r.status_code == 409, r.text
         body = r.json()
         assert body["error_code"] == "already_member"
-        assert body["details"]["subnet_id"] == SUBNET_ID
+        assert body["details"]["slug"] == SUBNET_ID
         assert body["details"]["agent_id"] == INVITEE_AGENT_ID
 
     def test_path_agent_mismatch_returns_403_before_dispatch(self, wire):

--- a/tests/routes/test_subnet_admission_join_requests.py
+++ b/tests/routes/test_subnet_admission_join_requests.py
@@ -266,7 +266,7 @@ class TestListJoinRequests:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == SUBNET_ID
+        assert body["slug"] == SUBNET_ID
         assert len(body["items"]) == 2
         # Default kind filter is join_request.
         subnet_svc.list_join_requests.assert_awaited_once_with(

--- a/tests/routes/test_subnets_create_membership.py
+++ b/tests/routes/test_subnets_create_membership.py
@@ -7,7 +7,7 @@ ACN stores subnet membership as a bidirectional pair:
 Both must be written for the membership to be visible to every consumer.
 ``SubnetService.create_subnet`` only writes the subnet side via
 ``subnet.add_member(owner)``; the route handler ``POST /api/v1/subnets``
-must mirror this with an ``agent_service.join_subnet(owner, subnet_id)``
+must mirror this with an ``agent_service.join_subnet(owner, slug)``
 call so the agent side is also written.
 
 Without this, freshly created subnets show ``member_count=0`` in any
@@ -51,9 +51,9 @@ def stub_agent_service():
     return svc
 
 
-def _make_subnet_mock(subnet_id: str = "subnet-new-abc123", owner: str = "agent-target"):
+def _make_subnet_mock(slug: str = "subnet-new-abc123", owner: str = "agent-target"):
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.owner = owner
     sn.is_private = False
     sn.harness_url = None
@@ -76,7 +76,7 @@ def stub_subnet_service():
         # Reflect that on the returned mock so tests asserting on the
         # subnet side see what production sees.
         return _make_subnet_mock(
-            subnet_id=kwargs["subnet_id"],
+            slug=kwargs["slug"],
             owner=kwargs["owner"],
         )
 
@@ -85,7 +85,7 @@ def stub_subnet_service():
     return svc
 
 
-# Pin an explicit subnet_id in test request bodies so we can assert on it
+# Pin an explicit slug in test request bodies so we can assert on it
 # without depending on the route's _generate_subnet_id() randomness.
 _EXPLICIT_SUBNET_ID = "subnet-explicit-test-001"
 
@@ -121,7 +121,7 @@ class TestCreateSubnetMembership:
             r = client.post(
                 "/api/v1/subnets",
                 headers={"Authorization": "Bearer owner-key"},
-                json={"name": "Demo Subnet", "subnet_id": _EXPLICIT_SUBNET_ID},
+                json={"name": "Demo Subnet", "slug": _EXPLICIT_SUBNET_ID},
             )
 
         assert r.status_code == 200, r.text
@@ -142,13 +142,13 @@ class TestCreateSubnetMembership:
             r = client.post(
                 "/api/v1/subnets",
                 headers={"Authorization": "Bearer owner-key"},
-                json={"name": "Demo Subnet", "subnet_id": _EXPLICIT_SUBNET_ID},
+                json={"name": "Demo Subnet", "slug": _EXPLICIT_SUBNET_ID},
             )
 
         assert r.status_code == 200
         body = r.json()
         assert body["status"] == "created"
-        assert body["subnet_id"] == _EXPLICIT_SUBNET_ID
+        assert body["slug"] == _EXPLICIT_SUBNET_ID
         assert body["is_public"] is True
 
     def test_create_subnet_rolls_back_when_agent_join_fails(
@@ -170,7 +170,7 @@ class TestCreateSubnetMembership:
             r = client.post(
                 "/api/v1/subnets",
                 headers={"Authorization": "Bearer owner-key"},
-                json={"name": "Demo Subnet", "subnet_id": _EXPLICIT_SUBNET_ID},
+                json={"name": "Demo Subnet", "slug": _EXPLICIT_SUBNET_ID},
             )
 
         assert r.status_code == 500

--- a/tests/routes/test_subnets_error_schema.py
+++ b/tests/routes/test_subnets_error_schema.py
@@ -34,22 +34,22 @@ Coverage choice rationale
   endpoint shapes that together touch every distinct ``raise … from
   …`` style and every migrated ``ErrorCode``:
 
-  * ``GET /subnets/{subnet_id}`` — the simplest ``except … from e``
+  * ``GET /subnets/{slug}`` — the simplest ``except … from e``
     re-raise, the public discovery 404 surface for SDK clients.
-  * ``GET /subnets/{subnet_id}/agents`` — same domain exception
+  * ``GET /subnets/{slug}/agents`` — same domain exception
     re-raise but with an *early-out* ``try`` block that wraps a
     single ``await``; the rest of the handler runs at top-level.
     Pins that the migration didn't accidentally widen the ``try``.
-  * ``POST /subnets/{agent_id}/subnets/{subnet_id}`` (403 path) —
+  * ``POST /subnets/{agent_id}/subnets/{slug}`` (403 path) —
     the ``if agent_info[...] != agent_id: raise`` shape (raise at
     function top-level, not in any ``try``). One of three identical
     ``API_KEY_AGENT_MISMATCH`` sites; representative coverage.
-  * ``POST /subnets/{agent_id}/subnets/{subnet_id}`` (404 subnet) —
+  * ``POST /subnets/{agent_id}/subnets/{slug}`` (404 subnet) —
     the *first* ``try`` block of a multi-try handler raises
     ``ACNHTTPError`` from ``SubnetNotFoundException`` before the
     second ``try`` runs. Pins that mid-handler ``ACNHTTPError``
     propagates without being swallowed by a *later* catch-all.
-  * ``POST /subnets/{agent_id}/subnets/{subnet_id}`` (404 agent) —
+  * ``POST /subnets/{agent_id}/subnets/{slug}`` (404 agent) —
     the *last* ``try`` block reraises ``ACNHTTPError`` from
     ``AgentNotFoundException``; the surrounding ``except Exception``
     catch-all is the one that *would* swallow the new exception
@@ -138,7 +138,7 @@ def stub_subnet_service():
     svc = AsyncMock()
 
     target_subnet = MagicMock()
-    target_subnet.subnet_id = "subnet-1"
+    target_subnet.slug="subnet-1"
     target_subnet.name = "test"
     target_subnet.owner = "user-1"
     target_subnet.is_private = False
@@ -149,10 +149,10 @@ def stub_subnet_service():
     target_subnet.created_at = "2025-01-01T00:00:00Z"
     target_subnet.metadata = {}
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == "subnet-1":
+    async def _get_subnet(slug: str):
+        if slug == "subnet-1":
             return target_subnet
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     svc.add_member = AsyncMock(return_value=None)
@@ -170,10 +170,10 @@ def stub_join_flow_service(stub_subnet_service):
     """
     svc = AsyncMock()
 
-    async def _join_subnet(subnet_id: str, agent_id: str):
-        await stub_subnet_service.get_subnet(subnet_id)
-        await stub_subnet_service.add_member(subnet_id, agent_id)
-        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+    async def _join_subnet(slug: str, agent_id: str):
+        await stub_subnet_service.get_subnet(slug)
+        await stub_subnet_service.add_member(slug, agent_id)
+        return JoinFlowJoinedOpenResult(slug=slug, agent_id=agent_id)
 
     svc.join_subnet = AsyncMock(side_effect=_join_subnet)
     app.dependency_overrides[get_join_flow_service] = lambda: svc
@@ -206,7 +206,7 @@ class TestSubnetsFlatErrorSchema:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "subnet-missing"}
+        assert body["details"] == {"slug": "subnet-missing"}
         assert r.headers.get("X-Request-ID") == body["request_id"]
 
     def test_get_subnet_agents_404_early_out(
@@ -226,12 +226,12 @@ class TestSubnetsFlatErrorSchema:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "subnet-missing"}
+        assert body["details"] == {"slug": "subnet-missing"}
 
     def test_join_subnet_403_api_key_agent_mismatch(
         self, stub_agent_service, stub_subnet_service
     ):
-        """``POST /api/v1/subnets/{path_agent}/subnets/{subnet_id}``
+        """``POST /api/v1/subnets/{path_agent}/subnets/{slug}``
         — the ``if agent_info[...] != agent_id: raise`` top-level
         check. Cross-tenant joins must surface the path/key tuple
         in ``details`` so the SDK can show "you tried to join with
@@ -277,12 +277,12 @@ class TestSubnetsFlatErrorSchema:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "subnet-missing"}
+        assert body["details"] == {"slug": "subnet-missing"}
 
     def test_join_subnet_404_agent_inside_catchall_try(
         self, stub_agent_service, stub_subnet_service
     ):
-        """``POST /subnets/{agent}/subnets/{subnet_id}`` —
+        """``POST /subnets/{agent}/subnets/{slug}`` —
         ``join_subnet`` raises ``AgentNotFoundException`` *inside*
         a ``try`` whose final clause is a catch-all
         ``except Exception``. The ``ACNHTTPError`` is raised from
@@ -323,7 +323,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         representative test per site so each site's
         ``details.reason`` and field set is pinned independently —
         unlike registry's `replace_all=true` cohorts, the subnets
-        sites differ in payload shape (``subnet_id`` vs
+        sites differ in payload shape (``slug`` vs
         ``requested_owner`` vs free-form ``reason``) so per-site
         pinning is more useful here.
 
@@ -361,7 +361,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
                 "/api/v1/subnets",
                 headers={"Authorization": "Bearer owner-key"},
                 json={
-                    "subnet_id": "test-subnet",
+                    "slug": "test-subnet",
                     "name": "Test Subnet",
                 },
             )
@@ -449,7 +449,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         """
         stub_subnet_service.get_subnet.side_effect = None
         target_subnet = MagicMock()
-        target_subnet.subnet_id = "subnet-private"
+        target_subnet.slug="subnet-private"
         target_subnet.owner = "user-1"
         target_subnet.is_private = True
         target_subnet.member_agent_ids = set()
@@ -464,7 +464,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         body = r.json()
         assert body["agents"] == []
         assert body["count"] == 0
-        assert body["subnet_id"] == "subnet-private"
+        assert body["slug"] == "subnet-private"
 
     def test_get_subnet_agents_private_cross_tenant_returns_empty_list(
         self, stub_agent_service, stub_subnet_service, monkeypatch
@@ -479,7 +479,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         """
         stub_subnet_service.get_subnet.side_effect = None
         target_subnet = MagicMock()
-        target_subnet.subnet_id = "subnet-private"
+        target_subnet.slug="subnet-private"
         target_subnet.owner = "user-1"
         target_subnet.is_private = True
         target_subnet.member_agent_ids = set()
@@ -503,14 +503,14 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         body = r.json()
         assert body["agents"] == []
         assert body["count"] == 0
-        assert body["subnet_id"] == "subnet-private"
+        assert body["slug"] == "subnet-private"
 
     def test_delete_subnet_permission_error_returns_ownership_mismatch(
         self, stub_agent_service, stub_subnet_service
     ):
         """``DELETE /api/v1/subnets/{id}`` when the service raises
         ``PermissionError`` — pins ``OWNERSHIP_MISMATCH`` with
-        ``subnet_id`` and the underlying reason in ``details``.
+        ``slug`` and the underlying reason in ``details``.
 
         Auth note
             ``delete_subnet`` is now gated by ``AgentApiKeyDep``;
@@ -537,7 +537,7 @@ class TestSubnetsFlatErrorSchemaCrossModule:
         _assert_flat_shape(body)
         assert body["error_code"] == "ownership_mismatch"
         assert body["details"] == {
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
             "reason": "owner_mismatch",
         }
 
@@ -629,7 +629,7 @@ class TestSubnetsCatchAllDefence:
         with TestClient(app) as client:
             r = client.post(
                 "/api/v1/subnets/",
-                json={"subnet_id": "sn-x", "name": "x", "owner": "o"},
+                json={"slug": "sn-x", "name": "x", "owner": "o"},
                 headers={"Authorization": "Bearer owner-key"},
             )
 

--- a/tests/routes/test_subnets_get_detail_privacy.py
+++ b/tests/routes/test_subnets_get_detail_privacy.py
@@ -1,4 +1,4 @@
-"""Route-level tests for ``GET /api/v1/subnets/{subnet_id}`` privacy
+"""Route-level tests for ``GET /api/v1/subnets/{slug}`` privacy
 contract (ACL V6 / issue #114).
 
 Contract:
@@ -10,9 +10,9 @@ Contract:
 3. **Private subnets — anon or authed non-member** receive a
    ``SubnetStub`` (200) — opaque UUID plus minimal structural metadata.
    Sensitive fields (slug, name, owner, description, harness_url,
-   security_schemes, parent_subnet_id) are omitted.
+   security_schemes, parent_slug) are omitted.
 4. **Genuinely missing subnets** still 404 with ``SUBNET_NOT_FOUND``.
-5. **``SubnetInfo`` no longer leaks ``parent_subnet_id`` slug** (B6) —
+5. **``SubnetInfo`` no longer leaks ``parent_slug`` slug** (B6) —
    the field is always ``None`` in responses; ``parent_id`` UUID is
    used instead.
 """
@@ -36,20 +36,20 @@ from acn.routes.dependencies import get_agent_service, get_subnet_service
 
 
 def _make_subnet(
-    subnet_id: str,
+    slug: str,
     *,
     owner: str,
     is_private: bool,
     member_agent_ids: set[str] | None = None,
     name: str = "Test Subnet",
     opaque_id: str | None = None,
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
 ) -> MagicMock:
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     # Opaque UUID — defaults to a deterministic-per-slug value so test
     # assertions can predict which UUID a stub will surface.
-    sn.id = opaque_id or f"00000000-0000-0000-0000-{subnet_id.replace('-', '')[:12]:0<12}"
+    sn.id = opaque_id or f"00000000-0000-0000-0000-{slug.replace('-', '')[:12]:0<12}"
     sn.name = name
     sn.owner = owner
     sn.description = None
@@ -59,7 +59,7 @@ def _make_subnet(
     sn.harness_url = "https://harness.example.org" if is_private else None
     sn.created_at = datetime(2026, 5, 18, tzinfo=UTC)
     sn.member_agent_ids = set(member_agent_ids or ())
-    sn.parent_subnet_id = parent_subnet_id
+    sn.parent_slug = parent_slug
     sn.lifecycle = "persistent"
     sn.linked_task_id = None
     return sn
@@ -91,11 +91,11 @@ def private_subnet() -> MagicMock:
 def stub_subnet_service(public_subnet, private_subnet):
     svc = AsyncMock()
 
-    async def _get_subnet(subnet_id: str):
+    async def _get_subnet(slug: str):
         for sn in (public_subnet, private_subnet):
-            if sn.subnet_id == subnet_id:
+            if sn.slug == slug:
                 return sn
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     return svc
@@ -156,18 +156,18 @@ def _fake_verify_token(
 
 def _assert_stub(body: dict) -> None:
     """Discoverable-private callers must get a SubnetStub — opaque UUID
-    plus minimal structural metadata. The human-readable ``subnet_id``
+    plus minimal structural metadata. The human-readable ``slug``
     slug, ``name``, and all sensitive fields must be absent."""
     # Opaque UUID is the only identifier surfaced.
     assert "id" in body and body["id"], "stub must carry the opaque UUID"
     assert body["is_private"] is True
     # Privacy contract: human-readable identifiers must be absent.
-    for leak in ("subnet_id", "name", "slug"):
+    for leak in ("slug", "name", "slug"):
         assert leak not in body, f"stub must not leak {leak!r} (organisational naming)"
     # Other sensitive fields must also be absent.
     for sensitive in ("owner", "description", "harness_url", "metadata",
                       "security_schemes", "default_security",
-                      "parent_subnet_id"):
+                      "parent_slug"):
         assert sensitive not in body, f"stub must not leak {sensitive!r}"
 
 
@@ -187,7 +187,7 @@ class TestPublicSubnetUnchanged:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == "subnet-public"
+        assert body["slug"] == "subnet-public"
         assert body["owner"] == "agent-owner"
 
     def test_authed_non_member_can_still_read_public_subnet(self, monkeypatch):
@@ -204,14 +204,14 @@ class TestPublicSubnetUnchanged:
         assert r.status_code == 200, r.text
 
     def test_public_subnet_parent_subnet_id_suppressed(self):
-        """B6: SubnetInfo must never expose parent_subnet_id slug."""
+        """B6: SubnetInfo must never expose parent_slug slug."""
         with TestClient(app) as client:
             r = client.get("/api/v1/subnets/subnet-public")
 
         assert r.status_code == 200
         body = r.json()
-        # parent_subnet_id slug is always None; parent_id UUID is the new field.
-        assert body.get("parent_subnet_id") is None
+        # parent_slug slug is always None; parent_id UUID is the new field.
+        assert body.get("parent_slug") is None
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +234,7 @@ class TestPrivateSubnetAuthorisedCallers:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == "subnet-private"
+        assert body["slug"] == "subnet-private"
         assert body["owner"] == "agent-owner"
         assert body["harness_url"] == "https://harness.example.org"
 
@@ -251,7 +251,7 @@ class TestPrivateSubnetAuthorisedCallers:
             )
 
         assert r.status_code == 200, r.text
-        assert r.json()["subnet_id"] == "subnet-private"
+        assert r.json()["slug"] == "subnet-private"
 
     def test_admin_sees_full_payload(self, monkeypatch):
         """``acn:admin`` is a platform-level permission (ops, support,
@@ -291,11 +291,11 @@ class TestPrivateSubnetAuthorisedCallers:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == "subnet-private"
+        assert body["slug"] == "subnet-private"
         assert body["owner"] == "agent-owner"
 
     def test_full_payload_parent_subnet_id_suppressed(self, monkeypatch):
-        """B6: even authorised callers must not receive parent_subnet_id slug."""
+        """B6: even authorised callers must not receive parent_slug slug."""
         monkeypatch.setattr(
             "acn.routes.subnets.verify_token",
             _fake_verify_token(sub="agent-owner", caller_type="agent"),
@@ -307,7 +307,7 @@ class TestPrivateSubnetAuthorisedCallers:
             )
 
         assert r.status_code == 200, r.text
-        assert r.json().get("parent_subnet_id") is None
+        assert r.json().get("parent_slug") is None
 
 
 # ---------------------------------------------------------------------------
@@ -317,7 +317,7 @@ class TestPrivateSubnetAuthorisedCallers:
 
 class TestPrivateSubnetDiscoverable:
     """Anon and non-member callers now get structural metadata (SubnetStub)
-    instead of 404.  The subnet_id is already discoverable via public
+    instead of 404.  The slug is already discoverable via public
     agent subnet_ids, so existence-hiding provides no real security."""
 
     def test_anon_gets_stub(self):
@@ -400,7 +400,7 @@ class TestPrivateSubnetDiscoverable:
         """Discoverable-private returns 200 (stub); genuinely missing
         returns 404.  Callers can tell the difference via status_code —
         the *body* of the stub deliberately does NOT echo back the
-        requested ``subnet_id`` (that slug carries organisational
+        requested ``slug`` (that slug carries organisational
         semantics for private subnets).  Instead the stub carries an
         opaque ``id`` (UUID) which is safe to expose.
         """
@@ -413,7 +413,7 @@ class TestPrivateSubnetDiscoverable:
         body = stub_resp.json()
         assert body["is_private"] is True
         assert body.get("id"), "stub must carry the opaque UUID"
-        assert "subnet_id" not in body, "stub must not echo back the slug"
+        assert "slug" not in body, "stub must not echo back the slug"
         assert missing_resp.json()["error_code"] == "subnet_not_found"
 
 
@@ -430,7 +430,7 @@ class TestMissingSubnetRegression:
         assert r.status_code == 404
         body = r.json()
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "never-existed"}
+        assert body["details"] == {"slug": "never-existed"}
 
     def test_authed_truly_missing_subnet_404(self, monkeypatch):
         """The fix must not let the auth branch swallow a real 404

--- a/tests/routes/test_subnets_harness.py
+++ b/tests/routes/test_subnets_harness.py
@@ -1,12 +1,12 @@
 """Route-level tests for the pluggable Org Harness endpoints.
 
 Covers:
-- ``PATCH /api/v1/subnets/{subnet_id}/harness`` — owner can register / clear,
+- ``PATCH /api/v1/subnets/{slug}/harness`` — owner can register / clear,
   non-owner gets 403 ``OWNERSHIP_MISMATCH``, missing subnet gets 404.
-- ``POST /api/v1/subnets/{agent_id}/subnets/{subnet_id}`` (join) — when the
+- ``POST /api/v1/subnets/{agent_id}/subnets/{slug}`` (join) — when the
   subnet has a registered harness, ``WebhookService.send_to`` is called with
   the ``agent.joined_subnet`` event.
-- ``DELETE /api/v1/subnets/{agent_id}/subnets/{subnet_id}`` (leave) — same
+- ``DELETE /api/v1/subnets/{agent_id}/subnets/{slug}`` (leave) — same
   contract for ``agent.left_subnet``.
 - Harness-webhook failure during join/leave must NOT surface a 5xx to the
   client.
@@ -61,13 +61,13 @@ def stub_agent_service():
 
 
 def _make_subnet_mock(
-    subnet_id: str = "subnet-1",
+    slug: str = "subnet-1",
     owner: str = "agent-target",
     harness_url: str | None = None,
     harness_secret: str | None = None,
 ):
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.owner = owner
     sn.harness_url = harness_url
     sn.harness_secret = harness_secret
@@ -81,10 +81,10 @@ def stub_subnet_service():
     svc = AsyncMock()
     default = _make_subnet_mock()
 
-    async def _get_subnet(subnet_id: str):
-        if subnet_id == "subnet-1":
+    async def _get_subnet(slug: str):
+        if slug == "subnet-1":
             return default
-        raise SubnetNotFoundException(subnet_id)
+        raise SubnetNotFoundException(slug)
 
     svc.get_subnet = AsyncMock(side_effect=_get_subnet)
     svc.add_member = AsyncMock(return_value=None)
@@ -114,10 +114,10 @@ def stub_join_flow_service(stub_subnet_service):
     """
     svc = AsyncMock()
 
-    async def _join_subnet(subnet_id: str, agent_id: str):
-        await stub_subnet_service.get_subnet(subnet_id)
-        await stub_subnet_service.add_member(subnet_id, agent_id)
-        return JoinFlowJoinedOpenResult(subnet_id=subnet_id, agent_id=agent_id)
+    async def _join_subnet(slug: str, agent_id: str):
+        await stub_subnet_service.get_subnet(slug)
+        await stub_subnet_service.add_member(slug, agent_id)
+        return JoinFlowJoinedOpenResult(slug=slug, agent_id=agent_id)
 
     svc.join_subnet = AsyncMock(side_effect=_join_subnet)
     app.dependency_overrides[get_join_flow_service] = lambda: svc
@@ -135,7 +135,7 @@ def _wire(agent_svc, subnet_svc, webhook_svc=None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# PATCH /api/v1/subnets/{subnet_id}/harness
+# PATCH /api/v1/subnets/{slug}/harness
 # ---------------------------------------------------------------------------
 
 
@@ -164,14 +164,14 @@ class TestPatchSubnetHarness:
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["status"] == "updated"
-        assert body["subnet_id"] == "subnet-1"
+        assert body["slug"] == "subnet-1"
         assert body["harness_url"] == "https://paperclip.example/acn"
         assert body["harness_registered"] is True
         # Secret must NEVER be echoed back over the wire
         assert "harness_secret" not in body
 
         stub_subnet_service.update_harness.assert_awaited_once_with(
-            subnet_id="subnet-1",
+            slug="subnet-1",
             owner="agent-target",
             harness_url="https://paperclip.example/acn",
             harness_secret="topsecret",
@@ -217,7 +217,7 @@ class TestPatchSubnetHarness:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "ownership_mismatch"
-        assert body["details"]["subnet_id"] == "subnet-1"
+        assert body["details"]["slug"] == "subnet-1"
         assert "reason" in body["details"]
 
     def test_missing_subnet_returns_404(
@@ -239,7 +239,7 @@ class TestPatchSubnetHarness:
         body = r.json()
         _assert_flat_shape(body)
         assert body["error_code"] == "subnet_not_found"
-        assert body["details"] == {"subnet_id": "ghost"}
+        assert body["details"] == {"slug": "ghost"}
 
     def test_unauthenticated_does_not_succeed(
         self, stub_agent_service, stub_subnet_service, stub_webhook_service
@@ -288,7 +288,7 @@ class TestJoinLeaveWebhookDelivery:
         assert kw["url"] == "https://h.example/hook"
         assert kw["secret"] == "hs"
         assert kw["event"] == WebhookEventType.AGENT_JOINED_SUBNET
-        assert kw["data"]["subnet_id"] == "subnet-1"
+        assert kw["data"]["slug"] == "subnet-1"
         assert kw["data"]["agent_id"] == "agent-target"
 
     def test_join_without_registered_harness_skips_send_to(

--- a/tests/routes/test_subnets_join_policy.py
+++ b/tests/routes/test_subnets_join_policy.py
@@ -63,14 +63,14 @@ def stub_agent_service():
 
 
 def _make_subnet_mock(
-    subnet_id: str,
+    slug: str,
     *,
     owner: str = "agent-target",
     is_private: bool = False,
     join_policy: str = "open",
 ):
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.owner = owner
     sn.is_private = is_private
     sn.harness_url = None
@@ -100,7 +100,7 @@ def stub_subnet_service():
                 )
             effective = join_policy
         return _make_subnet_mock(
-            kwargs["subnet_id"],
+            kwargs["slug"],
             owner=kwargs["owner"],
             is_private=is_private,
             join_policy=effective,
@@ -133,7 +133,7 @@ class TestJoinPolicyInference:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Legacy Private",
-                    "subnet_id": "subnet-legacy-priv",
+                    "slug": "subnet-legacy-priv",
                     "is_private": True,
                 },
             )
@@ -156,7 +156,7 @@ class TestJoinPolicyInference:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Legacy Public",
-                    "subnet_id": "subnet-legacy-pub",
+                    "slug": "subnet-legacy-pub",
                 },
             )
 
@@ -180,7 +180,7 @@ class TestExplicitJoinPolicy:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Curated Board",
-                    "subnet_id": "subnet-curated",
+                    "slug": "subnet-curated",
                     "is_private": False,
                     "join_policy": "approval",
                 },
@@ -201,7 +201,7 @@ class TestExplicitJoinPolicy:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Forward-Aware Private",
-                    "subnet_id": "subnet-aware-priv",
+                    "slug": "subnet-aware-priv",
                     "is_private": True,
                     "join_policy": "approval",
                 },
@@ -226,7 +226,7 @@ class TestExplicitJoinPolicy:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Conflict",
-                    "subnet_id": "subnet-conflict",
+                    "slug": "subnet-conflict",
                     "is_private": True,
                     "join_policy": "open",
                 },
@@ -257,7 +257,7 @@ class TestRequestModelValidation:
                 headers={"Authorization": "Bearer owner-key"},
                 json={
                     "name": "Bad",
-                    "subnet_id": "subnet-bad",
+                    "slug": "subnet-bad",
                     "join_policy": "moderated",  # not in the literal set
                 },
             )

--- a/tests/routes/test_subnets_nesting.py
+++ b/tests/routes/test_subnets_nesting.py
@@ -69,21 +69,21 @@ def stub_agent_service():
 
 
 def _make_subnet_entity(
-    subnet_id: str = "subnet-1",
+    slug: str = "subnet-1",
     owner: str = "agent-target",
     *,
     is_private: bool = False,
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
     lifecycle: str = "persistent",
     linked_task_id: str | None = None,
     member_agent_ids: set[str] | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         is_private=is_private,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         lifecycle=lifecycle,  # type: ignore[arg-type]
         linked_task_id=linked_task_id,
         member_agent_ids=member_agent_ids or {owner},
@@ -128,13 +128,13 @@ def test_create_subnet_invariant_rejection(reason, stub_agent_service):
     )
     _wire(stub_agent_service, subnet_svc)
 
-    body: dict = {"name": "Squad", "subnet_id": "squad-1"}
+    body: dict = {"name": "Squad", "slug": "squad-1"}
     # Send a body shape that *could* plausibly produce each reason —
     # the stub raises regardless, but a realistic payload helps the
     # contract test document each variant's intended call site.
     if reason in {REASON_PARENT_NOT_FOUND, REASON_PARENT_IS_RESERVED,
                   REASON_PARENT_IS_NESTED}:
-        body["parent_subnet_id"] = "some-parent"
+        body["parent_slug"] = "some-parent"
     if reason == REASON_TASK_SCOPED_REQUIRES_LINKED_TASK:
         body["lifecycle"] = "task_scoped"
     if reason == REASON_LINKED_TASK_NOT_FOUND:
@@ -163,9 +163,9 @@ def test_create_subnet_happy_path_with_nesting(stub_agent_service):
 
     async def _create(**kwargs):
         return _make_subnet_entity(
-            subnet_id=kwargs["subnet_id"],
+            slug=kwargs["slug"],
             owner=kwargs["owner"],
-            parent_subnet_id=kwargs.get("parent_subnet_id"),
+            parent_slug=kwargs.get("parent_slug"),
             lifecycle=kwargs.get("lifecycle", "persistent"),
             linked_task_id=kwargs.get("linked_task_id"),
         )
@@ -179,8 +179,8 @@ def test_create_subnet_happy_path_with_nesting(stub_agent_service):
             headers={"Authorization": "Bearer owner-key"},
             json={
                 "name": "Bug Squad",
-                "subnet_id": "squad-1",
-                "parent_subnet_id": "parent-1",
+                "slug": "squad-1",
+                "parent_slug": "parent-1",
                 "lifecycle": "task_scoped",
                 "linked_task_id": "task-42",
             },
@@ -188,11 +188,11 @@ def test_create_subnet_happy_path_with_nesting(stub_agent_service):
 
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["subnet_id"] == "squad-1"
+    assert body["slug"] == "squad-1"
     # Service was called with the three nesting fields wired through
     subnet_svc.create_subnet.assert_awaited_once()
     call_kwargs = subnet_svc.create_subnet.await_args.kwargs
-    assert call_kwargs["parent_subnet_id"] == "parent-1"
+    assert call_kwargs["parent_slug"] == "parent-1"
     assert call_kwargs["lifecycle"] == "task_scoped"
     assert call_kwargs["linked_task_id"] == "task-42"
 
@@ -206,14 +206,14 @@ class TestListSubnetsParentFilter:
     def test_parent_filter_returns_children(self, stub_agent_service):
         children = [
             _make_subnet_entity(
-                subnet_id="child-1",
+                slug="child-1",
                 owner="agent-target",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
             ),
             _make_subnet_entity(
-                subnet_id="child-2",
+                slug="child-2",
                 owner="agent-target",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
             ),
         ]
         subnet_svc = AsyncMock()
@@ -226,11 +226,11 @@ class TestListSubnetsParentFilter:
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["count"] == 2
-        ids = {s["subnet_id"] for s in body["subnets"]}
+        ids = {s["slug"] for s in body["subnets"]}
         assert ids == {"child-1", "child-2"}
         # ACL: anonymous → requester_id=None
         subnet_svc.list_children.assert_awaited_once_with(
-            parent_subnet_id="parent-1", requester_id=None
+            parent_slug="parent-1", requester_id=None
         )
 
     def test_parent_filter_no_existence_leak_returns_empty(
@@ -261,19 +261,19 @@ class TestListSubnetsParentFilter:
 
 class TestGetSubnetChildren:
     def test_children_endpoint_returns_count_and_subnets(self, stub_agent_service):
-        parent = _make_subnet_entity(subnet_id="parent-1")
+        parent = _make_subnet_entity(slug="parent-1")
         children = [
             _make_subnet_entity(
-                subnet_id="child-A",
-                parent_subnet_id="parent-1",
+                slug="child-A",
+                parent_slug="parent-1",
             ),
         ]
         subnet_svc = AsyncMock()
 
-        async def _get_subnet(subnet_id: str):
-            if subnet_id == "parent-1":
+        async def _get_subnet(slug: str):
+            if slug == "parent-1":
                 return parent
-            raise SubnetNotFoundException(subnet_id)
+            raise SubnetNotFoundException(slug)
 
         subnet_svc.get_subnet = AsyncMock(side_effect=_get_subnet)
         subnet_svc.list_children = AsyncMock(return_value=children)
@@ -285,9 +285,9 @@ class TestGetSubnetChildren:
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["count"] == 1
-        assert body["subnets"][0]["subnet_id"] == "child-A"
-        # ACL V6 B6: parent_subnet_id slug is always suppressed in responses.
-        assert body["subnets"][0].get("parent_subnet_id") is None
+        assert body["subnets"][0]["slug"] == "child-A"
+        # ACL V6 B6: parent_slug slug is always suppressed in responses.
+        assert body["subnets"][0].get("parent_slug") is None
         # parent_id (UUID) is the new field — non-None for child subnets.
         assert body["subnets"][0].get("parent_id") is not None
 
@@ -318,8 +318,8 @@ class TestGetSubnetChildren:
 class TestPromoteSubnet:
     def test_promote_returns_updated_subnet_info(self, stub_agent_service):
         promoted = _make_subnet_entity(
-            subnet_id="squad-1",
-            parent_subnet_id="parent-1",
+            slug="squad-1",
+            parent_slug="parent-1",
             lifecycle="persistent",
             linked_task_id=None,
         )
@@ -335,11 +335,11 @@ class TestPromoteSubnet:
 
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["subnet_id"] == "squad-1"
+        assert body["slug"] == "squad-1"
         assert body["lifecycle"] == "persistent"
         assert body["linked_task_id"] is None
         subnet_svc.promote_to_persistent.assert_awaited_once_with(
-            subnet_id="squad-1", owner="agent-target"
+            slug="squad-1", owner="agent-target"
         )
 
     def test_promote_404_for_missing_subnet(self, stub_agent_service):

--- a/tests/routes/test_subnets_owner_field.py
+++ b/tests/routes/test_subnets_owner_field.py
@@ -31,14 +31,14 @@ from acn.routes.dependencies import get_subnet_service
 
 
 def _make_subnet_mock(
-    subnet_id: str,
+    slug: str,
     *,
     owner: str,
     name: str = "Test Subnet",
     is_private: bool = False,
 ):
     sn = MagicMock()
-    sn.subnet_id = subnet_id
+    sn.slug = slug
     sn.name = name
     sn.owner = owner
     sn.description = None
@@ -64,11 +64,11 @@ def stub_subnet_service():
     async def _list_subnets(owner=None):
         return [user_subnet, system_subnet]
 
-    async def _get_subnet(subnet_id: str):
+    async def _get_subnet(slug: str):
         for sn in (user_subnet, system_subnet):
-            if sn.subnet_id == subnet_id:
+            if sn.slug == slug:
                 return sn
-        raise KeyError(subnet_id)
+        raise KeyError(slug)
 
     svc.list_subnets = AsyncMock(side_effect=_list_subnets)
     svc.list_public_subnets = AsyncMock(side_effect=_list_subnets)  # kept for compat
@@ -95,7 +95,7 @@ class TestListSubnetsOwnerField:
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["count"] == 2
-        owners_by_id = {s["subnet_id"]: s.get("owner") for s in body["subnets"]}
+        owners_by_id = {s["slug"]: s.get("owner") for s in body["subnets"]}
         assert owners_by_id == {
             "subnet-user-001": "agent-creator",
             "ws-system-001": "backend@internal",
@@ -113,11 +113,11 @@ class TestListSubnetsOwnerField:
         assert r.status_code == 200
         for s in r.json()["subnets"]:
             assert "owner" in s, f"missing owner field: {s}"
-            assert s["owner"], f"empty owner for {s['subnet_id']}: {s}"
+            assert s["owner"], f"empty owner for {s['slug']}: {s}"
 
 
 # ---------------------------------------------------------------------------
-# GET /api/v1/subnets/{subnet_id} — single
+# GET /api/v1/subnets/{slug} — single
 # ---------------------------------------------------------------------------
 
 

--- a/tests/routes/test_task_acl_scope_b.py
+++ b/tests/routes/test_task_acl_scope_b.py
@@ -8,10 +8,10 @@ Three ACL rules introduced in Scope B:
 
   B-A  accept gate: POST /tasks/{id}/accept and POST /tasks/agent/{id}/accept
        reject non-subnet-members with 403 NOT_SUBNET_MEMBER when the task
-       has a ``subnet_id``.
+       has a ``slug``.
 
   B-C  create gate: POST /tasks (and POST /tasks/agent/create) reject a
-       creator who is not a member of the specified ``subnet_id`` with
+       creator who is not a member of the specified ``slug`` with
        403 NOT_SUBNET_MEMBER.
 
 Implementation notes for dev_mode interactions
@@ -70,7 +70,7 @@ def _make_task(
     task_id: str | None = None,
     creator_id: str = _AGENT_A,
     assignee_id: str | None = None,
-    subnet_id: str | None = None,
+    slug: str | None = None,
     submission: str | None = "secret-work",
 ) -> MagicMock:
     t = MagicMock()
@@ -107,7 +107,7 @@ def _make_task(
     t.metadata = {}
     t.submission = submission
     t.submission_artifacts = []
-    t.subnet_id = subnet_id
+    t.slug = slug
     t.max_resubmit_attempts = None
     return t
 
@@ -292,7 +292,7 @@ class TestAcceptGate:
         """Agent that is not in the task's subnet gets 403."""
         _disable_dev_mode(monkeypatch, agent_svc)
 
-        task = _make_task(subnet_id=_SUBNET_ID)
+        task = _make_task(slug=_SUBNET_ID)
         stub_task_service.get_task = AsyncMock(return_value=task)
         stub_task_service.is_subnet_member = AsyncMock(return_value=False)
 
@@ -311,7 +311,7 @@ class TestAcceptGate:
         """Agent that is a subnet member can accept the task."""
         _disable_dev_mode(monkeypatch, agent_svc)
 
-        task = _make_task(creator_id=_AGENT_A, subnet_id=_SUBNET_ID)
+        task = _make_task(creator_id=_AGENT_A, slug=_SUBNET_ID)
         stub_task_service.get_task = AsyncMock(return_value=task)
         stub_task_service.is_subnet_member = AsyncMock(return_value=True)
         stub_task_service.accept_task = AsyncMock(return_value=(task, "part-123"))
@@ -327,8 +327,8 @@ class TestAcceptGate:
         stub_task_service.accept_task.assert_awaited_once()
 
     def test_public_task_can_be_accepted_without_membership(self, stub_task_service):
-        """Public tasks (no subnet_id) require no subnet membership check."""
-        task = _make_task(creator_id=_AGENT_A, subnet_id=None)
+        """Public tasks (no slug) require no subnet membership check."""
+        task = _make_task(creator_id=_AGENT_A, slug=None)
         stub_task_service.get_task = AsyncMock(return_value=task)
         stub_task_service.accept_task = AsyncMock(return_value=(task, None))
 
@@ -346,7 +346,7 @@ class TestAcceptGate:
         """POST /tasks/agent/{id}/accept — non-member gets 403."""
         _disable_dev_mode(monkeypatch, agent_svc)
 
-        task = _make_task(subnet_id=_SUBNET_ID)
+        task = _make_task(slug=_SUBNET_ID)
         stub_task_service.get_task = AsyncMock(return_value=task)
         stub_task_service.is_subnet_member = AsyncMock(return_value=False)
 
@@ -369,12 +369,12 @@ _VALID_TASK_BODY: dict[str, Any] = {
     "description": "A sufficiently long description for the task creation gate test.",
     "deadline_hours": 24,
     "reward": "0",
-    "subnet_id": _SUBNET_ID,
+    "slug": _SUBNET_ID,
 }
 
 
 class TestCreateGate:
-    """POST /tasks — subnet membership required when subnet_id is set."""
+    """POST /tasks — subnet membership required when slug is set."""
 
     def test_non_member_cannot_create_subnet_task(self, monkeypatch, agent_svc, stub_task_service):
         """Agent not in the subnet cannot create a task inside it."""
@@ -397,7 +397,7 @@ class TestCreateGate:
         """Agent in the subnet can create a task."""
         _disable_dev_mode(monkeypatch, agent_svc)
 
-        task = _make_task(creator_id=_AGENT_A, subnet_id=_SUBNET_ID)
+        task = _make_task(creator_id=_AGENT_A, slug=_SUBNET_ID)
         stub_task_service.is_subnet_member = AsyncMock(return_value=True)
         stub_task_service.create_task = AsyncMock(return_value=task)
 
@@ -412,11 +412,11 @@ class TestCreateGate:
         stub_task_service.create_task.assert_awaited_once()
 
     def test_no_subnet_id_skips_membership_check(self, stub_task_service):
-        """Creating a public task (no subnet_id) skips the membership check."""
-        task = _make_task(creator_id=_AGENT_A, subnet_id=None)
+        """Creating a public task (no slug) skips the membership check."""
+        task = _make_task(creator_id=_AGENT_A, slug=None)
         stub_task_service.create_task = AsyncMock(return_value=task)
 
-        body = {k: v for k, v in _VALID_TASK_BODY.items() if k != "subnet_id"}
+        body = {k: v for k, v in _VALID_TASK_BODY.items() if k != "slug"}
         with TestClient(app) as client:
             r = client.post(
                 "/api/v1/tasks",

--- a/tests/routes/test_task_acl_scope_b.py
+++ b/tests/routes/test_task_acl_scope_b.py
@@ -107,7 +107,11 @@ def _make_task(
     t.metadata = {}
     t.submission = submission
     t.submission_artifacts = []
-    t.slug = slug
+    # ``Task`` entity still uses ``subnet_id`` until Step 2 of the
+    # slug rename; the test parameter is named ``slug`` for parity
+    # with the route layer's URL parameter naming, but the value is
+    # written to the entity attribute the production code reads.
+    t.subnet_id = slug
     t.max_resubmit_attempts = None
     return t
 
@@ -369,7 +373,9 @@ _VALID_TASK_BODY: dict[str, Any] = {
     "description": "A sufficiently long description for the task creation gate test.",
     "deadline_hours": 24,
     "reward": "0",
-    "slug": _SUBNET_ID,
+    # ``TaskCreateRequest`` keeps the legacy ``subnet_id`` field name
+    # until Step 2 of the slug rename migrates cross-entity references.
+    "subnet_id": _SUBNET_ID,
 }
 
 
@@ -412,11 +418,11 @@ class TestCreateGate:
         stub_task_service.create_task.assert_awaited_once()
 
     def test_no_subnet_id_skips_membership_check(self, stub_task_service):
-        """Creating a public task (no slug) skips the membership check."""
+        """Creating a public task (no subnet_id) skips the membership check."""
         task = _make_task(creator_id=_AGENT_A, slug=None)
         stub_task_service.create_task = AsyncMock(return_value=task)
 
-        body = {k: v for k, v in _VALID_TASK_BODY.items() if k != "slug"}
+        body = {k: v for k, v in _VALID_TASK_BODY.items() if k != "subnet_id"}
         with TestClient(app) as client:
             r = client.post(
                 "/api/v1/tasks",

--- a/tests/routes/test_tasks_error_schema.py
+++ b/tests/routes/test_tasks_error_schema.py
@@ -234,7 +234,7 @@ def stub_task_service_for_followup():
     target = MagicMock()
     target.task_id = "task-target"
     target.creator_id = "user-1"
-    target.subnet_id = None  # public task by default
+    target.slug = None  # public task by default
     target.status = "open"
     target.mode = "single"
     target.title = "Test"
@@ -388,7 +388,7 @@ class TestTasksFlatErrorSchemaCrossModule:
     def test_get_task_private_subnet_anonymous_returns_not_subnet_member(
         self, stub_task_service_for_followup, stub_agent_service
     ):
-        """``GET /tasks/{id}`` against a task whose ``subnet_id``
+        """``GET /tasks/{id}`` against a task whose ``slug``
         is set, with no authentication — pins ``NOT_SUBNET_MEMBER``
         with ``reason="anonymous_caller"``.
 
@@ -399,7 +399,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         disambiguates anonymous vs non-member callers for the SDK.
         """
         target = MagicMock()
-        target.subnet_id = "subnet-private"
+        target.slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         _wire(stub_task_service_for_followup, stub_agent_service)
@@ -413,7 +413,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["error_code"] == "not_subnet_member"
         assert body["details"] == {
             "task_id": "task-target",
-            "subnet_id": "subnet-private",
+            "slug": "subnet-private",
             "reason": "anonymous_caller",
         }
 
@@ -430,7 +430,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         private-subnet gate's second branch fires.
         """
         target = MagicMock()
-        target.subnet_id = "subnet-private"
+        target.slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         stub_task_service_for_followup.is_subnet_member = AsyncMock(
@@ -457,7 +457,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["error_code"] == "not_subnet_member"
         assert body["details"] == {
             "task_id": "task-target",
-            "subnet_id": "subnet-private",
+            "slug": "subnet-private",
             "agent_id": "user-2",
             "reason": "not_member",
         }

--- a/tests/routes/test_tasks_error_schema.py
+++ b/tests/routes/test_tasks_error_schema.py
@@ -234,7 +234,10 @@ def stub_task_service_for_followup():
     target = MagicMock()
     target.task_id = "task-target"
     target.creator_id = "user-1"
-    target.slug = None  # public task by default
+    # Task entity attribute is still ``subnet_id`` until Step 2 of the
+    # slug rename migrates cross-entity references; the test is set up
+    # to the field name production code reads.
+    target.subnet_id = None  # public task by default
     target.status = "open"
     target.mode = "single"
     target.title = "Test"
@@ -399,7 +402,8 @@ class TestTasksFlatErrorSchemaCrossModule:
         disambiguates anonymous vs non-member callers for the SDK.
         """
         target = MagicMock()
-        target.slug = "subnet-private"
+        # Task entity attribute is still ``subnet_id`` (Step 2).
+        target.subnet_id = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         _wire(stub_task_service_for_followup, stub_agent_service)
@@ -413,7 +417,10 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["error_code"] == "not_subnet_member"
         assert body["details"] == {
             "task_id": "task-target",
-            "slug": "subnet-private",
+            # The route's error payload mirrors the request's URL/JSON
+            # field name. Until Step 2 ships, that's still ``subnet_id``
+            # in the task error contract.
+            "subnet_id": "subnet-private",
             "reason": "anonymous_caller",
         }
 
@@ -430,7 +437,9 @@ class TestTasksFlatErrorSchemaCrossModule:
         private-subnet gate's second branch fires.
         """
         target = MagicMock()
-        target.slug = "subnet-private"
+        # See ``test_get_task_private_subnet_anonymous_returns_not_subnet_member``
+        # — task entity attribute is still ``subnet_id`` until Step 2.
+        target.subnet_id = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         stub_task_service_for_followup.is_subnet_member = AsyncMock(
@@ -457,7 +466,9 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["error_code"] == "not_subnet_member"
         assert body["details"] == {
             "task_id": "task-target",
-            "slug": "subnet-private",
+            # See sibling test — error payload field still uses
+            # ``subnet_id`` until Step 2 of the slug rename.
+            "subnet_id": "subnet-private",
             "agent_id": "user-2",
             "reason": "not_member",
         }

--- a/tests/scripts/test_backfill_subnet_join_policy.py
+++ b/tests/scripts/test_backfill_subnet_join_policy.py
@@ -83,7 +83,7 @@ class TestBackfillOne:
         is one HGETALL, period."""
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            "subnet_id": "subnet-1",
+            "slug": "subnet-1",
             "is_private": "True",
             "join_policy": "approval",
             "backfill_v0004": "done",
@@ -106,7 +106,7 @@ class TestBackfillOne:
         a user just set."""
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            "subnet_id": "subnet-2",
+            "slug": "subnet-2",
             "is_private": "False",
             "join_policy": "approval",
             # no sentinel
@@ -136,7 +136,7 @@ class TestBackfillOne:
         sentinel, in a single HSET."""
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            "subnet_id": "subnet-priv-legacy",
+            "slug": "subnet-priv-legacy",
             "is_private": "True",
             # no join_policy, no sentinel
         }
@@ -164,7 +164,7 @@ class TestBackfillOne:
         already auto-infer on read."""
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            "subnet_id": "subnet-pub-legacy",
+            "slug": "subnet-pub-legacy",
             "is_private": "False",
         }
 
@@ -188,7 +188,7 @@ class TestBackfillOne:
         crashing or writing ``'approval'`` (which would over-restrict
         a row that was never marked private)."""
         redis = AsyncMock()
-        redis.hgetall.return_value = {"subnet_id": "subnet-pathological"}
+        redis.hgetall.return_value = {"slug": "subnet-pathological"}
 
         status, value = await backfill_module._backfill_one(
             redis, "acn:subnets:info:subnet-pathological"
@@ -215,7 +215,7 @@ class TestDualDecode:
     async def test_bytes_keys_and_values_decoded_correctly(self, backfill_module):
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            b"subnet_id": b"subnet-bytes",
+            b"slug": b"subnet-bytes",
             b"is_private": b"True",
             # no join_policy, no sentinel
         }
@@ -233,7 +233,7 @@ class TestDualDecode:
         as ``bytes`` or ``str``."""
         redis = AsyncMock()
         redis.hgetall.return_value = {
-            b"subnet_id": b"subnet-bytes-done",
+            b"slug": b"subnet-bytes-done",
             b"is_private": b"True",
             b"join_policy": b"approval",
             b"backfill_v0004": b"done",

--- a/tests/services/test_join_flow_foundations.py
+++ b/tests/services/test_join_flow_foundations.py
@@ -65,10 +65,10 @@ from acn.services._no_op_join_flow_event_publisher import (
 # ---------------------------------------------------------------------------
 
 
-def _subnet(subnet_id: str = "s-1", owner: str = "alice") -> Subnet:
+def _subnet(slug: str = "s-1", owner: str = "alice") -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         created_at=datetime.now(UTC),
     )
@@ -76,13 +76,13 @@ def _subnet(subnet_id: str = "s-1", owner: str = "alice") -> Subnet:
 
 def _pending_request(
     request_id: str = "rq-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
     kind: str = "join_request",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind=kind,
         status="pending",
@@ -176,7 +176,7 @@ class TestNoOpJoinFlowEventPublisher:
                 JoinFlowEventType.INVITATION_ACCEPTED,
                 subnet=_subnet("s-7"),
                 request=_pending_request(
-                    "rq-9", subnet_id="s-7", agent_id="bob", kind="invitation"
+                    "rq-9", slug="s-7", agent_id="bob", kind="invitation"
                 ),
                 trigger="auto_on_join",
                 via="self_join",
@@ -189,7 +189,7 @@ class TestNoOpJoinFlowEventPublisher:
         # ``join_flow_event`` rather than ``event`` — structlog
         # reserves the ``event`` keyword for the log message.
         assert kwargs["join_flow_event"] == "subnet.invitation_accepted"
-        assert kwargs["subnet_id"] == "s-7"
+        assert kwargs["slug"] == "s-7"
         assert kwargs["request_id"] == "rq-9"
         assert kwargs["agent_id"] == "bob"
         assert kwargs["trigger"] == "auto_on_join"
@@ -209,19 +209,19 @@ class TestJoinFlowResultVariants:
     a downstream pattern-match."""
 
     def test_joined_open_branch_1(self) -> None:
-        result = JoinFlowJoinedOpenResult(subnet_id="s-1", agent_id="bob")
-        assert result.subnet_id == "s-1"
+        result = JoinFlowJoinedOpenResult(slug="s-1", agent_id="bob")
+        assert result.slug == "s-1"
         assert result.agent_id == "bob"
 
     def test_joined_as_owner_branch_2(self) -> None:
-        result = JoinFlowJoinedAsOwnerResult(subnet_id="s-1", agent_id="alice")
-        assert result.subnet_id == "s-1"
+        result = JoinFlowJoinedAsOwnerResult(slug="s-1", agent_id="alice")
+        assert result.slug == "s-1"
         assert result.agent_id == "alice"
 
     def test_auto_accepted_invitation_via_self_join_branch_3(self) -> None:
         invite = _pending_request(kind="invitation")
         result = JoinFlowAutoAcceptedInvitationResult(
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             invitation=invite,
             via="self_join",
@@ -232,7 +232,7 @@ class TestJoinFlowResultVariants:
     def test_auto_accepted_invitation_via_allowlist_branch_4(self) -> None:
         invite = _pending_request(kind="invitation")
         result = JoinFlowAutoAcceptedInvitationResult(
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             invitation=invite,
             via="allowlist",
@@ -242,7 +242,7 @@ class TestJoinFlowResultVariants:
     def test_allowlist_auto_approved_branch_5(self) -> None:
         req = SubnetJoinRequest(
             request_id="rq-1",
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             kind="allowlist_auto",
             status="approved",
@@ -250,21 +250,21 @@ class TestJoinFlowResultVariants:
             decided_by="system:allowlist",
             decided_at=datetime.now(UTC),
         )
-        result = JoinFlowAllowlistAutoApprovedResult(subnet_id="s-1", agent_id="bob", request=req)
+        result = JoinFlowAllowlistAutoApprovedResult(slug="s-1", agent_id="bob", request=req)
         assert result.request.kind == "allowlist_auto"
         assert result.request.status == "approved"
 
     def test_pending_branch_6(self) -> None:
         req = _pending_request()
-        result = JoinFlowPendingResult(subnet_id="s-1", agent_id="bob", request=req)
+        result = JoinFlowPendingResult(slug="s-1", agent_id="bob", request=req)
         assert result.request.status == "pending"
 
     def test_variants_are_frozen(self) -> None:
         # Frozen dataclass — protects against accidental mutation
         # at the route ↔ service boundary.
-        result = JoinFlowJoinedOpenResult(subnet_id="s-1", agent_id="bob")
+        result = JoinFlowJoinedOpenResult(slug="s-1", agent_id="bob")
         with pytest.raises((AttributeError, Exception)):
-            result.subnet_id = "s-2"  # type: ignore[misc]
+            result.slug="s-2"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -277,7 +277,7 @@ class TestJoinFlowExceptions:
     the route layer's ``_join_flow_error_to_acn`` mapper can
     isinstance-dispatch on the base; the per-subclass attribute
     fields (``existing_request_id`` / ``current_status`` /
-    ``subnet_id`` / ``agent_id``) are what the route echoes into
+    ``slug`` / ``agent_id``) are what the route echoes into
     the 4xx response body."""
 
     def test_join_flow_error_inherits_acn_exception(self) -> None:
@@ -326,13 +326,13 @@ class TestJoinFlowExceptions:
 
     def test_already_member_carries_subnet_and_agent(self) -> None:
         err = AlreadyMemberError("s-1", "bob")
-        assert err.subnet_id == "s-1"
+        assert err.slug == "s-1"
         assert err.agent_id == "bob"
         assert err.reason == "already_member"
 
     def test_allowlist_entry_exists_carries_subnet_and_agent(self) -> None:
         err = AllowlistEntryExistsError("s-1", "bob")
-        assert err.subnet_id == "s-1"
+        assert err.slug == "s-1"
         assert err.agent_id == "bob"
         assert err.reason == "already_on_allowlist"
 

--- a/tests/services/test_join_flow_service.py
+++ b/tests/services/test_join_flow_service.py
@@ -1,7 +1,7 @@
 """JoinFlowService — six-branch decision tree tests (ADR-0004 Slice 2.2).
 
 Each of the six branches in ADR §"POST /api/v1/agents/{agent_id}/
-subnets/{subnet_id} (join entry)" is verified with its happy path
+subnets/{slug} (join entry)" is verified with its happy path
 plus the relevant ``State machine edges`` markers from the ADR.
 
 Branch matrix:
@@ -57,15 +57,15 @@ from acn.services.subnet_service import SubnetService
 
 
 def _subnet(
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     owner: str = "alice",
     join_policy: str = "approval",
     members: set[str] | None = None,
     is_private: bool = False,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         is_private=is_private,
         join_policy=join_policy,
@@ -76,12 +76,12 @@ def _subnet(
 
 def _pending_invitation(
     request_id: str = "inv-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="invitation",
         status="pending",
@@ -91,12 +91,12 @@ def _pending_invitation(
 
 def _pending_join_request(
     request_id: str = "rq-OLD",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="join_request",
         status="pending",
@@ -184,7 +184,7 @@ class TestBranch1Open:
         result = await service.join_subnet("s-1", "bob")
 
         assert isinstance(result, JoinFlowJoinedOpenResult)
-        assert result.subnet_id == "s-1"
+        assert result.slug == "s-1"
         assert result.agent_id == "bob"
 
         # NO row created in subnet_join_requests.

--- a/tests/services/test_join_flow_webhook_composition.py
+++ b/tests/services/test_join_flow_webhook_composition.py
@@ -42,7 +42,7 @@ from acn.services.webhook_join_flow_event_publisher import (
 
 def _subnet() -> Subnet:
     return Subnet(
-        subnet_id="s-1",
+        slug="s-1",
         name="s-1",
         owner="alice",
         member_agent_ids={"alice"},
@@ -55,7 +55,7 @@ def _subnet() -> Subnet:
 def _pending_join_request() -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id="rq-1",
-        subnet_id="s-1",
+        slug="s-1",
         agent_id="bob",
         kind="join_request",
         status="pending",
@@ -128,7 +128,7 @@ class TestWireThroughHappyPath:
         assert kwargs["url"] == "https://harness.example/webhook"
         assert kwargs["secret"] == "secret"
         assert kwargs["task_id"] == "s-1"
-        assert kwargs["data"]["subnet_id"] == "s-1"
+        assert kwargs["data"]["slug"] == "s-1"
         assert kwargs["data"]["agent_id"] == "bob"
         assert kwargs["data"]["request_id"] == "rq-1"
         assert kwargs["data"]["kind"] == "join_request"
@@ -137,7 +137,7 @@ class TestWireThroughHappyPath:
         assert kwargs["data"]["trigger"] == "explicit"
         assert kwargs["data"]["via"] is None
         # ADR-0003 nesting carry-through: top-level subnet has no parent.
-        assert kwargs["data"]["parent_subnet_id"] is None
+        assert kwargs["data"]["parent_slug"] is None
 
     @pytest.mark.asyncio
     async def test_subnet_without_harness_url_skips_send_to(
@@ -149,7 +149,7 @@ class TestWireThroughHappyPath:
         # Re-pin the subnet repo to return a harnessless subnet —
         # the adapter must short-circuit so no transport call fires.
         mock_subnet_repo.find_by_id.return_value = Subnet(
-            subnet_id="s-1",
+            slug="s-1",
             name="s-1",
             owner="alice",
             member_agent_ids={"alice"},

--- a/tests/services/test_org_harness.py
+++ b/tests/services/test_org_harness.py
@@ -47,7 +47,7 @@ def subnet_service(mock_subnet_repo):
 
 def _make_subnet(**overrides) -> Subnet:
     defaults = {
-        "subnet_id": "sn-paperclip",
+        "slug": "sn-paperclip",
         "name": "Paperclip Subnet",
         "owner": "agent-owner",
     }
@@ -61,7 +61,7 @@ class TestSubnetServiceUpdateHarness:
         mock_subnet_repo.find_by_id.return_value = sn
 
         result = await subnet_service.update_harness(
-            subnet_id="sn-paperclip",
+            slug="sn-paperclip",
             owner="agent-owner",
             harness_url="https://paperclip.example.com/acn/webhook",
             harness_secret="s3cr3t",
@@ -76,7 +76,7 @@ class TestSubnetServiceUpdateHarness:
         mock_subnet_repo.find_by_id.return_value = sn
 
         result = await subnet_service.update_harness(
-            subnet_id="sn-paperclip",
+            slug="sn-paperclip",
             owner="agent-owner",
             harness_url=None,
             harness_secret=None,
@@ -92,7 +92,7 @@ class TestSubnetServiceUpdateHarness:
 
         with pytest.raises(PermissionError, match="Owner mismatch"):
             await subnet_service.update_harness(
-                subnet_id="sn-paperclip",
+                slug="sn-paperclip",
                 owner="agent-hacker",
                 harness_url="https://evil.example",
                 harness_secret="pwn",
@@ -104,7 +104,7 @@ class TestSubnetServiceUpdateHarness:
         mock_subnet_repo.find_by_id.return_value = sn
 
         await subnet_service.update_harness(
-            subnet_id="sn-paperclip",
+            slug="sn-paperclip",
             owner="system",
             harness_url="https://platform-managed.example",
             harness_secret=None,
@@ -115,7 +115,7 @@ class TestSubnetServiceUpdateHarness:
         mock_subnet_repo.find_by_id.return_value = None
         with pytest.raises(SubnetNotFoundException):
             await subnet_service.update_harness(
-                subnet_id="nope",
+                slug="nope",
                 owner="agent-owner",
                 harness_url="https://x",
                 harness_secret=None,
@@ -172,7 +172,7 @@ class TestWebhookServiceSendTo:
             secret="topsecret",
             event=WebhookEventType.AGENT_JOINED_SUBNET,
             task_id="sn-1",
-            data={"subnet_id": "sn-1", "agent_id": "agent-007"},
+            data={"slug": "sn-1", "agent_id": "agent-007"},
             retry_count=1,
             retry_delay=0,
         )
@@ -196,7 +196,7 @@ class TestWebhookServiceSendTo:
             secret=None,
             event=WebhookEventType.AGENT_LEFT_SUBNET,
             task_id="sn-1",
-            data={"subnet_id": "sn-1", "agent_id": "agent-007"},
+            data={"slug": "sn-1", "agent_id": "agent-007"},
             retry_count=1,
             retry_delay=0,
         )
@@ -429,8 +429,8 @@ class TestNotifyWebhookDualDelivery:
         send_event_kwargs = webhook.send_event.await_args.kwargs
         assert send_event_kwargs["event"] == WebhookEventType.TASK_ACCEPTED
         assert send_event_kwargs["task_id"] == "t-harness-1"
-        # payload includes subnet_id so receivers can correlate
-        assert send_event_kwargs["data"]["subnet_id"] == "sn-paperclip"
+        # payload includes slug so receivers can correlate
+        assert send_event_kwargs["data"]["slug"] == "sn-paperclip"
 
         webhook.send_to.assert_awaited_once()
         send_to_kwargs = webhook.send_to.await_args.kwargs

--- a/tests/services/test_subnet_service.py
+++ b/tests/services/test_subnet_service.py
@@ -32,7 +32,7 @@ class TestSubnetServiceCreate:
 
         service = SubnetService(mock_subnet_repository)
         subnet = await service.create_subnet(
-            subnet_id="subnet-test",
+            slug="subnet-test",
             name="Test Subnet",
             owner="agent-owner-123",
         )
@@ -57,7 +57,7 @@ class TestSubnetServiceCreate:
 
         service = SubnetService(mock_subnet_repository)
         subnet = await service.create_subnet(
-            subnet_id="subnet-test",
+            slug="subnet-test",
             name="Test Subnet",
             owner="agent-owner-123",
         )
@@ -72,7 +72,7 @@ class TestSubnetServiceCreate:
         service = SubnetService(mock_subnet_repository)
         with pytest.raises(ValueError, match="already exists"):
             await service.create_subnet(
-                subnet_id="subnet-test",
+                slug="subnet-test",
                 name="Test Subnet",
                 owner="agent-owner-123",
             )
@@ -93,7 +93,7 @@ class TestSubnetServiceADR0002:
         service = SubnetService(mock_subnet_repository)
         with pytest.raises(ValueError, match="ADR-0002"):
             await service.create_subnet(
-                subnet_id="ws-mirror-001",
+                slug="ws-mirror-001",
                 name="Workspace Mirror",
                 owner="backend@internal",
             )
@@ -107,7 +107,7 @@ class TestSubnetServiceADR0002:
 
         service = SubnetService(mock_subnet_repository)
         subnet = await service.create_subnet(
-            subnet_id="ws-mirror-002",
+            slug="ws-mirror-002",
             name="Workspace Mirror",
             owner="svc-backend-prod-agent-uuid",
         )
@@ -144,7 +144,7 @@ class TestSubnetServiceADR0004JoinPolicy:
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="subnet-pub-default",
+            slug="subnet-pub-default",
             name="Public Default",
             owner="agent-1",
             is_private=False,
@@ -166,7 +166,7 @@ class TestSubnetServiceADR0004JoinPolicy:
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="subnet-priv-default",
+            slug="subnet-priv-default",
             name="Private Default",
             owner="agent-1",
             is_private=True,
@@ -184,7 +184,7 @@ class TestSubnetServiceADR0004JoinPolicy:
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="subnet-pub-approval",
+            slug="subnet-pub-approval",
             name="Public Approval",
             owner="agent-1",
             is_private=False,
@@ -206,7 +206,7 @@ class TestSubnetServiceADR0004JoinPolicy:
 
         with pytest.raises(SubnetInvariantError) as exc_info:
             await service.create_subnet(
-                subnet_id="subnet-priv-open",
+                slug="subnet-priv-open",
                 name="Private Open",
                 owner="agent-1",
                 is_private=True,
@@ -224,7 +224,7 @@ class TestSubnetServiceADR0004JoinPolicy:
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="subnet-priv-approval",
+            slug="subnet-priv-approval",
             name="Private Approval",
             owner="agent-1",
             is_private=True,
@@ -245,7 +245,7 @@ class TestSubnetServiceADR0004JoinPolicy:
         service = SubnetService(mock_subnet_repository)
 
         subnet = await service.create_subnet(
-            subnet_id="subnet-pub-open-explicit",
+            slug="subnet-pub-open-explicit",
             name="Public Open Explicit",
             owner="agent-1",
             is_private=False,

--- a/tests/services/test_subnet_service_allowlist.py
+++ b/tests/services/test_subnet_service_allowlist.py
@@ -34,10 +34,10 @@ from acn.services._no_op_join_flow_event_publisher import (
 from acn.services.subnet_service import SubnetService
 
 
-def _subnet(subnet_id: str = "s-1", owner: str = "alice") -> Subnet:
+def _subnet(slug: str = "s-1", owner: str = "alice") -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         created_at=datetime.now(UTC),
         member_agent_ids={owner},
@@ -85,13 +85,13 @@ class TestAddAllowlist:
     ) -> None:
         entry = await service.add_allowlist("s-1", "bob", added_by="alice")
 
-        assert entry.subnet_id == "s-1"
+        assert entry.slug == "s-1"
         assert entry.agent_id == "bob"
         assert entry.added_by == "alice"
         mock_allowlist_repo.add.assert_awaited_once()
         saved = mock_allowlist_repo.add.await_args.args[0]
         assert isinstance(saved, SubnetAllowlist)
-        assert saved.subnet_id == "s-1"
+        assert saved.slug == "s-1"
         assert saved.agent_id == "bob"
 
     @pytest.mark.asyncio
@@ -104,7 +104,7 @@ class TestAddAllowlist:
         with pytest.raises(AllowlistEntryExistsError) as exc_info:
             await service.add_allowlist("s-1", "bob", added_by="alice")
 
-        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.slug == "s-1"
         assert exc_info.value.agent_id == "bob"
         assert exc_info.value.reason == "already_on_allowlist"
 
@@ -184,13 +184,13 @@ class TestListAllowlist:
     ) -> None:
         entries = [
             SubnetAllowlist(
-                subnet_id="s-1",
+                slug="s-1",
                 agent_id="bob",
                 added_by="alice",
                 added_at=datetime.now(UTC),
             ),
             SubnetAllowlist(
-                subnet_id="s-1",
+                slug="s-1",
                 agent_id="carol",
                 added_by="alice",
                 added_at=datetime.now(UTC),

--- a/tests/services/test_subnet_service_back_refs.py
+++ b/tests/services/test_subnet_service_back_refs.py
@@ -1,7 +1,7 @@
 """SubnetService — agent-side back-reference cleanup on delete (issue #56).
 
 Pins the contract that ``delete_subnet`` symmetrically clears the
-``subnet_id`` from each member's ``agent.subnet_ids`` set before the
+``slug`` from each member's ``agent.subnet_ids`` set before the
 subnet record itself is removed. Without this cleanup, ADR-0003
 cascade deletes amplify pre-existing dual-store dust (per-child member
 × per-subnet) into a much larger orphan surface.
@@ -33,16 +33,16 @@ from acn.services.subnet_service import SubnetService
 
 
 def _make_subnet(
-    subnet_id: str,
+    slug: str,
     owner: str = "alice",
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
     members: set[str] | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         member_agent_ids=members if members is not None else {owner},
         created_at=datetime.now(UTC),
     )
@@ -206,13 +206,13 @@ class TestCascadeDeleteClearsBackRefs:
             _make_subnet(
                 "squad-1",
                 owner="alice",
-                parent_subnet_id="team",
+                parent_slug="team",
                 members={"alice", "bob"},
             ),
             _make_subnet(
                 "squad-2",
                 owner="carol",
-                parent_subnet_id="team",
+                parent_slug="team",
                 members={"carol"},
             ),
         ]
@@ -273,7 +273,7 @@ class TestCascadeDeleteClearsBackRefs:
             _make_subnet(
                 "squad-1",
                 owner="alice",
-                parent_subnet_id="team",
+                parent_slug="team",
                 members={"alice"},
             ),
         ]
@@ -389,7 +389,7 @@ class TestCleanupBestEffort:
             _make_subnet(
                 "squad-1",
                 owner="alice",
-                parent_subnet_id="team",
+                parent_slug="team",
                 members={"alice"},
             ),
         ]

--- a/tests/services/test_subnet_service_cascade.py
+++ b/tests/services/test_subnet_service_cascade.py
@@ -16,15 +16,15 @@ from acn.services.subnet_service import SubnetService
 
 
 def _make_subnet(
-    subnet_id: str,
+    slug: str,
     owner: str = "alice",
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         member_agent_ids={owner},
         created_at=datetime.now(UTC),
     )
@@ -43,8 +43,8 @@ class TestDeleteSubnetCascade:
         """
         parent = _make_subnet("parent")
         children = [
-            _make_subnet("child-1", parent_subnet_id="parent"),
-            _make_subnet("child-2", parent_subnet_id="parent"),
+            _make_subnet("child-1", parent_slug="parent"),
+            _make_subnet("child-2", parent_slug="parent"),
         ]
         mock_subnet_repository.find_by_id.return_value = parent
         mock_subnet_repository.find_by_parent.return_value = children
@@ -79,14 +79,14 @@ class TestDeleteSubnetCascade:
         cannot itself have children) — saves a redundant
         ``find_by_parent`` round-trip.
         """
-        child = _make_subnet("child-1", parent_subnet_id="parent")
+        child = _make_subnet("child-1", parent_slug="parent")
         mock_subnet_repository.find_by_id.return_value = child
         mock_subnet_repository.delete.return_value = True
         service = SubnetService(mock_subnet_repository)
 
         await service.delete_subnet("child-1", owner="alice")
 
-        # Cascade only fires when ``parent_subnet_id is None``.
+        # Cascade only fires when ``parent_slug is None``.
         mock_subnet_repository.find_by_parent.assert_not_called()
         mock_subnet_repository.delete_with_children.assert_not_called()
         # Single-row delete path used directly. Session-agnostic per
@@ -104,7 +104,7 @@ class TestDeleteSubnetCascade:
         the parent subnet remains addressable (best-effort guarantee
         from the repo)."""
         parent = _make_subnet("parent")
-        children = [_make_subnet("child-1", parent_subnet_id="parent")]
+        children = [_make_subnet("child-1", parent_slug="parent")]
         mock_subnet_repository.find_by_id.return_value = parent
         mock_subnet_repository.find_by_parent.return_value = children
         mock_subnet_repository.delete_with_children.side_effect = RuntimeError(
@@ -150,7 +150,7 @@ class TestDeleteSubnetCascade:
         # Reserved subnets must have owner="system" (entity
         # invariant), so we build it explicitly here.
         public_subnet = Subnet(
-            subnet_id="public",
+            slug="public",
             name="Public",
             owner="system",
         )

--- a/tests/services/test_subnet_service_cascade_atomic.py
+++ b/tests/services/test_subnet_service_cascade_atomic.py
@@ -5,9 +5,9 @@ What this pins
 ADR-0004 §"Cascade deletion: Postgres" promises:
 
 > ``delete_subnet`` runs a single ``session.begin()`` transaction
-> containing ``DELETE FROM subnet_join_requests WHERE subnet_id=...``,
-> ``DELETE FROM subnet_allowlist WHERE subnet_id=...``, and
-> ``DELETE FROM subnets WHERE subnet_id=...`` in that order. Any
+> containing ``DELETE FROM subnet_join_requests WHERE slug=...``,
+> ``DELETE FROM subnet_allowlist WHERE slug=...``, and
+> ``DELETE FROM subnets WHERE slug=...`` in that order. Any
 > failure rolls back the whole batch.
 
 Slice 2.1 shipped the three cascade methods but had them each open
@@ -46,12 +46,12 @@ from acn.services.subnet_service import SubnetService
 # ---------------------------------------------------------------------------
 
 
-def _subnet(subnet_id: str, parent_subnet_id: str | None = None) -> Subnet:
+def _subnet(slug: str, parent_slug: str | None = None) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner="alice",
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
     )
 
 
@@ -211,8 +211,8 @@ class TestAtomicCascadeWithChildren:
         as N+1 independent transactions."""
         parent = _subnet("parent")
         children = [
-            _subnet("child-1", parent_subnet_id="parent"),
-            _subnet("child-2", parent_subnet_id="parent"),
+            _subnet("child-1", parent_slug="parent"),
+            _subnet("child-2", parent_slug="parent"),
         ]
         mock_subnet_repo.find_by_id.return_value = parent
         mock_subnet_repo.find_by_parent.return_value = children

--- a/tests/services/test_subnet_service_invitations.py
+++ b/tests/services/test_subnet_service_invitations.py
@@ -48,13 +48,13 @@ from acn.services.subnet_service import SubnetService
 
 
 def _subnet(
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     owner: str = "alice",
     members: set[str] | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         created_at=datetime.now(UTC),
         member_agent_ids=members if members is not None else {owner},
@@ -63,13 +63,13 @@ def _subnet(
 
 def _pending_invitation(
     request_id: str = "inv-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
     initiated_by: str = "alice",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="invitation",
         status="pending",
@@ -79,12 +79,12 @@ def _pending_invitation(
 
 def _pending_join_request(
     request_id: str = "rq-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="join_request",
         status="pending",
@@ -156,7 +156,7 @@ class TestInviteAgentNormalPath:
 
         with pytest.raises(AlreadyMemberError) as exc_info:
             await service.invite_agent("s-1", "bob", owner_id="alice")
-        assert exc_info.value.subnet_id == "s-1"
+        assert exc_info.value.slug == "s-1"
         assert exc_info.value.agent_id == "bob"
 
     @pytest.mark.asyncio
@@ -292,7 +292,7 @@ class TestAcceptInvitation:
     ) -> None:
         decided = SubnetJoinRequest(
             request_id="inv-1",
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             kind="invitation",
             status="approved",
@@ -370,7 +370,7 @@ class TestCancelInvitation:
     ) -> None:
         decided = SubnetJoinRequest(
             request_id="inv-1",
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             kind="invitation",
             status="rejected",

--- a/tests/services/test_subnet_service_join_policy_cascade.py
+++ b/tests/services/test_subnet_service_join_policy_cascade.py
@@ -41,15 +41,15 @@ from acn.services.subnet_service import SubnetService
 
 
 def _subnet(
-    subnet_id: str,
+    slug: str,
     owner: str = "alice",
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         member_agent_ids={owner},
         created_at=datetime.now(UTC),
     )
@@ -195,7 +195,7 @@ class TestSingleSubnetCascade:
             and c.args[0] == "delete_subnet_cascade_join_requests"
         )
         assert jr_call.kwargs.get("deleted_count") == 7
-        assert jr_call.kwargs.get("subnet_id") == "s-with-rows"
+        assert jr_call.kwargs.get("slug") == "s-with-rows"
 
     @pytest.mark.asyncio
     async def test_cascade_silent_when_zero_rows_deleted(
@@ -250,8 +250,8 @@ class TestTopLevelCascadeWithChildren:
         every subnet HASH for orphan secondary keys."""
         parent = _subnet("parent")
         children = [
-            _subnet("child-1", parent_subnet_id="parent"),
-            _subnet("child-2", parent_subnet_id="parent"),
+            _subnet("child-1", parent_slug="parent"),
+            _subnet("child-2", parent_slug="parent"),
         ]
         mock_subnet_repo.find_by_id.return_value = parent
         mock_subnet_repo.find_by_parent.return_value = children

--- a/tests/services/test_subnet_service_join_requests.py
+++ b/tests/services/test_subnet_service_join_requests.py
@@ -40,13 +40,13 @@ from acn.services.subnet_service import SubnetService
 
 
 def _subnet(
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     owner: str = "alice",
     members: set[str] | None = None,
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
         created_at=datetime.now(UTC),
         member_agent_ids=members if members is not None else {owner},
@@ -55,12 +55,12 @@ def _subnet(
 
 def _pending_join_request(
     request_id: str = "rq-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="join_request",
         status="pending",
@@ -70,14 +70,14 @@ def _pending_join_request(
 
 def _decided_row(
     request_id: str = "rq-1",
-    subnet_id: str = "s-1",
+    slug: str = "s-1",
     agent_id: str = "bob",
     status: str = "approved",
     decided_by: str = "alice",
 ) -> SubnetJoinRequest:
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind="join_request",
         status=status,
@@ -189,7 +189,7 @@ class TestApproveJoinRequest:
         # /join-requests/ path returns JOIN_REQUEST_NOT_FOUND.
         wrong_kind = SubnetJoinRequest(
             request_id="rq-1",
-            subnet_id="s-1",
+            slug="s-1",
             agent_id="bob",
             kind="invitation",
             status="pending",
@@ -205,7 +205,7 @@ class TestApproveJoinRequest:
     ) -> None:
         # request_id exists but belongs to a different subnet → 404
         # (no existence leak across subnets).
-        other_subnet_row = _pending_join_request(subnet_id="s-OTHER")
+        other_subnet_row = _pending_join_request(slug="s-OTHER")
         mock_join_repo.find_by_id.return_value = other_subnet_row
         with pytest.raises(JoinRequestNotFoundError):
             await service.approve_join_request("s-1", "rq-1", owner_id="alice")

--- a/tests/services/test_subnet_service_nesting.py
+++ b/tests/services/test_subnet_service_nesting.py
@@ -26,10 +26,10 @@ from acn.services.subnet_service import (
 
 
 def _make_parent_subnet(
-    subnet_id: str = "parent",
+    slug: str = "parent",
     owner: str = "alice",
     members: set[str] | None = None,
-    parent_subnet_id: str | None = None,
+    parent_slug: str | None = None,
 ) -> Subnet:
     """Build a parent ``Subnet`` entity for repository mocks.
 
@@ -38,11 +38,11 @@ def _make_parent_subnet(
     """
     members = members or {owner}
     return Subnet(
-        subnet_id=subnet_id,
-        name=f"Subnet {subnet_id}",
+        slug=slug,
+        name=f"Subnet {slug}",
         owner=owner,
         member_agent_ids=members,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         created_at=datetime.now(UTC),
     )
 
@@ -61,10 +61,10 @@ class TestCreateSubnetNestingInvariants:
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="child-1",
+                slug="child-1",
                 name="Squad",
                 owner="alice",
-                parent_subnet_id="missing-parent",
+                parent_slug="missing-parent",
             )
         assert exc.value.reason == REASON_PARENT_NOT_FOUND
         mock_subnet_repository.save.assert_not_called()
@@ -81,15 +81,15 @@ class TestCreateSubnetNestingInvariants:
         # Wire find_by_id to return a stub so the ID check is what
         # rejects, not the existence check.
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="public", owner="system"
+            slug="public", owner="system"
         )
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="child-1",
+                slug="child-1",
                 name="Squad",
                 owner="alice",
-                parent_subnet_id="public",
+                parent_slug="public",
             )
         assert exc.value.reason == REASON_PARENT_IS_RESERVED
 
@@ -102,16 +102,16 @@ class TestCreateSubnetNestingInvariants:
         ``public``/``system`` list (future reserved subnets)."""
         mock_subnet_repository.exists.return_value = False
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="custom-system-subnet", owner="system"
+            slug="custom-system-subnet", owner="system"
         )
         service = SubnetService(mock_subnet_repository)
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="child-1",
+                slug="child-1",
                 name="Squad",
                 owner="alice",
-                parent_subnet_id="custom-system-subnet",
+                parent_slug="custom-system-subnet",
             )
         assert exc.value.reason == REASON_PARENT_IS_RESERVED
 
@@ -122,18 +122,18 @@ class TestCreateSubnetNestingInvariants:
         """Single-layer cap — the parent must itself be top-level."""
         mock_subnet_repository.exists.return_value = False
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="mid-level",
+            slug="mid-level",
             owner="alice",
-            parent_subnet_id="grand-parent",
+            parent_slug="grand-parent",
         )
         service = SubnetService(mock_subnet_repository)
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="grandchild",
+                slug="grandchild",
                 name="Too deep",
                 owner="alice",
-                parent_subnet_id="mid-level",
+                parent_slug="mid-level",
             )
         assert exc.value.reason == REASON_PARENT_IS_NESTED
 
@@ -146,7 +146,7 @@ class TestCreateSubnetNestingInvariants:
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="task-squad",
+                slug="task-squad",
                 name="Task Squad",
                 owner="alice",
                 lifecycle="task_scoped",
@@ -161,7 +161,7 @@ class TestCreateSubnetNestingInvariants:
         self, mock_subnet_repository: ISubnetRepository
     ):
         mock_subnet_repository.exists.return_value = False
-        # We allow parent_subnet_id=None for this case — the
+        # We allow parent_slug=None for this case — the
         # linked_task_id check is independent of parenting.
         mock_task_repository = AsyncMock(spec=ITaskRepository)
         mock_task_repository.exists.return_value = False
@@ -171,7 +171,7 @@ class TestCreateSubnetNestingInvariants:
 
         with pytest.raises(SubnetInvariantError) as exc:
             await service.create_subnet(
-                subnet_id="task-squad",
+                slug="task-squad",
                 name="Task Squad",
                 owner="alice",
                 lifecycle="task_scoped",
@@ -195,7 +195,7 @@ class TestCreateSubnetNestingInvariants:
 
         # No exception even though no task repository is wired.
         subnet = await service.create_subnet(
-            subnet_id="task-squad",
+            slug="task-squad",
             name="Task Squad",
             owner="alice",
             lifecycle="task_scoped",
@@ -212,7 +212,7 @@ class TestCreateSubnetNestingInvariants:
         """Valid nested + task_scoped create — service writes through."""
         mock_subnet_repository.exists.return_value = False
         mock_subnet_repository.find_by_id.return_value = _make_parent_subnet(
-            subnet_id="parent-1", owner="alice", members={"alice", "bob"}
+            slug="parent-1", owner="alice", members={"alice", "bob"}
         )
         mock_task_repository = AsyncMock(spec=ITaskRepository)
         mock_task_repository.exists.return_value = True
@@ -221,15 +221,15 @@ class TestCreateSubnetNestingInvariants:
         )
 
         subnet = await service.create_subnet(
-            subnet_id="squad-1",
+            slug="squad-1",
             name="Bug Squad",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
             lifecycle="task_scoped",
             linked_task_id="task-42",
         )
 
-        assert subnet.parent_subnet_id == "parent-1"
+        assert subnet.parent_slug == "parent-1"
         assert subnet.lifecycle == "task_scoped"
         assert subnet.linked_task_id == "task-42"
         # Owner-as-member invariant preserved for child subnets too.
@@ -250,17 +250,17 @@ class TestAddMemberMembershipSubset:
         """``add_member`` on a child subnet rejects agents who aren't
         already members of the parent (ADR-0003 §A invariant 2)."""
         child = _make_parent_subnet(
-            subnet_id="child-1",
+            slug="child-1",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
         )
         parent = _make_parent_subnet(
-            subnet_id="parent-1",
+            slug="parent-1",
             owner="alice",
             members={"alice"},  # bob is NOT in the parent
         )
         # find_by_id called twice: once for ``get_subnet(child)``,
-        # once for ``find_by_id(parent_subnet_id)`` inside add_member.
+        # once for ``find_by_id(parent_slug)`` inside add_member.
         mock_subnet_repository.find_by_id.side_effect = [child, parent]
         service = SubnetService(mock_subnet_repository)
 
@@ -274,12 +274,12 @@ class TestAddMemberMembershipSubset:
         self, mock_subnet_repository: ISubnetRepository
     ):
         child = _make_parent_subnet(
-            subnet_id="child-1",
+            slug="child-1",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
         )
         parent = _make_parent_subnet(
-            subnet_id="parent-1",
+            slug="parent-1",
             owner="alice",
             members={"alice", "bob"},  # bob IS in the parent
         )
@@ -299,9 +299,9 @@ class TestAddMemberMembershipSubset:
         add rather than silently bypass the subset invariant. Ops
         should ``delete_subnet`` the orphan."""
         child = _make_parent_subnet(
-            subnet_id="child-1",
+            slug="child-1",
             owner="alice",
-            parent_subnet_id="parent-gone",
+            parent_slug="parent-gone",
         )
         mock_subnet_repository.find_by_id.side_effect = [child, None]
         service = SubnetService(mock_subnet_repository)
@@ -315,7 +315,7 @@ class TestAddMemberMembershipSubset:
         self, mock_subnet_repository: ISubnetRepository
     ):
         """Top-level subnets (no parent) skip the subset check entirely."""
-        top = _make_parent_subnet(subnet_id="top", owner="alice")
+        top = _make_parent_subnet(slug="top", owner="alice")
         mock_subnet_repository.find_by_id.return_value = top
         service = SubnetService(mock_subnet_repository)
 
@@ -341,15 +341,15 @@ class TestListChildrenACL:
         """
         children = [
             Subnet(
-                subnet_id="public-child",
+                slug="public-child",
                 name="Public",
                 owner="alice",
                 is_private=False,
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
                 member_agent_ids={"alice"},
             ),
             Subnet(
-                subnet_id="private-child",
+                slug="private-child",
                 name="Private",
                 owner="alice",
                 is_private=True,
@@ -357,7 +357,7 @@ class TestListChildrenACL:
                 # ``join_policy='approval'``; the entity invariant
                 # rejects the legacy ``private + open`` combination.
                 join_policy="approval",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
                 member_agent_ids={"alice"},
             ),
         ]
@@ -365,7 +365,7 @@ class TestListChildrenACL:
         service = SubnetService(mock_subnet_repository)
 
         result = await service.list_children("parent-1", requester_id=None)
-        ids = {c.subnet_id for c in result}
+        ids = {c.slug for c in result}
         # Service now returns all children; route applies per-row V6 rendering.
         assert ids == {"public-child", "private-child"}
 
@@ -377,22 +377,22 @@ class TestListChildrenACL:
         at the route layer (per-row SubnetStub vs SubnetInfo)."""
         children = [
             Subnet(
-                subnet_id="private-mine",
+                slug="private-mine",
                 name="Mine",
                 owner="alice",
                 is_private=True,
                 # ADR-0004 invariant: see "private-child" above.
                 join_policy="approval",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
                 member_agent_ids={"alice", "bob"},
             ),
             Subnet(
-                subnet_id="private-theirs",
+                slug="private-theirs",
                 name="Theirs",
                 owner="carol",
                 is_private=True,
                 join_policy="approval",
-                parent_subnet_id="parent-1",
+                parent_slug="parent-1",
                 member_agent_ids={"carol"},
             ),
         ]
@@ -400,7 +400,7 @@ class TestListChildrenACL:
         service = SubnetService(mock_subnet_repository)
 
         result = await service.list_children("parent-1", requester_id="bob")
-        ids = {c.subnet_id for c in result}
+        ids = {c.slug for c in result}
         # Service returns all; route renders private-theirs as Stub for bob.
         assert ids == {"private-mine", "private-theirs"}
 
@@ -428,10 +428,10 @@ class TestPromoteToPersistent:
         self, mock_subnet_repository: ISubnetRepository
     ):
         subnet = Subnet(
-            subnet_id="squad-1",
+            slug="squad-1",
             name="Squad",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
             lifecycle="task_scoped",
             linked_task_id="task-42",
         )
@@ -450,7 +450,7 @@ class TestPromoteToPersistent:
     ):
         """Idempotent — no repository write, no error."""
         subnet = Subnet(
-            subnet_id="persistent-1",
+            slug="persistent-1",
             name="Persistent",
             owner="alice",
             lifecycle="persistent",
@@ -469,10 +469,10 @@ class TestPromoteToPersistent:
         self, mock_subnet_repository: ISubnetRepository
     ):
         subnet = Subnet(
-            subnet_id="squad-1",
+            slug="squad-1",
             name="Squad",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
             lifecycle="task_scoped",
             linked_task_id="task-42",
         )
@@ -499,10 +499,10 @@ class TestPromoteToPersistent:
         # Repository ``find_by_id`` is only called once — for the
         # subnet being promoted. The parent is never fetched.
         subnet = Subnet(
-            subnet_id="squad-1",
+            slug="squad-1",
             name="Squad",
             owner="alice",
-            parent_subnet_id="parent-1",
+            parent_slug="parent-1",
             lifecycle="task_scoped",
             linked_task_id="task-42",
         )

--- a/tests/services/test_task_service_squad_cascade.py
+++ b/tests/services/test_task_service_squad_cascade.py
@@ -73,18 +73,18 @@ def _make_task(
 
 
 def _make_subnet(
-    subnet_id: str,
+    slug: str,
     *,
     owner: str = "alice",
     lifecycle: str = "task_scoped",
     linked_task_id: str | None = "task-42",
-    parent_subnet_id: str | None = "parent-1",
+    parent_slug: str | None = "parent-1",
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner=owner,
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         lifecycle=lifecycle,  # type: ignore[arg-type]
         linked_task_id=linked_task_id,
         member_agent_ids={owner},

--- a/tests/services/test_webhook_join_flow_event_publisher.py
+++ b/tests/services/test_webhook_join_flow_event_publisher.py
@@ -8,7 +8,7 @@ Pins the adapter contract documented at the top of
 2. **1-1 enum mapping** — every ``JoinFlowEventType`` resolves to
    the matching ``WebhookEventType`` member (string value preserved).
 3. **Payload shape** — the ``data`` block carries the canonical
-   ADR §"Payload shape" fields verbatim, including ``parent_subnet_id``
+   ADR §"Payload shape" fields verbatim, including ``parent_slug``
    from ADR-0003 nesting.
 4. **Never raise** — transport exceptions are caught and logged; the
    adapter returns ``None`` so the calling service-layer state
@@ -40,16 +40,16 @@ from acn.services.webhook_join_flow_event_publisher import (
 
 def _make_subnet(
     *,
-    subnet_id: str = "subnet-1",
-    parent_subnet_id: str | None = None,
+    slug: str = "subnet-1",
+    parent_slug: str | None = None,
     harness_url: str | None = "https://harness.example/webhook",
     harness_secret: str | None = "s3cr3t",
 ) -> Subnet:
     return Subnet(
-        subnet_id=subnet_id,
-        name=subnet_id,
+        slug=slug,
+        name=slug,
         owner="alice",
-        parent_subnet_id=parent_subnet_id,
+        parent_slug=parent_slug,
         member_agent_ids={"alice"},
         harness_url=harness_url,
         harness_secret=harness_secret,
@@ -60,7 +60,7 @@ def _make_subnet(
 def _make_join_request(
     *,
     request_id: str = "req-1",
-    subnet_id: str = "subnet-1",
+    slug: str = "subnet-1",
     agent_id: str = "bob",
     kind: str = "join_request",
     status: str = "pending",
@@ -75,7 +75,7 @@ def _make_join_request(
     )
     return SubnetJoinRequest(
         request_id=request_id,
-        subnet_id=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         kind=kind,  # type: ignore[arg-type]
         status=status,  # type: ignore[arg-type]
@@ -207,7 +207,7 @@ class TestPayloadShape:
     async def test_top_level_subnet_sets_parent_to_null(
         self, publisher, webhook_service
     ):
-        subnet = _make_subnet(parent_subnet_id=None)
+        subnet = _make_subnet(parent_slug=None)
         request = _make_join_request()
 
         await publisher.publish(
@@ -215,30 +215,30 @@ class TestPayloadShape:
         )
 
         data = webhook_service.send_to.await_args.kwargs["data"]
-        assert data["parent_subnet_id"] is None
+        assert data["parent_slug"] is None
 
     @pytest.mark.asyncio
     async def test_child_subnet_propagates_parent_id(
         self, publisher, webhook_service
     ):
-        subnet = _make_subnet(subnet_id="squad-1", parent_subnet_id="parent-1")
-        request = _make_join_request(subnet_id="squad-1")
+        subnet = _make_subnet(slug="squad-1", parent_slug="parent-1")
+        request = _make_join_request(slug="squad-1")
 
         await publisher.publish(
             JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request
         )
 
         data = webhook_service.send_to.await_args.kwargs["data"]
-        assert data["parent_subnet_id"] == "parent-1"
+        assert data["parent_slug"] == "parent-1"
 
     @pytest.mark.asyncio
     async def test_data_block_carries_all_adr_fields(
         self, publisher, webhook_service
     ):
-        subnet = _make_subnet(subnet_id="subnet-X", parent_subnet_id="parent-X")
+        subnet = _make_subnet(slug="subnet-X", parent_slug="parent-X")
         request = _make_join_request(
             request_id="req-X",
-            subnet_id="subnet-X",
+            slug="subnet-X",
             agent_id="bob",
             kind="invitation",
             status="approved",
@@ -256,10 +256,10 @@ class TestPayloadShape:
 
         data = webhook_service.send_to.await_args.kwargs["data"]
         assert data == {
-            "subnet_id": "subnet-X",
+            "slug": "subnet-X",
             "agent_id": "bob",
             "request_id": "req-X",
-            "parent_subnet_id": "parent-X",
+            "parent_slug": "parent-X",
             "kind": "invitation",
             "initiated_by": "alice",
             "decided_by": "bob",
@@ -301,10 +301,10 @@ class TestPayloadShape:
         self, publisher, webhook_service
     ):
         """ADR-0003 convention: ``WebhookPayload.task_id`` is set to
-        the subnet_id for non-payment events so Harnesses keying on
+        the slug for non-payment events so Harnesses keying on
         the wrapper field still route correctly."""
-        subnet = _make_subnet(subnet_id="subnet-route-1")
-        request = _make_join_request(subnet_id="subnet-route-1")
+        subnet = _make_subnet(slug="subnet-route-1")
+        request = _make_join_request(slug="subnet-route-1")
 
         await publisher.publish(
             JoinFlowEventType.JOIN_REQUESTED, subnet=subnet, request=request

--- a/tests/test_error_code_details_consistency.py
+++ b/tests/test_error_code_details_consistency.py
@@ -101,7 +101,7 @@ UNION_SCHEMA_CODES: dict[str, str] = {
     ),
     "OWNERSHIP_MISMATCH": (
         "registry uses {requested_owner, token_owner} for owner-token "
-        "mismatch; subnets/tasks use {agent_id?, subnet_id?, task_id?, "
+        "mismatch; subnets/tasks use {agent_id?, slug?, task_id?, "
         "reason?} for PermissionError re-raises (free-form str(e))"
     ),
     "INVALID_REQUEST": (
@@ -110,7 +110,7 @@ UNION_SCHEMA_CODES: dict[str, str] = {
         "uses {field, value, allowed?, task_id?, agent_id?, reason?}"
     ),
     "NOT_SUBNET_MEMBER": (
-        "subnets variant uses {subnet_id}; tasks get-task gate adds "
+        "subnets variant uses {slug}; tasks get-task gate adds "
         "{task_id, reason} where reason ∈ {anonymous_caller, not_member}"
     ),
     "AUTHENTICATION_REQUIRED": (


### PR DESCRIPTION
## Summary

- Renames `subnet_id` (the URL-safe slug) to `slug` and `parent_subnet_id` to `parent_slug` throughout the backend domain, following mainstream API naming conventions
- Covers: Subnet entity, SubnetAllowlist, SubnetJoinRequest, JoinFlowResult, all Pydantic API models, ORM mapped columns, Redis/Postgres repos, services, routes, and tests
- Alembic migration renames `subnets.subnet_id` → `subnets.slug` and `subnets.parent_subnet_id` → `subnets.parent_slug` in the DB
- SubnetStub now exposes desensitized metadata: `member_count`, `created_year_month`, `harness_registered`, `linked_task_id`
- Back-compat shims: `Subnet.from_dict` and `SubnetJoinRequest.from_dict` accept legacy `"subnet_id"` key; A2A subnet routing accepts both `"slug"` and `"subnet_id"` in the message payload

**Deferred to Step 2:** `Task.subnet_id` → `Task.subnet_slug`, `Agent.subnet_ids` (cross-entity references)  
**Deferred to Step 3:** Frontend `ACNSubnet` type, CLI output field names

## Test plan

- [x] `ruff check acn/ --select F,E9` — no errors
- [x] `tests/core/` — 717 passed
- [x] `tests/services/` — 717 passed (joint with core)
- [x] `tests/protocols/` — included in above
- [x] Key route tests (103 tests): subnets nesting, privacy matrix, create/detail, broadcast — all passed

Made with [Cursor](https://cursor.com)