### PR TITLE
refactor(step2): rename Task.subnet_id→subnet_slug + cross-entity slug params

### DIFF
--- a/acn/core/entities/agent.py
+++ b/acn/core/entities/agent.py
@@ -184,19 +184,19 @@ class Agent:
     # dual-source drift the alive-as-single-source refactor eliminates.
     # Callers should ``await agent_service.is_alive(agent.agent_id)``.
 
-    def is_in_subnet(self, subnet_id: str) -> bool:
+    def is_in_subnet(self, slug: str) -> bool:
         """Check if agent belongs to a subnet"""
-        return subnet_id in self.subnet_ids
+        return slug in self.subnet_ids
 
-    def add_to_subnet(self, subnet_id: str) -> None:
+    def add_to_subnet(self, slug: str) -> None:
         """Add agent to a subnet"""
-        if subnet_id not in self.subnet_ids:
-            self.subnet_ids.append(subnet_id)
+        if slug not in self.subnet_ids:
+            self.subnet_ids.append(slug)
 
-    def remove_from_subnet(self, subnet_id: str) -> None:
+    def remove_from_subnet(self, slug: str) -> None:
         """Remove agent from a subnet"""
-        if subnet_id in self.subnet_ids:
-            self.subnet_ids.remove(subnet_id)
+        if slug in self.subnet_ids:
+            self.subnet_ids.remove(slug)
         # Ensure at least one subnet
         if not self.subnet_ids:
             self.subnet_ids = ["public"]

--- a/acn/core/entities/task.py
+++ b/acn/core/entities/task.py
@@ -269,8 +269,11 @@ class Task:
     # Collaboration
     group_id: str | None = None  # Link related subtasks into a collaborative group
 
-    # Visibility — NULL means public; set to an ACN Subnet ID to restrict to members only
-    subnet_id: str | None = None
+    # Visibility — NULL means public; set to a subnet slug to restrict to members.
+    # Renamed from ``subnet_id`` in Step 2 of the slug-rename migration.
+    # DB column renamed ``tasks.subnet_id`` → ``subnet_slug`` via
+    # migration ``b1c2d3e4f5a6``.
+    subnet_slug: str | None = None
 
     # Max resubmit attempts per participation. None = unlimited.
     # Org Harnesses use this to prevent infinite grader-retry loops.
@@ -569,7 +572,7 @@ class Task:
             "deadline": self.deadline.isoformat() if self.deadline else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
             "metadata": self.metadata,
-            "subnet_id": self.subnet_id,
+            "subnet_slug": self.subnet_slug,
             "max_resubmit_attempts": self.max_resubmit_attempts,
             "resubmit_count": self.resubmit_count,
         }
@@ -615,5 +618,12 @@ class Task:
         # Default completion_mode for tasks created before this field existed
         if "completion_mode" not in data:
             data["completion_mode"] = "independent"
+
+        # Back-compat: rows serialised before the slug rename used ``subnet_id``.
+        # Accept both keys; ``subnet_slug`` wins when both are present.
+        if "subnet_id" in data and "subnet_slug" not in data:
+            data["subnet_slug"] = data.pop("subnet_id")
+        elif "subnet_id" in data:
+            data.pop("subnet_id")
 
         return cls(**data)

--- a/acn/core/exceptions/__init__.py
+++ b/acn/core/exceptions/__init__.py
@@ -185,12 +185,12 @@ class AlreadyMemberError(JoinFlowError):
     See ADR §State machine edges for both cases.
     """
 
-    def __init__(self, subnet_id: str, agent_id: str) -> None:
-        self.slug = subnet_id
+    def __init__(self, slug: str, agent_id: str) -> None:
+        self.slug = slug
         self.agent_id = agent_id
         super().__init__(
             "already_member",
-            f"agent {agent_id} is already a member of subnet {subnet_id}",
+            f"agent {agent_id} is already a member of subnet {slug}",
         )
 
 
@@ -201,12 +201,12 @@ class AllowlistEntryExistsError(JoinFlowError):
     add path raises; ADR §"Allowlist endpoints" pins the 409 here.
     """
 
-    def __init__(self, subnet_id: str, agent_id: str) -> None:
-        self.slug = subnet_id
+    def __init__(self, slug: str, agent_id: str) -> None:
+        self.slug = slug
         self.agent_id = agent_id
         super().__init__(
             "already_on_allowlist",
-            f"agent {agent_id} is already on subnet {subnet_id}'s allowlist",
+            f"agent {agent_id} is already on subnet {slug}'s allowlist",
         )
 
 

--- a/acn/core/interfaces/agent_repository.py
+++ b/acn/core/interfaces/agent_repository.py
@@ -64,12 +64,12 @@ class IAgentRepository(ABC):
         pass
 
     @abstractmethod
-    async def find_by_subnet(self, subnet_id: str) -> list[Agent]:
+    async def find_by_subnet(self, slug: str) -> list[Agent]:
         """
         Find all agents in a subnet
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet slug identifier
 
         Returns:
             List of agents in the subnet
@@ -134,12 +134,12 @@ class IAgentRepository(ABC):
         pass
 
     @abstractmethod
-    async def count_by_subnet(self, subnet_id: str) -> int:
+    async def count_by_subnet(self, slug: str) -> int:
         """
         Count agents in a subnet
 
         Args:
-            subnet_id: Subnet identifier
+            slug: Subnet slug identifier
 
         Returns:
             Number of agents in the subnet

--- a/acn/core/interfaces/subnet_allowlist_repository.py
+++ b/acn/core/interfaces/subnet_allowlist_repository.py
@@ -53,7 +53,7 @@ class ISubnetAllowlistRepository(ABC):
         """
 
     @abstractmethod
-    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+    async def remove(self, slug: str, agent_id: str) -> bool:
         """Drop ``(subnet_id, agent_id)`` from the allowlist.
 
         Idempotent: removing an absent pair is a no-op. Removing
@@ -69,7 +69,7 @@ class ISubnetAllowlistRepository(ABC):
         """
 
     @abstractmethod
-    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+    async def is_member(self, slug: str, agent_id: str) -> bool:
         """Check whether ``agent_id`` is on ``subnet_id``'s allowlist.
 
         Cold-path consultation point for the §join flow's branch 4.
@@ -80,7 +80,7 @@ class ISubnetAllowlistRepository(ABC):
 
     @abstractmethod
     async def list_for_subnet(
-        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+        self, slug: str, *, limit: int = 100, offset: int = 0
     ) -> list[SubnetAllowlist]:
         """List allowlist entries for one subnet, most-recent first.
 
@@ -91,7 +91,7 @@ class ISubnetAllowlistRepository(ABC):
 
     @abstractmethod
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: Any | None = None
+        self, slug: str, *, session: Any | None = None
     ) -> int:
         """Cascade-delete all entries for a subnet. Returns count deleted.
 

--- a/acn/core/interfaces/subnet_join_request_repository.py
+++ b/acn/core/interfaces/subnet_join_request_repository.py
@@ -71,7 +71,7 @@ class ISubnetJoinRequestRepository(ABC):
 
     @abstractmethod
     async def find_pending_for(
-        self, subnet_id: str, agent_id: str
+        self, slug: str, agent_id: str
     ) -> SubnetJoinRequest | None:
         """Return the unique pending row for ``(subnet_id, agent_id)``, if any.
 
@@ -92,7 +92,7 @@ class ISubnetJoinRequestRepository(ABC):
     @abstractmethod
     async def list_by_subnet(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         kind: str | None = None,
         status: str | None = None,
@@ -129,7 +129,7 @@ class ISubnetJoinRequestRepository(ABC):
 
     @abstractmethod
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: Any | None = None
+        self, slug: str, *, session: Any | None = None
     ) -> int:
         """Cascade-delete all rows for a subnet. Returns count deleted.
 

--- a/acn/infrastructure/persistence/postgres/agent_repository.py
+++ b/acn/infrastructure/persistence/postgres/agent_repository.py
@@ -196,12 +196,12 @@ class PostgresAgentRepository(IAgentRepository):
             result = await session.execute(select(AgentModel))
             return [self._model_to_agent(r) for r in result.scalars().all()]
 
-    async def find_by_subnet(self, subnet_id: str) -> list[Agent]:
+    async def find_by_subnet(self, slug: str) -> list[Agent]:
         """Agents whose subnet_ids array contains the given subnet_id."""
         async with self._session_factory() as session:
             result = await session.execute(
                 select(AgentModel).where(
-                    AgentModel.subnet_ids.contains(cast([subnet_id], ARRAY(String)))
+                    AgentModel.subnet_ids.contains(cast([slug], ARRAY(String)))
                 )
             )
             return [self._model_to_agent(r) for r in result.scalars().all()]
@@ -254,8 +254,8 @@ class PostgresAgentRepository(IAgentRepository):
                 if row.owner:
                     await self._redis.srem(f"acn:agents:by_owner:{row.owner}", agent_id)
                 await self._redis.srem("acn:agents:unclaimed", agent_id)
-                for subnet_id in (row.subnet_ids or []):
-                    await self._redis.srem(f"acn:subnets:{subnet_id}:agents", agent_id)
+                for slug in (row.subnet_ids or []):
+                    await self._redis.srem(f"acn:subnets:{slug}:agents", agent_id)
 
         return deleted
 
@@ -266,11 +266,11 @@ class PostgresAgentRepository(IAgentRepository):
             )
             return result.scalar() is not None
 
-    async def count_by_subnet(self, subnet_id: str) -> int:
+    async def count_by_subnet(self, slug: str) -> int:
         async with self._session_factory() as session:
             result = await session.execute(
                 select(func.count()).where(
-                    AgentModel.subnet_ids.contains(cast([subnet_id], ARRAY(String)))
+                    AgentModel.subnet_ids.contains(cast([slug], ARRAY(String)))
                 )
             )
             return result.scalar() or 0

--- a/acn/infrastructure/persistence/postgres/models.py
+++ b/acn/infrastructure/persistence/postgres/models.py
@@ -60,7 +60,12 @@ class TaskModel(Base):
     )
     deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     task_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
-    subnet_id: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
+    # Python attribute and DB column both named ``subnet_slug`` after
+    # migration ``b1c2d3e4f5a6_rename_cross_table_subnet_id_to_subnet_slug``.
+    # The explicit column name override is kept for safety until all
+    # environments have run the migration; remove the "subnet_slug" string
+    # arg once the rename is confirmed deployed everywhere.
+    subnet_slug: Mapped[str | None] = mapped_column("subnet_slug", String(100), nullable=True, index=True)
 
     __table_args__ = (
         Index("ix_tasks_mode", "mode"),
@@ -638,7 +643,9 @@ class SubnetJoinRequestModel(Base):
     # use ``uuid.UUID`` rather than the lower-case-hex string the rest of
     # the codebase passes around.
     request_id: Mapped[str] = mapped_column(String, primary_key=True)
-    slug: Mapped[str] = mapped_column("subnet_id", String, nullable=False)
+    # DB column renamed from ``subnet_id`` → ``slug`` in migration
+    # ``b1c2d3e4f5a6_rename_cross_table_subnet_id_to_subnet_slug``.
+    slug: Mapped[str] = mapped_column("slug", String, nullable=False)
     agent_id: Mapped[str] = mapped_column(String, nullable=False)
     # ``length=16`` mirrors the ADR data-model table for ``kind``; the
     # three legal values (``join_request`` is the longest at 13 chars)
@@ -672,7 +679,7 @@ class SubnetJoinRequestModel(Base):
         # cache layer.
         Index(
             "subnet_join_requests_pending_unique",
-            "subnet_id",
+            "slug",
             "agent_id",
             unique=True,
             postgresql_where=text("status = 'pending'"),
@@ -680,8 +687,8 @@ class SubnetJoinRequestModel(Base):
         # Owner-facing listing path:
         # ``GET /subnets/{s}/join-requests`` and ``/invitations``. The
         # filter on ``kind`` / ``status`` is application-side; the index
-        # only needs ``subnet_id`` to seek.
-        Index("ix_subnet_join_requests_subnet_id", "subnet_id"),
+        # only needs ``slug`` to seek.
+        Index("ix_subnet_join_requests_slug", "slug"),
         # Invitee-facing listing path:
         # ``GET /agents/{a}/subnet-invitations``. Composite predicate
         # selects the pending invitations the agent must decide; partial
@@ -716,7 +723,9 @@ class SubnetJoinRequestModel(Base):
 class SubnetAllowlistModel(Base):
     __tablename__ = "subnet_allowlist"
 
-    slug: Mapped[str] = mapped_column("subnet_id", String, nullable=False)
+    # DB column renamed from ``subnet_id`` → ``slug`` in migration
+    # ``b1c2d3e4f5a6_rename_cross_table_subnet_id_to_subnet_slug``.
+    slug: Mapped[str] = mapped_column("slug", String, nullable=False)
     # ``agent_id`` references ``agents.agent_id`` — but **no FK**. Symmetric
     # with ``subnet_join_requests``: ADR §"Cascade deletion" makes the
     # cascade manual for observability, and the route-layer existence
@@ -735,7 +744,7 @@ class SubnetAllowlistModel(Base):
     )
 
     __table_args__ = (
-        PrimaryKeyConstraint("subnet_id", "agent_id"),
+        PrimaryKeyConstraint("slug", "agent_id"),
         # Reverse lookup: "which subnets is agent X preauthorised on?"
         # — used by the agent-facing dashboard view; ops-only today,
         # cheap enough to keep around for future API surfaces.

--- a/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
@@ -113,18 +113,18 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             # insert; presence of any row means a new entry was created.
             return result.first() is not None
 
-    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+    async def remove(self, slug: str, agent_id: str) -> bool:
         async with self._session_factory() as session:
             result = await session.execute(
                 delete(SubnetAllowlistModel).where(
-                    SubnetAllowlistModel.slug == subnet_id,
+                    SubnetAllowlistModel.slug == slug,
                     SubnetAllowlistModel.agent_id == agent_id,
                 )
             )
             await session.commit()
             return (result.rowcount or 0) > 0
 
-    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+    async def is_member(self, slug: str, agent_id: str) -> bool:
         """Cold-path membership check for the §join flow's branch 4.
 
         ``SELECT 1 WHERE ... LIMIT 1`` instead of ``SELECT *`` —
@@ -136,7 +136,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             result = await session.execute(
                 select(SubnetAllowlistModel.slug)
                 .where(
-                    SubnetAllowlistModel.slug == subnet_id,
+                    SubnetAllowlistModel.slug == slug,
                     SubnetAllowlistModel.agent_id == agent_id,
                 )
                 .limit(1)
@@ -144,12 +144,12 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             return result.scalar() is not None
 
     async def list_for_subnet(
-        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+        self, slug: str, *, limit: int = 100, offset: int = 0
     ) -> list[SubnetAllowlist]:
         async with self._session_factory() as session:
             result = await session.execute(
                 select(SubnetAllowlistModel)
-                .where(SubnetAllowlistModel.slug == subnet_id)
+                .where(SubnetAllowlistModel.slug == slug)
                 .order_by(desc(SubnetAllowlistModel.added_at))
                 .limit(limit)
                 .offset(offset)
@@ -157,7 +157,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
             return [self._model_to_entity(r) for r in result.scalars().all()]
 
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: AsyncSession | None = None
+        self, slug: str, *, session: AsyncSession | None = None
     ) -> int:
         """Cascade-delete all entries for a subnet. Returns count deleted.
 
@@ -171,7 +171,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
         async with self._session_scope(session) as sess:
             result = await sess.execute(
                 delete(SubnetAllowlistModel).where(
-                    SubnetAllowlistModel.slug == subnet_id
+                    SubnetAllowlistModel.slug == slug
                 )
             )
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_allowlist_repository.py
@@ -103,7 +103,7 @@ class PostgresSubnetAllowlistRepository(ISubnetAllowlistRepository):
                     added_at=entry.added_at,
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["subnet_id", "agent_id"]
+                    index_elements=["slug", "agent_id"]
                 )
                 .returning(SubnetAllowlistModel.slug)
             )

--- a/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/postgres/subnet_join_request_repository.py
@@ -38,12 +38,12 @@ class SubnetJoinRequestPendingError(Exception):
     ``INVITATION_PENDING``); the route layer maps the token to the
     appropriate envelope per ADR §HTTP status code conventions."""
 
-    def __init__(self, subnet_id: str, agent_id: str) -> None:
+    def __init__(self, slug: str, agent_id: str) -> None:
         super().__init__(
             f"pending join request already exists for "
-            f"(slug={subnet_id!r}, agent_id={agent_id!r})"
+            f"(slug={slug!r}, agent_id={agent_id!r})"
         )
-        self.slug = subnet_id
+        self.slug = slug
         self.agent_id = agent_id
 
 
@@ -182,12 +182,12 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             return self._model_to_entity(row) if row else None
 
     async def find_pending_for(
-        self, subnet_id: str, agent_id: str
+        self, slug: str, agent_id: str
     ) -> SubnetJoinRequest | None:
         async with self._session_factory() as session:
             result = await session.execute(
                 select(SubnetJoinRequestModel).where(
-                    SubnetJoinRequestModel.slug == subnet_id,
+                    SubnetJoinRequestModel.slug == slug,
                     SubnetJoinRequestModel.agent_id == agent_id,
                     SubnetJoinRequestModel.status == "pending",
                 )
@@ -197,7 +197,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
 
     async def list_by_subnet(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         kind: str | None = None,
         status: str | None = None,
@@ -206,7 +206,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
     ) -> list[SubnetJoinRequest]:
         async with self._session_factory() as session:
             stmt = select(SubnetJoinRequestModel).where(
-                SubnetJoinRequestModel.slug == subnet_id
+                SubnetJoinRequestModel.slug == slug
             )
             if kind is not None:
                 stmt = stmt.where(SubnetJoinRequestModel.kind == kind)
@@ -236,7 +236,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             return [self._model_to_entity(r) for r in result.scalars().all()]
 
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: AsyncSession | None = None
+        self, slug: str, *, session: AsyncSession | None = None
     ) -> int:
         """Cascade-delete all rows for a subnet. Returns count deleted.
 
@@ -267,7 +267,7 @@ class PostgresSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         async with self._session_scope(session) as sess:
             result = await sess.execute(
                 delete(SubnetJoinRequestModel).where(
-                    SubnetJoinRequestModel.slug == subnet_id
+                    SubnetJoinRequestModel.slug == slug
                 )
             )
             return result.rowcount or 0

--- a/acn/infrastructure/persistence/postgres/task_repository.py
+++ b/acn/infrastructure/persistence/postgres/task_repository.py
@@ -140,7 +140,7 @@ class PostgresTaskRepository(ITaskRepository):
             and datetime.fromisoformat(meta["completed_at"]),
             invited_agent_ids=meta.get("invited_agent_ids", []),
             metadata=meta.get("extra_metadata", {}),
-            subnet_id=row.subnet_id,
+            subnet_slug=row.subnet_slug,
             max_resubmit_attempts=meta.get("max_resubmit_attempts"),
             resubmit_count=int(meta.get("resubmit_count", 0)),
         )
@@ -201,7 +201,7 @@ class PostgresTaskRepository(ITaskRepository):
             created_at=_tz(task.created_at) or datetime.now(UTC),
             deadline=_tz(task.deadline),
             task_metadata=extra_meta,
-            subnet_id=task.subnet_id,
+            subnet_slug=task.subnet_slug,
         )
 
     # ---- Participation mapping -----------------------------------------------
@@ -281,7 +281,7 @@ class PostgresTaskRepository(ITaskRepository):
                         required_tags=model.required_tags,
                         deadline=model.deadline,
                         task_metadata=model.task_metadata,
-                        subnet_id=model.subnet_id,
+                        subnet_slug=model.subnet_slug,
                     )
                 )
             else:
@@ -328,7 +328,7 @@ class PostgresTaskRepository(ITaskRepository):
                     required_tags=model.required_tags,
                     deadline=model.deadline,
                     task_metadata=model.task_metadata,
-                    subnet_id=model.subnet_id,
+                    subnet_slug=model.subnet_slug,
                 )
             )
             return result.rowcount == 1
@@ -372,20 +372,20 @@ class PostgresTaskRepository(ITaskRepository):
                 from .subnet_repository import PostgresSubnetRepository
                 subnet_repo = PostgresSubnetRepository(self._session_factory)
                 agent_subnets = await subnet_repo.list_subnets_for_agent(requesting_agent_id)
-                agent_subnet_ids = [s.subnet_id for s in agent_subnets]
-                if agent_subnet_ids:
+                agent_subnet_slugs = [s.slug for s in agent_subnets]
+                if agent_subnet_slugs:
                     stmt = stmt.where(
                         or_(
-                            TaskModel.subnet_id.is_(None),
-                            TaskModel.subnet_id.in_(agent_subnet_ids),
+                            TaskModel.subnet_slug.is_(None),
+                            TaskModel.subnet_slug.in_(agent_subnet_slugs),
                         )
                     )
                 else:
                     # Agent not in any subnet — only public tasks
-                    stmt = stmt.where(TaskModel.subnet_id.is_(None))
+                    stmt = stmt.where(TaskModel.subnet_slug.is_(None))
             else:
                 # Anonymous caller — only public tasks
-                stmt = stmt.where(TaskModel.subnet_id.is_(None))
+                stmt = stmt.where(TaskModel.subnet_slug.is_(None))
             stmt = stmt.order_by(TaskModel.created_at.desc()).limit(limit).offset(offset)
             result = await session.execute(stmt)
             rows = result.scalars().all()

--- a/acn/infrastructure/persistence/redis/agent_repository.py
+++ b/acn/infrastructure/persistence/redis/agent_repository.py
@@ -147,8 +147,8 @@ class RedisAgentRepository(IAgentRepository):
             )
 
         # 6. Subnet indices
-        for subnet_id in agent.subnet_ids:
-            await self.redis.sadd(f"acn:subnets:{subnet_id}:agents", agent.agent_id)
+        for slug in agent.subnet_ids:
+            await self.redis.sadd(f"acn:subnets:{slug}:agents", agent.agent_id)
 
         # Clean up old subnet indices
         if existing:
@@ -195,9 +195,9 @@ class RedisAgentRepository(IAgentRepository):
                 agents.append(self._dict_to_agent(agent_dict))
         return agents
 
-    async def find_by_subnet(self, subnet_id: str) -> list[Agent]:
+    async def find_by_subnet(self, slug: str) -> list[Agent]:
         """Find all agents in a subnet"""
-        agent_ids = await self.redis.smembers(f"acn:subnets:{subnet_id}:agents")
+        agent_ids = await self.redis.smembers(f"acn:subnets:{slug}:agents")
         agents = []
         for agent_id in agent_ids:
             agent = await self.find_by_id(agent_id)
@@ -247,8 +247,8 @@ class RedisAgentRepository(IAgentRepository):
             await self.redis.delete(api_key_index)
 
         # Remove from subnet indices
-        for subnet_id in agent.subnet_ids:
-            await self.redis.srem(f"acn:subnets:{subnet_id}:agents", agent_id)
+        for slug in agent.subnet_ids:
+            await self.redis.srem(f"acn:subnets:{slug}:agents", agent_id)
 
         # Remove from owner index
         if agent.owner:
@@ -279,9 +279,9 @@ class RedisAgentRepository(IAgentRepository):
         """Check if agent exists"""
         return await self.redis.exists(f"acn:agents:{agent_id}") > 0
 
-    async def count_by_subnet(self, subnet_id: str) -> int:
+    async def count_by_subnet(self, slug: str) -> int:
         """Count agents in a subnet"""
-        return await self.redis.scard(f"acn:subnets:{subnet_id}:agents")
+        return await self.redis.scard(f"acn:subnets:{slug}:agents")
 
     async def find_by_api_key(self, key_hash: str) -> Agent | None:
         """Find agent by SHA-256 hash of their API key."""

--- a/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_allowlist_repository.py
@@ -47,12 +47,12 @@ from ._hash_utils import normalize_hash as _normalize_hash
 logger = logging.getLogger(__name__)
 
 
-def _allowlist_set_key(subnet_id: str) -> str:
-    return f"acn:subnets:{subnet_id}:allowlist"
+def _allowlist_set_key(slug: str) -> str:
+    return f"acn:subnets:{slug}:allowlist"
 
 
-def _allowlist_meta_key(subnet_id: str, agent_id: str) -> str:
-    return f"acn:subnets:{subnet_id}:allowlist_meta:{agent_id}"
+def _allowlist_meta_key(slug: str, agent_id: str) -> str:
+    return f"acn:subnets:{slug}:allowlist_meta:{agent_id}"
 
 
 class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
@@ -92,7 +92,7 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         await self.redis.hset(meta_key, mapping=entry.to_dict())  # type: ignore[misc]
         return added_count > 0
 
-    async def remove(self, subnet_id: str, agent_id: str) -> bool:
+    async def remove(self, slug: str, agent_id: str) -> bool:
         """Remove from the SET and DEL the meta HASH.
 
         Returns ``True`` iff the SET membership was actually
@@ -101,23 +101,23 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         cleanup. A crash between them leaves an orphan meta HASH
         that the cascade deletion path sweeps later.
         """
-        set_key = _allowlist_set_key(subnet_id)
-        meta_key = _allowlist_meta_key(subnet_id, agent_id)
+        set_key = _allowlist_set_key(slug)
+        meta_key = _allowlist_meta_key(slug, agent_id)
 
         removed_count = await self.redis.srem(set_key, agent_id)
         await self.redis.delete(meta_key)
         return removed_count > 0
 
-    async def is_member(self, subnet_id: str, agent_id: str) -> bool:
+    async def is_member(self, slug: str, agent_id: str) -> bool:
         """O(1) SISMEMBER check; the hot path for the §join flow."""
         return bool(
             await self.redis.sismember(
-                _allowlist_set_key(subnet_id), agent_id
+                _allowlist_set_key(slug), agent_id
             )
         )
 
     async def list_for_subnet(
-        self, subnet_id: str, *, limit: int = 100, offset: int = 0
+        self, slug: str, *, limit: int = 100, offset: int = 0
     ) -> list[SubnetAllowlist]:
         """List allowlist entries for a subnet, most-recent first.
 
@@ -127,13 +127,13 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         cache-only crash artefact (see class docstring's "write
         atomicity" section).
         """
-        set_key = _allowlist_set_key(subnet_id)
+        set_key = _allowlist_set_key(slug)
         agent_ids = await self.redis.smembers(set_key)
 
         entries: list[SubnetAllowlist] = []
         for raw_aid in agent_ids:
             aid = _decode(raw_aid)
-            meta_key = _allowlist_meta_key(subnet_id, aid)
+            meta_key = _allowlist_meta_key(slug, aid)
             hash_data = await self.redis.hgetall(meta_key)
             if not hash_data:
                 # SET-only orphan; cache crash artefact. Don't fabricate
@@ -148,7 +148,7 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         return entries[offset : offset + limit]
 
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: object | None = None
+        self, slug: str, *, session: object | None = None
     ) -> int:
         """Cascade-delete all allowlist entries for a subnet.
 
@@ -168,7 +168,7 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
         Returns the count of meta HASHes actually deleted.
         """
         del session  # explicit ignore — see docstring
-        set_key = _allowlist_set_key(subnet_id)
+        set_key = _allowlist_set_key(slug)
         agent_ids = await self.redis.smembers(set_key)
 
         deleted_count = 0
@@ -176,7 +176,7 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
 
         for raw_aid in agent_ids:
             aid = _decode(raw_aid)
-            meta_key = _allowlist_meta_key(subnet_id, aid)
+            meta_key = _allowlist_meta_key(slug, aid)
             try:
                 await self.redis.delete(meta_key)
                 deleted_count += 1
@@ -189,7 +189,7 @@ class RedisSubnetAllowlistRepository(ISubnetAllowlistRepository):
             logger.warning(
                 "delete_with_children_partial",
                 extra={
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "table": "subnet_allowlist",
                     "failures": partial_failures,
                 },

--- a/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
+++ b/acn/infrastructure/persistence/redis/subnet_join_request_repository.py
@@ -126,7 +126,7 @@ return 1
 """
 
 
-def _invitation_set_member(subnet_id: str, request_id: str) -> str:
+def _invitation_set_member(slug: str, request_id: str) -> str:
     """The composite key used as a member of
     ``acn:agents:{a}:subnet_invitations``.
 
@@ -142,19 +142,19 @@ def _invitation_set_member(subnet_id: str, request_id: str) -> str:
     separator — so the composite member can never collide with a
     legitimate single-component id.
     """
-    return f"{subnet_id}:{request_id}"
+    return f"{slug}:{request_id}"
 
 
-def _request_hash_key(subnet_id: str, request_id: str) -> str:
-    return f"acn:subnets:{subnet_id}:requests:{request_id}"
+def _request_hash_key(slug: str, request_id: str) -> str:
+    return f"acn:subnets:{slug}:requests:{request_id}"
 
 
-def _pending_by_agent_key(subnet_id: str, agent_id: str) -> str:
-    return f"acn:subnets:{subnet_id}:pending_by_agent:{agent_id}"
+def _pending_by_agent_key(slug: str, agent_id: str) -> str:
+    return f"acn:subnets:{slug}:pending_by_agent:{agent_id}"
 
 
-def _subnet_listing_key(subnet_id: str) -> str:
-    return f"acn:subnets:{subnet_id}:requests"
+def _subnet_listing_key(slug: str) -> str:
+    return f"acn:subnets:{slug}:requests"
 
 
 def _agent_invitations_key(agent_id: str) -> str:
@@ -276,14 +276,14 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         return None
 
     async def find_pending_for(
-        self, subnet_id: str, agent_id: str
+        self, slug: str, agent_id: str
     ) -> SubnetJoinRequest | None:
-        pending_key = _pending_by_agent_key(subnet_id, agent_id)
+        pending_key = _pending_by_agent_key(slug, agent_id)
         request_id = _decode(await self.redis.get(pending_key))
         if not request_id:
             return None
         hash_data = await self.redis.hgetall(
-            _request_hash_key(subnet_id, request_id)
+            _request_hash_key(slug, request_id)
         )
         if not hash_data:
             # Reverse index points at a non-existent HASH — the very
@@ -295,7 +295,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                 "subnet_join_request: dangling reverse index "
                 "(reverse points at missing HASH)",
                 extra={
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "agent_id": agent_id,
                     "request_id": request_id,
                 },
@@ -305,20 +305,20 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
 
     async def list_by_subnet(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         kind: str | None = None,
         status: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[SubnetJoinRequest]:
-        listing_key = _subnet_listing_key(subnet_id)
+        listing_key = _subnet_listing_key(slug)
         request_ids = await self.redis.smembers(listing_key)
         rows: list[SubnetJoinRequest] = []
         for raw_rid in request_ids:
             rid = _decode(raw_rid)
             hash_data = await self.redis.hgetall(
-                _request_hash_key(subnet_id, rid)
+                _request_hash_key(slug, rid)
             )
             if not hash_data:
                 continue
@@ -378,9 +378,9 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                 # no way to reconstruct the subnet without the
                 # expensive scan we are trying to avoid.
                 continue
-            subnet_id, request_id = member.split(":", 1)
+            _slug, request_id = member.split(":", 1)
             hash_data = await self.redis.hgetall(
-                _request_hash_key(subnet_id, request_id)
+                _request_hash_key(_slug, request_id)
             )
             if not hash_data:
                 continue
@@ -391,7 +391,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         return rows
 
     async def delete_for_subnet(
-        self, subnet_id: str, *, session: object | None = None
+        self, slug: str, *, session: object | None = None
     ) -> int:
         """Cascade-delete all rows for a subnet.
 
@@ -418,7 +418,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
         audit log; not gated on by the cascade control flow).
         """
         del session  # explicit ignore — see docstring
-        listing_key = _subnet_listing_key(subnet_id)
+        listing_key = _subnet_listing_key(slug)
         request_ids = await self.redis.smembers(listing_key)
 
         deleted_count = 0
@@ -426,7 +426,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
 
         for raw_rid in request_ids:
             rid = _decode(raw_rid)
-            hash_key = _request_hash_key(subnet_id, rid)
+            hash_key = _request_hash_key(slug, rid)
             try:
                 # Need to read kind + agent_id before deleting the HASH
                 # so we know which secondary indexes to clean up.
@@ -439,7 +439,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                         pipe.delete(hash_key)
                         if agent_id:
                             pipe.delete(
-                                _pending_by_agent_key(subnet_id, agent_id)
+                                _pending_by_agent_key(slug, agent_id)
                             )
                             if kind == "invitation":
                                 # Composite-key SREM — must match the
@@ -449,7 +449,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
                                 pipe.srem(
                                     _agent_invitations_key(agent_id),
                                     _invitation_set_member(
-                                        subnet_id, rid
+                                        slug, rid
                                     ),
                                 )
                         await pipe.execute()
@@ -467,7 +467,7 @@ class RedisSubnetJoinRequestRepository(ISubnetJoinRequestRepository):
             logger.warning(
                 "delete_with_children_partial",
                 extra={
-                    "subnet_id": subnet_id,
+                    "slug": slug,
                     "table": "subnet_join_requests",
                     "failures": partial_failures,
                 },

--- a/acn/infrastructure/persistence/redis/task_repository.py
+++ b/acn/infrastructure/persistence/redis/task_repository.py
@@ -402,8 +402,8 @@ class RedisTaskRepository(ITaskRepository):
                 continue
 
             # Subnet visibility: public (no subnet_id) or agent is a member
-            if task.subnet_id:
-                if not requesting_agent_id or task.subnet_id not in visible_subnet_ids:
+            if task.subnet_slug:
+                if not requesting_agent_id or task.subnet_slug not in visible_subnet_ids:
                     continue
 
             tasks.append(task)

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -206,7 +206,7 @@ async def add_to_allowlist(
 
     logger.info(
         "subnet_allowlist_added_via_http",
-        subnet_id=subnet_id,
+        slug=subnet_id,
         agent_id=body.agent_id,
         added_by=agent_info["agent_id"],
     )
@@ -253,7 +253,7 @@ async def remove_from_allowlist(
 
     logger.info(
         "subnet_allowlist_removed_via_http",
-        subnet_id=subnet_id,
+        slug=subnet_id,
         agent_id=agent_id,
         removed_by=agent_info["agent_id"],
     )
@@ -416,7 +416,7 @@ async def withdraw_join_request(
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=subnet_id,
+            expected_slug=subnet_id,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
@@ -600,7 +600,7 @@ async def accept_invitation(
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=subnet_id,
+            expected_slug=subnet_id,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
@@ -626,7 +626,7 @@ async def accept_invitation(
         logger.warning(
             "accept_invitation_back_ref_failed_agent_not_found",
             agent_id=agent_info["agent_id"],
-            subnet_id=subnet_id,
+            slug=subnet_id,
         )
         raise ACNHTTPError(
             ErrorCode.AGENT_NOT_FOUND,
@@ -637,7 +637,7 @@ async def accept_invitation(
         logger.error(
             "accept_invitation_back_ref_failed",
             agent_id=agent_info["agent_id"],
-            subnet_id=subnet_id,
+            slug=subnet_id,
             error=str(e),
             exc_info=True,
         )
@@ -652,13 +652,13 @@ async def accept_invitation(
             logger.info(
                 "accept_invitation_rollback_ok",
                 agent_id=agent_info["agent_id"],
-                subnet_id=subnet_id,
+                slug=subnet_id,
             )
         except Exception as rollback_err:  # noqa: BLE001
             logger.error(
                 "accept_invitation_rollback_failed",
                 agent_id=agent_info["agent_id"],
-                subnet_id=subnet_id,
+                slug=subnet_id,
                 rollback_error=str(rollback_err),
             )
         raise HTTPException(
@@ -690,7 +690,7 @@ async def reject_invitation(
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=subnet_id,
+            expected_slug=subnet_id,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -816,12 +816,7 @@ async def get_subnet_agents(
             return _empty_response
 
     try:
-        # ``AgentService.search_agents`` keeps its parameter named
-        # ``subnet_id=`` until Step 2 of the slug rename migrates the
-        # cross-entity references (Agent.subnet_ids, Task.subnet_id).
-        # The argument *value* is the slug — only the keyword name
-        # has not been renamed yet.
-        agents = await agent_service.search_agents(subnet_id=slug)
+        agents = await agent_service.search_agents(slug=slug)
 
         from .registry import _agent_entities_to_infos
 

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -882,7 +882,7 @@ async def get_task(
                 message="Authentication required to view this task.",
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_slug,
+                    "slug": task.subnet_slug,
                     "reason": "anonymous_caller",
                 },
             )
@@ -893,7 +893,7 @@ async def get_task(
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_slug,
+                    "slug": task.subnet_slug,
                     "agent_id": caller_id,
                     "reason": "not_member",
                 },
@@ -962,7 +962,7 @@ async def create_task(
                     403,
                     message="You must be a member of the subnet to create a task within it.",
                     details={
-                        "subnet_id": body.subnet_slug,
+                        "slug": body.subnet_slug,
                         "reason": "creator_not_subnet_member",
                     },
                 )
@@ -1057,7 +1057,7 @@ async def accept_task(
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_slug,
+                    "slug": task.subnet_slug,
                     "reason": "not_subnet_member",
                 },
             )
@@ -1318,7 +1318,7 @@ async def list_participations(
                     403,
                     details={
                         "task_id": task_id,
-                        "subnet_id": task.subnet_slug,
+                        "slug": task.subnet_slug,
                         "reason": "not_member",
                     },
                 )
@@ -1555,7 +1555,7 @@ async def agent_create_task(
                 403,
                 message="Agent must be a member of the subnet to create a task within it.",
                 details={
-                    "subnet_id": body.subnet_slug,
+                    "slug": body.subnet_slug,
                     "reason": "creator_not_subnet_member",
                 },
             )
@@ -1616,7 +1616,7 @@ async def agent_accept_task(
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task_entity.subnet_slug,
+                    "slug": task_entity.subnet_slug,
                     "reason": "not_subnet_member",
                 },
             )

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -10,7 +10,7 @@ import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, Request
 from fastapi import Request as _Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ..auth.middleware import verify_token
 from ..config import get_settings
@@ -277,11 +277,17 @@ class TaskCreateRequest(BaseModel):
     group_id: str | None = Field(default=None, max_length=128, description="Link related subtasks into a collaborative group")
 
     # ── Visibility ────────────────────────────────────────
-    # Length matches ``SubnetCreateRequest.subnet_id`` (64). Allowing a
+    # Length matches ``SubnetCreateRequest.slug`` (64). Allowing a
     # wider value here would just defer the rejection to the subnet
-    # lookup — and 65–128 char IDs are guaranteed to miss because the
-    # creation path won't accept them.  Round-2 audit: pin them together.
-    subnet_id: str | None = Field(default=None, max_length=64, description="Restrict task visibility to ACN Subnet members (NULL=public)")
+    # lookup — and 65–128 char slugs are guaranteed to miss because
+    # the creation path won't accept them.  Round-2 audit: pin them together.
+    # Legacy alias ``subnet_id`` accepted on input for backward compat.
+    subnet_slug: str | None = Field(
+        default=None,
+        max_length=64,
+        validation_alias=AliasChoices("subnet_slug", "subnet_id"),
+        description="Restrict task visibility to ACN Subnet members (NULL=public). Legacy alias 'subnet_id' accepted on input.",
+    )
 
     # ── A2UI: Declarative interactive UI ─────────────────────────────────────
     ui_spec: dict | None = Field(
@@ -381,9 +387,18 @@ class TaskResponse(BaseModel):
     # frontend DeliverablesPanel can display the submitted content.
     submission: str | None = None
     submission_artifacts: list[dict] = Field(default_factory=list)
-    subnet_id: str | None = None
+    # Canonical field name after the Step 2 rename.
+    # ``subnet_id`` kept as a backward-compat serialization alias so
+    # existing frontend / SDK clients reading the old key don't break
+    # mid-rollout. Remove alias in Step 3 (frontend update).
+    subnet_slug: str | None = Field(
+        default=None,
+        serialization_alias="subnet_id",
+        description="Subnet slug restricting task visibility (NULL=public).",
+    )
     max_resubmit_attempts: int | None = None
 
+    model_config = ConfigDict(populate_by_name=True)
 
 class ParticipationResponse(BaseModel):
     """Participation response model"""
@@ -443,7 +458,13 @@ class TaskHistoryItem(BaseModel):
 
     # Context
     participation_id: str | None = None
-    subnet_id: str | None = None
+    subnet_slug: str | None = Field(
+        default=None,
+        serialization_alias="subnet_id",
+        description="Subnet slug (legacy alias 'subnet_id' on output; removed in Step 3).",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
 
     # Timestamps
     joined_at: str | None = None
@@ -554,7 +575,7 @@ def _task_to_response(task, *, expose_submission: bool = False) -> TaskResponse:
         ui_spec=(task.metadata or {}).get("ui_spec"),
         submission=task.submission if expose_submission else None,
         submission_artifacts=task.submission_artifacts or [] if expose_submission else [],
-        subnet_id=task.subnet_id,
+        subnet_slug=task.subnet_slug,
         max_resubmit_attempts=task.max_resubmit_attempts,
     )
 
@@ -853,7 +874,7 @@ async def get_task(
     # submission-visibility decision.
     caller_id = await _resolve_caller_identity(request, credentials)
 
-    if task.subnet_id:
+    if task.subnet_slug:
         if not caller_id:
             raise ACNHTTPError(
                 ErrorCode.NOT_SUBNET_MEMBER,
@@ -861,18 +882,18 @@ async def get_task(
                 message="Authentication required to view this task.",
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_id,
+                    "subnet_id": task.subnet_slug,
                     "reason": "anonymous_caller",
                 },
             )
-        is_member = await task_service.is_subnet_member(task.subnet_id, caller_id)
+        is_member = await task_service.is_subnet_member(task.subnet_slug, caller_id)
         if not is_member:
             raise ACNHTTPError(
                 ErrorCode.NOT_SUBNET_MEMBER,
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_id,
+                    "subnet_id": task.subnet_slug,
                     "agent_id": caller_id,
                     "reason": "not_member",
                 },
@@ -932,16 +953,16 @@ async def create_task(
     # ACL V6 Scope B — subnet membership gate on creation.
     # If the caller specifies a subnet_id, they must be a member of that subnet.
     # internal / admin callers are exempt (they act on behalf of others).
-    if body.subnet_id and auth_type not in ("internal", "dev"):
+    if body.subnet_slug and auth_type not in ("internal", "dev"):
         if "acn:admin" not in payload.get("permissions", []):
-            is_creator_member = await task_service.is_subnet_member(body.subnet_id, token_owner)
+            is_creator_member = await task_service.is_subnet_member(body.subnet_slug, token_owner)
             if not is_creator_member:
                 raise ACNHTTPError(
                     ErrorCode.NOT_SUBNET_MEMBER,
                     403,
                     message="You must be a member of the subnet to create a task within it.",
                     details={
-                        "subnet_id": body.subnet_id,
+                        "subnet_id": body.subnet_slug,
                         "reason": "creator_not_subnet_member",
                     },
                 )
@@ -972,7 +993,7 @@ async def create_task(
             group_id=body.group_id,
             deadline_hours=body.deadline_hours,
             metadata=merged_metadata,
-            subnet_id=body.subnet_id,
+            subnet_slug=body.subnet_slug,
             max_resubmit_attempts=body.max_resubmit_attempts,
         )
 
@@ -1028,15 +1049,15 @@ async def accept_task(
         ) from None
 
     # Gate: private subnet task — caller must be a subnet member.
-    if task.subnet_id and "acn:admin" not in payload.get("permissions", []):
-        is_member = await task_service.is_subnet_member(task.subnet_id, agent_id)
+    if task.subnet_slug and "acn:admin" not in payload.get("permissions", []):
+        is_member = await task_service.is_subnet_member(task.subnet_slug, agent_id)
         if not is_member:
             raise ACNHTTPError(
                 ErrorCode.NOT_SUBNET_MEMBER,
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task.subnet_id,
+                    "subnet_id": task.subnet_slug,
                     "reason": "not_subnet_member",
                 },
             )
@@ -1289,15 +1310,15 @@ async def list_participations(
         # Internal / admin callers are exempted.
         permissions = payload.get("permissions", [])
         is_internal = payload.get("type") == "internal" or "acn:admin" in permissions
-        if task.subnet_id and not is_internal:
-            is_member = await task_service.is_subnet_member(task.subnet_id, caller_id)
+        if task.subnet_slug and not is_internal:
+            is_member = await task_service.is_subnet_member(task.subnet_slug, caller_id)
             if not is_member:
                 raise ACNHTTPError(
                     ErrorCode.NOT_SUBNET_MEMBER,
                     403,
                     details={
                         "task_id": task_id,
-                        "subnet_id": task.subnet_id,
+                        "subnet_id": task.subnet_slug,
                         "reason": "not_member",
                     },
                 )
@@ -1524,9 +1545,9 @@ async def agent_create_task(
         merged_metadata["ui_spec"] = body.ui_spec
 
     # Subnet membership gate for agent/create (same as POST /tasks).
-    if body.subnet_id:
+    if body.subnet_slug:
         is_creator_member = await task_service.is_subnet_member(
-            body.subnet_id, agent_info["agent_id"]
+            body.subnet_slug, agent_info["agent_id"]
         )
         if not is_creator_member:
             raise ACNHTTPError(
@@ -1534,7 +1555,7 @@ async def agent_create_task(
                 403,
                 message="Agent must be a member of the subnet to create a task within it.",
                 details={
-                    "subnet_id": body.subnet_id,
+                    "subnet_id": body.subnet_slug,
                     "reason": "creator_not_subnet_member",
                 },
             )
@@ -1559,7 +1580,7 @@ async def agent_create_task(
         group_id=body.group_id,
         deadline_hours=body.deadline_hours,
         metadata=merged_metadata,
-        subnet_id=body.subnet_id,  # P1-3: was missing, task was created without subnet context
+        subnet_slug=body.subnet_slug,  # P1-3: was missing, task was created without subnet context
     )
 
     return _task_to_response(task, expose_submission=True)
@@ -1585,9 +1606,9 @@ async def agent_accept_task(
             details={"task_id": task_id},
         ) from None
 
-    if task_entity.subnet_id:
+    if task_entity.subnet_slug:
         is_member = await task_service.is_subnet_member(
-            task_entity.subnet_id, agent_info["agent_id"]
+            task_entity.subnet_slug, agent_info["agent_id"]
         )
         if not is_member:
             raise ACNHTTPError(
@@ -1595,7 +1616,7 @@ async def agent_accept_task(
                 403,
                 details={
                     "task_id": task_id,
-                    "subnet_id": task_entity.subnet_id,
+                    "subnet_id": task_entity.subnet_slug,
                     "reason": "not_subnet_member",
                 },
             )

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -558,38 +558,38 @@ class AgentService:
         """
         return await self.repository.find_by_owner(owner)
 
-    async def join_subnet(self, agent_id: str, subnet_id: str) -> Agent:
+    async def join_subnet(self, agent_id: str, slug: str) -> Agent:
         """
         Add agent to a subnet
 
         Args:
             agent_id: Agent identifier
-            subnet_id: Subnet identifier
+            slug: Subnet slug
 
         Returns:
             Updated agent entity
         """
         agent = await self.get_agent(agent_id)
-        agent.add_to_subnet(subnet_id)
+        agent.add_to_subnet(slug)
         await self.repository.save(agent)
-        logger.info("agent_joined_subnet", agent_id=agent_id, subnet_id=subnet_id)
+        logger.info("agent_joined_subnet", agent_id=agent_id, slug=slug)
         return agent
 
-    async def leave_subnet(self, agent_id: str, subnet_id: str) -> Agent:
+    async def leave_subnet(self, agent_id: str, slug: str) -> Agent:
         """
         Remove agent from a subnet
 
         Args:
             agent_id: Agent identifier
-            subnet_id: Subnet identifier
+            slug: Subnet slug
 
         Returns:
             Updated agent entity
         """
         agent = await self.get_agent(agent_id)
-        agent.remove_from_subnet(subnet_id)
+        agent.remove_from_subnet(slug)
         await self.repository.save(agent)
-        logger.info("agent_left_subnet", agent_id=agent_id, subnet_id=subnet_id)
+        logger.info("agent_left_subnet", agent_id=agent_id, slug=slug)
         return agent
 
     # ========== Autonomous Agent Methods ==========

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -357,7 +357,7 @@ class AgentService:
         self,
         tags: list[str] | None = None,
         status: str = "online",
-        subnet_id: str | None = None,
+        slug: str | None = None,
     ) -> list[Agent]:
         """
         Search for agents.
@@ -365,7 +365,7 @@ class AgentService:
         Args:
             tags: Required tags (filters agents that have ALL tags)
             status: Agent status filter ("online" | "offline" | "all")
-            subnet_id: Subnet filter
+            slug: Subnet slug filter (renamed from ``subnet_id`` in Step 2)
 
         Returns:
             List of matching agents
@@ -379,8 +379,8 @@ class AgentService:
         an explicit ``POST /heartbeat`` re-stamped ``status='online'``
         in the database.
         """
-        if subnet_id:
-            candidates = await self.repository.find_by_subnet(subnet_id)
+        if slug:
+            candidates = await self.repository.find_by_subnet(slug)
             if tags:
                 candidates = [a for a in candidates if a.has_all_tags(tags)]
         elif tags:

--- a/acn/services/join_flow_service.py
+++ b/acn/services/join_flow_service.py
@@ -121,7 +121,7 @@ class JoinFlowService:
             event_publisher or NoOpJoinFlowEventPublisher()
         )
 
-    async def join_subnet(self, subnet_id: str, agent_id: str) -> JoinFlowResult:
+    async def join_subnet(self, slug: str, agent_id: str) -> JoinFlowResult:
         """Dispatch the six branches.
 
         Note on branch ordering: ADR §join states "the branch order
@@ -132,25 +132,25 @@ class JoinFlowService:
         takes branch 1 (open) — semantically equivalent (owner is a
         member either way) but the response shape is the "open" 200.
         """
-        subnet = await self._subnet_service.get_subnet(subnet_id)
+        subnet = await self._subnet_service.get_subnet(slug)
 
         # ADR §State machine edges "Agent self-join a subnet they
         # are already in" → 409 ALREADY_MEMBER. Check applies to
         # every branch including open, so we hoist it above the
         # branch dispatch.
         if agent_id in subnet.member_agent_ids:
-            raise AlreadyMemberError(subnet_id, agent_id)
+            raise AlreadyMemberError(slug, agent_id)
 
         # Branch 1 — open subnet, immediate add_member.
         if subnet.join_policy == "open":
-            await self._subnet_service.add_member(subnet_id, agent_id)
+            await self._subnet_service.add_member(slug, agent_id)
             logger.info(
                 "join_flow_branch_open",
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 branch=1,
             )
-            return JoinFlowJoinedOpenResult(slug=subnet_id, agent_id=agent_id)
+            return JoinFlowJoinedOpenResult(slug=slug, agent_id=agent_id)
 
         # From here on ``join_policy == 'approval'``.
 
@@ -158,26 +158,26 @@ class JoinFlowService:
         # member of their subnet (ADR §State machine edges), so the
         # request table is bypassed entirely.
         if agent_id == subnet.owner:
-            await self._subnet_service.add_member(subnet_id, agent_id)
+            await self._subnet_service.add_member(slug, agent_id)
             logger.info(
                 "join_flow_branch_owner_self_join",
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 branch=2,
             )
-            return JoinFlowJoinedAsOwnerResult(slug=subnet_id, agent_id=agent_id)
+            return JoinFlowJoinedAsOwnerResult(slug=slug, agent_id=agent_id)
 
         # The three remaining branches all hinge on the pending row
         # / allowlist presence. Compute both up front so the
         # decision tree is a straight ``if/elif`` chain.
-        pending = await self._join_request_repository.find_pending_for(subnet_id, agent_id)
-        is_allowlisted = await self._allowlist_repository.is_member(subnet_id, agent_id)
+        pending = await self._join_request_repository.find_pending_for(slug, agent_id)
+        is_allowlisted = await self._allowlist_repository.is_member(slug, agent_id)
 
         # Branches 3 + 4 — pending invitation auto-accept.
         if pending is not None and pending.kind == "invitation":
             via = "allowlist" if is_allowlisted else "self_join"
             accepted = await self._subnet_service.accept_invitation(
-                subnet_id,
+                slug,
                 pending.request_id,
                 # On the allowlist merge path ADR §"Merge-path event
                 # mapping" pins decided_by='system:allowlist'; on
@@ -190,14 +190,14 @@ class JoinFlowService:
             )
             logger.info(
                 "join_flow_branch_invitation_auto_accept",
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 invitation_id=accepted.request_id,
                 via=via,
                 branch=4 if is_allowlisted else 3,
             )
             return JoinFlowAutoAcceptedInvitationResult(
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 invitation=accepted,
                 via=via,
@@ -219,7 +219,7 @@ class JoinFlowService:
         if is_allowlisted:
             request = SubnetJoinRequest(
                 request_id=str(uuid.uuid4()),
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 kind="allowlist_auto",
                 status="approved",
@@ -228,7 +228,7 @@ class JoinFlowService:
                 decided_at=datetime.now(UTC),
             )
             await self._join_request_repository.save(request)
-            await self._subnet_service.add_member(subnet_id, agent_id)
+            await self._subnet_service.add_member(slug, agent_id)
             # Slice 2.2 emits ``JOIN_APPROVED`` for the auto-approval —
             # branch 5 doesn't go through join_request → approved, it
             # is born approved, so the canonical "approval happened"
@@ -244,13 +244,13 @@ class JoinFlowService:
             )
             logger.info(
                 "join_flow_branch_allowlist_auto_approved",
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 request_id=request.request_id,
                 branch=5,
             )
             return JoinFlowAllowlistAutoApprovedResult(
-                slug=subnet_id,
+                slug=slug,
                 agent_id=agent_id,
                 request=request,
             )
@@ -260,7 +260,7 @@ class JoinFlowService:
         # member; the owner owes a decision.
         request = SubnetJoinRequest(
             request_id=str(uuid.uuid4()),
-            slug=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             kind="join_request",
             status="pending",
@@ -274,13 +274,13 @@ class JoinFlowService:
         )
         logger.info(
             "join_flow_branch_pending_join_request",
-            slug=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             request_id=request.request_id,
             branch=6,
         )
         return JoinFlowPendingResult(
-            slug=subnet_id,
+            slug=slug,
             agent_id=agent_id,
             request=request,
         )

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -1085,7 +1085,7 @@ class SubnetService:
         request_id: str,
         *,
         expected_kind: Literal["join_request", "invitation"],
-        expected_subnet_id: str | None = None,
+        expected_slug: str | None = None,
     ) -> SubnetJoinRequest:
         """Look up a single request row + enforce kind / subnet binding.
 
@@ -1095,7 +1095,7 @@ class SubnetService:
         This blocks cross-namespace mistakes without leaking the
         existence of the row in the other namespace.
 
-        The optional ``expected_subnet_id`` adds an extra binding check
+        The optional ``expected_slug`` adds an extra binding check
         — Slice 2.3's route layer extracts the subnet from the URL,
         and a request_id that exists but belongs to a different subnet
         MUST return the same 404 (same anti-existence-leak reason).
@@ -1108,7 +1108,7 @@ class SubnetService:
         if (
             row is None
             or row.kind != expected_kind
-            or (expected_subnet_id is not None and row.slug != expected_subnet_id)
+            or (expected_slug is not None and row.slug != expected_slug)
         ):
             if expected_kind == "invitation":
                 raise InvitationNotFoundError(request_id)
@@ -1268,7 +1268,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1321,7 +1321,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1362,7 +1362,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise JoinRequestAlreadyDecidedError(request_id, row.status)
@@ -1517,7 +1517,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)
@@ -1563,7 +1563,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)
@@ -1603,7 +1603,7 @@ class SubnetService:
         row = await self.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_subnet_id=slug,
+            expected_slug=slug,
         )
         if not row.is_pending:
             raise InvitationAlreadyDecidedError(request_id, row.status)

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -176,7 +176,7 @@ class TaskService:
         group_id: str | None = None,
         deadline_hours: int | None = None,
         metadata: dict | None = None,
-        subnet_id: str | None = None,
+        subnet_slug: str | None = None,
         max_resubmit_attempts: int | None = None,
     ) -> Task:
         """
@@ -230,13 +230,13 @@ class TaskService:
         # bound to the harness that owned them at creation, which is the
         # desired guarantee for any orchestrator that has already taken over.
         metadata = dict(metadata) if metadata else {}
-        if subnet_id and self.subnet_repository:
+        if subnet_slug and self.subnet_repository:
             try:
-                parent_subnet = await self.subnet_repository.find_by_id(subnet_id)
+                parent_subnet = await self.subnet_repository.find_by_id(subnet_slug)
             except Exception as e:  # noqa: BLE001
                 logger.warning(
                     "task_create_subnet_harness_snapshot_failed",
-                    subnet_id=subnet_id,
+                    subnet_slug=subnet_slug,
                     error=str(e),
                 )
                 parent_subnet = None
@@ -268,7 +268,7 @@ class TaskService:
             group_id=group_id,
             deadline=deadline,
             metadata=metadata or {},
-            subnet_id=subnet_id,
+            subnet_slug=subnet_slug,
             max_resubmit_attempts=max_resubmit_attempts,
         )
 
@@ -385,10 +385,10 @@ class TaskService:
             raise PermissionError("Creator cannot accept their own task")
 
         # ---- Subnet access control ----
-        if task.subnet_id:
+        if task.subnet_slug:
             if not self.subnet_repository:
                 raise PermissionError("Subnet access control not configured")
-            subnet = await self.subnet_repository.find_by_id(task.subnet_id)
+            subnet = await self.subnet_repository.find_by_id(task.subnet_slug)
             if not subnet:
                 raise PermissionError("Task subnet not found or deleted")
             if agent_id not in (subnet.member_agent_ids or set()):
@@ -1852,7 +1852,7 @@ class TaskService:
                 "reward": task.reward,
                 "reward_currency": task.reward_currency,
                 "participation_id": None,
-                "slug": task.subnet_id,
+                "slug": task.subnet_slug,
                 "joined_at": task.assigned_at.isoformat() if task.assigned_at else None,
                 "submitted_at": task.submitted_at.isoformat() if task.submitted_at else None,
                 "completed_at": task.completed_at.isoformat() if task.completed_at else None,
@@ -1888,7 +1888,7 @@ class TaskService:
                 "reward": task.reward,
                 "reward_currency": task.reward_currency,
                 "participation_id": p.participation_id,
-                "slug": task.subnet_id,
+                "slug": task.subnet_slug,
                 "joined_at": p.joined_at.isoformat() if p.joined_at else None,
                 "submitted_at": p.submitted_at.isoformat() if p.submitted_at else None,
                 "completed_at": p.completed_at.isoformat() if p.completed_at else None,
@@ -1901,11 +1901,11 @@ class TaskService:
         results.sort(key=_sort_key, reverse=True)
         return results[:limit]
 
-    async def is_subnet_member(self, subnet_id: str, agent_id: str) -> bool:
+    async def is_subnet_member(self, slug: str, agent_id: str) -> bool:
         """Check whether an agent is a member of the given subnet."""
         if not self.subnet_repository:
             return False
-        subnet = await self.subnet_repository.find_by_id(subnet_id)
+        subnet = await self.subnet_repository.find_by_id(slug)
         if not subnet:
             return False
         return agent_id in (subnet.member_agent_ids or set())
@@ -1974,7 +1974,7 @@ class TaskService:
                 logger.info(
                     "task_scoped_subnet_dissolved",
                     task_id=task_id,
-                    subnet_id=subnet.slug,
+                    subnet_slug=subnet.slug,
                 )
             except SubnetNotFoundException:
                 # Concurrent dissolve already won — treat as success
@@ -1982,13 +1982,13 @@ class TaskService:
                 logger.debug(
                     "task_scoped_cascade_subnet_already_gone",
                     task_id=task_id,
-                    subnet_id=subnet.slug,
+                    subnet_slug=subnet.slug,
                 )
             except Exception as exc:  # noqa: BLE001 - best-effort cleanup
                 logger.warning(
                     "task_scoped_cascade_failed",
                     task_id=task_id,
-                    subnet_id=subnet.slug,
+                    subnet_slug=subnet.slug,
                     error=str(exc),
                 )
 
@@ -2016,7 +2016,7 @@ class TaskService:
             "reward": task.reward,
             "reward_currency": task.reward_currency,
             "max_participants": task.max_participants,
-            "slug": task.subnet_id,
+            "slug": task.subnet_slug,
         }
 
         try:
@@ -2044,7 +2044,7 @@ class TaskService:
                 logger.warning(
                     "task_harness_webhook_failed",
                     task_id=task.task_id,
-                    subnet_id=task.subnet_id,
+                    subnet_slug=task.subnet_slug,
                     webhook_event=event.value if hasattr(event, "value") else str(event),
                     error=str(e),
                 )
@@ -2067,7 +2067,7 @@ class TaskService:
         payload = {
             "status": task.status.value,
             "creator_id": task.creator_id,
-            "slug": task.subnet_id,
+            "slug": task.subnet_slug,
             "participation_id": participation.participation_id,
             "participant_id": participation.participant_id,
             "participant_name": participation.participant_name,
@@ -2101,7 +2101,7 @@ class TaskService:
                 logger.warning(
                     "task_harness_participation_webhook_failed",
                     task_id=task.task_id,
-                    subnet_id=task.subnet_id,
+                    subnet_slug=task.subnet_slug,
                     webhook_event=event.value if hasattr(event, "value") else str(event),
                     error=str(e),
                 )

--- a/alembic/versions/b1c2d3e4f5a6_rename_cross_table_subnet_id_to_subnet_slug.py
+++ b/alembic/versions/b1c2d3e4f5a6_rename_cross_table_subnet_id_to_subnet_slug.py
@@ -1,0 +1,60 @@
+"""rename tasks.subnet_id → subnet_slug; allowlist/join_requests .subnet_id → slug
+
+Revision ID: b1c2d3e4f5a6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-24
+
+Step 2 of the slug-rename migration (ADR slug rename).
+
+Step 1 (``a1b2c3d4e5f6``) renamed the Postgres PK column of the
+``subnets`` table from ``subnet_id`` → ``slug`` and the self-reference
+``parent_subnet_id`` → ``parent_slug``.
+
+This step renames the *cross-table* FK-style columns that carry a slug
+value but whose column names were still the legacy ``subnet_id``:
+
+- ``tasks.subnet_id``             → ``tasks.subnet_slug``
+- ``subnet_join_requests.subnet_id`` → ``subnet_join_requests.slug``
+- ``subnet_allowlist.subnet_id``  → ``subnet_allowlist.slug``
+
+These three columns are NOT true FK columns (they reference the
+subnets slug but carry no FK constraint — see ADR notes on schema
+decisions).  Renaming is therefore a pure ``ALTER COLUMN … RENAME``
+with no FK cascade work needed.
+
+The Python ORM models already use the new attribute names (``slug``,
+``subnet_slug``) with ``mapped_column("subnet_id", …)`` overrides;
+once this migration runs the overrides become redundant and should be
+removed in a follow-up cleanup commit.
+
+Indexes are automatically updated by PostgreSQL on a column rename;
+no manual index rebuild is required here.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # tasks: subnet_id → subnet_slug
+    op.alter_column("tasks", "subnet_id", new_column_name="subnet_slug")
+
+    # subnet_join_requests: subnet_id → slug
+    # The composite PK is (subnet_id, agent_id) or (subnet_id, request_id)
+    # depending on table; column rename is safe — the PK constraint stays,
+    # only the column name changes.
+    op.alter_column("subnet_join_requests", "subnet_id", new_column_name="slug")
+
+    # subnet_allowlist: subnet_id → slug
+    op.alter_column("subnet_allowlist", "subnet_id", new_column_name="slug")
+
+
+def downgrade() -> None:
+    op.alter_column("subnet_allowlist", "slug", new_column_name="subnet_id")
+    op.alter_column("subnet_join_requests", "slug", new_column_name="subnet_id")
+    op.alter_column("tasks", "subnet_slug", new_column_name="subnet_id")

--- a/tests/core/test_models_slug_backcompat.py
+++ b/tests/core/test_models_slug_backcompat.py
@@ -103,29 +103,26 @@ class TestAgentServiceSearchAgentsKwargCompat:
     ``slug=slug`` call site that mock-based route tests fail to
     catch."""
 
-    def test_search_agents_signature_uses_subnet_id_kwarg(self):
+    def test_search_agents_signature_uses_slug_kwarg(self):
+        """Step 2 migrated AgentService.search_agents to use ``slug=``."""
         import inspect
 
         from acn.services.agent_service import AgentService
 
         sig = inspect.signature(AgentService.search_agents)
         params = sig.parameters
-        assert "subnet_id" in params, (
-            "AgentService.search_agents must accept ``subnet_id=`` "
-            "until Step 2 migrates Agent.subnet_ids; routes/subnets.py "
-            "calls it with this kwarg."
+        assert "slug" in params, (
+            "AgentService.search_agents must accept ``slug=`` "
+            "after Step 2 migrates the parameter name."
         )
-        # And it must NOT accept the new name yet — that would mask the
-        # very inconsistency this test pins. Step 2 migrates this; this
-        # assertion is expected to be updated alongside that migration.
-        assert "slug" not in params
+        assert "subnet_id" not in params, (
+            "Legacy ``subnet_id`` parameter removed in Step 2; "
+            "callers should use ``slug=`` now."
+        )
 
     @pytest.mark.asyncio
-    async def test_route_calls_with_subnet_id_kwarg(self):
-        # Real-call regression: mock the service with a strict spec so
-        # an unexpected kwarg raises (the loose ``AsyncMock(return_value=[])``
-        # used elsewhere swallows the error). Imports kept local because
-        # ``agent_service`` constructs are heavy to import.
+    async def test_route_calls_with_slug_kwarg(self):
+        """routes/subnets.py calls search_agents(slug=...) after Step 2."""
         from unittest.mock import AsyncMock
 
         from acn.services.agent_service import AgentService
@@ -133,7 +130,105 @@ class TestAgentServiceSearchAgentsKwargCompat:
         service = AsyncMock(spec=AgentService)
         service.search_agents.return_value = []
 
-        # This is the call shape from routes/subnets.py::get_subnet_agents.
-        await service.search_agents(subnet_id="some-slug")
+        await service.search_agents(slug="some-slug")
 
-        service.search_agents.assert_awaited_once_with(subnet_id="some-slug")
+        service.search_agents.assert_awaited_once_with(slug="some-slug")
+
+
+# ===========================================================================
+# Step 2: Task entity backward compatibility
+# ===========================================================================
+class TestTaskFromDictLegacySubnetId:
+    """Back-compat: Task.from_dict must accept legacy ``subnet_id`` key."""
+
+    def test_subnet_id_key_translated_to_subnet_slug(self):
+        from acn.core.entities import Task, TaskStatus
+
+        data = {
+            "task_id": "t1",
+            "creator_type": "agent",
+            "creator_id": "a1",
+            "creator_name": "Alice",
+            "title": "T",
+            "description": "",
+            "reward": "10",
+            "reward_currency": "credits",
+            "max_participants": 1,
+            "status": TaskStatus.OPEN,
+            "required_tags": [],
+            "subnet_id": "acnlabs-core",
+        }
+        task = Task.from_dict(data)
+        assert task.subnet_slug == "acnlabs-core"
+
+    def test_subnet_slug_key_takes_precedence(self):
+        """subnet_slug wins when both keys are present (shouldn't happen, but safe)."""
+        from acn.core.entities import Task, TaskStatus
+
+        data = {
+            "task_id": "t1",
+            "creator_type": "agent",
+            "creator_id": "a1",
+            "creator_name": "Alice",
+            "title": "T",
+            "description": "",
+            "reward": "10",
+            "reward_currency": "credits",
+            "max_participants": 1,
+            "status": TaskStatus.OPEN,
+            "required_tags": [],
+            "subnet_slug": "correct-slug",
+            "subnet_id": "stale-old-key",
+        }
+        task = Task.from_dict(data)
+        assert task.subnet_slug == "correct-slug"
+
+    def test_no_subnet_gives_none(self):
+        from acn.core.entities import Task, TaskStatus
+
+        data = {
+            "task_id": "t1",
+            "creator_type": "agent",
+            "creator_id": "a1",
+            "creator_name": "Alice",
+            "title": "T",
+            "description": "",
+            "reward": "10",
+            "reward_currency": "credits",
+            "max_participants": 1,
+            "status": TaskStatus.OPEN,
+            "required_tags": [],
+        }
+        task = Task.from_dict(data)
+        assert task.subnet_slug is None
+
+
+class TestTaskCreateRequestLegacySubnetId:
+    """Back-compat: TaskCreateRequest must accept legacy ``subnet_id`` in request body."""
+
+    def test_subnet_id_body_key_translated(self):
+        import sys
+        import os
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+        from acn.routes.tasks import TaskCreateRequest  # type: ignore[attr-defined]
+
+        req = TaskCreateRequest.model_validate({
+            "title": "Test task",
+            "description": "A meaningful description",
+            "reward": "10",
+            "deadline_hours": 24,
+            "subnet_id": "acnlabs-core",
+        })
+        assert req.subnet_slug == "acnlabs-core"
+
+    def test_subnet_slug_body_key_accepted(self):
+        from acn.routes.tasks import TaskCreateRequest  # type: ignore[attr-defined]
+
+        req = TaskCreateRequest.model_validate({
+            "title": "Test task",
+            "description": "A meaningful description",
+            "reward": "10",
+            "deadline_hours": 24,
+            "subnet_slug": "acnlabs-core",
+        })
+        assert req.subnet_slug == "acnlabs-core"

--- a/tests/core/test_models_slug_backcompat.py
+++ b/tests/core/test_models_slug_backcompat.py
@@ -207,8 +207,8 @@ class TestTaskCreateRequestLegacySubnetId:
     """Back-compat: TaskCreateRequest must accept legacy ``subnet_id`` in request body."""
 
     def test_subnet_id_body_key_translated(self):
-        import sys
         import os
+        import sys
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
         from acn.routes.tasks import TaskCreateRequest  # type: ignore[attr-defined]
 

--- a/tests/infrastructure/test_task_repository_subnet_visibility.py
+++ b/tests/infrastructure/test_task_repository_subnet_visibility.py
@@ -61,7 +61,7 @@ def _make_repo(task_by_id: dict[str, Task], open_ids: list[str], agent_subnet_id
 @pytest.mark.asyncio
 async def test_private_subnet_task_visible_to_member():
     """An agent whose subnet_ids include the task's subnet must see the task."""
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(subnet_slug="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -74,7 +74,7 @@ async def test_private_subnet_task_visible_to_member():
 
 @pytest.mark.asyncio
 async def test_private_subnet_task_hidden_from_non_member():
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(subnet_slug="subnet-sec")
     repo, _ = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -88,7 +88,7 @@ async def test_private_subnet_task_hidden_from_non_member():
 @pytest.mark.asyncio
 async def test_public_task_always_visible_even_without_requesting_agent():
     """Tasks with no slug (public) bypass the visibility check."""
-    t = _make_task(subnet_id=None)
+    t = _make_task(subnet_slug=None)
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -108,7 +108,7 @@ async def test_visibility_never_touches_legacy_broken_keys():
     `acn:subnet:{sid}` paths. Both were empty/wrong and made private
     subnets invisible.
     """
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(subnet_slug="subnet-sec")
     repo, fake_redis = _make_repo(
         task_by_id={"task-001": t},
         open_ids=["task-001"],
@@ -140,7 +140,7 @@ async def test_corrupt_subnet_ids_does_not_crash_and_hides_private_tasks():
         return "{not json"  # garbage
 
     fake_redis.hget.side_effect = fake_hget
-    t = _make_task(subnet_id="subnet-sec")
+    t = _make_task(subnet_slug="subnet-sec")
     repo = RedisTaskRepository(redis_client=fake_redis)
     repo.find_by_id = AsyncMock(return_value=t)  # type: ignore[method-assign]
 

--- a/tests/routes/test_get_task_h8_auth.py
+++ b/tests/routes/test_get_task_h8_auth.py
@@ -51,7 +51,7 @@ def _public_task() -> SimpleNamespace:
     must match the entity attribute the production code reads."""
     return SimpleNamespace(
         task_id="task-public",
-        subnet_id=None,
+        subnet_slug=None,
         creator_id="creator-1",
         creator_name="Creator",
         creator_type="human",
@@ -98,7 +98,7 @@ def _private_task(slug: str = "sn-1") -> SimpleNamespace:
     t = _public_task()
     t.task_id = "task-private"
     # See ``_public_task`` — entity attribute is still ``subnet_id``.
-    t.subnet_id = slug
+    t.subnet_slug = slug
     return t
 
 

--- a/tests/routes/test_task_acl_scope_b.py
+++ b/tests/routes/test_task_acl_scope_b.py
@@ -111,7 +111,7 @@ def _make_task(
     # slug rename; the test parameter is named ``slug`` for parity
     # with the route layer's URL parameter naming, but the value is
     # written to the entity attribute the production code reads.
-    t.subnet_id = slug
+    t.subnet_slug = slug
     t.max_resubmit_attempts = None
     return t
 

--- a/tests/routes/test_tasks_error_schema.py
+++ b/tests/routes/test_tasks_error_schema.py
@@ -234,10 +234,8 @@ def stub_task_service_for_followup():
     target = MagicMock()
     target.task_id = "task-target"
     target.creator_id = "user-1"
-    # Task entity attribute is still ``subnet_id`` until Step 2 of the
-    # slug rename migrates cross-entity references; the test is set up
-    # to the field name production code reads.
-    target.subnet_id = None  # public task by default
+    # Step 2 complete: entity attribute is now ``subnet_slug``.
+    target.subnet_slug = None  # public task by default
     target.status = "open"
     target.mode = "single"
     target.title = "Test"
@@ -402,7 +400,6 @@ class TestTasksFlatErrorSchemaCrossModule:
         disambiguates anonymous vs non-member callers for the SDK.
         """
         target = MagicMock()
-        # Task entity attribute is still ``subnet_id`` (Step 2).
         target.subnet_slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
@@ -417,10 +414,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["error_code"] == "not_subnet_member"
         assert body["details"] == {
             "task_id": "task-target",
-            # The route's error payload mirrors the request's URL/JSON
-            # field name. Until Step 2 ships, that's still ``subnet_id``
-            # in the task error contract.
-            "subnet_id": "subnet-private",
+            "slug": "subnet-private",
             "reason": "anonymous_caller",
         }
 
@@ -437,8 +431,6 @@ class TestTasksFlatErrorSchemaCrossModule:
         private-subnet gate's second branch fires.
         """
         target = MagicMock()
-        # See ``test_get_task_private_subnet_anonymous_returns_not_subnet_member``
-        # — task entity attribute is still ``subnet_id`` until Step 2.
         target.subnet_slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
@@ -467,8 +459,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         assert body["details"] == {
             "task_id": "task-target",
             # See sibling test — error payload field still uses
-            # ``subnet_id`` until Step 2 of the slug rename.
-            "subnet_id": "subnet-private",
+            "slug": "subnet-private",
             "agent_id": "user-2",
             "reason": "not_member",
         }

--- a/tests/routes/test_tasks_error_schema.py
+++ b/tests/routes/test_tasks_error_schema.py
@@ -403,7 +403,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         """
         target = MagicMock()
         # Task entity attribute is still ``subnet_id`` (Step 2).
-        target.subnet_id = "subnet-private"
+        target.subnet_slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         _wire(stub_task_service_for_followup, stub_agent_service)
@@ -439,7 +439,7 @@ class TestTasksFlatErrorSchemaCrossModule:
         target = MagicMock()
         # See ``test_get_task_private_subnet_anonymous_returns_not_subnet_member``
         # — task entity attribute is still ``subnet_id`` until Step 2.
-        target.subnet_id = "subnet-private"
+        target.subnet_slug = "subnet-private"
         target.creator_id = "user-1"
         stub_task_service_for_followup.get_task = AsyncMock(return_value=target)
         stub_task_service_for_followup.is_subnet_member = AsyncMock(

--- a/tests/services/test_agent_service.py
+++ b/tests/services/test_agent_service.py
@@ -146,7 +146,7 @@ class TestAgentService:
 
         service = AgentService(mock_agent_repository)
 
-        agents = await service.search_agents(subnet_id="public")
+        agents = await service.search_agents(slug="public")
 
         assert len(agents) == 1
         assert agents[0].agent_id == sample_agent.agent_id

--- a/tests/services/test_org_harness.py
+++ b/tests/services/test_org_harness.py
@@ -289,7 +289,7 @@ class TestCreateTaskHarnessSnapshot:
             reward="0",
             reward_currency="credits",
             max_participants=1,
-            subnet_id="sn-paperclip",
+            subnet_slug="sn-paperclip",
         )
 
         assert task.metadata.get("harness_url") == "https://paperclip.example/acn"
@@ -312,7 +312,7 @@ class TestCreateTaskHarnessSnapshot:
             reward="0",
             reward_currency="credits",
             max_participants=1,
-            subnet_id="sn-plain",
+            subnet_slug="sn-plain",
         )
 
         assert "harness_url" not in task.metadata
@@ -330,7 +330,7 @@ class TestCreateTaskHarnessSnapshot:
             reward="0",
             reward_currency="credits",
             max_participants=1,
-            subnet_id=None,
+            subnet_slug=None,
         )
 
         assert "harness_url" not in task.metadata
@@ -353,7 +353,7 @@ class TestCreateTaskHarnessSnapshot:
             reward="0",
             reward_currency="credits",
             max_participants=1,
-            subnet_id="sn-paperclip",
+            subnet_slug="sn-paperclip",
         )
         # Task still created, harness simply not snapshotted
         assert "harness_url" not in task.metadata
@@ -380,7 +380,7 @@ class TestCreateTaskHarnessSnapshot:
             reward_currency="credits",
             max_participants=1,
             metadata=caller_metadata,
-            subnet_id="sn-paperclip",
+            subnet_slug="sn-paperclip",
         )
 
         assert caller_metadata == {"foo": "bar"}  # unchanged
@@ -409,7 +409,7 @@ def _make_task_with_harness(**overrides) -> Task:
         "reward": "0",
         "reward_currency": "credits",
         "max_participants": 1,
-        "subnet_id": "sn-paperclip",
+        "subnet_slug": "sn-paperclip",
         "metadata": metadata,
         "status": TaskStatus.IN_PROGRESS,
     }


### PR DESCRIPTION
## Summary

Step 2 of the subnet_id→slug rename migration, following Step 1 (PR #132).

- **Task entity**: Task.subnet_id → Task.subnet_slug; from_dict accepts legacy subnet_id key for backward compat with cached rows
- **ORM / persistence**: TaskModel.subnet_slug column override, SubnetJoinRequestModel.slug / SubnetAllowlistModel.slug column overrides updated; all Postgres + Redis repo implementations updated
- **Alembic migration b1c2d3e4f5a6**: renames tasks.subnet_id→subnet_slug, subnet_join_requests.subnet_id→slug, subnet_allowlist.subnet_id→slug
- **API back-compat**: TaskCreateRequest accepts legacy subnet_id via AliasChoices; TaskResponse serializes subnet_slug as subnet_id via serialization_alias (remove in Step 3)
- **Service/interface params**: AgentService.search_agents(slug=), TaskService.create_task(subnet_slug=), is_subnet_member(slug=), all repo interface methods slug: str
- **Agent entity methods**: is_in_subnet(slug), add_to_subnet(slug), remove_from_subnet(slug)

## Backward compatibility

| Layer | Input back-compat | Output back-compat |
|---|---|---|
| Task.from_dict | accepts subnet_id key | — |
| TaskCreateRequest | AliasChoices("subnet_slug","subnet_id") | — |
| TaskResponse | — | serialization_alias="subnet_id" (remove in Step 3) |
| Redis cached rows | from_dict translates subnet_id key | next save() rewrites with new key |

## Test plan

- pytest tests/core/ — 445 passed
- pytest tests/routes/ key files — 68 passed
- pytest tests/core/test_models_slug_backcompat.py — 13 passed (includes Step 2 regression tests)
- ruff check acn/ alembic/ tests/ --select=E,F,W --ignore=E501 — all passed

## Next step

Step 3: frontend + CLI updates, then remove serialization_alias from response models.

Made with [Cursor](https://cursor.com)