### PR TITLE
refactor(step3): finalize subnet slug rename — URL params, clients, SDK

### DIFF
--- a/acn/routes/_subnet_admission.py
+++ b/acn/routes/_subnet_admission.py
@@ -390,7 +390,7 @@ def invite_agent_result_to_response(
 # ---------------------------------------------------------------------------
 
 
-async def load_subnet_or_404(subnet_service: Any, subnet_id: str) -> Subnet:
+async def load_subnet_or_404(subnet_service: Any, slug: str) -> Subnet:
     """``SubnetService.get_subnet`` wrapped in the canonical 404 conversion.
 
     Every admission endpoint starts with a subnet lookup; the
@@ -399,10 +399,10 @@ async def load_subnet_or_404(subnet_service: Any, subnet_id: str) -> Subnet:
     ``_require_owner`` without re-fetching.
     """
     try:
-        return await subnet_service.get_subnet(subnet_id)
+        return await subnet_service.get_subnet(slug)
     except SubnetNotFoundException as e:
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             404,
-            details={"slug": subnet_id},
+            details={"slug": slug},
         ) from e

--- a/acn/routes/gateway_connect.py
+++ b/acn/routes/gateway_connect.py
@@ -1,6 +1,6 @@
 """Subnet gateway WebSocket — binds ``SubnetManager.handle_connection``.
 
-Exposes ``/gateway/connect/{subnet_id}/{agent_id}`` on the root ``app``.
+Exposes ``/gateway/connect/{slug}/{agent_id}`` on the root ``app``.
 Clients must immediately send the REGISTER JSON frame documented in
 ``SubnetManager``. Inbound heartbeat frames refresh Redis ``alive`` TTL via
 implicit heartbeat when ``SubnetManager`` receives ``agent_service`` from
@@ -57,10 +57,10 @@ def _extract_gateway_credentials(websocket: WebSocket) -> dict | None:
     return None
 
 
-@router.websocket("/gateway/connect/{subnet_id}/{agent_id}")
+@router.websocket("/gateway/connect/{slug}/{agent_id}")
 async def gateway_connect(
     websocket: WebSocket,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_id: AgentIdPath,
     subnet_manager: SubnetManager = Depends(get_subnet_manager),
 ):
@@ -84,9 +84,9 @@ async def gateway_connect(
         # can detect abuse patterns.
         logger.info(
             "gateway_connect_unauthenticated",
-            subnet_id=subnet_id,
+            slug=slug,
             agent_id=agent_id,
         )
     await subnet_manager.handle_connection(
-        websocket, subnet_id, agent_id, credentials=credentials
+        websocket, slug, agent_id, credentials=credentials
     )

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -457,12 +457,12 @@ async def dev_register_agent(
     subnet_ids = request.get_subnet_ids()
 
     # Validate subnets
-    for subnet_id in subnet_ids:
-        if subnet_id != "public" and not subnet_manager.subnet_exists(subnet_id):
+    for slug in subnet_ids:
+        if slug != "public" and not subnet_manager.subnet_exists(slug):
             raise ACNHTTPError(
                 ErrorCode.SUBNET_NOT_FOUND,
                 400,
-                details={"slug": subnet_id},
+                details={"slug": slug},
             )
 
     try:
@@ -664,12 +664,12 @@ async def register_agent(
     subnet_ids = request.get_subnet_ids()
 
     # Validate subnets
-    for subnet_id in subnet_ids:
-        if subnet_id != "public" and not subnet_manager.subnet_exists(subnet_id):
+    for slug in subnet_ids:
+        if slug != "public" and not subnet_manager.subnet_exists(slug):
             raise ACNHTTPError(
                 ErrorCode.SUBNET_NOT_FOUND,
                 400,
-                details={"slug": subnet_id},
+                details={"slug": slug},
             )
 
     try:

--- a/acn/routes/subnet_admission.py
+++ b/acn/routes/subnet_admission.py
@@ -11,7 +11,7 @@ Fourteen handlers covering the three resources the ADR introduces:
   pending-invitation view.
 
 The join-entry verb (``POST /api/v1/agents/{agent_id}/subnets/
-{subnet_id}``) still lives in ``routes/agent_subnets.py`` (and the
+{slug}``) still lives in ``routes/agent_subnets.py`` (and the
 legacy mirror in ``routes/subnets.py``); both delegate to
 ``_subnet_membership.do_join_subnet`` which now dispatches the
 six-branch decision tree via ``JoinFlowService``.
@@ -109,7 +109,7 @@ _MAX_NOTE_LEN: int = 500
 
 
 class AllowlistAddBody(BaseModel):
-    """POST /api/v1/subnets/{subnet_id}/allowlist body."""
+    """POST /api/v1/subnets/{slug}/allowlist body."""
 
     agent_id: str = Field(..., min_length=1, max_length=128)
 
@@ -162,17 +162,17 @@ class CancelInvitationBody(_OptionalNoteBody):
 # leaks relationship metadata if exposed publicly).
 
 
-@router.post("/subnets/{subnet_id}/allowlist", status_code=201)
+@router.post("/subnets/{slug}/allowlist", status_code=201)
 @limiter.limit("30/minute")
 async def add_to_allowlist(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     body: AllowlistAddBody,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     agent_service: AgentServiceDep = None,
 ):
-    """Pre-authorise ``body.agent_id`` for ``subnet_id``'s allowlist.
+    """Pre-authorise ``body.agent_id`` for ``slug``'s allowlist.
 
     Owner-only. Idempotent failure (existing entry) returns 409
     ``ALREADY_ON_ALLOWLIST`` per ADR §"Allowlist endpoints" — the
@@ -185,7 +185,7 @@ async def add_to_allowlist(
     because the route is the only caller — pushing the existence
     check up here keeps the service-layer shape minimal.)
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     try:
@@ -199,14 +199,14 @@ async def add_to_allowlist(
 
     try:
         entry = await subnet_service.add_allowlist(
-            subnet_id, body.agent_id, added_by=agent_info["agent_id"]
+            slug, body.agent_id, added_by=agent_info["agent_id"]
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
 
     logger.info(
         "subnet_allowlist_added_via_http",
-        slug=subnet_id,
+        slug=slug,
         agent_id=body.agent_id,
         added_by=agent_info["agent_id"],
     )
@@ -214,19 +214,19 @@ async def add_to_allowlist(
 
 
 @router.delete(
-    "/subnets/{subnet_id}/allowlist/{agent_id}",
+    "/subnets/{slug}/allowlist/{agent_id}",
     status_code=204,
     responses={**ACN_DEFAULT_RESPONSES, 204: {"description": "Entry removed"}},
 )
 @limiter.limit("30/minute")
 async def remove_from_allowlist(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_id: AgentIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
 ):
-    """Remove ``agent_id`` from ``subnet_id``'s allowlist (owner-only).
+    """Remove ``agent_id`` from ``slug``'s allowlist (owner-only).
 
     Idempotent per ADR §"Allowlist endpoints" — removing an entry
     that doesn't exist is a 204 (not a 404). This matches the
@@ -238,7 +238,7 @@ async def remove_from_allowlist(
     member if they had already joined. The route layer does not
     revoke membership.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     # Service-layer ``remove_allowlist`` is already idempotent (returns
@@ -246,31 +246,31 @@ async def remove_from_allowlist(
     # same either way per ADR §"Allowlist endpoints".
     try:
         await subnet_service.remove_allowlist(
-            subnet_id, agent_id, remover=agent_info["agent_id"]
+            slug, agent_id, remover=agent_info["agent_id"]
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
 
     logger.info(
         "subnet_allowlist_removed_via_http",
-        slug=subnet_id,
+        slug=slug,
         agent_id=agent_id,
         removed_by=agent_info["agent_id"],
     )
     return Response(status_code=204)
 
 
-@router.get("/subnets/{subnet_id}/allowlist")
+@router.get("/subnets/{slug}/allowlist")
 @limiter.limit("60/minute")
 async def list_allowlist(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ):
-    """List allowlist entries for ``subnet_id`` (owner-only).
+    """List allowlist entries for ``slug`` (owner-only).
 
     Owner-only by design per ADR §"GET /subnets/{s}/allowlist is
     owner-only deliberately" — the allowlist is a privacy-sensitive
@@ -281,19 +281,19 @@ async def list_allowlist(
     default page, 500 max page. Allowlists are bounded (no
     universal cap, but practical sizes are well under 500).
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     entries = await subnet_service.list_allowlist(
-        subnet_id, limit=limit, offset=offset
+        slug, limit=limit, offset=offset
     )
     return {
         # ``slug`` is the canonical key after the Step 1 rename.
-        # The previous ``subnet_id`` field is intentionally not emitted
+        # The previous ``slug`` field is intentionally not emitted
         # alongside — its absence is what the route's tests pin via
-        # equality assertion. SDK clients that still read ``subnet_id``
+        # equality assertion. SDK clients that still read ``slug``
         # from this response shape must roll forward to ``slug``.
-        "slug": subnet_id,
+        "slug": slug,
         "entries": [serialize_allowlist_entry(e) for e in entries],
     }
 
@@ -314,11 +314,11 @@ async def list_allowlist(
 # leaking the existence of a row in the other namespace.
 
 
-@router.post("/subnets/{subnet_id}/join-requests/{request_id}/approve")
+@router.post("/subnets/{slug}/join-requests/{request_id}/approve")
 @limiter.limit("30/minute")
 async def approve_join_request(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     body: ApproveBody | None = None,
@@ -336,13 +336,13 @@ async def approve_join_request(
     - ``subnet.join_approved`` webhook fires (logged-only stub
       pending Slice 2.4).
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
     note = body.note if body is not None else None
 
     try:
         row = await subnet_service.approve_join_request(
-            subnet_id,
+            slug,
             request_id,
             owner_id=agent_info["agent_id"],
             note=note,
@@ -353,11 +353,11 @@ async def approve_join_request(
     return serialize_join_request(row)
 
 
-@router.post("/subnets/{subnet_id}/join-requests/{request_id}/reject")
+@router.post("/subnets/{slug}/join-requests/{request_id}/reject")
 @limiter.limit("30/minute")
 async def reject_join_request(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     body: RejectBody | None = None,
@@ -370,13 +370,13 @@ async def reject_join_request(
     endpoints" lets the owner record a human-readable reason in the
     audit trail.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
     note = body.note if body is not None else None
 
     try:
         row = await subnet_service.reject_join_request(
-            subnet_id,
+            slug,
             request_id,
             owner_id=agent_info["agent_id"],
             note=note,
@@ -387,11 +387,11 @@ async def reject_join_request(
     return serialize_join_request(row)
 
 
-@router.delete("/subnets/{subnet_id}/join-requests/{request_id}")
+@router.delete("/subnets/{slug}/join-requests/{request_id}")
 @limiter.limit("30/minute")
 async def withdraw_join_request(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     note: str | None = Query(default=None, description="Optional reason for withdrawal."),
@@ -408,7 +408,7 @@ async def withdraw_join_request(
 
     No membership change. ``subnet.join_withdrawn`` webhook fires.
     """
-    await load_subnet_or_404(subnet_service, subnet_id)
+    await load_subnet_or_404(subnet_service, slug)
 
     # Load + namespace-check the row up front so we can authz
     # against initiated_by. Wrong namespace → 404 surfaces here.
@@ -416,7 +416,7 @@ async def withdraw_join_request(
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="join_request",
-            expected_slug=subnet_id,
+            expected_slug=slug,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
@@ -440,7 +440,7 @@ async def withdraw_join_request(
     # note comes from query param (P3-8: removed optional body on DELETE)
     try:
         withdrawn = await subnet_service.withdraw_join_request(
-            subnet_id,
+            slug,
             request_id,
             applicant_id=agent_info["agent_id"],
             note=note,
@@ -451,11 +451,11 @@ async def withdraw_join_request(
     return serialize_join_request(withdrawn)
 
 
-@router.get("/subnets/{subnet_id}/join-requests")
+@router.get("/subnets/{slug}/join-requests")
 @limiter.limit("60/minute")
 async def list_join_requests(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     status: Literal["pending", "approved", "rejected", "withdrawn"] | None = Query(
@@ -473,14 +473,14 @@ async def list_join_requests(
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ):
-    """Owner lists join_request / allowlist_auto rows for ``subnet_id``.
+    """Owner lists join_request / allowlist_auto rows for ``slug``.
 
     ADR §"Application-side endpoints" forbids ``kind=invitation`` on
     this path; rejecting at the request boundary with 400
     ``INVALID_KIND_FILTER`` prevents SDK clients from accidentally
     surfacing invitation rows through the join-request channel.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     if kind == "invitation":
@@ -491,7 +491,7 @@ async def list_join_requests(
         )
 
     rows = await subnet_service.list_join_requests(
-        subnet_id,
+        slug,
         kind=kind,
         status=status,
         limit=limit,
@@ -499,7 +499,7 @@ async def list_join_requests(
     )
     return {
         # ``slug`` only — see allowlist endpoint for the rationale.
-        "slug": subnet_id,
+        "slug": slug,
         "items": [serialize_join_request(r) for r in rows],
     }
 
@@ -514,11 +514,11 @@ async def list_join_requests(
 # discriminates 202 (normal send) vs 200 (merge).
 
 
-@router.post("/subnets/{subnet_id}/invitations")
+@router.post("/subnets/{slug}/invitations")
 @limiter.limit("30/minute")
 async def send_invitation(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     body: InviteBody,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
@@ -540,7 +540,7 @@ async def send_invitation(
     - Target already has a pending invitation → 409
       ``INVITATION_PENDING`` with the existing id echoed.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     try:
@@ -554,7 +554,7 @@ async def send_invitation(
 
     try:
         result = await subnet_service.invite_agent(
-            subnet_id,
+            slug,
             body.agent_id,
             owner_id=agent_info["agent_id"],
             note=body.note,
@@ -568,11 +568,11 @@ async def send_invitation(
     return JSONResponse(status_code=status_code, content=payload)
 
 
-@router.post("/subnets/{subnet_id}/invitations/{request_id}/accept")
+@router.post("/subnets/{slug}/invitations/{request_id}/accept")
 @limiter.limit("30/minute")
 async def accept_invitation(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     body: AcceptInvitationBody | None = None,
@@ -593,14 +593,14 @@ async def accept_invitation(
       path).
     - ``subnet.invitation_accepted`` webhook fires.
     """
-    await load_subnet_or_404(subnet_service, subnet_id)
+    await load_subnet_or_404(subnet_service, slug)
 
     # Load + namespace-check up front so authz uses the loaded row.
     try:
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_slug=subnet_id,
+            expected_slug=slug,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
@@ -609,7 +609,7 @@ async def accept_invitation(
 
     try:
         accepted = await subnet_service.accept_invitation(
-            subnet_id,
+            slug,
             request_id,
             invitee_id=agent_info["agent_id"],
         )
@@ -621,12 +621,12 @@ async def accept_invitation(
     # the member; failure to write the back-ref leaves a
     # half-joined state we best-effort recover.
     try:
-        await agent_service.join_subnet(agent_info["agent_id"], subnet_id)
+        await agent_service.join_subnet(agent_info["agent_id"], slug)
     except AgentNotFoundException as e:
         logger.warning(
             "accept_invitation_back_ref_failed_agent_not_found",
             agent_id=agent_info["agent_id"],
-            slug=subnet_id,
+            slug=slug,
         )
         raise ACNHTTPError(
             ErrorCode.AGENT_NOT_FOUND,
@@ -637,7 +637,7 @@ async def accept_invitation(
         logger.error(
             "accept_invitation_back_ref_failed",
             agent_id=agent_info["agent_id"],
-            slug=subnet_id,
+            slug=slug,
             error=str(e),
             exc_info=True,
         )
@@ -648,17 +648,17 @@ async def accept_invitation(
         # already-decided check will surface 409 INVITATION_ALREADY_DECIDED
         # which is preferable to a permanent inconsistency.
         try:
-            await subnet_service.remove_member(subnet_id, agent_info["agent_id"])
+            await subnet_service.remove_member(slug, agent_info["agent_id"])
             logger.info(
                 "accept_invitation_rollback_ok",
                 agent_id=agent_info["agent_id"],
-                slug=subnet_id,
+                slug=slug,
             )
         except Exception as rollback_err:  # noqa: BLE001
             logger.error(
                 "accept_invitation_rollback_failed",
                 agent_id=agent_info["agent_id"],
-                slug=subnet_id,
+                slug=slug,
                 rollback_error=str(rollback_err),
             )
         raise HTTPException(
@@ -669,11 +669,11 @@ async def accept_invitation(
     return serialize_join_request(accepted)
 
 
-@router.post("/subnets/{subnet_id}/invitations/{request_id}/reject")
+@router.post("/subnets/{slug}/invitations/{request_id}/reject")
 @limiter.limit("30/minute")
 async def reject_invitation(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     body: RejectInvitationBody | None = None,
@@ -684,13 +684,13 @@ async def reject_invitation(
     No membership change. ``subnet.invitation_rejected`` webhook
     fires. Optional ``note`` lets the invitee record a reason.
     """
-    await load_subnet_or_404(subnet_service, subnet_id)
+    await load_subnet_or_404(subnet_service, slug)
 
     try:
         row = await subnet_service.load_join_request_or_404(
             request_id,
             expected_kind="invitation",
-            expected_slug=subnet_id,
+            expected_slug=slug,
         )
     except JoinFlowError as e:
         raise _map_join_flow_error(e) from e
@@ -700,7 +700,7 @@ async def reject_invitation(
 
     try:
         rejected = await subnet_service.reject_invitation(
-            subnet_id,
+            slug,
             request_id,
             invitee_id=agent_info["agent_id"],
             note=note,
@@ -711,11 +711,11 @@ async def reject_invitation(
     return serialize_join_request(rejected)
 
 
-@router.delete("/subnets/{subnet_id}/invitations/{request_id}")
+@router.delete("/subnets/{slug}/invitations/{request_id}")
 @limiter.limit("30/minute")
 async def cancel_invitation(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     request_id: RequestIdPath,
     agent_info: AgentApiKeyDep,
     body: CancelInvitationBody | None = None,
@@ -731,13 +731,13 @@ async def cancel_invitation(
 
     ``subnet.invitation_canceled`` webhook fires.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
     note = body.note if body is not None else None
 
     try:
         canceled = await subnet_service.cancel_invitation(
-            subnet_id,
+            slug,
             request_id,
             owner_id=agent_info["agent_id"],
             note=note,
@@ -748,11 +748,11 @@ async def cancel_invitation(
     return serialize_join_request(canceled)
 
 
-@router.get("/subnets/{subnet_id}/invitations")
+@router.get("/subnets/{slug}/invitations")
 @limiter.limit("60/minute")
 async def list_invitations(
     request: Request,
-    subnet_id: SubnetIdPath,
+    slug: SubnetIdPath,
     agent_info: AgentApiKeyDep,
     subnet_service: SubnetServiceDep = None,
     status: Literal["pending", "approved", "rejected", "withdrawn"] | None = Query(
@@ -761,23 +761,23 @@ async def list_invitations(
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ):
-    """Owner lists invitation rows for ``subnet_id``.
+    """Owner lists invitation rows for ``slug``.
 
     Owner-only — invitees use the per-agent endpoint
     ``GET /agents/{a}/subnet-invitations`` for their own view.
     """
-    subnet = await load_subnet_or_404(subnet_service, subnet_id)
+    subnet = await load_subnet_or_404(subnet_service, slug)
     _require_owner(agent_info, subnet)
 
     rows = await subnet_service.list_invitations(
-        subnet_id,
+        slug,
         status=status,
         limit=limit,
         offset=offset,
     )
     return {
         # ``slug`` only — see allowlist endpoint for the rationale.
-        "slug": subnet_id,
+        "slug": slug,
         "items": [serialize_join_request(r) for r in rows],
     }
 

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -387,18 +387,11 @@ class TaskResponse(BaseModel):
     # frontend DeliverablesPanel can display the submitted content.
     submission: str | None = None
     submission_artifacts: list[dict] = Field(default_factory=list)
-    # Canonical field name after the Step 2 rename.
-    # ``subnet_id`` kept as a backward-compat serialization alias so
-    # existing frontend / SDK clients reading the old key don't break
-    # mid-rollout. Remove alias in Step 3 (frontend update).
     subnet_slug: str | None = Field(
         default=None,
-        serialization_alias="subnet_id",
         description="Subnet slug restricting task visibility (NULL=public).",
     )
     max_resubmit_attempts: int | None = None
-
-    model_config = ConfigDict(populate_by_name=True)
 
 class ParticipationResponse(BaseModel):
     """Participation response model"""
@@ -460,8 +453,7 @@ class TaskHistoryItem(BaseModel):
     participation_id: str | None = None
     subnet_slug: str | None = Field(
         default=None,
-        serialization_alias="subnet_id",
-        description="Subnet slug (legacy alias 'subnet_id' on output; removed in Step 3).",
+        description="Subnet slug (NULL=public).",
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/clients/cli/src/commands/subnet.ts
+++ b/clients/cli/src/commands/subnet.ts
@@ -4,7 +4,7 @@ import { loadConfig } from '../config.js';
 import { output, handleError } from '../output.js';
 
 interface SubnetInfo {
-  subnet_id: string;
+  slug: string;
   name: string;
   owner?: string;
   description?: string;
@@ -15,7 +15,8 @@ interface SubnetInfo {
   metadata?: Record<string, unknown>;
   // ADR-0003 nesting fields (optional + back-compat default
   // tolerant — older servers may omit them).
-  parent_subnet_id?: string | null;
+  parent_slug?: string | null;
+  /** @deprecated */ parent_subnet_id?: string | null;
   lifecycle?: 'persistent' | 'task_scoped';
   linked_task_id?: string | null;
 }
@@ -27,7 +28,7 @@ interface SubnetListResponse {
 
 interface SubnetCreateResponse {
   status: string;
-  subnet_id: string;
+  slug: string;
   is_public: boolean;
   gateway_a2a_url: string;
   gateway_ws_url: string;
@@ -54,7 +55,7 @@ type SubnetJoinRequestStatus =
 
 interface SubnetJoinRequestDTO {
   request_id: string;
-  subnet_id: string;
+  slug: string;
   agent_id: string;
   kind: SubnetJoinRequestKind;
   status: SubnetJoinRequestStatus;
@@ -66,24 +67,24 @@ interface SubnetJoinRequestDTO {
 }
 
 interface SubnetAllowlistEntryDTO {
-  subnet_id: string;
+  slug: string;
   agent_id: string;
   added_by: string;
   added_at: string | null;
 }
 
 interface JoinRequestListResponse {
-  subnet_id: string;
+  slug: string;
   items: SubnetJoinRequestDTO[];
 }
 
 interface InvitationListResponse {
-  subnet_id: string;
+  slug: string;
   items: SubnetJoinRequestDTO[];
 }
 
 interface AllowlistListResponse {
-  subnet_id: string;
+  slug: string;
   entries: SubnetAllowlistEntryDTO[];
 }
 
@@ -98,23 +99,23 @@ interface AgentInvitationsResponse {
 // on body shape (not HTTP status, which the fetch wrapper doesn't expose).
 // All variants carry ``subnet_id`` + ``agent_id``.
 type JoinResponseBody =
-  | { status: 'joined'; subnet_id: string; agent_id: string } // branches 1+2
+  | { status: 'joined'; slug: string; agent_id: string } // branches 1+2
   | {
       auto_resolved: true;
       resolved_kind: 'invitation';
-      subnet_id: string;
+      slug: string;
       agent_id: string;
       invitation_id: string;
       via: 'self_join' | 'allowlist';
     } // branches 3+4
   | {
-      subnet_id: string;
+      slug: string;
       agent_id: string;
       request_id: string;
       via: 'allowlist';
     } // branch 5
   | {
-      subnet_id: string;
+      slug: string;
       agent_id: string;
       request_id: string;
       status: 'pending';
@@ -125,7 +126,7 @@ type JoinResponseBody =
 // or the merge path where the target already had a pending join_request.
 type InviteResponseBody =
   | {
-      subnet_id: string;
+      slug: string;
       agent_id: string;
       invitation_id: string;
       status: 'pending';
@@ -133,7 +134,7 @@ type InviteResponseBody =
   | {
       auto_resolved: true;
       resolved_kind: 'join_request';
-      subnet_id: string;
+      slug: string;
       agent_id: string;
       request_id: string;
     };
@@ -168,7 +169,7 @@ function formatJoinRequest(r: SubnetJoinRequestDTO, index?: number): string {
   const prefix = index !== undefined ? `[${index + 1}] ` : '';
   const lines = [
     `${prefix}${r.request_id}  [${r.kind} / ${r.status}]`,
-    `  Subnet     : ${r.subnet_id}`,
+    `  Subnet     : ${r.slug}`,
     `  Agent      : ${r.agent_id}`,
     `  InitiatedBy: ${r.initiated_by}`,
   ];
@@ -257,12 +258,12 @@ function formatInviteResponse(
 function formatSubnet(s: SubnetInfo, index?: number): string {
   const prefix = index !== undefined ? `[${index + 1}] ` : '';
   const privacy = s.is_private ? ' [private]' : ' [public]';
-  const lines = [`${prefix}${s.subnet_id}${privacy}`, `  Name  : ${s.name}`];
+  const lines = [`${prefix}${s.slug}${privacy}`, `  Name  : ${s.name}`];
   if (s.owner) lines.push(`  Owner : ${s.owner}`);
   if (s.description) lines.push(`  Desc  : ${s.description}`);
   if (s.created_at) lines.push(`  Since : ${s.created_at}`);
-  if (s.parent_subnet_id) {
-    lines.push(`  Parent: ${s.parent_subnet_id}`);
+  if (s.parent_slug ?? s.parent_subnet_id) {
+    lines.push(`  Parent: ${s.parent_slug ?? s.parent_subnet_id}`);
   }
   if (s.lifecycle && s.lifecycle !== 'persistent') {
     const task = s.linked_task_id ? ` (task=${s.linked_task_id})` : '';
@@ -354,7 +355,7 @@ export function subnetCommand(): Command {
     .description('List agents in a subnet')
     .action(async (subnetId: string) => {
       try {
-        const res = await acnGet<{ subnet_id: string; agents: unknown[]; count: number }>(
+        const res = await acnGet<{ slug: string; agents: unknown[]; count: number }>(
           `/subnets/${subnetId}/agents`
         );
         const count = res.count ?? (res.agents ?? []).length;
@@ -390,7 +391,7 @@ export function subnetCommand(): Command {
     .action(async (subnetId: string, opts: { agentId?: string }) => {
       const agentId = opts.agentId ?? requireAgentId();
       try {
-        const res = await acnDelete<{ status: string; agent_id: string; subnet_id: string }>(
+        const res = await acnDelete<{ status: string; agent_id: string; slug: string }>(
           `/agents/${agentId}/subnets/${subnetId}`
         );
         output(res, `Left subnet ${subnetId} (status: ${res.status})`);
@@ -484,16 +485,16 @@ export function subnetCommand(): Command {
           name: opts.name,
           is_private: !!opts.private,
         };
-        if (opts.id) body.subnet_id = opts.id;
+        if (opts.id) body.slug = opts.id;
         if (opts.description) body.description = opts.description;
         if (joinPolicy !== undefined) body.join_policy = joinPolicy;
-        if (opts.parent) body.parent_subnet_id = opts.parent;
+        if (opts.parent) body.parent_slug = opts.parent;
         body.lifecycle = lifecycle;
         if (opts.task) body.linked_task_id = opts.task;
         try {
           const res = await acnPost<SubnetCreateResponse>('/subnets', body);
           const lines = [
-            `Subnet created: ${res.subnet_id}`,
+            `Subnet created: ${res.slug}`,
             `  Visibility : ${res.is_public ? 'public' : 'private'}`,
             `  Gateway A2A: ${res.gateway_a2a_url}`,
             `  Gateway WS : ${res.gateway_ws_url}`,
@@ -528,7 +529,7 @@ export function subnetCommand(): Command {
         const lifecycle = res.lifecycle ?? 'persistent';
         output(
           res,
-          `Subnet ${res.subnet_id} lifecycle=${lifecycle}` +
+          `Subnet ${res.slug} lifecycle=${lifecycle}` +
             (res.linked_task_id ? ` (still linked to task ${res.linked_task_id})` : '')
         );
       } catch (err) {
@@ -546,10 +547,10 @@ export function subnetCommand(): Command {
         process.exit(1);
       }
       try {
-        const res = await acnDelete<{ status: string; subnet_id: string }>(
+        const res = await acnDelete<{ status: string; slug: string }>(
           `/subnets/${subnetId}`
         );
-        output(res, `Subnet ${res.subnet_id} ${res.status}`);
+        output(res, `Subnet ${res.slug} ${res.status}`);
       } catch (err) {
         handleError(err);
       }
@@ -643,7 +644,7 @@ export function subnetCommand(): Command {
         }>(`/agents/${agentId}/subnets`);
         const subnetIds = subs.subnets ?? [];
         const aggregated: Array<{
-          subnet_id: string;
+          slug: string;
           request: SubnetJoinRequestDTO;
         }> = [];
         for (const sid of subnetIds) {
@@ -652,7 +653,7 @@ export function subnetCommand(): Command {
               `/subnets/${sid}/join-requests?status=pending&kind=join_request`
             );
             for (const r of res.items ?? []) {
-              aggregated.push({ subnet_id: sid, request: r });
+              aggregated.push({ slug: sid, request: r });
             }
           } catch {
             // Owner-only — silently skip non-owned subnets (per
@@ -1065,7 +1066,7 @@ export function subnetCommand(): Command {
             `/subnets/${subnetId}/allowlist/${opts.agentId}`
           );
           output(
-            { subnet_id: subnetId, agent_id: opts.agentId, removed: true },
+            { slug: subnetId, agent_id: opts.agentId, removed: true },
             `removed ${opts.agentId} from allowlist of subnet ${subnetId}`
           );
         } catch (err) {
@@ -1095,7 +1096,7 @@ export function subnetCommand(): Command {
       try {
         const res = await acnPatch<{
           status: string;
-          subnet_id: string;
+          slug: string;
           harness_url: string | null;
           harness_registered: boolean;
         }>(`/subnets/${subnetId}/harness`, {
@@ -1103,7 +1104,7 @@ export function subnetCommand(): Command {
           harness_secret: opts.secret ?? null,
         });
         const lines = [
-          `Harness registered on subnet ${res.subnet_id}`,
+          `Harness registered on subnet ${res.slug}`,
           `  URL       : ${res.harness_url}`,
           `  Signed    : ${opts.secret ? 'yes (HMAC-SHA256)' : 'no (unsigned)'}`,
         ];
@@ -1125,14 +1126,14 @@ export function subnetCommand(): Command {
       try {
         const res = await acnPatch<{
           status: string;
-          subnet_id: string;
+          slug: string;
           harness_url: string | null;
           harness_registered: boolean;
         }>(`/subnets/${subnetId}/harness`, {
           harness_url: null,
           harness_secret: null,
         });
-        output(res, `Harness unregistered from subnet ${res.subnet_id}`);
+        output(res, `Harness unregistered from subnet ${res.slug}`);
       } catch (err) {
         handleError(err);
       }

--- a/clients/cli/tests/subnet-ad0003.test.ts
+++ b/clients/cli/tests/subnet-ad0003.test.ts
@@ -45,7 +45,7 @@ async function runSubnet(args: string[]): Promise<void> {
 describe('subnet create (ADR-0003)', () => {
   const createResponse = {
     status: 'created',
-    subnet_id: 'subnet-test-1',
+    slug: 'subnet-test-1',
     is_public: true,
     gateway_a2a_url: 'https://gw/a2a/subnet-test-1',
     gateway_ws_url: 'https://gw/ws/subnet-test-1',
@@ -64,7 +64,7 @@ describe('subnet create (ADR-0003)', () => {
     vi.clearAllMocks();
   });
 
-  it('passes parent_subnet_id when --parent is set', async () => {
+  it('passes parent_slug when --parent is set', async () => {
     await runSubnet(['create', '--name', 'Squad', '--parent', 'net-parent']);
 
     expect(acnPost).toHaveBeenCalledTimes(1);
@@ -72,7 +72,7 @@ describe('subnet create (ADR-0003)', () => {
       '/subnets',
       expect.objectContaining({
         name: 'Squad',
-        parent_subnet_id: 'net-parent',
+        parent_slug: 'net-parent',
         is_private: false,
         lifecycle: 'persistent',
       })
@@ -171,7 +171,7 @@ describe('subnet promote', () => {
       base_url: 'https://api.test',
     });
     vi.mocked(acnPost).mockResolvedValue({
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       name: 'Squad',
       lifecycle: 'persistent',
       linked_task_id: null,

--- a/clients/cli/tests/subnet-ad0004.test.ts
+++ b/clients/cli/tests/subnet-ad0004.test.ts
@@ -70,7 +70,7 @@ afterEach(() => {
 describe('subnet create --join-policy (ADR-0004)', () => {
   const createResponse = {
     status: 'created',
-    subnet_id: 'subnet-x',
+    slug: 'subnet-x',
     is_public: true,
     gateway_a2a_url: 'https://gw/a2a/subnet-x',
     gateway_ws_url: 'https://gw/ws/subnet-x',
@@ -179,7 +179,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
   it('hits the canonical /agents/{aid}/subnets/{sid} URL', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       status: 'joined',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'agent-1',
     } as never);
     await runSubnet(['join', 's1']);
@@ -189,7 +189,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
   it('branch 1/2 (joined): plain "joined subnet" line', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       status: 'joined',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'agent-1',
     } as never);
     await runSubnet(['join', 's1']);
@@ -201,7 +201,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
     vi.mocked(acnPost).mockResolvedValue({
       auto_resolved: true,
       resolved_kind: 'invitation',
-      subnet_id: 's2',
+      slug: 's2',
       agent_id: 'agent-1',
       invitation_id: 'inv-3',
       via: 'self_join',
@@ -217,7 +217,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
     vi.mocked(acnPost).mockResolvedValue({
       auto_resolved: true,
       resolved_kind: 'invitation',
-      subnet_id: 's3',
+      slug: 's3',
       agent_id: 'agent-1',
       invitation_id: 'inv-4',
       via: 'allowlist',
@@ -231,7 +231,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
 
   it('branch 5 (allowlist, no invitation): mentions allowlist match', async () => {
     vi.mocked(acnPost).mockResolvedValue({
-      subnet_id: 's4',
+      slug: 's4',
       agent_id: 'agent-1',
       request_id: 'req-5',
       via: 'allowlist',
@@ -243,7 +243,7 @@ describe('subnet join (ADR-0004 6 branches)', () => {
 
   it('branch 6 (pending): mentions pending owner approval', async () => {
     vi.mocked(acnPost).mockResolvedValue({
-      subnet_id: 's5',
+      slug: 's5',
       agent_id: 'agent-1',
       request_id: 'req-6',
       status: 'pending',
@@ -263,10 +263,10 @@ describe('subnet join (ADR-0004 6 branches)', () => {
 describe('subnet allowlist (ADR-0004)', () => {
   it('list hits GET /subnets/{sid}/allowlist', async () => {
     vi.mocked(acnGet).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       entries: [
         {
-          subnet_id: 's1',
+          slug: 's1',
           agent_id: 'a-1',
           added_by: 'owner-1',
           added_at: '2026-05-19T00:00:00Z',
@@ -284,7 +284,7 @@ describe('subnet allowlist (ADR-0004)', () => {
 
   it('list with empty result prints empty message', async () => {
     vi.mocked(acnGet).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       entries: [],
     } as never);
     await runSubnet(['allowlist', 'list', 's1']);
@@ -294,7 +294,7 @@ describe('subnet allowlist (ADR-0004)', () => {
 
   it('add posts {agent_id}', async () => {
     vi.mocked(acnPost).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-2',
       added_by: 'agent-1',
       added_at: '2026-05-19T00:00:00Z',
@@ -321,11 +321,11 @@ describe('subnet allowlist (ADR-0004)', () => {
 describe('subnet requests (ADR-0004)', () => {
   it('list hits GET /subnets/{sid}/join-requests with default kind', async () => {
     vi.mocked(acnGet).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       items: [
         {
           request_id: 'r-1',
-          subnet_id: 's1',
+          slug: 's1',
           agent_id: 'a-1',
           kind: 'join_request',
           status: 'pending',
@@ -345,7 +345,7 @@ describe('subnet requests (ADR-0004)', () => {
 
   it('list propagates --status + --kind filters', async () => {
     vi.mocked(acnGet).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       items: [],
     } as never);
     await runSubnet([
@@ -365,7 +365,7 @@ describe('subnet requests (ADR-0004)', () => {
   it('approve posts to /approve endpoint with optional note', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       request_id: 'r-1',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-1',
       kind: 'join_request',
       status: 'approved',
@@ -393,7 +393,7 @@ describe('subnet requests (ADR-0004)', () => {
   it('reject posts to /reject endpoint, omits body when no --note', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       request_id: 'r-2',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-1',
       kind: 'join_request',
       status: 'rejected',
@@ -413,7 +413,7 @@ describe('subnet requests (ADR-0004)', () => {
   it('withdraw deletes /subnets/{sid}/join-requests/{rid}', async () => {
     vi.mocked(acnDelete).mockResolvedValue({
       request_id: 'r-3',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'agent-1',
       kind: 'join_request',
       status: 'withdrawn',
@@ -439,11 +439,11 @@ describe('subnet requests (ADR-0004)', () => {
       }
       if (path.startsWith('/subnets/s1/')) {
         return Promise.resolve({
-          subnet_id: 's1',
+          slug: 's1',
           items: [
             {
               request_id: 'r-a',
-              subnet_id: 's1',
+              slug: 's1',
               agent_id: 'a-x',
               kind: 'join_request',
               status: 'pending',
@@ -490,7 +490,7 @@ describe('subnet requests (ADR-0004)', () => {
 describe('subnet invitations (ADR-0004)', () => {
   it('send posts {agent_id, note?}', async () => {
     vi.mocked(acnPost).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-2',
       invitation_id: 'inv-1',
       status: 'pending',
@@ -518,7 +518,7 @@ describe('subnet invitations (ADR-0004)', () => {
     vi.mocked(acnPost).mockResolvedValue({
       auto_resolved: true,
       resolved_kind: 'join_request',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-3',
       request_id: 'r-merge',
     } as never);
@@ -531,7 +531,7 @@ describe('subnet invitations (ADR-0004)', () => {
 
   it('list hits GET /subnets/{sid}/invitations', async () => {
     vi.mocked(acnGet).mockResolvedValue({
-      subnet_id: 's1',
+      slug: 's1',
       items: [],
     } as never);
     await runSubnet(['invitations', 'list', 's1']);
@@ -546,7 +546,7 @@ describe('subnet invitations (ADR-0004)', () => {
       items: [
         {
           request_id: 'inv-9',
-          subnet_id: 's1',
+          slug: 's1',
           agent_id: 'agent-1',
           kind: 'invitation',
           status: 'pending',
@@ -568,7 +568,7 @@ describe('subnet invitations (ADR-0004)', () => {
   it('accept posts to /invitations/{iid}/accept', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       request_id: 'inv-1',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'agent-1',
       kind: 'invitation',
       status: 'approved',
@@ -596,7 +596,7 @@ describe('subnet invitations (ADR-0004)', () => {
   it('reject posts to /invitations/{iid}/reject with optional note', async () => {
     vi.mocked(acnPost).mockResolvedValue({
       request_id: 'inv-2',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'agent-1',
       kind: 'invitation',
       status: 'rejected',
@@ -624,7 +624,7 @@ describe('subnet invitations (ADR-0004)', () => {
   it('cancel deletes /invitations/{iid}', async () => {
     vi.mocked(acnDelete).mockResolvedValue({
       request_id: 'inv-3',
-      subnet_id: 's1',
+      slug: 's1',
       agent_id: 'a-target',
       kind: 'invitation',
       status: 'withdrawn',

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -436,24 +436,24 @@ class ACNClient:
         )
 
     async def list_subnets(
-        self, parent_subnet_id: str | None = None
+        self, parent_slug: str | None = None
     ) -> list[SubnetInfo]:
         """List subnets.
 
         Args:
-            parent_subnet_id: When set, filter to immediate children
+            parent_slug: When set, filter to immediate children
                 of the given parent (ADR-0003). The server applies
                 the same ACL as the unfiltered list — private
                 children not visible to this client are silently
                 omitted.
         """
         params: dict[str, str] | None = None
-        if parent_subnet_id is not None:
-            params = {"parent": parent_subnet_id}
+        if parent_slug is not None:
+            params = {"parent": parent_slug}
         data = await self._request("GET", "/api/v1/subnets", params=params)
         return [SubnetInfo.model_validate(s) for s in data.get("subnets", [])]
 
-    async def list_children(self, parent_subnet_id: str) -> list[SubnetInfo]:
+    async def list_children(self, parent_slug: str) -> list[SubnetInfo]:
         """List immediate children of a subnet (ADR-0003).
 
         Convenience wrapper over the dedicated
@@ -463,47 +463,47 @@ class ACNClient:
         non-visible private children are omitted.
         """
         data = await self._request(
-            "GET", f"/api/v1/subnets/{parent_subnet_id}/children"
+            "GET", f"/api/v1/subnets/{parent_slug}/children"
         )
         return [SubnetInfo.model_validate(s) for s in data.get("subnets", [])]
 
-    async def promote_subnet(self, subnet_id: str) -> SubnetInfo:
+    async def promote_subnet(self, slug: str) -> SubnetInfo:
         """Promote a ``task_scoped`` subnet to ``persistent`` (ADR-0003).
 
         Owner-only. Idempotent — promoting an already-persistent
         subnet returns its current state unchanged.
         """
-        data = await self._request("POST", f"/api/v1/subnets/{subnet_id}/promote")
+        data = await self._request("POST", f"/api/v1/subnets/{slug}/promote")
         return SubnetInfo.model_validate(data)
 
-    async def get_subnet(self, subnet_id: str) -> SubnetInfo:
+    async def get_subnet(self, slug: str) -> SubnetInfo:
         """Get subnet by ID"""
-        data = await self._request("GET", f"/api/v1/subnets/{subnet_id}")
+        data = await self._request("GET", f"/api/v1/subnets/{slug}")
         return SubnetInfo.model_validate(data)
 
-    async def delete_subnet(self, subnet_id: str) -> dict[str, Any]:
+    async def delete_subnet(self, slug: str) -> dict[str, Any]:
         """Delete a subnet you own (requires Agent API Key — only the owning agent can delete)."""
         return await self._request(
             "DELETE",
-            f"/api/v1/subnets/{subnet_id}",
+            f"/api/v1/subnets/{slug}",
         )
 
-    async def get_subnet_agents(self, subnet_id: str) -> list[AgentInfo]:
+    async def get_subnet_agents(self, slug: str) -> list[AgentInfo]:
         """Get agents in a subnet"""
-        data = await self._request("GET", f"/api/v1/subnets/{subnet_id}/agents")
+        data = await self._request("GET", f"/api/v1/subnets/{slug}/agents")
         return [AgentInfo.model_validate(a) for a in data.get("agents", [])]
 
-    async def join_subnet(self, agent_id: str, subnet_id: str) -> dict[str, Any]:
+    async def join_subnet(self, agent_id: str, slug: str) -> dict[str, Any]:
         """Join agent to subnet"""
-        return await self._request("POST", f"/api/v1/agents/{agent_id}/subnets/{subnet_id}")
+        return await self._request("POST", f"/api/v1/agents/{agent_id}/subnets/{slug}")
 
-    async def leave_subnet(self, agent_id: str, subnet_id: str) -> dict[str, Any]:
+    async def leave_subnet(self, agent_id: str, slug: str) -> dict[str, Any]:
         """Remove agent from subnet"""
-        return await self._request("DELETE", f"/api/v1/agents/{agent_id}/subnets/{subnet_id}")
+        return await self._request("DELETE", f"/api/v1/agents/{agent_id}/subnets/{slug}")
 
     async def set_subnet_harness(
         self,
-        subnet_id: str,
+        slug: str,
         harness_url: str | None,
         harness_secret: str | None = None,
     ) -> dict[str, Any]:
@@ -529,7 +529,7 @@ class ACNClient:
         Example::
 
             await client.set_subnet_harness(
-                subnet_id="my-subnet",
+                slug="my-subnet",
                 harness_url="https://paperclip.example.com/acn/webhook",
                 harness_secret="your-hmac-secret",
             )
@@ -538,7 +538,7 @@ class ACNClient:
         """
         return await self._request(
             "PATCH",
-            f"/api/v1/subnets/{subnet_id}/harness",
+            f"/api/v1/subnets/{slug}/harness",
             json={"harness_url": harness_url, "harness_secret": harness_secret},
         )
 
@@ -563,16 +563,16 @@ class ACNClient:
     #
     # All methods return raw ``dict[str, Any]`` (matching server's
     # un-typed JSON responses); list endpoints return paginated
-    # ``{ subnet_id|agent_id, items|entries }`` envelopes.
+    # ``{ slug|agent_id, items|entries }`` envelopes.
 
     # ----- Allowlist (owner-only, 3 verbs) ---------------------------------
 
     async def subnet_allowlist_add(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
     ) -> dict[str, Any]:
-        """Pre-authorise ``agent_id`` on ``subnet_id``'s allowlist (owner only).
+        """Pre-authorise ``agent_id`` on ``slug``'s allowlist (owner only).
 
         Allowlisted agents skip the approval queue: their next
         ``join_subnet`` call lands in branch 4 (allowlist hit) and
@@ -585,16 +585,16 @@ class ACNClient:
         """
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/allowlist",
+            f"/api/v1/subnets/{slug}/allowlist",
             json={"agent_id": agent_id},
         )
 
     async def subnet_allowlist_remove(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
     ) -> None:
-        """Remove ``agent_id`` from ``subnet_id``'s allowlist (owner only).
+        """Remove ``agent_id`` from ``slug``'s allowlist (owner only).
 
         Idempotent — removing an entry that doesn't exist still
         returns 204. Per ADR-0004 §"Allowlist mutation does not
@@ -605,26 +605,26 @@ class ACNClient:
         """
         await self._request(
             "DELETE",
-            f"/api/v1/subnets/{subnet_id}/allowlist/{agent_id}",
+            f"/api/v1/subnets/{slug}/allowlist/{agent_id}",
         )
         return None
 
     async def subnet_allowlist_list(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         limit: int = 100,
         offset: int = 0,
     ) -> dict[str, Any]:
-        """List ``subnet_id``'s allowlist entries (owner only).
+        """List ``slug``'s allowlist entries (owner only).
 
         Owner-only by design — the allowlist is a privacy-sensitive
-        trust signal. Returns ``{ subnet_id, entries: [...] }``;
+        trust signal. Returns ``{ slug, entries: [...] }``;
         each entry carries ``agent_id``, ``added_by``, ``added_at``.
         """
         return await self._request(
             "GET",
-            f"/api/v1/subnets/{subnet_id}/allowlist",
+            f"/api/v1/subnets/{slug}/allowlist",
             params={"limit": limit, "offset": offset},
         )
 
@@ -632,7 +632,7 @@ class ACNClient:
 
     async def subnet_join_request_approve(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -652,13 +652,13 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}/approve",
+            f"/api/v1/subnets/{slug}/join-requests/{request_id}/approve",
             json=body or None,
         )
 
     async def subnet_join_request_reject(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -674,13 +674,13 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}/reject",
+            f"/api/v1/subnets/{slug}/join-requests/{request_id}/reject",
             json=body or None,
         )
 
     async def subnet_join_request_withdraw(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -696,20 +696,20 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "DELETE",
-            f"/api/v1/subnets/{subnet_id}/join-requests/{request_id}",
+            f"/api/v1/subnets/{slug}/join-requests/{request_id}",
             json=body or None,
         )
 
     async def subnet_join_request_list(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         kind: str = "join_request",
         status: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> dict[str, Any]:
-        """Owner lists join_request / allowlist_auto rows for ``subnet_id``.
+        """Owner lists join_request / allowlist_auto rows for ``slug``.
 
         ``kind`` defaults to ``"join_request"``; pass
         ``"allowlist_auto"`` to inspect the audit rows synthesised
@@ -726,7 +726,7 @@ class ACNClient:
             params["status"] = status
         return await self._request(
             "GET",
-            f"/api/v1/subnets/{subnet_id}/join-requests",
+            f"/api/v1/subnets/{slug}/join-requests",
             params=params,
         )
 
@@ -734,7 +734,7 @@ class ACNClient:
 
     async def subnet_invitation_send(
         self,
-        subnet_id: str,
+        slug: str,
         agent_id: str,
         *,
         note: str | None = None,
@@ -765,13 +765,13 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/invitations",
+            f"/api/v1/subnets/{slug}/invitations",
             json=body,
         )
 
     async def subnet_invitation_accept(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -788,13 +788,13 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}/accept",
+            f"/api/v1/subnets/{slug}/invitations/{request_id}/accept",
             json=body or None,
         )
 
     async def subnet_invitation_reject(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -810,13 +810,13 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "POST",
-            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}/reject",
+            f"/api/v1/subnets/{slug}/invitations/{request_id}/reject",
             json=body or None,
         )
 
     async def subnet_invitation_cancel(
         self,
-        subnet_id: str,
+        slug: str,
         request_id: str,
         *,
         note: str | None = None,
@@ -834,22 +834,22 @@ class ACNClient:
             body["note"] = note
         return await self._request(
             "DELETE",
-            f"/api/v1/subnets/{subnet_id}/invitations/{request_id}",
+            f"/api/v1/subnets/{slug}/invitations/{request_id}",
             json=body or None,
         )
 
     async def subnet_invitation_list(
         self,
-        subnet_id: str,
+        slug: str,
         *,
         status: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> dict[str, Any]:
-        """Owner lists invitation rows for ``subnet_id``.
+        """Owner lists invitation rows for ``slug``.
 
         Owner-only — invitees use :meth:`agent_subnet_invitations`
-        for their own cross-subnet view. Returns ``{ subnet_id,
+        for their own cross-subnet view. Returns ``{ slug,
         items: [...] }``.
         """
         params: dict[str, Any] = {"limit": limit, "offset": offset}
@@ -857,7 +857,7 @@ class ACNClient:
             params["status"] = status
         return await self._request(
             "GET",
-            f"/api/v1/subnets/{subnet_id}/invitations",
+            f"/api/v1/subnets/{slug}/invitations",
             params=params,
         )
 
@@ -1576,7 +1576,7 @@ class ACNClient:
             task_id, task_title, task_type, task_description, role,
             status, submission, review_notes, rejection_reason,
             resubmit_count, reward, reward_currency,
-            participation_id, subnet_id,
+            participation_id, slug,
             joined_at, submitted_at, completed_at.
         """
         response = await self._client.get(

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -245,7 +245,7 @@ class AgentSearchOptions(BaseModel):
 
     skills: str | None = None
     status: AgentStatus | None = None
-    subnet_id: str | None = None
+    slug: str | None = None
 
 
 # ============================================
@@ -258,7 +258,7 @@ class SubnetInfo(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    id: str = Field(alias="subnet_id")
+    id: str = Field(validation_alias=AliasChoices("slug", "subnet_id"))
     name: str
     # Owner agent_id of the subnet. Defaults to ``""`` so older clients
     # talking to a server that does not yet expose ``owner`` still parse
@@ -284,7 +284,10 @@ class SubnetInfo(BaseModel):
     # in ``SubnetInfo`` responses — use ``parent_id`` (UUID) instead.
     # ``parent_subnet_id`` is kept here for backward-compat parsing of
     # responses from older server versions.
-    parent_subnet_id: str | None = None
+    parent_slug: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("parent_slug", "parent_subnet_id"),
+    )
     parent_id: str | None = None
     lifecycle: str = "persistent"
     linked_task_id: str | None = None
@@ -293,7 +296,7 @@ class SubnetInfo(BaseModel):
 class SubnetCreateRequest(BaseModel):
     """Subnet creation request.
 
-    ADR-0003 nesting params (``parent_subnet_id`` / ``lifecycle`` /
+    ADR-0003 nesting params (``parent_slug`` / ``lifecycle`` /
     ``linked_task_id``) are optional; defaults preserve the legacy
     "flat top-level persistent subnet" shape.
 
@@ -307,7 +310,7 @@ class SubnetCreateRequest(BaseModel):
     name: str
     description: str | None = None
     metadata: dict[str, Any] | None = None
-    parent_subnet_id: str | None = None
+    parent_slug: str | None = None
     lifecycle: str = "persistent"
     linked_task_id: str | None = None
     join_policy: str | None = None

--- a/clients/typescript/src/admission.test.ts
+++ b/clients/typescript/src/admission.test.ts
@@ -16,7 +16,7 @@
  *   `createSubnet` and is omitted when not set (back-compat for
  *   legacy callers).
  * - `SubnetCreateRequest` ADR-0003 nesting fields
- *   (`parent_subnet_id`, `lifecycle`, `linked_task_id`)
+ *   (`parent_slug`, `lifecycle`, `linked_task_id`)
  *   round-trip through `createSubnet` and are all omitted when
  *   not set (back-compat for legacy callers).
  * - `listChildren` / `promoteSubnet` issue the ADR-0003
@@ -75,7 +75,7 @@ describe('SubnetCreateRequest.join_policy', () => {
   it('serialises join_policy when set', async () => {
     const { client, calls } = setupFetchStub(201, {
       success: true,
-      subnet_id: 'gated',
+      slug: 'gated',
       message: 'ok',
     });
     await client.createSubnet({ name: 'Gated', join_policy: 'approval' });
@@ -87,7 +87,7 @@ describe('SubnetCreateRequest.join_policy', () => {
   it('omits join_policy from body when not set (back-compat)', async () => {
     const { client, calls } = setupFetchStub(201, {
       success: true,
-      subnet_id: 'open',
+      slug: 'open',
       message: 'ok',
     });
     await client.createSubnet({ name: 'Open' });
@@ -102,24 +102,24 @@ describe('SubnetCreateRequest.join_policy', () => {
 // ---------------------------------------------------------------------------
 
 describe('SubnetCreateRequest ADR-0003 nesting', () => {
-  it('serialises parent_subnet_id for nested subnets', async () => {
+  it('serialises parent_slug for nested subnets', async () => {
     const { client, calls } = setupFetchStub(201, {
       success: true,
-      subnet_id: 'child',
+      slug: 'child',
       message: 'ok',
     });
     await client.createSubnet({
       name: 'Child',
-      parent_subnet_id: 'top-level',
+      parent_slug: 'top-level',
     });
     const body = readBody(calls[0].init) as Record<string, unknown>;
-    expect(body.parent_subnet_id).toBe('top-level');
+    expect(body.parent_slug).toBe('top-level');
   });
 
   it('serialises lifecycle + linked_task_id together for task-scoped subnets', async () => {
     const { client, calls } = setupFetchStub(201, {
       success: true,
-      subnet_id: 'scoped',
+      slug: 'scoped',
       message: 'ok',
     });
     await client.createSubnet({
@@ -135,13 +135,13 @@ describe('SubnetCreateRequest ADR-0003 nesting', () => {
   it('omits all nesting fields from body when not set (back-compat)', async () => {
     const { client, calls } = setupFetchStub(201, {
       success: true,
-      subnet_id: 'flat',
+      slug: 'flat',
       message: 'ok',
     });
     await client.createSubnet({ name: 'Flat' });
     const body = readBody(calls[0].init) as Record<string, unknown>;
     expect(body).toStrictEqual({ name: 'Flat' });
-    expect(body).not.toHaveProperty('parent_subnet_id');
+    expect(body).not.toHaveProperty('parent_slug');
     expect(body).not.toHaveProperty('lifecycle');
     expect(body).not.toHaveProperty('linked_task_id');
   });
@@ -155,10 +155,10 @@ function serverSubnetPayload(
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
-    subnet_id: 'squad-1',
+    slug: 'squad-1',
     name: 'Squad 1',
     owner: 'alice',
-    parent_subnet_id: 'parent-1',
+    parent_slug: 'parent-1',
     lifecycle: 'task_scoped',
     linked_task_id: 'task-42',
     ...overrides,
@@ -167,7 +167,7 @@ function serverSubnetPayload(
 
 describe('ADR-0003 listChildren / promoteSubnet', () => {
   it('listChildren GETs /subnets/{parent}/children and returns subnets array', async () => {
-    const child = serverSubnetPayload({ subnet_id: 'child-1' });
+    const child = serverSubnetPayload({ slug: 'child-1' });
     const { client, calls } = setupFetchStub(200, {
       count: 1,
       subnets: [child],
@@ -176,7 +176,7 @@ describe('ADR-0003 listChildren / promoteSubnet', () => {
     const children = await client.listChildren('parent-1');
 
     expect(children).toHaveLength(1);
-    expect(children[0].subnet_id).toBe('child-1');
+    expect(children[0].slug).toBe('child-1');
     expect(calls).toHaveLength(1);
     expect(calls[0].init.method).toBe('GET');
     expect(calls[0].url.pathname).toBe('/api/v1/subnets/parent-1/children');
@@ -230,7 +230,7 @@ describe('subnet allowlist', () => {
 
   it('subnetAllowlistList passes pagination params', async () => {
     const { client, calls } = setupFetchStub(200, {
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       entries: [],
     });
     await client.subnetAllowlistList('squad-1', { limit: 50, offset: 10 });
@@ -287,7 +287,7 @@ describe('subnet join requests', () => {
 
   it('subnetJoinRequestList defaults kind to join_request', async () => {
     const { client, calls } = setupFetchStub(200, {
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       items: [],
     });
     await client.subnetJoinRequestList('squad-1');
@@ -302,7 +302,7 @@ describe('subnet join requests', () => {
 
   it('subnetJoinRequestList passes status + allowlist_auto kind', async () => {
     const { client, calls } = setupFetchStub(200, {
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       items: [],
     });
     await client.subnetJoinRequestList('squad-1', {
@@ -397,7 +397,7 @@ describe('subnet invitations', () => {
 
   it('subnetInvitationList omits status when none and uses default pagination', async () => {
     const { client, calls } = setupFetchStub(200, {
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       items: [],
     });
     await client.subnetInvitationList('squad-1');
@@ -409,7 +409,7 @@ describe('subnet invitations', () => {
 
   it('subnetInvitationList includes status filter', async () => {
     const { client, calls } = setupFetchStub(200, {
-      subnet_id: 'squad-1',
+      slug: 'squad-1',
       items: [],
     });
     await client.subnetInvitationList('squad-1', { status: 'pending' });

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -342,21 +342,21 @@ export class ACNClient {
   }
 
   /** Get subnet by ID */
-  async getSubnet(subnetId: string): Promise<SubnetInfo> {
-    return this.get(`/api/v1/subnets/${subnetId}`);
+  async getSubnet(slug: string): Promise<SubnetInfo> {
+    return this.get(`/api/v1/subnets/${slug}`);
   }
 
   /**
    * List immediate children of a subnet (ADR-0003).
    *
-   * Wraps `GET /api/v1/subnets/{parentSubnetId}/children`. Returns
+   * Wraps `GET /api/v1/subnets/{parentSlug}/children`. Returns
    * `SUBNET_NOT_FOUND` when the parent does not exist. Visibility
    * matches `listSubnets` — private children you cannot see are
    * omitted from the result set.
    */
-  async listChildren(parentSubnetId: string): Promise<SubnetInfo[]> {
+  async listChildren(parentSlug: string): Promise<SubnetInfo[]> {
     const data = await this.get<SubnetChildrenListResponse>(
-      `/api/v1/subnets/${parentSubnetId}/children`,
+      `/api/v1/subnets/${parentSlug}/children`,
     );
     return data.subnets;
   }
@@ -367,18 +367,18 @@ export class ACNClient {
    * Owner-only. Idempotent — promoting an already-persistent subnet
    * returns its current state unchanged.
    */
-  async promoteSubnet(subnetId: string): Promise<SubnetInfo> {
-    return this.post(`/api/v1/subnets/${subnetId}/promote`);
+  async promoteSubnet(slug: string): Promise<SubnetInfo> {
+    return this.post(`/api/v1/subnets/${slug}/promote`);
   }
 
   /** Delete a subnet you own (requires Agent API Key — only the owning agent can delete) */
-  async deleteSubnet(subnetId: string): Promise<{ success: boolean }> {
-    return this.request('DELETE', `/api/v1/subnets/${subnetId}`);
+  async deleteSubnet(slug: string): Promise<{ success: boolean }> {
+    return this.request('DELETE', `/api/v1/subnets/${slug}`);
   }
 
   /** Get agents in a subnet */
-  async getSubnetAgents(subnetId: string): Promise<{ agents: AgentInfo[] }> {
-    return this.get(`/api/v1/subnets/${subnetId}/agents`);
+  async getSubnetAgents(slug: string): Promise<{ agents: AgentInfo[] }> {
+    return this.get(`/api/v1/subnets/${slug}/agents`);
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -395,13 +395,13 @@ export class ACNClient {
   // ──────────────────────────────────────────────────────────────────────
 
   /** Join agent to subnet */
-  async joinSubnet(agentId: string, subnetId: string): Promise<{ success: boolean }> {
-    return this.post(`/api/v1/agents/${agentId}/subnets/${subnetId}`);
+  async joinSubnet(agentId: string, slug: string): Promise<{ success: boolean }> {
+    return this.post(`/api/v1/agents/${agentId}/subnets/${slug}`);
   }
 
   /** Remove agent from subnet */
-  async leaveSubnet(agentId: string, subnetId: string): Promise<{ success: boolean }> {
-    return this.delete(`/api/v1/agents/${agentId}/subnets/${subnetId}`);
+  async leaveSubnet(agentId: string, slug: string): Promise<{ success: boolean }> {
+    return this.delete(`/api/v1/agents/${agentId}/subnets/${slug}`);
   }
 
   /** Get agent's subnets */
@@ -431,7 +431,7 @@ export class ACNClient {
   // ----- Allowlist (owner-only, 3 verbs) ---------------------------------
 
   /**
-   * Pre-authorise `agentId` on `subnetId`'s allowlist (owner only).
+   * Pre-authorise `agentId` on `slug`'s allowlist (owner only).
    *
    * Allowlisted agents skip the approval queue: their next
    * `joinSubnet` lands in branch 4 (allowlist hit) and becomes an
@@ -442,16 +442,16 @@ export class ACNClient {
    * silently no-op'd).
    */
   async subnetAllowlistAdd(
-    subnetId: string,
+    slug: string,
     agentId: string,
   ): Promise<SubnetAllowlistEntry> {
-    return this.post(`/api/v1/subnets/${subnetId}/allowlist`, {
+    return this.post(`/api/v1/subnets/${slug}/allowlist`, {
       agent_id: agentId,
     });
   }
 
   /**
-   * Remove `agentId` from `subnetId`'s allowlist (owner only).
+   * Remove `agentId` from `slug`'s allowlist (owner only).
    *
    * Idempotent — removing an entry that doesn't exist still
    * returns 204. Per ADR-0004 §"Allowlist mutation does not
@@ -459,28 +459,28 @@ export class ACNClient {
    * membership for agents already admitted via the allowlist.
    */
   async subnetAllowlistRemove(
-    subnetId: string,
+    slug: string,
     agentId: string,
   ): Promise<void> {
-    await this.delete(`/api/v1/subnets/${subnetId}/allowlist/${agentId}`);
+    await this.delete(`/api/v1/subnets/${slug}/allowlist/${agentId}`);
   }
 
   /**
-   * List `subnetId`'s allowlist entries (owner only).
+   * List `slug`'s allowlist entries (owner only).
    *
    * Owner-only by design — the allowlist is a privacy-sensitive
    * trust signal and exposing it publicly would leak relationship
    * metadata.
    */
   async subnetAllowlistList(
-    subnetId: string,
+    slug: string,
     options?: { limit?: number; offset?: number },
   ): Promise<SubnetAllowlistListResponse> {
     const params: Record<string, number> = {
       limit: options?.limit ?? 100,
       offset: options?.offset ?? 0,
     };
-    return this.get(`/api/v1/subnets/${subnetId}/allowlist`, params);
+    return this.get(`/api/v1/subnets/${slug}/allowlist`, params);
   }
 
   // ----- Join requests (4 verbs: 3 owner-side + 1 applicant-side) --------
@@ -497,12 +497,12 @@ export class ACNClient {
    * Optional `note` (≤500 chars) is recorded on the audit row.
    */
   async subnetJoinRequestApprove(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.post(
-      `/api/v1/subnets/${subnetId}/join-requests/${requestId}/approve`,
+      `/api/v1/subnets/${slug}/join-requests/${requestId}/approve`,
       options?.note !== undefined ? { note: options.note } : undefined,
     );
   }
@@ -513,12 +513,12 @@ export class ACNClient {
    * No membership change. `subnet.join_rejected` webhook fires.
    */
   async subnetJoinRequestReject(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.post(
-      `/api/v1/subnets/${subnetId}/join-requests/${requestId}/reject`,
+      `/api/v1/subnets/${slug}/join-requests/${requestId}/reject`,
       options?.note !== undefined ? { note: options.note } : undefined,
     );
   }
@@ -530,19 +530,19 @@ export class ACNClient {
    * the request. `subnet.join_withdrawn` webhook fires.
    */
   async subnetJoinRequestWithdraw(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.request(
       'DELETE',
-      `/api/v1/subnets/${subnetId}/join-requests/${requestId}`,
+      `/api/v1/subnets/${slug}/join-requests/${requestId}`,
       options?.note !== undefined ? { body: { note: options.note } } : undefined,
     );
   }
 
   /**
-   * Owner lists join_request / allowlist_auto rows for `subnetId`.
+   * Owner lists join_request / allowlist_auto rows for `slug`.
    *
    * `kind` defaults to `'join_request'`; pass `'allowlist_auto'`
    * to inspect synthesised allowlist-hit audit rows. Server
@@ -550,7 +550,7 @@ export class ACNClient {
    * use `subnetInvitationList` instead.
    */
   async subnetJoinRequestList(
-    subnetId: string,
+    slug: string,
     options?: SubnetJoinRequestListOptions,
   ): Promise<SubnetJoinRequestListResponse> {
     const params: Record<string, string | number> = {
@@ -559,7 +559,7 @@ export class ACNClient {
       offset: options?.offset ?? 0,
     };
     if (options?.status !== undefined) params.status = options.status;
-    return this.get(`/api/v1/subnets/${subnetId}/join-requests`, params);
+    return this.get(`/api/v1/subnets/${slug}/join-requests`, params);
   }
 
   // ----- Invitations (5 + 1 verbs) ---------------------------------------
@@ -577,13 +577,13 @@ export class ACNClient {
    * Discriminate on `auto_resolved` to dispatch.
    */
   async subnetInvitationSend(
-    subnetId: string,
+    slug: string,
     agentId: string,
     options?: { note?: string },
   ): Promise<SubnetInvitationSendResponse> {
     const body: Record<string, string> = { agent_id: agentId };
     if (options?.note !== undefined) body.note = options.note;
-    return this.post(`/api/v1/subnets/${subnetId}/invitations`, body);
+    return this.post(`/api/v1/subnets/${slug}/invitations`, body);
   }
 
   /**
@@ -595,12 +595,12 @@ export class ACNClient {
    * webhook fires.
    */
   async subnetInvitationAccept(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.post(
-      `/api/v1/subnets/${subnetId}/invitations/${requestId}/accept`,
+      `/api/v1/subnets/${slug}/invitations/${requestId}/accept`,
       options?.note !== undefined ? { note: options.note } : undefined,
     );
   }
@@ -612,12 +612,12 @@ export class ACNClient {
    * fires.
    */
   async subnetInvitationReject(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.post(
-      `/api/v1/subnets/${subnetId}/invitations/${requestId}/reject`,
+      `/api/v1/subnets/${slug}/invitations/${requestId}/reject`,
       options?.note !== undefined ? { note: options.note } : undefined,
     );
   }
@@ -630,25 +630,25 @@ export class ACNClient {
    * consumers can tell "owner gave up" from "invitee said no".
    */
   async subnetInvitationCancel(
-    subnetId: string,
+    slug: string,
     requestId: string,
     options?: { note?: string },
   ): Promise<SubnetJoinRequestRow> {
     return this.request(
       'DELETE',
-      `/api/v1/subnets/${subnetId}/invitations/${requestId}`,
+      `/api/v1/subnets/${slug}/invitations/${requestId}`,
       options?.note !== undefined ? { body: { note: options.note } } : undefined,
     );
   }
 
   /**
-   * Owner lists invitation rows for `subnetId`.
+   * Owner lists invitation rows for `slug`.
    *
    * Owner-only — invitees use `agentSubnetInvitations` for their
    * own cross-subnet view.
    */
   async subnetInvitationList(
-    subnetId: string,
+    slug: string,
     options?: SubnetInvitationListOptions,
   ): Promise<SubnetInvitationListResponse> {
     const params: Record<string, string | number> = {
@@ -656,7 +656,7 @@ export class ACNClient {
       offset: options?.offset ?? 0,
     };
     if (options?.status !== undefined) params.status = options.status;
-    return this.get(`/api/v1/subnets/${subnetId}/invitations`, params);
+    return this.get(`/api/v1/subnets/${slug}/invitations`, params);
   }
 
   /**
@@ -1489,11 +1489,11 @@ export class ACNClient {
    * Pass `harnessUrl: null` to deregister.
    */
   async registerSubnetHarness(
-    subnetId: string,
+    slug: string,
     harnessUrl: string | null,
     harnessSecret?: string | null,
   ): Promise<void> {
-    await this.request('PATCH', `/api/v1/subnets/${subnetId}/harness`, {
+    await this.request('PATCH', `/api/v1/subnets/${slug}/harness`, {
       body: {
         harness_url: harnessUrl,
         harness_secret: harnessSecret ?? null,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -124,7 +124,7 @@ export interface AgentSearchOptions {
   skills?: string;
   /** online (default) | offline | all. Public list does not include verification_code. */
   status?: AgentSearchStatus;
-  subnet_id?: string;
+  slug?: string;
 }
 
 // ============================================
@@ -134,12 +134,12 @@ export interface AgentSearchOptions {
 /** Subnet information */
 export interface SubnetInfo {
   /**
-   * Subnet identifier. The server wire field is `subnet_id`; some
-   * older responses may also surface `id`. Prefer `subnet_id` when
-   * present, falling back to `id`.
+   * Opaque UUID identifier from the persistence layer.
    */
   id: string;
-  /** Wire-side identifier (ADR-0003+ servers always emit this). */
+  /** URL-safe slug identifier (server wire field). */
+  slug?: string;
+  /** @deprecated Use `slug` instead. */
   subnet_id?: string;
   name: string;
   description?: string;
@@ -154,6 +154,8 @@ export interface SubnetInfo {
    * Use `parent_id` (UUID) instead.  Kept for backward-compat parsing
    * of responses from older server versions.
    */
+  parent_slug?: string | null;
+  /** @deprecated Use `parent_slug` instead. */
   parent_subnet_id?: string | null;
   /** ACL V6 B6 — parent subnet's opaque UUID. */
   parent_id?: string | null;
@@ -185,10 +187,10 @@ export interface SubnetCreateRequest {
   metadata?: Record<string, unknown>;
   /**
    * ADR-0003 nested-subnet parent. When set, the new subnet becomes a
-   * child of `parent_subnet_id`. Single-layer cap: the parent itself
+   * child of `parent_slug`. Single-layer cap: the parent itself
    * must be top-level. Immutable after creation.
    */
-  parent_subnet_id?: string;
+  parent_slug?: string;
   /**
    * ADR-0003 lifecycle. Defaults to `'persistent'` when omitted.
    * `'task_scoped'` requires `linked_task_id` and the subnet
@@ -214,7 +216,7 @@ export interface SubnetCreateRequest {
 /** Subnet creation response */
 export interface SubnetCreateResponse {
   success: boolean;
-  subnet_id: string;
+  slug: string;
   message: string;
 }
 
@@ -243,7 +245,7 @@ export interface SubnetAllowlistEntry {
 
 /** Response envelope for `subnetAllowlistList` (owner only). */
 export interface SubnetAllowlistListResponse {
-  subnet_id: string;
+  slug: string;
   entries: SubnetAllowlistEntry[];
   [key: string]: unknown;
 }
@@ -258,7 +260,7 @@ export interface SubnetAllowlistListResponse {
  */
 export interface SubnetJoinRequestRow {
   request_id: string;
-  subnet_id: string;
+  slug: string;
   kind: 'join_request' | 'allowlist_auto' | 'invitation';
   status: 'pending' | 'approved' | 'rejected' | 'withdrawn';
   initiated_by: string;
@@ -272,14 +274,14 @@ export interface SubnetJoinRequestRow {
 
 /** Response envelope for `subnetJoinRequestList` (owner only). */
 export interface SubnetJoinRequestListResponse {
-  subnet_id: string;
+  slug: string;
   items: SubnetJoinRequestRow[];
   [key: string]: unknown;
 }
 
 /** Response envelope for `subnetInvitationList` (owner only). */
 export interface SubnetInvitationListResponse {
-  subnet_id: string;
+  slug: string;
   items: SubnetJoinRequestRow[];
   [key: string]: unknown;
 }
@@ -666,7 +668,7 @@ export interface Task {
   required_tags?: string[];
   /** Reward in numeric form — convenience alias, equals `parseFloat(reward)`. */
   reward_amount?: number;
-  subnet_id: string | null;
+  subnet_slug: string | null;
   created_at: string;
   deadline?: string | null;
   use_escrow?: boolean;
@@ -705,7 +707,7 @@ export interface TaskCreateRequest {
   reward: string;
   /** Deadline in hours (1–2 160). Required. */
   deadline_hours: number;
-  subnet_id?: string | null;
+  subnet_slug?: string | null;
   /** Default: "credits" */
   reward_currency?: string;
   /** Default: 1 */


### PR DESCRIPTION
## Summary

Step 3 (final) of the `subnet_id → slug` rename ADR.

### Backend
- **`subnet_admission.py`**: 10 routes renamed `/subnets/{subnet_id}/...` → `/subnets/{slug}/...` (allowlist, join-requests, invitations)
- **`gateway_connect.py`**: WebSocket route `/gateway/connect/{subnet_id}/...` → `/{slug}/...`
- **`routes/tasks.py`**: Remove `serialization_alias="subnet_id"` from `TaskResponse.subnet_slug` and `TaskHistoryItem.subnet_slug` — server now emits `"subnet_slug"` natively

### Python client (`acn_client`)
- `SubnetInfo.id`: alias updated to `AliasChoices("slug", "subnet_id")` for backward compat with old servers
- `SubnetInfo.parent_subnet_id` → `parent_slug` (AliasChoices back-compat)
- `SubnetCreateRequest.parent_subnet_id` → `parent_slug`
- `AgentSearchOptions.subnet_id` → `slug`
- All `client.py` method params renamed accordingly

### TypeScript SDK + CLI
- `types.ts`: `subnet_id` → `slug` across all admission/subnet/task interfaces; deprecated fields kept for IDE autocomplete backward compat
- `admission.test.ts`, `subnet-ad0003.test.ts`, `subnet-ad0004.test.ts`: test data updated

**No DB migration needed** — URL parameter renames have no schema impact.

## Test plan
- [ ] ruff check passes (✅ verified locally)
- [ ] Key route + service + consistency tests pass (✅ verified locally)
- [ ] CI Python 3.11 + 3.12
- [ ] CLI + TypeScript SDK CI jobs

Made with [Cursor](https://cursor.com)