### PR TITLE
feat: add subnet ownership transfer (ADR-0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Subnet ownership transfer** (`POST /api/v1/subnets/{slug}/transfer`, ADR-0005) —
+  the current owner can hand off ownership to any registered agent.
+  Prevents the "orphan subnet" failure mode documented in ADR-0004: if an owner
+  agent goes dark before reassigning its subnets, the approval / invitation /
+  allowlist workflows become permanently unreachable.
+
+  Business rules (see `docs/adr/0005-subnet-ownership-transfer.md`):
+
+  - Only the current owner may call the endpoint (403 `OWNERSHIP_MISMATCH` otherwise).
+  - Reserved system subnets (`public`, `system`) cannot be transferred.
+  - The new owner must differ from the current owner.
+  - The new owner must not be a reserved platform identity (`backend@internal`,
+    `system`).
+  - The new owner is automatically added to the subnet's member set.
+  - Rate-limited to 5 requests / minute per caller.
+
+  CLI: `acn subnet transfer <slug> --to <new_owner_agent_id>`
+
 ## [0.14.0] - 2026-05-24
 
 Coordinated release: server **0.14.0**, Python SDK **0.12.0**, TypeScript SDK

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -1077,6 +1077,7 @@ async def transfer_subnet_owner(
         raise ACNHTTPError(
             ErrorCode.SUBNET_NOT_FOUND,
             status_code=404,
+            details={"slug": slug},
         ) from exc
     except PermissionError as exc:
         raise ACNHTTPError(

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -1049,6 +1049,50 @@ async def get_agent_subnets(
     )
 
 
+class TransferOwnerRequest(BaseModel):
+    new_owner: str = Field(..., min_length=1, description="Agent ID of the new subnet owner")
+
+
+@router.post("/{slug}/transfer")
+@limiter.limit("5/minute")
+async def transfer_subnet_owner(
+    request: Request,
+    slug: str,
+    body: TransferOwnerRequest,
+    agent_info: AgentApiKeyDep,
+    subnet_service: SubnetServiceDep,
+) -> dict:
+    """Transfer ownership of a subnet to another agent.
+
+    The caller must be the current owner. The new owner will be added to
+    the subnet's member set automatically. See ADR-0005.
+    """
+    try:
+        transferred = await subnet_service.transfer_owner(
+            slug=slug,
+            current_owner=agent_info["agent_id"],
+            new_owner=body.new_owner,
+        )
+    except SubnetNotFoundException as exc:
+        raise ACNHTTPError(
+            ErrorCode.SUBNET_NOT_FOUND,
+            status_code=404,
+        ) from exc
+    except PermissionError as exc:
+        raise ACNHTTPError(
+            ErrorCode.OWNERSHIP_MISMATCH,
+            status_code=403,
+            details={"reason": str(exc)},
+        ) from exc
+    except ValueError as exc:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            status_code=400,
+            details={"reason": str(exc)},
+        ) from exc
+    return {"slug": transferred.slug, "owner": transferred.owner}
+
+
 @router.delete("/{slug}")
 @limiter.limit("10/minute")
 async def delete_subnet(

--- a/acn/services/subnet_service.py
+++ b/acn/services/subnet_service.py
@@ -1679,3 +1679,121 @@ class SubnetService:
         """
         repo = self._require_join_repo()
         return await repo.list_pending_invitations_for_agent(agent_id)
+
+    # ------------------------------------------------------------------
+    # Ownership transfer (ADR-0005: Subnet ownership transfer)
+    # ------------------------------------------------------------------
+
+    async def transfer_owner(
+        self,
+        slug: str,
+        current_owner: str,
+        new_owner: str,
+    ) -> Subnet:
+        """Transfer subnet ownership from ``current_owner`` to ``new_owner``.
+
+        Implements ADR-0005. Prevents the "orphan subnet" failure mode
+        described in ADR-0004 §"Out of scope": when an owner agent goes
+        dark or its key is revoked, ownership can be handed off before
+        that happens so the approval / invitation / allowlist workflows
+        remain reachable.
+
+        Business rules:
+
+        - Only the current owner may invoke this (``PermissionError`` on
+          mismatch — route maps it to ``OWNERSHIP_MISMATCH 403``).
+        - Reserved subnets (``public``/``system``) cannot be transferred
+          (``PermissionError`` — same 403 surface).
+        - ``new_owner`` must differ from ``current_owner`` (``ValueError``
+          — route maps to ``INVALID_REQUEST 400``).
+        - ``new_owner`` must not be the reserved platform identities
+          ``"backend@internal"`` (ADR-0002) or ``"system"``
+          (``ValueError`` — same 400). These guards run unconditionally,
+          regardless of whether ``agent_repository`` is wired.
+        - ``new_owner`` must be a registered agent when
+          ``agent_repository`` is wired (``ValueError`` — same 400).
+        - After the owner field is updated, ``new_owner`` is added to the
+          subnet's member set (idempotent — ``set.add`` is a no-op if
+          already a member, matching the ADR-0001 invariant that the owner
+          is always a member).
+
+        Child-subnet note (ADR-0003)
+        ----------------------------
+        When transferring a child subnet, the ``new_owner`` is added to
+        the child's member set by direct set mutation, deliberately
+        bypassing :meth:`add_member`'s parent-membership check — the same
+        deliberate bypass documented in :meth:`create_subnet`. The owner
+        is allowed to be outside the parent subnet (delegated-admin
+        pattern). See ``create_subnet`` for the full rationale.
+
+        Args:
+            slug: Subnet to transfer.
+            current_owner: Authenticated agent making the request.
+            new_owner: Agent that will become the new owner.
+
+        Returns:
+            Updated subnet entity with ``owner == new_owner``.
+
+        Raises:
+            SubnetNotFoundException: Subnet does not exist.
+            PermissionError: ``current_owner`` does not own the subnet,
+                or the subnet is a reserved system subnet.
+            ValueError: Any of — ``new_owner == current_owner``;
+                ``new_owner`` is ``"backend@internal"`` or ``"system"``;
+                ``new_owner`` is not a registered agent (when repo wired).
+        """
+        subnet = await self.get_subnet(slug)
+
+        if subnet.owner != current_owner:
+            raise PermissionError(
+                f"Owner mismatch: {current_owner} != {subnet.owner}"
+            )
+
+        if slug in {"public", "system"}:
+            raise PermissionError(f"Cannot transfer system subnet: {slug}")
+
+        if new_owner == current_owner:
+            raise ValueError("new_owner must differ from current_owner")
+
+        # ADR-0002 defence-in-depth — unconditional, same guard as create_subnet.
+        if new_owner == "backend@internal":
+            raise ValueError(
+                "ADR-0002: 'backend@internal' is not a valid subnet owner; "
+                "use a registered service-account agent as transfer target."
+            )
+
+        # Prevent elevating to the reserved platform identity.
+        if new_owner == "system":
+            raise ValueError(
+                "'system' is a reserved platform identity and cannot be "
+                "used as a subnet owner."
+            )
+
+        if self.agent_repository is not None:
+            agent = await self.agent_repository.find_by_id(new_owner)
+            if agent is None:
+                raise ValueError(
+                    f"Agent '{new_owner}' is not registered; "
+                    "transfer target must be a registered agent"
+                )
+
+        # Explicit set copy: dataclasses.replace shallow-copies fields;
+        # without this, new_members would share identity with subnet.member_agent_ids.
+        # Direct set.add (not add_member): intentionally bypasses parent-membership
+        # check for child subnets — same deliberate decision as create_subnet.
+        new_members = set(subnet.member_agent_ids)
+        new_members.add(new_owner)
+        transferred = dataclasses.replace(
+            subnet,
+            owner=new_owner,
+            member_agent_ids=new_members,
+        )
+        await self.repository.save(transferred)
+
+        logger.info(
+            "subnet_owner_transferred",
+            slug=slug,
+            previous_owner=current_owner,
+            new_owner=new_owner,
+        )
+        return transferred

--- a/docs/adr/0005-subnet-ownership-transfer.md
+++ b/docs/adr/0005-subnet-ownership-transfer.md
@@ -1,0 +1,302 @@
+# ADR-0005: Subnet ownership transfer
+
+- **Status**: Implemented (2026-05-25)
+- **Date**: 2026-05-25
+- **Implemented**: 2026-05-25
+- **Decision drivers**: prevent orphan subnets when an owner goes dark,
+  minimal new surface area, consistent with existing ownership-transfer
+  pattern on `Agent` entities, defence-in-depth against reserved
+  identity escalation.
+
+## Context
+
+ADR-0004 §Security considerations and §Out of scope explicitly seed this
+ADR:
+
+> **Orphan subnets.** If a subnet owner's agent is deleted or its API
+> key is revoked, every owner-only endpoint returns 403. Any pending
+> join\_request / invitation rows stay `pending` indefinitely…
+> Permanent resolution is deferred to the **ownership transfer ADR**.
+
+Without a transfer primitive, subnet operators facing planned turnover
+(employee offboarding, service key rotation, agent retirement) have no
+path to hand off ownership before going dark. Every ADR-0004 owner-only
+capability (approve join requests, send invitations, manage allowlist,
+register Org Harness) becomes permanently unreachable the moment the
+original owner's key is revoked. The subnet must be deleted and
+recreated under a new owner — losing all membership history, pending
+requests, and allowlist configuration — or it becomes an untended
+orphan.
+
+ACN already exposes a transfer-ownership concept for agents (via service
+key rotation and re-registration), so a subnet analogue is a natural
+extension. The scope is narrow: one `POST` endpoint, one service method.
+
+## Considered options
+
+### A. `POST /subnets/{id}/transfer` owner-driven endpoint (chosen)
+
+The current owner authenticates via their existing API key and submits
+the new owner's `agent_id` in the request body. ACN validates the
+transfer, updates the subnet entity, automatically adds `new_owner` to
+the member set, and returns the updated `SubnetInfo`. The previous owner
+retains membership but loses all owner-only privileges.
+
+**Pros**
+
+- Single endpoint, single service method. Minimal new surface area.
+- Consistent with the design principle "owner is the authority on their
+  own subnet" — the transfer is owner-initiated and owner-authenticated.
+- The new owner becomes a member automatically (idempotent), preserving
+  the ADR-0001 invariant that the owner is always a member.
+- Works for planned handoffs (offboarding, key rotation, agent
+  migration). Does not require admin involvement.
+
+**Cons**
+
+- Cannot rescue a subnet whose owner key is already revoked. An
+  operator who loses the key before transferring must still delete and
+  recreate. The "emergency recovery" case is explicitly out of scope
+  (see below) and deferred to a future admin-override ADR.
+
+### B. Admin-initiated override (rejected)
+
+A privileged platform admin endpoint that can set `subnet.owner` to any
+registered agent without the current owner's authentication.
+
+**Rejected** because it requires a separate admin-authentication scheme
+(outside the current `AgentApiKeyDep` model) and introduces an asymmetric
+power that is hard to audit. The current service design has no
+admin-identity concept; introducing one for a narrow recovery case adds
+complexity disproportionate to the gain. Operators who lose the owner
+key can recover by deleting and recreating the subnet; the data loss is
+acceptable at v0.x. An admin override can be added in a follow-up ADR
+once an admin-auth primitive exists.
+
+### C. Custody escrow / multi-party approval (rejected)
+
+A transfer that requires both the current owner and the new owner to
+sign off, or that uses a time-locked escrow, to prevent hostile
+takeover via a stolen key.
+
+**Rejected** as over-engineering for v0.x. ACN's trust model places
+the owner's API key as the singular authority for all owner operations;
+adding a second-factor specifically for transfer would require a new
+confirmation mechanism not yet in scope. The security posture is
+consistent with other owner-only destructive operations (e.g. `DELETE
+/subnets/{id}`, `PATCH /subnets/{id}/harness`) which also require only
+the owner's API key.
+
+## Decision
+
+Adopt option A. Implement `POST /api/v1/subnets/{id}/transfer` backed by
+`SubnetService.transfer_owner`.
+
+## Business rules
+
+The following rules are enforced in order (earlier rules short-circuit
+later ones):
+
+1. **Owner-only** — `current_owner` (authenticated via `AgentApiKeyDep`)
+   must equal `subnet.owner`. `PermissionError` → `403 OWNERSHIP_MISMATCH`.
+2. **Reserved subnets** — `subnet_id ∈ {"public", "system"}` cannot be
+   transferred. `PermissionError` → `403 OWNERSHIP_MISMATCH`.
+3. **Self-transfer rejected** — `new_owner == current_owner` is a no-op
+   that offers no operational value and likely indicates a client error.
+   `ValueError` → `400 INVALID_REQUEST`.
+4. **ADR-0002 guard (unconditional)** — `new_owner == "backend@internal"`
+   is always rejected. The `backend@internal` identity is a routing
+   placeholder for internal service calls (ADR-0002); it cannot own any
+   subnet. This guard runs regardless of whether `agent_repository` is
+   wired, providing defence-in-depth against callers that bypass the
+   route layer.
+5. **`"system"` identity guard (unconditional)** — `new_owner == "system"`
+   is always rejected. `"system"` is the platform identity that owns the
+   two reserved subnets; no other subnet may be transferred to it. Same
+   unconditional semantics as the ADR-0002 guard.
+6. **Registered-agent check (conditional)** — when `agent_repository` is
+   wired, `new_owner` must correspond to a registered agent.
+   `ValueError` → `400 INVALID_REQUEST`. When the repo is absent (legacy
+   Redis-only fixtures), this check is skipped; rules 4 and 5 still
+   apply.
+7. **Member set update** — `new_owner` is added to `subnet.member_agent_ids`
+   via an explicit set copy (not via `Subnet.add_member`; see
+   §Child-subnet note). `dataclasses.replace` is used to avoid mutating
+   the original entity.
+
+**Child-subnet note (ADR-0003)**: when transferring a child subnet, the
+`new_owner` is added to the child's member set by direct `set.add`,
+intentionally bypassing `add_member`'s parent-membership check. This is
+the same deliberate bypass documented in `create_subnet` (delegated-admin
+pattern): the owner may be outside the parent subnet; the membership-subset
+invariant limits what they can do after the transfer (they cannot add
+members who are not in the parent). See `SubnetService.create_subnet` for
+the full rationale.
+
+**Previous owner membership**: the previous owner retains membership in
+the subnet after the transfer. Ownership transfer does not remove any
+memberships. An owner who wishes to leave after transferring must call
+`DELETE /agents/{id}/subnets/{subnet_id}` separately.
+
+## Rate limiting
+
+`POST /{slug}/transfer` is limited to `10/minute` per client, the
+same limit applied to `POST /{slug}/promote` and
+`DELETE /{slug}`. Transfer is a rare, high-stakes operation; the
+limit prevents accidental rapid-fire retries without impeding normal use.
+
+## API
+
+```http
+POST /api/v1/subnets/{slug}/transfer
+Authorization: Bearer <owner_api_key>
+Content-Type: application/json
+
+{ "new_owner": "<agent_id>" }
+```
+
+**Request body**
+
+| field | type | constraints | description |
+|---|---|---|---|
+| `new_owner` | `string` | `min_length=1`, `max_length=128` | Agent ID of the new subnet owner |
+
+**Responses**
+
+| status | `error_code` | condition |
+|---|---|---|
+| 200 | — | Transfer succeeded; returns updated `SubnetInfo` with `owner == new_owner` |
+| 400 | `invalid_request` | Self-transfer; `backend@internal`; `system` identity; unregistered agent |
+| 403 | `ownership_mismatch` | Caller is not `subnet.owner`; or subnet is a reserved system subnet |
+| 404 | `subnet_not_found` | `subnet_id` does not exist |
+| 422 | `validation_failed` | Missing or invalid `Authorization` header, or empty `new_owner` string |
+| 500 | — | Unexpected error (details not leaked to client) |
+
+## CLI
+
+```bash
+acn subnet transfer <subnet_id> --to <new_owner_agent_id>
+```
+
+## Error codes
+
+No new `ErrorCode` enum members are added. The existing codes
+`OWNERSHIP_MISMATCH`, `INVALID_REQUEST`, `SUBNET_NOT_FOUND`, and
+`VALIDATION_FAILED` cover all transfer-specific failure modes with
+`details.reason` providing discrimination where needed.
+
+## Security considerations
+
+**Key-already-revoked case.** If the owner's API key is revoked before
+transfer, the owner can no longer authenticate and the `POST /transfer`
+endpoint returns 401/422. This ADR's scope is **planned handoffs**, not
+emergency recovery. A compromised or lost key requires out-of-band
+operator intervention (database repair, admin override — neither is
+implemented here). The failure mode is identical to losing the key for
+any other owner-only operation and is considered acceptable at v0.x.
+
+**Hostile transfer via stolen key.** If an attacker obtains the owner's
+API key, they can transfer the subnet to an agent they control, gaining
+full owner capabilities. The risk is equal to the existing attack surface
+of any owner-only operation (delete subnet, register harness) with a
+stolen key. Mitigations are out of scope for this ADR (2FA, key-signing,
+audit alerts on transfers) and are noted as follow-up concerns.
+
+**ADR-0002 defence-in-depth.** The `backend@internal` guard runs in the
+service layer unconditionally, even when the transfer arrives via an
+internal caller that bypasses route-layer authentication. This prevents
+the routing placeholder identity from ever appearing in `subnet.owner`
+regardless of call path.
+
+## Out of scope
+
+- **Emergency admin override** — recovering a subnet whose owner key is
+  already revoked or whose owner agent is deleted.
+- **Transfer confirmation by new owner** — requiring the new owner to
+  accept the transfer before it takes effect (custody escrow / two-party
+  sign-off).
+- **Ownership history / audit trail** — a queryable log of past transfers.
+  The structured log event `subnet_owner_transferred` (emitted by the
+  service layer at every transfer) serves as the audit record; a
+  queryable API is deferred.
+- **Webhook on ownership transfer** — no new webhook event is emitted.
+  Operators monitoring subnet lifecycle via webhooks should poll
+  `GET /subnets/{id}` after a transfer to detect owner changes.
+- **Automatic member eviction of old owner** — the previous owner is
+  intentionally not removed from the member set.
+
+## Relationship to other ADRs
+
+- **ADR-0001** — "owner is always a member" invariant is preserved: the
+  new owner is added to `member_agent_ids` as part of the transfer
+  operation.
+- **ADR-0002** — `backend@internal` guard is applied unconditionally at
+  the service layer, matching the same guard in `create_subnet`.
+- **ADR-0003** — child-subnet transfer bypasses `add_member`'s
+  parent-membership check, matching the same deliberate bypass in
+  `create_subnet` (delegated-admin pattern).
+- **ADR-0004** — this ADR implements the "ownership transfer" item that
+  was explicitly deferred in ADR-0004 §Out of scope and seeded in
+  §Security considerations (`"ADR-00XX: Subnet ownership transfer"`).
+
+## Implementation evidence
+
+Implemented in `feat/subnet-owner-transfer` on the `acn-ts-admission`
+worktree (commits `d7adb09`, `17718df`).
+
+| file | change |
+|---|---|
+| `acn/services/subnet_service.py` | `transfer_owner` method (lines 1680–1815) |
+| `acn/routes/subnets.py` | `TransferOwnerRequest` model + `transfer_subnet_owner` endpoint |
+| `tests/routes/test_subnets_transfer.py` | 9 route-layer test cases |
+| `tests/services/test_subnet_service_transfer.py` | 17 service-layer white-box test cases |
+| `skills/acn/references/API.md` | `POST /{id}/transfer` endpoint added to Subnets table |
+| `.claude/skills/acn/SKILL.md` | `acn subnet transfer` CLI command added |
+| `CHANGELOG.md` | `[Unreleased]` entry |
+
+### Test coverage
+
+**Route layer** (`tests/routes/test_subnets_transfer.py`, 9 cases)
+
+- Happy path: `200` with updated `owner`
+- Non-owner: `403 ownership_mismatch`
+- Missing auth: `422 validation_failed`
+- Subnet not found: `404 subnet_not_found`
+- Self-transfer: `400 invalid_request`
+- Unregistered agent: `400 invalid_request`
+- Empty `new_owner`: `422` Pydantic validation
+- `backend@internal`: `400 invalid_request`
+- `"system"` identity: `400 invalid_request`
+
+**Service layer** (`tests/services/test_subnet_service_transfer.py`, 17 cases)
+
+- Owner field updated in returned entity
+- `new_owner` added to member set
+- Previous owner retains membership
+- `repository.save` called with updated entity
+- Idempotent when `new_owner` already a member
+- Agent repo wired + registered owner accepted
+- Original `member_agent_ids` set not mutated (shallow-copy safety)
+- Non-owner `PermissionError`
+- Reserved subnet `"public"` `PermissionError`
+- Reserved subnet `"system"` `PermissionError`
+- Non-owner check fires before reserved-subnet check
+- Self-transfer `ValueError`
+- `backend@internal` `ValueError` (unconditional, no agent repo needed)
+- `"system"` identity `ValueError` (unconditional)
+- Unregistered agent `ValueError` (with agent repo wired)
+- Existence check skipped when agent repo is `None`
+- `SubnetNotFoundException` propagates on missing subnet
+
+## References
+
+- [ADR-0001](./0001-subnet-creator-must-be-member.md) — owner-is-member
+  invariant preserved by the transfer.
+- [ADR-0002](./0002-subnet-owner-must-be-registered-agent.md) —
+  `backend@internal` guard applied in the transfer path.
+- [ADR-0003](./0003-subnet-nesting-single-layer.md) — child-subnet
+  `add_member` bypass rationale.
+- [ADR-0004](./0004-subnet-join-policy.md) §Security considerations and
+  §Out of scope — origin of this ADR.
+- `acn/services/subnet_service.py::transfer_owner` — implementation.
+- `acn/routes/subnets.py::transfer_subnet_owner` — HTTP surface.

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -115,6 +115,7 @@ acn config set agent_id YOUR_AGENT_ID
 | `acn subnet leave <subnet_id>` | Leave a subnet |
 | `acn subnet create --name <name> [--id <id>] [--description ...] [--private]` | Create a subnet (you become the owner) |
 | `acn subnet delete <subnet_id>` | Delete a subnet you own |
+| `acn subnet transfer <subnet_id> --to <new_owner_agent_id>` | Transfer subnet ownership to another registered agent (ADR-0005) |
 | `acn subnet harness set <subnet_id> --url <url> [--secret <secret>]` | Register an Org Harness webhook endpoint on a subnet you own |
 | `acn subnet harness clear <subnet_id>` | Unregister the Org Harness from a subnet you own |
 | **Wallet** | |

--- a/tests/routes/test_subnets_transfer.py
+++ b/tests/routes/test_subnets_transfer.py
@@ -1,0 +1,272 @@
+"""Route-level tests for ``POST /api/v1/subnets/{slug}/transfer``.
+
+Covers:
+- Owner transfers to a registered agent → 200 with updated slug/owner
+- Non-owner → 403 ``OWNERSHIP_MISMATCH``
+- Missing subnet → 404 ``SUBNET_NOT_FOUND``
+- Transfer to self → 400 ``INVALID_REQUEST``
+- Transfer to unregistered agent → 400 ``INVALID_REQUEST``
+- Transfer to ``backend@internal`` (ADR-0002) → 400 ``INVALID_REQUEST``
+- Transfer to ``"system"`` platform identity → 400 ``INVALID_REQUEST``
+- Missing auth header → 422 ``validation_failed``
+- Empty ``new_owner`` string → 422 Pydantic validation failure
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import SubnetNotFoundException
+from acn.routes.dependencies import (
+    get_agent_service,
+    get_subnet_service,
+    verify_agent_api_key,
+)
+from tests.routes.conftest import _assert_flat_shape
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subnet(
+    slug: str = "subnet-1",
+    owner: str = "agent-owner",
+) -> MagicMock:
+    sn = MagicMock()
+    sn.slug = slug
+    sn.name = "Test Subnet"
+    sn.owner = owner
+    sn.description = None
+    sn.is_private = False
+    sn.security_config = {}
+    sn.created_at = MagicMock()
+    sn.metadata = {}
+    sn.harness_url = None
+    sn.harness_registered = False
+    sn.parent_slug = None
+    sn.lifecycle = "persistent"
+    sn.linked_task_id = None
+    sn.member_agent_ids = {"agent-owner"}
+    return sn
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_subnet_service():
+    svc = AsyncMock()
+    default = _make_subnet()
+
+    async def _transfer(slug: str, current_owner: str, new_owner: str):
+        if slug != "subnet-1":
+            raise SubnetNotFoundException(slug)
+        if current_owner != default.owner:
+            raise PermissionError(f"Owner mismatch: {current_owner} != {default.owner}")
+        if new_owner == current_owner:
+            raise ValueError("new_owner must differ from current_owner")
+        updated = _make_subnet(slug=slug, owner=new_owner)
+        return updated
+
+    svc.transfer_owner = AsyncMock(side_effect=_transfer)
+    svc._default_subnet = default
+    return svc
+
+
+@pytest.fixture(autouse=True)
+def _wire_services(stub_subnet_service):
+    stub_agent_svc = AsyncMock()
+    app.dependency_overrides[get_subnet_service] = lambda: stub_subnet_service
+    app.dependency_overrides[get_agent_service] = lambda: stub_agent_svc
+    yield
+    app.dependency_overrides.pop(get_subnet_service, None)
+    app.dependency_overrides.pop(get_agent_service, None)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def owner_client(client):
+    """Client with auth pre-wired as 'agent-owner'."""
+    app.dependency_overrides[verify_agent_api_key] = lambda: {"agent_id": "agent-owner"}
+    yield client
+    app.dependency_overrides.pop(verify_agent_api_key, None)
+
+
+@pytest.fixture
+def other_client(client):
+    """Client with auth pre-wired as 'agent-other' (not the subnet owner)."""
+    app.dependency_overrides[verify_agent_api_key] = lambda: {"agent_id": "agent-other"}
+    yield client
+    app.dependency_overrides.pop(verify_agent_api_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_owner_success(owner_client, stub_subnet_service):
+    """Owner transfers to another agent → 200 with new owner in response."""
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "agent-other"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["owner"] == "agent-other"
+    assert body["slug"] == "subnet-1"
+    stub_subnet_service.transfer_owner.assert_awaited_once_with(
+        slug="subnet-1",
+        current_owner="agent-owner",
+        new_owner="agent-other",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authorization errors
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_owner_non_owner_403(other_client, stub_subnet_service):
+    """Non-owner gets 403 OWNERSHIP_MISMATCH."""
+    resp = other_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "agent-owner"},
+        headers={"Authorization": "Bearer other-key"},
+    )
+    assert resp.status_code == 403, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "ownership_mismatch"
+
+
+def test_transfer_owner_no_auth_422(client):
+    """Missing auth token → 422 validation_failed (AgentApiKeyDep requires the header)."""
+    resp = client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "agent-other"},
+    )
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["error_code"] == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
+# Not found
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_owner_subnet_not_found_404(owner_client):
+    """Unknown subnet → 404 SUBNET_NOT_FOUND."""
+    resp = owner_client.post(
+        "/api/v1/subnets/no-such-subnet/transfer",
+        json={"new_owner": "agent-other"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 404, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "subnet_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_owner_self_400(owner_client, stub_subnet_service):
+    """Transferring to oneself → 400 INVALID_REQUEST."""
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "agent-owner"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "invalid_request"
+
+
+def test_transfer_owner_unregistered_agent_400(owner_client, stub_subnet_service):
+    """Transfer to unregistered agent → 400 INVALID_REQUEST."""
+
+    async def _transfer_unregistered(slug, current_owner, new_owner):
+        if new_owner == "ghost-agent":
+            raise ValueError("Agent 'ghost-agent' is not registered")
+        return _make_subnet(owner=new_owner)
+
+    stub_subnet_service.transfer_owner = AsyncMock(side_effect=_transfer_unregistered)
+
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "ghost-agent"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "invalid_request"
+
+
+def test_transfer_owner_empty_new_owner_422(owner_client):
+    """Empty new_owner string fails Pydantic validation → 422."""
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": ""},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_transfer_owner_backend_internal_400(owner_client, stub_subnet_service):
+    """ADR-0002: transferring to 'backend@internal' → 400 INVALID_REQUEST."""
+
+    async def _transfer_adr0002(slug, current_owner, new_owner):
+        if new_owner == "backend@internal":
+            raise ValueError("ADR-0002: 'backend@internal' is not a valid subnet owner")
+        return _make_subnet(owner=new_owner)
+
+    stub_subnet_service.transfer_owner = AsyncMock(side_effect=_transfer_adr0002)
+
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "backend@internal"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "invalid_request"
+
+
+def test_transfer_owner_system_identity_400(owner_client, stub_subnet_service):
+    """Transferring to the reserved 'system' identity → 400 INVALID_REQUEST."""
+
+    async def _transfer_system(slug, current_owner, new_owner):
+        if new_owner == "system":
+            raise ValueError("'system' is a reserved platform identity")
+        return _make_subnet(owner=new_owner)
+
+    stub_subnet_service.transfer_owner = AsyncMock(side_effect=_transfer_system)
+
+    resp = owner_client.post(
+        "/api/v1/subnets/subnet-1/transfer",
+        json={"new_owner": "system"},
+        headers={"Authorization": "Bearer owner-key"},
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    _assert_flat_shape(body)
+    assert body["error_code"] == "invalid_request"

--- a/tests/services/test_subnet_service_transfer.py
+++ b/tests/services/test_subnet_service_transfer.py
@@ -1,0 +1,291 @@
+"""Service-layer unit tests for ``SubnetService.transfer_owner``.
+
+White-box coverage that complements the route-layer smoke tests in
+``tests/routes/test_subnets_transfer.py``.  These tests drive the
+service directly (no HTTP stack) so they can assert internal details
+such as the shallow-copy protection, the saved entity shape, and the
+conditional agent-existence check.
+
+Test matrix
+-----------
+- Happy path: owner field updated, new_owner added to member set,
+  repository.save called with the transferred entity.
+- Shallow-copy safety: original ``member_agent_ids`` set is NOT mutated
+  after the transfer.
+- Previous owner retains membership after transfer.
+- ``PermissionError`` on non-owner caller.
+- ``PermissionError`` on reserved system subnet (``public`` / ``system``).
+- ``ValueError`` on self-transfer.
+- ``ValueError`` on ``backend@internal`` new_owner (ADR-0002).
+- ``ValueError`` on ``system`` new_owner (reserved platform identity).
+- ``ValueError`` on unregistered new_owner when agent_repository is wired.
+- Agent-existence check is skipped when agent_repository is ``None``.
+- ``SubnetNotFoundException`` propagates when subnet does not exist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities.subnet import Subnet  # noqa: E402
+from acn.core.exceptions import SubnetNotFoundException
+from acn.services import SubnetService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subnet(
+    slug: str = "subnet-abc",
+    owner: str = "alice",
+    members: set[str] | None = None,
+) -> Subnet:
+    """Return a minimal ``Subnet`` entity with the given owner/members."""
+    return Subnet(
+        slug=slug,
+        name="Test",
+        owner=owner,
+        member_agent_ids=members if members is not None else {owner},
+    )
+
+
+def _make_repo(subnet: Subnet | MagicMock | None) -> AsyncMock:
+    """Subnet repository that returns *subnet* on ``find_by_id``."""
+    repo = AsyncMock()
+    repo.find_by_id = AsyncMock(return_value=subnet)
+    repo.save = AsyncMock()
+    return repo
+
+
+def _make_agent_repo(known_ids: set[str]) -> AsyncMock:
+    """Agent repository that returns a mock agent for IDs in *known_ids*."""
+    repo = AsyncMock()
+
+    async def _find(agent_id: str):
+        if agent_id in known_ids:
+            m = MagicMock()
+            m.agent_id = agent_id
+            return m
+        return None
+
+    repo.find_by_id = AsyncMock(side_effect=_find)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransferOwnerSuccess:
+    @pytest.mark.asyncio
+    async def test_owner_field_is_updated(self):
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        assert result.owner == "bob"
+
+    @pytest.mark.asyncio
+    async def test_new_owner_is_added_to_member_set(self):
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        assert "bob" in result.member_agent_ids
+
+    @pytest.mark.asyncio
+    async def test_previous_owner_retains_membership(self):
+        """alice's membership is not revoked by the transfer."""
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        assert "alice" in result.member_agent_ids
+
+    @pytest.mark.asyncio
+    async def test_repository_save_called_with_transferred_entity(self):
+        subnet = _make_subnet(owner="alice")
+        repo = _make_repo(subnet)
+        svc = SubnetService(repo)
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        repo.save.assert_awaited_once()
+        saved = repo.save.call_args.args[0]
+        assert saved.owner == "bob"
+        assert saved is result  # same object returned and persisted
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_new_owner_already_a_member(self):
+        """If bob is already a member, the transfer still succeeds."""
+        subnet = _make_subnet(owner="alice", members={"alice", "bob"})
+        svc = SubnetService(_make_repo(subnet))
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        assert result.owner == "bob"
+        assert "bob" in result.member_agent_ids
+
+    @pytest.mark.asyncio
+    async def test_agent_repo_wired_accepts_registered_new_owner(self):
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(
+            _make_repo(subnet),
+            agent_repository=_make_agent_repo({"bob"}),
+        )
+
+        result = await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        assert result.owner == "bob"
+
+
+# ---------------------------------------------------------------------------
+# Shallow-copy safety
+# ---------------------------------------------------------------------------
+
+
+class TestTransferOwnerShallowCopySafety:
+    @pytest.mark.asyncio
+    async def test_original_member_set_is_not_mutated(self):
+        """``dataclasses.replace`` is shallow — verify we make an explicit copy
+        so the original entity's ``member_agent_ids`` is unaffected."""
+        subnet = _make_subnet(owner="alice")
+        original_members = set(subnet.member_agent_ids)  # snapshot before call
+        repo = _make_repo(subnet)
+        svc = SubnetService(repo)
+
+        await svc.transfer_owner("subnet-abc", "alice", "bob")
+
+        # The object that was passed to the repo and then returned shares no
+        # identity with the original set; the original must be unchanged.
+        assert subnet.member_agent_ids == original_members
+
+
+# ---------------------------------------------------------------------------
+# PermissionError paths
+# ---------------------------------------------------------------------------
+
+
+class TestTransferOwnerPermission:
+    @pytest.mark.asyncio
+    async def test_non_owner_raises_permission_error(self):
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))
+
+        with pytest.raises(PermissionError, match="mismatch"):
+            await svc.transfer_owner("subnet-abc", "charlie", "bob")
+
+    @pytest.mark.asyncio
+    async def test_reserved_subnet_public_raises_permission_error(self):
+        # The ``Subnet`` entity rejects reserved IDs at construction time, so
+        # real ``public`` / ``system`` subnets are stored via internal bootstrap
+        # paths that bypass entity validation.  We use a MagicMock to simulate
+        # the repository returning such an object.
+        stub = MagicMock()
+        stub.slug = "public"
+        stub.owner = "alice"
+        svc = SubnetService(_make_repo(stub))
+
+        with pytest.raises(PermissionError, match="Cannot transfer system subnet"):
+            await svc.transfer_owner("public", "alice", "bob")
+
+    @pytest.mark.asyncio
+    async def test_reserved_subnet_system_raises_permission_error(self):
+        stub = MagicMock()
+        stub.slug = "system"
+        stub.owner = "alice"
+        svc = SubnetService(_make_repo(stub))
+
+        with pytest.raises(PermissionError, match="Cannot transfer system subnet"):
+            await svc.transfer_owner("system", "alice", "bob")
+
+    @pytest.mark.asyncio
+    async def test_non_owner_check_fires_before_reserved_subnet_check(self):
+        """Owner mismatch takes priority — a non-owner cannot even learn the
+        subnet is reserved or non-reserved via the error type."""
+        stub = MagicMock()
+        stub.slug = "public"
+        stub.owner = "alice"
+        svc = SubnetService(_make_repo(stub))
+
+        with pytest.raises(PermissionError, match="mismatch"):
+            await svc.transfer_owner("public", "charlie", "bob")
+
+
+# ---------------------------------------------------------------------------
+# ValueError paths
+# ---------------------------------------------------------------------------
+
+
+class TestTransferOwnerValidation:
+    @pytest.mark.asyncio
+    async def test_self_transfer_raises_value_error(self):
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))
+
+        with pytest.raises(ValueError, match="new_owner must differ"):
+            await svc.transfer_owner("subnet-abc", "alice", "alice")
+
+    @pytest.mark.asyncio
+    async def test_backend_internal_new_owner_raises_value_error(self):
+        """ADR-0002 guard fires unconditionally — no agent_repo needed."""
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))  # no agent_repository
+
+        with pytest.raises(ValueError, match="ADR-0002"):
+            await svc.transfer_owner("subnet-abc", "alice", "backend@internal")
+
+    @pytest.mark.asyncio
+    async def test_system_identity_new_owner_raises_value_error(self):
+        """``"system"`` guard fires unconditionally — no agent_repo needed."""
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))  # no agent_repository
+
+        with pytest.raises(ValueError, match="reserved platform identity"):
+            await svc.transfer_owner("subnet-abc", "alice", "system")
+
+    @pytest.mark.asyncio
+    async def test_unregistered_new_owner_raises_value_error(self):
+        """When agent_repository is wired, unknown agents are rejected."""
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(
+            _make_repo(subnet),
+            agent_repository=_make_agent_repo(set()),  # no agents known
+        )
+
+        with pytest.raises(ValueError, match="not registered"):
+            await svc.transfer_owner("subnet-abc", "alice", "ghost")
+
+    @pytest.mark.asyncio
+    async def test_agent_existence_check_skipped_without_repo(self):
+        """When agent_repository is ``None``, unverified owners are allowed
+        through (legacy fixtures / Redis-only deployments)."""
+        subnet = _make_subnet(owner="alice")
+        svc = SubnetService(_make_repo(subnet))  # agent_repository=None (default)
+
+        # Should NOT raise — the existence check is skipped.
+        result = await svc.transfer_owner("subnet-abc", "alice", "unverified-bob")
+
+        assert result.owner == "unverified-bob"
+
+
+# ---------------------------------------------------------------------------
+# Not-found path
+# ---------------------------------------------------------------------------
+
+
+class TestTransferOwnerNotFound:
+    @pytest.mark.asyncio
+    async def test_missing_subnet_raises_subnet_not_found(self):
+        repo = _make_repo(None)  # find_by_id returns None → not found
+        svc = SubnetService(repo)
+
+        with pytest.raises(SubnetNotFoundException):
+            await svc.transfer_owner("no-such-subnet", "alice", "bob")


### PR DESCRIPTION
## Summary

- **新增 `POST /api/v1/subnets/{slug}/transfer`** — 当前 owner 将 subnet 所有权移交给另一个已注册的 agent，防止 ADR-0004 描述的「孤儿 subnet」问题（owner 失联后，approval / invitation / allowlist 工作流永久不可达）。
- **新增 `SubnetService.transfer_owner`** — 完整业务规则：owner 校验、保留 subnet 拦截、自转移拦截、保留身份拦截（ADR-0002）、agent 注册检查（可选）、shallow-copy 安全的成员集更新。
- **新增 ADR-0005** — 正式记录设计决策，关联 ADR-0001/0002/0003/0004。
- **26 tests** — 9 条 route 层 + 17 条 service 层，全部通过；ruff lint clean。

## 变更文件

| 文件 | 内容 |
|---|---|
| `acn/services/subnet_service.py` | 新增 `transfer_owner` 方法 |
| `acn/routes/subnets.py` | 新增 `POST /{slug}/transfer` endpoint，`TransferOwnerRequest` 模型 |
| `tests/routes/test_subnets_transfer.py` | 9 个 route 层测试 |
| `tests/services/test_subnet_service_transfer.py` | 17 个 service 层测试 |
| `docs/adr/0005-subnet-ownership-transfer.md` | 正式 ADR |
| `skills/acn/SKILL.md` | 新增 `acn subnet transfer` CLI 命令 |
| `CHANGELOG.md` | `[Unreleased]` 条目 |

## Test plan

- [ ] `uv run pytest tests/routes/test_subnets_transfer.py tests/services/test_subnet_service_transfer.py` — 26 passed
- [ ] `uv run ruff check acn/routes/subnets.py acn/services/subnet_service.py` — All checks passed
- [ ] 端到端：创建 subnet → `POST /transfer` → 验证新 owner 可访问 approval/invitation 工作流


Made with [Cursor](https://cursor.com)