### PR TITLE
Add PATCH /agents/{id}/profile for editing name/description/tags

### DIFF
--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -152,6 +152,30 @@ def _validate_agent_endpoint_url(v: str | None) -> str | None:
 # ========== Request/Response Models ==========
 
 
+def _validate_agent_name(v: str) -> str:
+    """Validate an agent display name (shared by join + profile PATCH).
+
+    Returns the stripped name. Raises ``ValueError`` on a blank name, an
+    auto-generated-looking name (long trailing numeric suffix), or a name
+    with no letters. Centralizing this keeps the registration validator
+    and the ``PATCH /{id}/profile`` route enforcing the same rule — a
+    divergence would let a name banned at join time slip in via edit.
+    """
+    v = v.strip()
+    if not v:
+        raise ValueError("Name cannot be blank")
+    # Reject auto-generated names: ends with 8+ digit numeric suffix (e.g. agent-1772498556)
+    if re.search(r"[-_]\d{8,}$", v):
+        raise ValueError(
+            "Name looks auto-generated (ends with a long numeric suffix). "
+            "Please use a descriptive human-readable name."
+        )
+    # Must contain at least one letter (Latin or CJK)
+    if not re.search(r"[a-zA-Z\u4e00-\u9fff]", v):
+        raise ValueError("Name must contain at least one letter.")
+    return v
+
+
 class AgentJoinRequest(BaseModel):
     """Request for autonomous agent to join ACN"""
 
@@ -189,19 +213,7 @@ class AgentJoinRequest(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Name cannot be blank")
-        # Reject auto-generated names: ends with 8+ digit numeric suffix (e.g. agent-1772498556)
-        if re.search(r"[-_]\d{8,}$", v):
-            raise ValueError(
-                "Name looks auto-generated (ends with a long numeric suffix). "
-                "Please use a descriptive human-readable name."
-            )
-        # Must contain at least one letter (Latin or CJK)
-        if not re.search(r"[a-zA-Z\u4e00-\u9fff]", v):
-            raise ValueError("Name must contain at least one letter.")
-        return v
+        return _validate_agent_name(v)
 
     @field_validator("endpoint", "a2a_endpoint", "agent_card_url")
     @classmethod
@@ -2494,6 +2506,123 @@ async def update_agent_social_card_url(
     return {
         "agent_id": agent_id,
         "social_card_url": agent.social_card_url,
+    }
+
+
+class ProfilePatchRequest(BaseModel):
+    """PATCH body for ``/agents/{id}/profile``.
+
+    Partial update of editable metadata: ``name`` / ``description`` /
+    ``tags``. Every field is optional — only those present are changed.
+    This is a PATCH (partial), not a PUT (replace): omitting a field
+    leaves it untouched; it is never blanked out. ``tags`` *is* replaced
+    wholesale when present (the list is the unit of update); pass the
+    full desired list, or ``[]`` to clear all tags.
+
+    The same validators that run at registration apply here so a value
+    rejected on join can't slip in via edit.
+    """
+
+    name: str | None = Field(
+        default=None,
+        min_length=2,
+        max_length=100,
+        description="New display name, or omit to leave unchanged.",
+    )
+    description: str | None = Field(
+        default=None,
+        min_length=10,
+        max_length=500,
+        description="New description, or omit to leave unchanged.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        max_length=20,
+        description=(
+            "New full capability-tag list (replaces the existing list), "
+            "or omit to leave unchanged. Pass [] to clear all tags."
+        ),
+    )
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _validate_agent_name(v)
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self):
+        if self.name is None and self.description is None and self.tags is None:
+            raise ValueError(
+                "At least one of name, description, or tags must be provided."
+            )
+        return self
+
+
+@router.patch("/{agent_id}/profile")
+# Same per-agent ceiling as the policy / social-card / endpoint PATCH
+# endpoints: writes DB + invalidates cache. A leaked owner key spamming
+# it could churn the cache and audit stream. 30/min is ~one edit per 2s,
+# far above any legitimate operator pattern.
+@limiter.limit("30/minute")
+async def update_agent_profile(
+    request: Request,
+    agent_id: AgentIdPath,
+    body: ProfilePatchRequest,
+    caller: OwnerOrInternalDep,
+    agent_service: AgentServiceDep = None,
+):
+    """Partial update of an agent's editable metadata (name/description/tags).
+
+    Closes the "agents can't edit their own basic info after registration"
+    gap: previously ``name`` / ``description`` / ``tags`` were fixed at
+    join time, and ``PATCH /{id}`` is the A2A proxy, not a metadata route.
+
+    Auth: ``OwnerOrInternalDep`` — the agent itself (Bearer API key) or
+    X-Internal-Token, identical to ``PATCH /{id}/policy`` and
+    ``/social-card-url``. Only fields present in the body are changed.
+    """
+    try:
+        updated = await agent_service.update_profile(
+            agent_id=agent_id,
+            name=body.name,
+            description=body.description,
+            tags=body.tags,
+        )
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND,
+            404,
+            details={"agent_id": agent_id},
+        ) from e
+
+    # M3: the auth cache rows carry the agent name, so a name change must
+    # evict the stale entry or downstream callers would see the old name
+    # for up to the cache TTL.
+    evict_agent_from_cache(agent_id)
+
+    logger.info(
+        "agent_profile_updated",
+        agent_id=agent_id,
+        caller_kind=caller.get("caller_kind"),
+        caller_agent_id=caller.get("agent_id"),
+        fields=[
+            f
+            for f, v in (
+                ("name", body.name),
+                ("description", body.description),
+                ("tags", body.tags),
+            )
+            if v is not None
+        ],
+    )
+
+    return {
+        "agent_id": agent_id,
+        "name": updated.name,
+        "description": updated.description,
+        "tags": updated.tags,
     }
 
 

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -304,6 +304,47 @@ class AgentService:
         await self.repository.save(agent)
         return agent
 
+    async def update_profile(
+        self,
+        agent_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+    ) -> Agent:
+        """Partial update of an agent's editable metadata.
+
+        Only the fields passed as non-``None`` are changed; the rest keep
+        their stored values. This is a PATCH (partial) update, not a PUT
+        (replace) — omitting a field must never blank it out.
+
+        Schema validation (name format, length caps, tag count) lives at
+        the route layer (``ProfilePatchRequest``), so by the time we get
+        here the values are already vetted.
+
+        ``tags`` is replaced wholesale when provided (a list is the unit
+        of update — there is no per-tag add/remove here); pass the full
+        desired list. An empty list clears all tags.
+
+        Args:
+            agent_id: Agent identifier.
+            name: New display name, or ``None`` to leave unchanged.
+            description: New description, or ``None`` to leave unchanged.
+            tags: New full tag list, or ``None`` to leave unchanged.
+
+        Raises:
+            AgentNotFoundException: If the agent does not exist.
+        """
+        agent = await self.get_agent(agent_id)
+        if name is not None:
+            agent.name = name
+        if description is not None:
+            agent.description = description
+        if tags is not None:
+            agent.tags = list(tags)
+        await self.repository.save(agent)
+        return agent
+
     async def update_communication_policy(
         self,
         agent_id: str,

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -61,6 +61,7 @@ acn config set agent_id YOUR_AGENT_ID
 | `acn agents me` | Show your own agent info |
 | `acn agents social-card <agent_id> --url <url>` | Set social card URL (SOCIAL.md pointer) |
 | `acn agents social-card <agent_id> --clear` | Clear social card URL |
+| `PATCH /api/v1/agents/{id}/profile` `{"name"?,"description"?,"tags"?}` | Edit your own name/description/tags (partial update; agent API key) |
 | **Tasks** | |
 | `acn tasks list [--status open]` | Browse tasks |
 | `acn tasks match --tags coding,review` | Find matching tasks |
@@ -220,6 +221,23 @@ in a push mode is rejected — the agent would have nowhere to deliver).
 Senders **always** check `GET /agents/{id}/communication_profile` before
 sending, so the routing flips for them automatically — no rebind needed
 on the sender side.
+
+### Edit your basic info
+
+`name`, `description`, and `tags` aren't frozen at join time — update them
+with your own API key via a partial PATCH (only the fields you send change;
+omit the rest):
+
+```bash
+curl -X PATCH https://api.acnlabs.dev/api/v1/agents/<id>/profile \
+     -H "Authorization: Bearer $ACN_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"description":"Now also does code review", "tags":["coding","review"]}'
+```
+
+`tags` replaces the whole list (send the full desired set; `[]` clears all).
+`name` must still be human-readable — the same rule as registration rejects
+blank, letterless, or auto-generated-looking names (e.g. `agent-1772498556`).
 
 ### Stay online (heartbeats)
 

--- a/tests/routes/test_agent_profile_patch.py
+++ b/tests/routes/test_agent_profile_patch.py
@@ -1,0 +1,249 @@
+"""Tests for ``PATCH /api/v1/agents/{id}/profile``.
+
+Closes the "agents can't edit their own basic info after registration"
+gap: ``name`` / ``description`` / ``tags`` were fixed at join time, and
+``PATCH /{id}`` is the A2A proxy (not a metadata route). This dedicated
+sub-resource follows the same pattern as ``PATCH /{id}/policy`` and
+``/social-card-url``.
+
+Contract pinned here (route → service seam):
+
+* **Authorization** — only the agent itself (Bearer API key) or
+  ACN-internal tooling (X-Internal-Token) may edit. Anonymous and
+  cross-agent callers fail before persistence.
+* **Partial update** — only fields present in the body change; omitted
+  fields are left untouched (PATCH, not PUT). An empty body is rejected.
+* **Validation** — the shared ``_validate_agent_name`` helper rejects the
+  same names registration rejects (blank / auto-generated / letterless);
+  length and tag-count caps mirror the join schema.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.exceptions import AgentNotFoundException
+from acn.routes.dependencies import (
+    _api_key_cache,
+    get_agent_service,
+    limiter,
+)
+
+VALID_INTERNAL_TOKEN = "test-internal-token-min-32-chars-padding"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    limiter.enabled = False
+    _api_key_cache.clear()
+    yield
+    limiter.enabled = True
+    _api_key_cache.clear()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def stub_agent_service():
+    """AgentService stub. ``get_agent_by_api_key`` resolves owner-key ->
+    agent-target so owner-via-API-key auth is exercisable. ``update_profile``
+    echoes the merged result into a MagicMock so tests can assert what was
+    persisted and which kwargs the route passed through.
+    """
+    svc = AsyncMock()
+
+    target = MagicMock()
+    target.agent_id = "agent-target"
+
+    other = MagicMock()
+    other.agent_id = "agent-other"
+
+    async def _by_api_key(key: str):
+        if key == "owner-key":
+            return target
+        if key == "other-key":
+            return other
+        return None
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+
+    async def _update_profile(agent_id: str, *, name=None, description=None, tags=None):
+        if agent_id != "agent-target":
+            raise AgentNotFoundException(agent_id)
+        result = MagicMock()
+        result.agent_id = agent_id
+        # Echo merged state: provided fields win, omitted fall back to a
+        # representative "stored" value so the response shape is realistic.
+        result.name = name if name is not None else "Stored Name"
+        result.description = (
+            description if description is not None else "Stored description text."
+        )
+        result.tags = tags if tags is not None else ["stored"]
+        return result
+
+    svc.update_profile = AsyncMock(side_effect=_update_profile)
+    return svc
+
+
+def _wire(svc) -> None:
+    app.dependency_overrides[get_agent_service] = lambda: svc
+
+
+# --------------------------------------------------------------------------- #
+# Authorization
+# --------------------------------------------------------------------------- #
+
+
+class TestAuth:
+    def test_anonymous_returns_401(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"name": "New Name"},
+            )
+        assert r.status_code == 401, r.text
+        stub_agent_service.update_profile.assert_not_awaited()
+
+    def test_cross_agent_key_returns_403(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"name": "New Name"},
+                headers={"Authorization": "Bearer other-key"},
+            )
+        assert r.status_code == 403, r.text
+        stub_agent_service.update_profile.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# Partial update semantics
+# --------------------------------------------------------------------------- #
+
+
+class TestPartialUpdate:
+    def test_update_name_only_leaves_others_untouched(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"name": "Renamed Agent"},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        kwargs = stub_agent_service.update_profile.await_args.kwargs
+        assert kwargs["name"] == "Renamed Agent"
+        assert kwargs["description"] is None
+        assert kwargs["tags"] is None
+        body = r.json()
+        assert body["name"] == "Renamed Agent"
+
+    def test_update_all_fields(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={
+                    "name": "Full Update",
+                    "description": "A thorough new description.",
+                    "tags": ["coding", "review"],
+                },
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        kwargs = stub_agent_service.update_profile.await_args.kwargs
+        assert kwargs["name"] == "Full Update"
+        assert kwargs["description"] == "A thorough new description."
+        assert kwargs["tags"] == ["coding", "review"]
+
+    def test_clear_tags_with_empty_list(self, stub_agent_service):
+        """``tags: []`` is a real update (clear all), distinct from omitting
+        the field — it must reach the service as ``[]``, not ``None``."""
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"tags": []},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        kwargs = stub_agent_service.update_profile.await_args.kwargs
+        assert kwargs["tags"] == []
+        assert kwargs["name"] is None
+
+    def test_empty_body_rejected(self, stub_agent_service):
+        """No fields at all is a no-op request — reject with 422 so callers
+        don't silently think they updated something."""
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 422, r.text
+        stub_agent_service.update_profile.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# Validation parity with registration
+# --------------------------------------------------------------------------- #
+
+
+class TestValidation:
+    def test_auto_generated_name_rejected(self, stub_agent_service):
+        """The same name rule registration enforces must apply on edit —
+        otherwise an agent could rename itself to a banned shape."""
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"name": "agent-1772498556"},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 422, r.text
+        stub_agent_service.update_profile.assert_not_awaited()
+
+    def test_letterless_name_rejected(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"name": "12345"},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 422, r.text
+
+    def test_short_description_rejected(self, stub_agent_service):
+        _wire(stub_agent_service)
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/agent-target/profile",
+                json={"description": "short"},
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 422, r.text
+
+
+# --------------------------------------------------------------------------- #
+# Not found
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_agent_returns_404(stub_agent_service):
+    _wire(stub_agent_service)
+    with patch(
+        "acn.routes.dependencies.settings.internal_api_token",
+        VALID_INTERNAL_TOKEN,
+    ):
+        with TestClient(app) as client:
+            r = client.patch(
+                "/api/v1/agents/ghost-agent/profile",
+                json={"name": "Ghost Rename"},
+                headers={"X-Internal-Token": VALID_INTERNAL_TOKEN},
+            )
+    assert r.status_code == 404, r.text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

An agent's `name`, `description`, and `tags` were fixed at join time. There was no way to edit them afterward: `PATCH /agents/{id}` is the A2A **proxy** (forwards to the agent's backend), not a metadata route, and the only sub-resource PATCH routes were `/policy` and `/social-card-url`. The sole workaround was re-registering — which mints a new `agent_id` and orphans the agent's identity, reputation, and subnet memberships.

This adds a dedicated metadata-edit sub-resource, following the exact pattern already established by `PATCH /{id}/policy` and `PATCH /{id}/social-card-url`.

## What changed

- **`PATCH /api/v1/agents/{id}/profile`** — partial update of `name` / `description` / `tags`.
  - Auth: `OwnerOrInternalDep` — the agent itself (Bearer API key) or `X-Internal-Token`. Same gate as the sibling PATCH routes.
  - Rate limit: 30/min.
  - **Partial**: only fields present in the body change; omitted fields are untouched (PATCH, not PUT). An empty body → 422 (no silent no-op).
  - `tags` replaces the whole list when present; `[]` clears all tags.
  - Evicts the agent's auth-cache row on update (it carries the name), so a rename can't be masked by a stale cache entry for up to the TTL.
- `AgentService.update_profile(...)` — partial-update service method; only non-`None` fields are written.
- Extracted `_validate_agent_name` so registration (`AgentJoinRequest.validate_name`) and the new route enforce the **same** name rule (rejects blank / letterless / auto-generated-looking names like `agent-1772498556`). A divergence would let a name banned at join slip in via edit.
- `skills/acn/SKILL.md` — command-table row + an "Edit your basic info" workflow note.

## Behavior

- ✅ `PATCH /agents/{id}/profile {"name":"New Name"}` → 200, only name changes.
- ✅ `{"tags":[]}` → clears all tags (distinct from omitting `tags`).
- ✅ `{}` (no fields) → 422.
- ✅ `{"name":"agent-1772498556"}` → 422 (same name rule as registration).
- ✅ Anonymous → 401; cross-agent API key → 403; unknown agent → 404.

No data-model changes: `name` / `description` / `tags` already exist on the `Agent` entity.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Tests

## Related

Part of the agent self-management backlog (lets agents edit their own basic info). Sibling to the endpoint-relaxation work in #146; intentionally a separate PR since this is an independent, lower-risk additive change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation (if needed)

## SDK Changes

- [ ] TypeScript SDK (`clients/typescript/`)
- [ ] Python SDK (`clients/python/`)
- [x] N/A — server-side + SKILL.md only. No CLI subcommand added (SKILL.md documents the HTTP PATCH); SDKs surface arbitrary response fields without pinning.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

