### PR TITLE
fix(registry): harden endpoint validation and reachability probe

### DIFF
--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -168,6 +168,21 @@ class AgentJoinRequest(BaseModel):
         v = v.strip()
         if not re.match(r"^https?://", v, re.IGNORECASE):
             raise ValueError("Endpoint must be an http:// or https:// URL.")
+        # Reject endpoints that point at ACN itself. An agent endpoint must be
+        # the agent's own server — using ACN's gateway as a placeholder passes
+        # the HTTP probe (ACN responds 405) while delivering nothing to the
+        # real agent. Compare normalized hosts to handle trailing slashes and
+        # port variations. Check both GATEWAY_BASE_URL and FRONTEND_BASE_URL.
+        from urllib.parse import urlparse as _urlparse
+        _v_host = _urlparse(v).netloc.lower()
+        for _gateway in (settings.gateway_base_url, settings.frontend_base_url):
+            if _gateway:
+                _gw_host = _urlparse(_gateway.rstrip("/")).netloc.lower()
+                if _v_host and _gw_host and _v_host == _gw_host:
+                    raise ValueError(
+                        "Endpoint must point to the agent's own server, "
+                        "not to the ACN gateway."
+                    )
         # SSRF guard: reject IP-literal endpoints in private/reserved ranges.
         # Hostname resolution is checked again at dispatch time (see
         # `_proxy_to_agent`) to defend against DNS rebinding.
@@ -179,8 +194,17 @@ class AgentJoinRequest(BaseModel):
 
     @model_validator(mode="after")
     def require_delivery_or_discovery_url(self):
+        # Agents in closed mode receive no inbound messages — they have no need
+        # for a delivery endpoint. All other modes (open, manifest, allowlist)
+        # require an endpoint because ACN must be able to deliver via HTTP.
+        policy_mode = (self.communication_policy or {}).get("mode", "manifest")
+        if policy_mode == "closed":
+            return self
         if not (self.a2a_endpoint or self.endpoint or self.agent_card_url):
-            raise ValueError("a2a_endpoint, endpoint, or agent_card_url is required")
+            raise ValueError(
+                "a2a_endpoint, endpoint, or agent_card_url is required. "
+                "If you have no public endpoint, set communication_policy.mode='closed'."
+            )
         return self
 
     def get_direct_a2a_endpoint(self) -> str | None:
@@ -368,6 +392,15 @@ async def _check_endpoint_reachability(endpoint: str) -> bool:
     reachable = await _probe_endpoint_http(endpoint)
     if not reachable:
         logger.warning("endpoint_http_probe_failed", endpoint=endpoint)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Endpoint did not respond to a reachability probe. "
+                "Make sure the server is running and publicly accessible before registering. "
+                "If you do not have a public endpoint, set communication_policy.mode to "
+                "'closed' and omit the endpoint field (inbox-only operation)."
+            ),
+        )
     return reachable
 
 

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -11,6 +11,7 @@ Supports two registration modes:
 import re
 import secrets
 from typing import Any, Literal
+from urllib.parse import quote, urlparse
 
 import httpx
 import structlog  # type: ignore[import-untyped]
@@ -173,11 +174,10 @@ class AgentJoinRequest(BaseModel):
         # the HTTP probe (ACN responds 405) while delivering nothing to the
         # real agent. Compare normalized hosts to handle trailing slashes and
         # port variations. Check both GATEWAY_BASE_URL and FRONTEND_BASE_URL.
-        from urllib.parse import urlparse as _urlparse
-        _v_host = _urlparse(v).netloc.lower()
+        _v_host = urlparse(v).netloc.lower()
         for _gateway in (settings.gateway_base_url, settings.frontend_base_url):
             if _gateway:
-                _gw_host = _urlparse(_gateway.rstrip("/")).netloc.lower()
+                _gw_host = urlparse(_gateway.rstrip("/")).netloc.lower()
                 if _v_host and _gw_host and _v_host == _gw_host:
                     raise ValueError(
                         "Endpoint must point to the agent's own server, "
@@ -1301,7 +1301,6 @@ async def _join_agent_impl(
         # ``searchParams.get("token")``). The earlier path-segment shape
         # ``/claim/{id}/{token}`` only ever rendered the Next.js 404 page
         # because the dynamic route has a single ``[id]`` segment.
-        from urllib.parse import quote
         claim_url = f"{frontend_url}/claim/{agent.agent_id}?token={quote(claim_token, safe='')}"
         return AgentJoinResponse(
             agent_id=agent.agent_id,

--- a/tests/routes/test_endpoint_reachability.py
+++ b/tests/routes/test_endpoint_reachability.py
@@ -7,13 +7,13 @@ ACN performs a two-layer check when an agent registers a direct ``a2a_endpoint``
    - This catches typos and unprovisioned DNS records before they enter
      the registry.
 
-2. **HTTP HEAD probe** (soft warning): ``_probe_endpoint_http`` fires a HEAD
+2. **HTTP HEAD probe** (hard fail): ``_probe_endpoint_http`` fires a HEAD
    request with a short timeout.
    - Any HTTP response (including 405 Method Not Allowed from a JSON-RPC-only
      server) counts as "reachable".
-   - Connection failures and timeouts set ``endpoint_reachable=False`` in the
-     join response without blocking registration — the server may not be
-     deployed yet at join time.
+   - Connection failures and timeouts raise HTTPException(400) — registration
+     is blocked. Agents must have a running, publicly reachable server before
+     registering (or use communication_policy.mode='closed').
 
 These tests are unit-level: they mock ``safe_resolve_target`` and
 ``_probe_endpoint_http`` so they never hit the network. The full
@@ -157,9 +157,9 @@ async def test_dns_ok_http_probe_success_returns_true():
 
 
 @pytest.mark.asyncio
-async def test_dns_ok_http_probe_failure_returns_false():
-    """DNS resolves but HTTP probe fails → reachable=False (soft warning,
-    registration is NOT blocked)."""
+async def test_dns_ok_http_probe_failure_raises_400():
+    """DNS resolves but HTTP probe fails → HTTPException(400).
+    Registration is now hard-blocked when the endpoint is unreachable."""
     with (
         patch(
             "acn.routes.registry.safe_resolve_target",
@@ -170,9 +170,10 @@ async def test_dns_ok_http_probe_failure_returns_false():
             new=AsyncMock(return_value=False),
         ),
     ):
-        result = await _check_endpoint_reachability("https://agent.example.com/a2a")
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_endpoint_reachability("https://agent.example.com/a2a")
 
-    assert result is False
+    assert exc_info.value.status_code == 400
 
 
 # ---------------------------------------------------------------------------
@@ -200,21 +201,21 @@ async def test_resolve_direct_endpoint_propagates_reachable_true():
 
 
 @pytest.mark.asyncio
-async def test_resolve_direct_endpoint_propagates_reachable_false():
-    """When the HTTP probe fails the tuple carries reachable=False but does
-    NOT raise — registration continues with a soft warning."""
+async def test_resolve_direct_endpoint_raises_on_probe_failure():
+    """When the HTTP probe fails, _resolve_registration_endpoint raises
+    HTTPException(400) — registration is hard-blocked."""
     with patch(
         "acn.routes.registry._check_endpoint_reachability",
-        new=AsyncMock(return_value=False),
+        new=AsyncMock(side_effect=HTTPException(status_code=400, detail="Endpoint did not respond")),
     ):
-        endpoint, card, reachable = await _resolve_registration_endpoint(
-            direct_endpoint="https://agent.example.com/a2a",
-            agent_card_url=None,
-            agent_card=None,
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            await _resolve_registration_endpoint(
+                direct_endpoint="https://agent.example.com/a2a",
+                agent_card_url=None,
+                agent_card=None,
+            )
 
-    assert endpoint == "https://agent.example.com/a2a"
-    assert reachable is False
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -282,28 +283,32 @@ async def test_join_response_endpoint_reachable_true_when_probe_succeeds():
 
 
 @pytest.mark.asyncio
-async def test_join_response_endpoint_reachable_false_when_probe_fails():
-    """When the HTTP probe fails (server not yet up), ``endpoint_reachable``
-    must be False in the response — but registration MUST succeed (no raise)."""
+async def test_join_blocked_when_probe_fails():
+    """When the HTTP probe fails, _join_agent_impl must re-raise the
+    HTTPException(400) — the agent must NOT be saved."""
     fake_agent = _make_fake_agent()
     svc = AsyncMock()
     svc.join_agent = AsyncMock(return_value=(fake_agent, "acn_test_key"))
 
     with patch(
         "acn.routes.registry._resolve_registration_endpoint",
-        new=AsyncMock(return_value=("https://agent.example.com/a2a", None, False)),
+        new=AsyncMock(
+            side_effect=HTTPException(
+                status_code=400,
+                detail="Endpoint did not respond to a reachability probe.",
+            )
+        ),
     ):
-        resp = await _join_agent_impl(
-            _make_join_body(),
-            BackgroundTasks(),
-            ref=None,
-            agent_service=svc,
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            await _join_agent_impl(
+                _make_join_body(),
+                BackgroundTasks(),
+                ref=None,
+                agent_service=svc,
+            )
 
-    # Registration succeeded (no exception raised)
-    assert resp.agent_id == fake_agent.agent_id
-    # Soft warning surfaced in response
-    assert resp.endpoint_reachable is False
+    assert exc_info.value.status_code == 400
+    svc.join_agent.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -334,3 +339,87 @@ async def test_join_blocked_on_dns_failure():
     assert exc_info.value.status_code == 400
     # join_agent must NOT have been called — agent was never persisted
     svc.join_agent.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #141 — ACN own gateway domain rejected at validation time
+# ---------------------------------------------------------------------------
+
+
+def test_join_request_rejects_acn_gateway_as_endpoint():
+    """An endpoint that points at ACN's own gateway (GATEWAY_BASE_URL host)
+    must be rejected at Pydantic validation time with a clear error message."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        AgentJoinRequest(
+            name="bad-agent",
+            description="Agent using ACN proxy as placeholder endpoint",
+            a2a_endpoint="https://api.acnlabs.dev/api/v1/agents/some-uuid",
+        )
+
+    errors = exc_info.value.errors()
+    assert any("ACN gateway" in str(e.get("msg", "")) for e in errors), (
+        f"Expected 'ACN gateway' in error message, got: {errors}"
+    )
+
+
+def test_join_request_rejects_acn_gateway_subpath():
+    """Any path under the ACN gateway host must be rejected — not just the
+    exact gateway URL."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        AgentJoinRequest(
+            name="bad-agent",
+            description="Agent using ACN proxy as placeholder endpoint",
+            endpoint="https://api.acnlabs.dev/anything",
+        )
+
+    errors = exc_info.value.errors()
+    assert any("ACN gateway" in str(e.get("msg", "")) for e in errors)
+
+
+def test_join_request_allows_non_acn_endpoint():
+    """A well-formed endpoint on a non-ACN domain must pass validation."""
+    req = AgentJoinRequest(
+        name="good-agent",
+        description="Agent with its own real endpoint",
+        a2a_endpoint="https://agent.example.com/a2a",
+    )
+    assert req.a2a_endpoint == "https://agent.example.com/a2a"
+
+
+# ---------------------------------------------------------------------------
+# closed-mode: endpoint is optional
+# ---------------------------------------------------------------------------
+
+
+def test_join_request_closed_mode_allows_no_endpoint():
+    """Agents in closed mode receive no inbound messages — endpoint is optional."""
+    req = AgentJoinRequest(
+        name="closed-agent",
+        description="Agent that operates in closed mode without public endpoint",
+        communication_policy={"mode": "closed"},
+    )
+    assert req.a2a_endpoint is None
+    assert req.endpoint is None
+    assert req.agent_card_url is None
+
+
+def test_join_request_open_mode_still_requires_endpoint():
+    """Open-mode agents still require an endpoint — the exemption is closed-only."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        AgentJoinRequest(
+            name="open-agent",
+            description="Open mode agent without any endpoint",
+            communication_policy={"mode": "open"},
+        )
+
+    errors = exc_info.value.errors()
+    assert any("endpoint" in str(e.get("msg", "")).lower() for e in errors)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #140, closes #141.

## Changes

### #141 — Block ACN own gateway domain as endpoint
`validate_endpoint` now rejects any URL whose host matches `GATEWAY_BASE_URL` or `FRONTEND_BASE_URL`. Previously, using `https://api.acnlabs.dev/api/v1/agents/some-name` as an endpoint passed all checks because ACN's own server returns `405 Method Not Allowed`, which the probe treated as "reachable."

### #140 — HTTP probe is now a hard block
`_check_endpoint_reachability` now raises `HTTPException(400)` when the HEAD probe fails instead of returning `False`. The error message explicitly tells operators to use `communication_policy.mode='closed'` if they have no public endpoint.

### Bonus — `closed`-mode agents may omit endpoint
`require_delivery_or_discovery_url` skips the endpoint requirement when `communication_policy.mode == "closed"`. Closed-mode agents reject all inbound messages and have no use for a delivery endpoint.

## Test changes

- Updated 3 existing tests to reflect hard-block semantics (was: soft warning)
- Added 5 new tests:
  - `test_join_request_rejects_acn_gateway_as_endpoint`
  - `test_join_request_rejects_acn_gateway_subpath`
  - `test_join_request_allows_non_acn_endpoint`
  - `test_join_request_closed_mode_allows_no_endpoint`
  - `test_join_request_open_mode_still_requires_endpoint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c94b68e-aba9-4d82-bad3-08dabe75dce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c94b68e-aba9-4d82-bad3-08dabe75dce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

