### PR TITLE
Emit system audit events for agent join and subnet creation

### DIFF
--- a/acn/monitoring/audit.py
+++ b/acn/monitoring/audit.py
@@ -446,6 +446,10 @@ class AuditLogger:
     # Query Methods
     # =========================================================================
 
+    _PUBLIC_BROADCAST_EVENT_TYPES = frozenset(
+        {AuditEventType.AGENT_REGISTERED, AuditEventType.SUBNET_CREATED}
+    )
+
     @staticmethod
     def is_public_broadcast_eligible(event: AuditEvent) -> bool:
         """Return True iff an audit event is eligible for public fan-out.
@@ -458,6 +462,53 @@ class AuditLogger:
         public streams.
         """
         return event.details.get("public_broadcast_eligible") is True
+
+    @classmethod
+    def to_public_broadcast_payload(cls, event: AuditEvent) -> dict[str, Any] | None:
+        """Build a fixed-schema payload for public broadcast channels.
+
+        Returns ``None`` when the event is not eligible (or unsupported).
+        This ensures downstream broadcasters can call one function and avoid
+        duplicating filter + redaction logic.
+        """
+        if not cls.is_public_broadcast_eligible(event):
+            return None
+        if event.event_type not in cls._PUBLIC_BROADCAST_EVENT_TYPES:
+            return None
+
+        base = {
+            "schema_version": 1,
+            "event_id": event.id,
+            "timestamp": event.timestamp.isoformat(),
+            "event_type": event.event_type.value,
+        }
+
+        if event.event_type == AuditEventType.AGENT_REGISTERED:
+            if not event.target_id:
+                return None
+            out = {
+                **base,
+                "agent_id": event.target_id,
+            }
+            source = event.details.get("source")
+            if isinstance(source, str) and source:
+                out["source"] = source
+            return out
+
+        if event.event_type == AuditEventType.SUBNET_CREATED:
+            if not event.target_id:
+                return None
+            out = {
+                **base,
+                "subnet_id": event.target_id,
+            }
+            join_policy = event.details.get("join_policy")
+            if isinstance(join_policy, str) and join_policy:
+                out["join_policy"] = join_policy
+            return out
+
+        # Future-proof fallback for mypy/control-flow completeness.
+        return None
 
     async def query_events(
         self,

--- a/acn/monitoring/audit.py
+++ b/acn/monitoring/audit.py
@@ -446,6 +446,19 @@ class AuditLogger:
     # Query Methods
     # =========================================================================
 
+    @staticmethod
+    def is_public_broadcast_eligible(event: AuditEvent) -> bool:
+        """Return True iff an audit event is eligible for public fan-out.
+
+        Eligibility is an explicit opt-in carried in ``event.details``:
+        ``{"public_broadcast_eligible": true}``.
+
+        We intentionally require a strict boolean ``True`` (not just truthy)
+        so malformed payloads like ``"true"`` or ``1`` do not leak into
+        public streams.
+        """
+        return event.details.get("public_broadcast_eligible") is True
+
     async def query_events(
         self,
         event_type: AuditEventType | None = None,
@@ -526,6 +539,42 @@ class AuditLogger:
                 continue
 
         return events
+
+    async def query_public_broadcast_events(
+        self,
+        *,
+        event_types: list[AuditEventType] | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AuditEvent]:
+        """Return audit events that are safe to forward to public feeds.
+
+        This is a read-side helper for downstream broadcasters so every
+        consumer applies the same strict eligibility rule.
+        """
+        # Read more than ``limit`` so post-filter pagination remains stable.
+        candidates = await self.query_events(
+            start_time=start_time,
+            end_time=end_time,
+            limit=limit + offset + 1000,
+            offset=0,
+        )
+        out: list[AuditEvent] = []
+        skipped = 0
+        for event in candidates:
+            if event_types and event.event_type not in event_types:
+                continue
+            if not self.is_public_broadcast_eligible(event):
+                continue
+            if skipped < offset:
+                skipped += 1
+                continue
+            out.append(event)
+            if len(out) >= limit:
+                break
+        return out
 
     async def get_event(self, event_id: str) -> AuditEvent | None:
         """Get a specific event by ID"""

--- a/acn/monitoring/audit.py
+++ b/acn/monitoring/audit.py
@@ -290,6 +290,8 @@ class AuditLogger:
         await self.redis.ltrim(type_key, 0, self.max_entries - 1)
         await self.redis.expire(type_key, self.retention_days * 24 * 3600)
 
+        await self.publish_public_system_event(event)
+
         return event_id
 
     # =========================================================================
@@ -449,6 +451,8 @@ class AuditLogger:
     _PUBLIC_BROADCAST_EVENT_TYPES = frozenset(
         {AuditEventType.AGENT_REGISTERED, AuditEventType.SUBNET_CREATED}
     )
+    _PUBLIC_SYSTEM_EVENTS_CHANNEL = "broadcast:system-events"
+    _PUBLIC_SYSTEM_EVENT_MESSAGE_TYPE = "public_system_event"
 
     @staticmethod
     def is_public_broadcast_eligible(event: AuditEvent) -> bool:
@@ -509,6 +513,35 @@ class AuditLogger:
 
         # Future-proof fallback for mypy/control-flow completeness.
         return None
+
+    async def publish_public_system_event(self, event: AuditEvent) -> None:
+        """Fan out public-eligible events to the WS public channel.
+
+        The feed is best-effort: audit persistence should succeed even when
+        realtime fan-out is temporarily degraded.
+        """
+        payload = self.to_public_broadcast_payload(event)
+        if payload is None:
+            return
+        try:
+            await self.redis.publish(
+                f"acn:ws:{self._PUBLIC_SYSTEM_EVENTS_CHANNEL}",
+                json.dumps(
+                    {
+                        "type": self._PUBLIC_SYSTEM_EVENT_MESSAGE_TYPE,
+                        "event": payload,
+                    }
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            _logger.debug(
+                "audit_public_system_event_publish_failed",
+                extra={
+                    "event_type": event.event_type.value,
+                    "event_id": event.id,
+                    "error": str(exc),
+                },
+            )
 
     async def query_events(
         self,

--- a/acn/routes/monitoring.py
+++ b/acn/routes/monitoring.py
@@ -20,7 +20,12 @@ from fastapi import APIRouter, Query
 from fastapi.responses import PlainTextResponse
 
 from ..monitoring import AuditEventType, AuditLogger
-from .dependencies import AnalyticsDep, AuditDep, InternalTokenDep, MetricsDep  # type: ignore[import-untyped]
+from .dependencies import (  # type: ignore[import-untyped]
+    AnalyticsDep,
+    AuditDep,
+    InternalTokenDep,
+    MetricsDep,
+)
 
 router = APIRouter(tags=["monitoring"])
 

--- a/acn/routes/monitoring.py
+++ b/acn/routes/monitoring.py
@@ -14,12 +14,21 @@ The previous version of this file invoked:
 so every endpoint here except `GET /metrics` previously returned 500.
 """
 
-from fastapi import APIRouter
+from typing import Literal
+
+from fastapi import APIRouter, Query
 from fastapi.responses import PlainTextResponse
 
-from .dependencies import AnalyticsDep, InternalTokenDep, MetricsDep  # type: ignore[import-untyped]
+from ..monitoring import AuditEventType, AuditLogger
+from .dependencies import AnalyticsDep, AuditDep, InternalTokenDep, MetricsDep  # type: ignore[import-untyped]
 
 router = APIRouter(tags=["monitoring"])
+
+PublicSystemEventType = Literal["agent_registered", "subnet_created"]
+_PUBLIC_EVENT_TYPE_MAP: dict[PublicSystemEventType, AuditEventType] = {
+    "agent_registered": AuditEventType.AGENT_REGISTERED,
+    "subnet_created": AuditEventType.SUBNET_CREATED,
+}
 
 
 @router.get("/metrics", response_class=PlainTextResponse)
@@ -55,3 +64,35 @@ async def get_dashboard_data(_: InternalTokenDep, analytics: AnalyticsDep = None
     trip to metrics here.
     """
     return await analytics.get_dashboard_data()
+
+
+@router.get("/api/v1/public/system-events")
+async def get_public_system_events(
+    event_type: list[PublicSystemEventType] | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    audit: AuditDep = None,
+):
+    """Public system-event feed with fixed, redacted output schema.
+
+    This endpoint is intentionally open (no auth dependency) so frontend and
+    third-party consumers can poll a stable read model without touching
+    internal audit fields.
+    """
+    event_types = [_PUBLIC_EVENT_TYPE_MAP[value] for value in event_type] if event_type else None
+    events = await audit.query_public_broadcast_events(
+        event_types=event_types,
+        limit=limit,
+        offset=offset,
+    )
+    items = [
+        payload
+        for event in events
+        if (payload := AuditLogger.to_public_broadcast_payload(event)) is not None
+    ]
+    return {
+        "items": items,
+        "limit": limit,
+        "offset": offset,
+        "count": len(items),
+    }

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -1251,6 +1251,28 @@ async def _join_agent_impl(
         frontend_url = (settings.frontend_base_url or base_url).rstrip("/")
 
         logger.info("agent_joined", agent_id=agent.agent_id, name=agent.name, referrer_id=referrer_id)
+        # System-level join event: emit only for production-visible agents.
+        # Internal probe joins stamp ``metadata.visibility="test"`` and must
+        # stay out of the default public event stream.
+        _raw_metadata = getattr(agent, "metadata", None)
+        _metadata = _raw_metadata if isinstance(_raw_metadata, dict) else {}
+        _visibility = str(_metadata.get("visibility", "real")).lower()
+        if _visibility == "real":
+            fire_and_forget_event(
+                get_audit_singleton(),
+                event_type=AuditEventType.AGENT_REGISTERED,
+                actor_id=agent.agent_id,
+                actor_type="agent",
+                target_id=agent.agent_id,
+                target_type="agent",
+                details={"source": "join", "visibility": _visibility},
+            )
+        else:
+            logger.debug(
+                "agent_join_audit_skipped",
+                agent_id=agent.agent_id,
+                visibility=_visibility,
+            )
 
         background_tasks.add_task(_grant_register_reward, agent_id=agent.agent_id)
 

--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -1251,28 +1251,25 @@ async def _join_agent_impl(
         frontend_url = (settings.frontend_base_url or base_url).rstrip("/")
 
         logger.info("agent_joined", agent_id=agent.agent_id, name=agent.name, referrer_id=referrer_id)
-        # System-level join event: emit only for production-visible agents.
-        # Internal probe joins stamp ``metadata.visibility="test"`` and must
-        # stay out of the default public event stream.
+        # System-level join event: always emit into the internal audit stream.
+        # Public feeds must filter by ``public_broadcast_eligible`` so probe /
+        # test registrations remain internal-only while still being auditable.
         _raw_metadata = getattr(agent, "metadata", None)
         _metadata = _raw_metadata if isinstance(_raw_metadata, dict) else {}
         _visibility = str(_metadata.get("visibility", "real")).lower()
-        if _visibility == "real":
-            fire_and_forget_event(
-                get_audit_singleton(),
-                event_type=AuditEventType.AGENT_REGISTERED,
-                actor_id=agent.agent_id,
-                actor_type="agent",
-                target_id=agent.agent_id,
-                target_type="agent",
-                details={"source": "join", "visibility": _visibility},
-            )
-        else:
-            logger.debug(
-                "agent_join_audit_skipped",
-                agent_id=agent.agent_id,
-                visibility=_visibility,
-            )
+        fire_and_forget_event(
+            get_audit_singleton(),
+            event_type=AuditEventType.AGENT_REGISTERED,
+            actor_id=agent.agent_id,
+            actor_type="agent",
+            target_id=agent.agent_id,
+            target_type="agent",
+            details={
+                "source": "join",
+                "visibility": _visibility,
+                "public_broadcast_eligible": _visibility == "real",
+            },
+        )
 
         background_tasks.add_task(_grant_register_reward, agent_id=agent.agent_id)
 

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -355,19 +355,19 @@ async def create_subnet(
         gateway_ws_url = f"{base_url}/gateway/ws/{subnet.slug}"
 
         logger.info("subnet_created", slug=subnet.slug, owner=owner)
-        if not subnet.is_private:
-            fire_and_forget_event(
-                get_audit_singleton(),
-                event_type=AuditEventType.SUBNET_CREATED,
-                actor_id=owner,
-                actor_type="agent",
-                target_id=subnet.slug,
-                target_type="subnet",
-                details={
-                    "is_private": subnet.is_private,
-                    "join_policy": subnet.join_policy,
-                },
-            )
+        fire_and_forget_event(
+            get_audit_singleton(),
+            event_type=AuditEventType.SUBNET_CREATED,
+            actor_id=owner,
+            actor_type="agent",
+            target_id=subnet.slug,
+            target_type="subnet",
+            details={
+                "is_private": subnet.is_private,
+                "join_policy": subnet.join_policy,
+                "public_broadcast_eligible": not subnet.is_private,
+            },
+        )
 
         return SubnetCreateResponse(
             status="created",

--- a/acn/routes/subnets.py
+++ b/acn/routes/subnets.py
@@ -355,6 +355,19 @@ async def create_subnet(
         gateway_ws_url = f"{base_url}/gateway/ws/{subnet.slug}"
 
         logger.info("subnet_created", slug=subnet.slug, owner=owner)
+        if not subnet.is_private:
+            fire_and_forget_event(
+                get_audit_singleton(),
+                event_type=AuditEventType.SUBNET_CREATED,
+                actor_id=owner,
+                actor_type="agent",
+                target_id=subnet.slug,
+                target_type="subnet",
+                details={
+                    "is_private": subnet.is_private,
+                    "join_policy": subnet.join_policy,
+                },
+            )
 
         return SubnetCreateResponse(
             status="created",

--- a/tests/infrastructure/test_audit_ws_public_event_fanout.py
+++ b/tests/infrastructure/test_audit_ws_public_event_fanout.py
@@ -1,0 +1,179 @@
+"""End-to-end test for the public system-event realtime channel.
+
+Verifies the full chain that backs the public WebSocket feed:
+
+1. ``AuditLogger.log_event`` is called with a public-eligible event.
+2. The logger writes to the audit stream and then publishes to the
+   shared Redis Pub/Sub channel ``acn:ws:broadcast:system-events``.
+3. ``WebSocketManager._listen_pubsub`` receives the published message
+   and fans it out to every local connection subscribed to the
+   ``broadcast:system-events`` channel.
+4. The client receives a JSON frame whose body matches the fixed
+   ``to_public_broadcast_payload`` schema.
+
+A non-eligible event must NOT reach the WebSocket — that pins the
+filter contract end-to-end so a regression in
+``publish_public_system_event`` cannot silently leak internal-only
+events to the public channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fakeredis import aioredis as _fakeredis_async
+
+from acn.infrastructure.messaging.websocket_manager import (
+    Connection,
+    WebSocketManager,
+)
+from acn.monitoring.audit import AuditEventType, AuditLogger
+
+
+@pytest.fixture
+async def shared_redis() -> AsyncGenerator[Any, None]:
+    """A single fakeredis async client shared by AuditLogger and WebSocketManager.
+
+    Both components must talk to the same backing fakeredis server so the
+    pubsub message published by ``AuditLogger`` is delivered to the
+    pubsub subscription registered by ``WebSocketManager``.
+    """
+    client = _fakeredis_async.FakeRedis(decode_responses=False)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.flushdb()
+        await client.aclose()
+
+
+async def _register_fake_connection(
+    ws_manager: WebSocketManager,
+    *,
+    connection_id: str,
+    user_id: str | None = None,
+) -> AsyncMock:
+    """Inject a fake Connection bypassing the real ``websocket.accept()`` path.
+
+    Returns the AsyncMock websocket so the test can read the frames the
+    manager pushed via ``send_json``.
+    """
+    fake_ws = AsyncMock()
+    connection = Connection(
+        connection_id=connection_id,
+        websocket=fake_ws,
+        user_id=user_id,
+    )
+    ws_manager._connections[connection_id] = connection
+    return fake_ws
+
+
+async def _wait_for_send_json_call(
+    fake_ws: AsyncMock,
+    *,
+    matcher,
+    timeout: float = 2.0,
+) -> dict[str, Any]:
+    """Poll the fake websocket until ``matcher`` returns True or timeout.
+
+    Polling rather than a single sleep keeps the test resilient to small
+    scheduling jitter between the publisher coroutine and the pubsub
+    listener task without forcing an artificially long fixed delay.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        for call in fake_ws.send_json.await_args_list:
+            payload = call.args[0]
+            if matcher(payload):
+                return payload
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(
+                "fake websocket did not receive a matching frame within "
+                f"{timeout}s. Captured: {fake_ws.send_json.await_args_list!r}"
+            )
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_eligible_event_fans_out_to_public_ws_channel(shared_redis) -> None:
+    audit = AuditLogger(redis=shared_redis)
+    ws_manager = WebSocketManager(redis_client=shared_redis)
+    await ws_manager.start()
+    try:
+        fake_ws = await _register_fake_connection(
+            ws_manager, connection_id="conn-public-1"
+        )
+        await ws_manager.subscribe("conn-public-1", "broadcast:system-events")
+
+        event_id = await audit.log_event(
+            event_type=AuditEventType.AGENT_REGISTERED,
+            target_id="agent-realtime-7",
+            target_type="agent",
+            details={
+                "source": "join",
+                "visibility": "real",
+                "public_broadcast_eligible": True,
+                "internal_only": "must-not-leak",
+            },
+        )
+
+        frame = await _wait_for_send_json_call(
+            fake_ws,
+            matcher=lambda f: f.get("type") == "public_system_event"
+            and f.get("event", {}).get("event_id") == event_id,
+        )
+
+        assert frame["event"] == {
+            "schema_version": 1,
+            "event_id": event_id,
+            "timestamp": frame["event"]["timestamp"],
+            "event_type": "agent_registered",
+            "agent_id": "agent-realtime-7",
+            "source": "join",
+        }
+    finally:
+        await ws_manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_non_eligible_event_does_not_reach_public_ws_channel(
+    shared_redis,
+) -> None:
+    audit = AuditLogger(redis=shared_redis)
+    ws_manager = WebSocketManager(redis_client=shared_redis)
+    await ws_manager.start()
+    try:
+        fake_ws = await _register_fake_connection(
+            ws_manager, connection_id="conn-public-2"
+        )
+        await ws_manager.subscribe("conn-public-2", "broadcast:system-events")
+
+        await audit.log_event(
+            event_type=AuditEventType.SUBNET_CREATED,
+            target_id="subnet-private-1",
+            target_type="subnet",
+            details={
+                "is_private": True,
+                "join_policy": "approval",
+                "public_broadcast_eligible": False,
+            },
+        )
+
+        # Give the listener some time to definitively NOT push anything.
+        await asyncio.sleep(0.15)
+
+        public_frames = [
+            call.args[0]
+            for call in fake_ws.send_json.await_args_list
+            if call.args and call.args[0].get("type") == "public_system_event"
+        ]
+        assert public_frames == [], (
+            "non-eligible audit events must not fan out to the public WS channel; "
+            f"got {public_frames!r}"
+        )
+    finally:
+        await ws_manager.stop()

--- a/tests/monitoring/test_audit_public_broadcast_filter.py
+++ b/tests/monitoring/test_audit_public_broadcast_filter.py
@@ -1,0 +1,67 @@
+"""Tests for ``AuditLogger.query_public_broadcast_events`` filtering contract."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.monitoring.audit import AuditEvent, AuditEventType, AuditLevel, AuditLogger
+
+
+def _event(
+    eid: str,
+    event_type: AuditEventType,
+    *,
+    eligible: object | None = None,
+) -> AuditEvent:
+    details = {}
+    if eligible is not None:
+        details["public_broadcast_eligible"] = eligible
+    return AuditEvent(
+        id=eid,
+        timestamp=datetime.now(UTC),
+        event_type=event_type,
+        level=AuditLevel.INFO,
+        target_id=f"target-{eid}",
+        target_type="agent",
+        details=details,
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_public_broadcast_events_filters_by_strict_boolean_true() -> None:
+    logger = AuditLogger(redis=AsyncMock())
+    logger.query_events = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            _event("e1", AuditEventType.AGENT_REGISTERED, eligible=True),
+            _event("e2", AuditEventType.AGENT_REGISTERED, eligible=False),
+            _event("e3", AuditEventType.AGENT_REGISTERED),  # missing key
+            _event("e4", AuditEventType.AGENT_REGISTERED, eligible="true"),  # malformed
+        ]
+    )
+
+    events = await logger.query_public_broadcast_events(limit=10)
+
+    assert [e.id for e in events] == ["e1"]
+
+
+@pytest.mark.asyncio
+async def test_query_public_broadcast_events_honors_event_type_filter_and_pagination() -> None:
+    logger = AuditLogger(redis=AsyncMock())
+    logger.query_events = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            _event("e1", AuditEventType.AGENT_REGISTERED, eligible=True),
+            _event("e2", AuditEventType.SUBNET_CREATED, eligible=True),
+            _event("e3", AuditEventType.AGENT_REGISTERED, eligible=True),
+        ]
+    )
+
+    events = await logger.query_public_broadcast_events(
+        event_types=[AuditEventType.AGENT_REGISTERED],
+        limit=1,
+        offset=1,
+    )
+
+    assert [e.id for e in events] == ["e3"]

--- a/tests/monitoring/test_audit_public_broadcast_filter.py
+++ b/tests/monitoring/test_audit_public_broadcast_filter.py
@@ -65,3 +65,48 @@ async def test_query_public_broadcast_events_honors_event_type_filter_and_pagina
     )
 
     assert [e.id for e in events] == ["e3"]
+
+
+def test_to_public_broadcast_payload_for_agent_registered_is_whitelisted() -> None:
+    event = _event("e1", AuditEventType.AGENT_REGISTERED, eligible=True)
+    event.actor_id = "secret-actor"
+    event.actor_type = "agent"
+    event.source_ip = "203.0.113.7"
+    event.user_agent = "sensitive-agent"
+    event.details.update(
+        {
+            "source": "join",
+            "visibility": "real",
+            "public_broadcast_eligible": True,
+            "internal_note": "must-not-leak",
+        }
+    )
+
+    payload = AuditLogger.to_public_broadcast_payload(event)
+
+    assert payload == {
+        "schema_version": 1,
+        "event_id": "e1",
+        "timestamp": event.timestamp.isoformat(),
+        "event_type": "agent_registered",
+        "agent_id": "target-e1",
+        "source": "join",
+    }
+
+
+def test_to_public_broadcast_payload_for_subnet_and_non_eligible_cases() -> None:
+    subnet_event = _event("e2", AuditEventType.SUBNET_CREATED, eligible=True)
+    subnet_event.target_id = "subnet-public-1"
+    subnet_event.details["join_policy"] = "open"
+    payload = AuditLogger.to_public_broadcast_payload(subnet_event)
+    assert payload == {
+        "schema_version": 1,
+        "event_id": "e2",
+        "timestamp": subnet_event.timestamp.isoformat(),
+        "event_type": "subnet_created",
+        "subnet_id": "subnet-public-1",
+        "join_policy": "open",
+    }
+
+    hidden_event = _event("e3", AuditEventType.SUBNET_CREATED, eligible=False)
+    assert AuditLogger.to_public_broadcast_payload(hidden_event) is None

--- a/tests/monitoring/test_audit_public_broadcast_filter.py
+++ b/tests/monitoring/test_audit_public_broadcast_filter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -110,3 +111,47 @@ def test_to_public_broadcast_payload_for_subnet_and_non_eligible_cases() -> None
 
     hidden_event = _event("e3", AuditEventType.SUBNET_CREATED, eligible=False)
     assert AuditLogger.to_public_broadcast_payload(hidden_event) is None
+
+
+@pytest.mark.asyncio
+async def test_log_event_publishes_fixed_schema_to_public_ws_channel() -> None:
+    redis = AsyncMock()
+    logger = AuditLogger(redis=redis)
+    event_id = await logger.log_event(
+        event_type=AuditEventType.AGENT_REGISTERED,
+        target_id="agent-realtime-1",
+        target_type="agent",
+        details={
+            "source": "join",
+            "public_broadcast_eligible": True,
+            "internal_only": "drop-me",
+        },
+    )
+
+    redis.publish.assert_awaited_once()
+    channel, raw_message = redis.publish.await_args.args
+    assert channel == "acn:ws:broadcast:system-events"
+    message = json.loads(raw_message)
+    assert message["type"] == "public_system_event"
+    assert message["event"] == {
+        "schema_version": 1,
+        "event_id": event_id,
+        "timestamp": message["event"]["timestamp"],
+        "event_type": "agent_registered",
+        "agent_id": "agent-realtime-1",
+        "source": "join",
+    }
+
+
+@pytest.mark.asyncio
+async def test_log_event_skips_public_ws_publish_for_non_eligible_event() -> None:
+    redis = AsyncMock()
+    logger = AuditLogger(redis=redis)
+    await logger.log_event(
+        event_type=AuditEventType.SUBNET_CREATED,
+        target_id="subnet-private",
+        target_type="subnet",
+        details={"public_broadcast_eligible": False, "join_policy": "approval"},
+    )
+
+    redis.publish.assert_not_awaited()

--- a/tests/routes/test_join_claim_url_shape.py
+++ b/tests/routes/test_join_claim_url_shape.py
@@ -40,6 +40,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import BackgroundTasks
 
+from acn.monitoring.audit import AuditEventType
 from acn.routes.registry import AgentJoinRequest, _join_agent_impl
 
 
@@ -138,3 +139,54 @@ async def test_claim_url_url_encodes_reserved_characters(stub_join_service, fake
     # And the raw form must NOT appear — that would mean we forgot to
     # call quote() somewhere on the path.
     assert "with/slash&amp=eq?qmark#hash" not in resp.claim_url
+
+
+@pytest.mark.asyncio
+async def test_join_emits_agent_registered_audit_for_real_visibility(stub_join_service):
+    """Public joins should emit a system-level registration audit event."""
+    with (
+        patch(
+            "acn.routes.registry._resolve_registration_endpoint",
+            new=AsyncMock(return_value=("https://probe.example.com/a2a", None, True)),
+        ),
+        patch("acn.routes.registry.get_audit_singleton", return_value=object()),
+        patch("acn.routes.registry.fire_and_forget_event") as fire,
+    ):
+        await _join_agent_impl(
+            _make_body(),
+            BackgroundTasks(),
+            ref=None,
+            agent_service=stub_join_service,
+        )
+
+    fire.assert_called_once()
+    kwargs = fire.call_args.kwargs
+    assert kwargs["event_type"] == AuditEventType.AGENT_REGISTERED
+    assert kwargs["details"]["source"] == "join"
+    assert kwargs["details"]["visibility"] == "real"
+
+
+@pytest.mark.asyncio
+async def test_join_skips_agent_registered_audit_for_non_real_visibility(
+    stub_join_service,
+    fake_agent,
+):
+    """Internal/test joins should not enter the public registration event stream."""
+    fake_agent.metadata = {"visibility": "test"}
+    with (
+        patch(
+            "acn.routes.registry._resolve_registration_endpoint",
+            new=AsyncMock(return_value=("https://probe.example.com/a2a", None, True)),
+        ),
+        patch("acn.routes.registry.get_audit_singleton", return_value=object()),
+        patch("acn.routes.registry.fire_and_forget_event") as fire,
+    ):
+        await _join_agent_impl(
+            _make_body(),
+            BackgroundTasks(),
+            ref=None,
+            agent_service=stub_join_service,
+            default_metadata={"visibility": "test"},
+        )
+
+    fire.assert_not_called()

--- a/tests/routes/test_join_claim_url_shape.py
+++ b/tests/routes/test_join_claim_url_shape.py
@@ -164,14 +164,15 @@ async def test_join_emits_agent_registered_audit_for_real_visibility(stub_join_s
     assert kwargs["event_type"] == AuditEventType.AGENT_REGISTERED
     assert kwargs["details"]["source"] == "join"
     assert kwargs["details"]["visibility"] == "real"
+    assert kwargs["details"]["public_broadcast_eligible"] is True
 
 
 @pytest.mark.asyncio
-async def test_join_skips_agent_registered_audit_for_non_real_visibility(
+async def test_join_emits_internal_audit_for_non_real_visibility(
     stub_join_service,
     fake_agent,
 ):
-    """Internal/test joins should not enter the public registration event stream."""
+    """Internal/test joins stay auditable but are marked non-public."""
     fake_agent.metadata = {"visibility": "test"}
     with (
         patch(
@@ -189,4 +190,8 @@ async def test_join_skips_agent_registered_audit_for_non_real_visibility(
             default_metadata={"visibility": "test"},
         )
 
-    fire.assert_not_called()
+    fire.assert_called_once()
+    kwargs = fire.call_args.kwargs
+    assert kwargs["event_type"] == AuditEventType.AGENT_REGISTERED
+    assert kwargs["details"]["visibility"] == "test"
+    assert kwargs["details"]["public_broadcast_eligible"] is False

--- a/tests/routes/test_monitoring_analytics_routes.py
+++ b/tests/routes/test_monitoring_analytics_routes.py
@@ -15,13 +15,21 @@ covered by `tests/monitoring/`. The point here is to guard against another
 "route calls a method that doesn't exist" regression.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from acn.api import app
-from acn.routes.dependencies import get_analytics, get_metrics, limiter, verify_internal_token
+from acn.monitoring.audit import AuditEvent, AuditEventType, AuditLevel
+from acn.routes.dependencies import (
+    get_analytics,
+    get_audit,
+    get_metrics,
+    limiter,
+    verify_internal_token,
+)
 
 # -----------------------------------------------------------------------------
 # Fixtures
@@ -116,7 +124,53 @@ def stub_analytics() -> AsyncMock:
 
 
 @pytest.fixture
-def client(stub_metrics: AsyncMock, stub_analytics: AsyncMock):
+def stub_audit() -> AsyncMock:
+    """A stub AuditLogger exposing only the public-feed query used by routes."""
+    a = AsyncMock()
+    a.query_public_broadcast_events = AsyncMock(
+        return_value=[
+            AuditEvent(
+                id="e-agent",
+                timestamp=datetime.now(UTC),
+                event_type=AuditEventType.AGENT_REGISTERED,
+                level=AuditLevel.INFO,
+                target_id="agent-1",
+                target_type="agent",
+                details={
+                    "public_broadcast_eligible": True,
+                    "source": "join",
+                    "internal_note": "must-not-leak",
+                },
+            ),
+            AuditEvent(
+                id="e-subnet",
+                timestamp=datetime.now(UTC),
+                event_type=AuditEventType.SUBNET_CREATED,
+                level=AuditLevel.INFO,
+                target_id="subnet-1",
+                target_type="subnet",
+                details={
+                    "public_broadcast_eligible": True,
+                    "join_policy": "open",
+                    "is_private": False,
+                },
+            ),
+            AuditEvent(
+                id="e-hidden",
+                timestamp=datetime.now(UTC),
+                event_type=AuditEventType.POLICY_CHANGED,
+                level=AuditLevel.INFO,
+                target_id="agent-2",
+                target_type="agent",
+                details={"public_broadcast_eligible": True},
+            ),
+        ]
+    )
+    return a
+
+
+@pytest.fixture
+def client(stub_metrics: AsyncMock, stub_analytics: AsyncMock, stub_audit: AsyncMock):
     """TestClient with dependencies overridden and rate limiter disabled.
 
     We override the *dependency functions* (not the underlying singletons)
@@ -131,6 +185,7 @@ def client(stub_metrics: AsyncMock, stub_analytics: AsyncMock):
 
     app.dependency_overrides[get_metrics] = lambda: stub_metrics
     app.dependency_overrides[get_analytics] = lambda: stub_analytics
+    app.dependency_overrides[get_audit] = lambda: stub_audit
     # Internal token is checked via verify_internal_token — override to no-op.
     app.dependency_overrides[verify_internal_token] = lambda: None
 
@@ -203,6 +258,60 @@ class TestMonitoringRoutes:
         stub_analytics.get_dashboard_data.assert_awaited_once()
         # metrics is not involved in dashboard anymore
         stub_metrics.get_all_metrics.assert_not_called()
+
+    def test_public_system_events_returns_fixed_redacted_schema(
+        self, client: TestClient, stub_audit: AsyncMock
+    ):
+        r = client.get("/api/v1/public/system-events")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 2
+        assert body["limit"] == 100
+        assert body["offset"] == 0
+        assert [item["event_type"] for item in body["items"]] == ["agent_registered", "subnet_created"]
+        assert body["items"][0]["agent_id"] == "agent-1"
+        assert "internal_note" not in body["items"][0]
+        assert "actor_id" not in body["items"][0]
+        assert "source_ip" not in body["items"][0]
+        assert body["items"][1]["subnet_id"] == "subnet-1"
+        assert "is_private" not in body["items"][1]
+        stub_audit.query_public_broadcast_events.assert_awaited_once_with(
+            event_types=None,
+            limit=100,
+            offset=0,
+        )
+
+    def test_public_system_events_maps_event_type_filter(
+        self, client: TestClient, stub_audit: AsyncMock
+    ):
+        stub_audit.query_public_broadcast_events.reset_mock()
+        stub_audit.query_public_broadcast_events.return_value = [
+            AuditEvent(
+                id="e-agent-only",
+                timestamp=datetime.now(UTC),
+                event_type=AuditEventType.AGENT_REGISTERED,
+                level=AuditLevel.INFO,
+                target_id="agent-9",
+                target_type="agent",
+                details={"public_broadcast_eligible": True, "source": "join"},
+            )
+        ]
+
+        r = client.get(
+            "/api/v1/public/system-events",
+            params=[("event_type", "agent_registered"), ("limit", "10"), ("offset", "2")],
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        assert body["items"][0]["event_type"] == "agent_registered"
+        stub_audit.query_public_broadcast_events.assert_awaited_once_with(
+            event_types=[AuditEventType.AGENT_REGISTERED],
+            limit=10,
+            offset=2,
+        )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/routes/test_subnets_create_membership.py
+++ b/tests/routes/test_subnets_create_membership.py
@@ -20,8 +20,7 @@ Tracking: ``docs/adr/0001-subnet-creator-must-be-member.md``.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/routes/test_subnets_create_membership.py
+++ b/tests/routes/test_subnets_create_membership.py
@@ -21,11 +21,13 @@ Tracking: ``docs/adr/0001-subnet-creator-must-be-member.md``.
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from acn.api import app
+from acn.monitoring.audit import AuditEventType
 from acn.routes.dependencies import (
     get_agent_service,
     get_subnet_service,
@@ -192,3 +194,54 @@ class TestCreateSubnetMembership:
         assert 400 <= r.status_code < 500
         stub_subnet_service.create_subnet.assert_not_awaited()
         stub_agent_service.join_subnet.assert_not_awaited()
+
+    def test_create_public_subnet_emits_subnet_created_audit(
+        self, stub_agent_service, stub_subnet_service
+    ):
+        _wire(stub_agent_service, stub_subnet_service)
+        with (
+            patch("acn.routes.subnets.get_audit_singleton", return_value=object()),
+            patch("acn.routes.subnets.fire_and_forget_event") as fire,
+            TestClient(app) as client,
+        ):
+            r = client.post(
+                "/api/v1/subnets",
+                headers={"Authorization": "Bearer owner-key"},
+                json={"name": "Demo Subnet", "slug": _EXPLICIT_SUBNET_ID},
+            )
+
+        assert r.status_code == 200, r.text
+        fire.assert_called_once()
+        kwargs = fire.call_args.kwargs
+        assert kwargs["event_type"] == AuditEventType.SUBNET_CREATED
+        assert kwargs["target_id"] == _EXPLICIT_SUBNET_ID
+        assert kwargs["details"]["is_private"] is False
+
+    def test_create_private_subnet_skips_subnet_created_audit(
+        self, stub_agent_service, stub_subnet_service
+    ):
+        async def _private_create(**kwargs):
+            sn = _make_subnet_mock(slug=kwargs["slug"], owner=kwargs["owner"])
+            sn.is_private = True
+            sn.join_policy = "approval"
+            return sn
+
+        stub_subnet_service.create_subnet = AsyncMock(side_effect=_private_create)
+        _wire(stub_agent_service, stub_subnet_service)
+        with (
+            patch("acn.routes.subnets.get_audit_singleton", return_value=object()),
+            patch("acn.routes.subnets.fire_and_forget_event") as fire,
+            TestClient(app) as client,
+        ):
+            r = client.post(
+                "/api/v1/subnets",
+                headers={"Authorization": "Bearer owner-key"},
+                json={
+                    "name": "Private Subnet",
+                    "slug": _EXPLICIT_SUBNET_ID,
+                    "is_private": True,
+                },
+            )
+
+        assert r.status_code == 200, r.text
+        fire.assert_not_called()

--- a/tests/routes/test_subnets_create_membership.py
+++ b/tests/routes/test_subnets_create_membership.py
@@ -215,8 +215,9 @@ class TestCreateSubnetMembership:
         assert kwargs["event_type"] == AuditEventType.SUBNET_CREATED
         assert kwargs["target_id"] == _EXPLICIT_SUBNET_ID
         assert kwargs["details"]["is_private"] is False
+        assert kwargs["details"]["public_broadcast_eligible"] is True
 
-    def test_create_private_subnet_skips_subnet_created_audit(
+    def test_create_private_subnet_emits_internal_audit_but_marks_non_public(
         self, stub_agent_service, stub_subnet_service
     ):
         async def _private_create(**kwargs):
@@ -243,4 +244,8 @@ class TestCreateSubnetMembership:
             )
 
         assert r.status_code == 200, r.text
-        fire.assert_not_called()
+        fire.assert_called_once()
+        kwargs = fire.call_args.kwargs
+        assert kwargs["event_type"] == AuditEventType.SUBNET_CREATED
+        assert kwargs["details"]["is_private"] is True
+        assert kwargs["details"]["public_broadcast_eligible"] is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implement dual-track system event semantics for lifecycle actions:
- `POST /api/v1/agents/join` now always emits `agent_registered` into internal audit, and attaches `details.public_broadcast_eligible` (`true` only for `visibility=real`).
- `POST /api/v1/subnets` now always emits `subnet_created` into internal audit, and attaches `details.public_broadcast_eligible` (`true` only for public subnets).

Add downstream-safe public-feed helpers in `AuditLogger`:
- `is_public_broadcast_eligible(event)` with strict boolean gate (`is True`).
- `query_public_broadcast_events(...)` to centralize eligibility filtering + pagination.
- `to_public_broadcast_payload(event)` to emit a fixed whitelist schema for public channels (`agent_registered` and `subnet_created` only), preventing sensitive field leakage.
- `publish_public_system_event(event)` for realtime fan-out to WS channel `broadcast:system-events` using payloads from the same fixed schema.

Expose an open, read-only public feed endpoint:
- `GET /api/v1/public/system-events`
- Supports `event_type` filter (`agent_registered`, `subnet_created`), `limit`, and `offset`.
- Returns redacted fixed-schema payloads only (`items`, `count`, `limit`, `offset`).

Realtime channel wiring:
- `AuditLogger.log_event` now invokes best-effort public WS publish **after** persistence succeeds.
- Channel: `acn:ws:broadcast:system-events`
- Message shape: `{ "type": "public_system_event", "event": <fixed schema payload> }`
- Publish failures are swallowed/logged so audit writes remain authoritative and non-blocking for callers.

Updated regression tests pin both producer and consumer contracts:
- join: real visibility => eligible=true; test visibility => eligible=false (still audited).
- subnet create: public => eligible=true; private => eligible=false (still audited).
- public-feed query: strict bool filtering + event_type + offset/limit behavior.
- public payload serializer: fixed whitelist schema + non-eligible suppression.
- public route: filter mapping + field redaction contract.
- realtime publish: eligible events fan out to WS channel with fixed schema; non-eligible events do not publish.
- end-to-end: real fakeredis pubsub round trip from `AuditLogger.log_event` through `WebSocketManager` to a subscribed fake client; eligible events arrive with fixed schema; non-eligible events never reach the public channel.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Tests (adding or updating tests)
- [ ] 📦 Dependencies (updating dependencies)

## Related Issues

Closes #

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated the documentation (if needed)

## SDK Changes

- [ ] TypeScript SDK (`clients/typescript/`)
- [ ] Python SDK (`clients/python/`)
- [x] N/A - No SDK changes

## Screenshots (if applicable)

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

