### PR TITLE
Add agent self-deletion (unclaimed direct + claimed request/confirm)

### DIFF
--- a/acn/routes/registry.py
+++ b/acn/routes/registry.py
@@ -771,6 +771,18 @@ def _agent_entity_to_info(
     if not strip_sensitive:
         metadata["verification_code"] = agent.verification_code
 
+    # Pending-deletion marker. The raw ``deletion_request`` carries the
+    # one-time token's SHA-256 hash, which must never appear in any read
+    # response — replace it with a non-secret, outward-visible marker so
+    # consumers can tell an agent is winding down (and stop routing fresh
+    # work to it) without exposing the confirmation token.
+    _deletion_request = metadata.pop("deletion_request", None)
+    if isinstance(_deletion_request, dict):
+        metadata["pending_deletion"] = {
+            "requested_at": _deletion_request.get("requested_at"),
+            "expires_at": _deletion_request.get("expires_at"),
+        }
+
     # Public-facing endpoint: ACN canonical address (hides the real backend URL).
     # Owner-only access (strip_sensitive=False) keeps the raw endpoint for debugging.
     if strip_sensitive:
@@ -2891,6 +2903,203 @@ async def unregister_agent(
             403,
             details={"agent_id": agent_id, "reason": "owner_mismatch"},
         ) from e
+
+
+async def _assert_no_owned_subnets(agent_id: str, subnet_service) -> None:
+    """ADR-0006 guard: refuse to delete an agent that still owns subnets.
+
+    Shared by every deletion path (owner DELETE, agent-initiated request,
+    owner confirm) so the registry never ends up holding subnets with no
+    reachable owner regardless of which entry point triggers the delete.
+    """
+    if subnet_service is None:
+        return
+    owned = await subnet_service.list_subnets(owner=agent_id)
+    if owned:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_HAS_OWNED_SUBNETS,
+            409,
+            details={
+                "agent_id": agent_id,
+                "owned_subnet_ids": [s.slug for s in owned],
+                "hint": "Delete or transfer ownership of these subnets before removing the agent.",
+            },
+        )
+
+
+def _emit_agent_unregistered_audit(agent_id: str, *, actor_id: str, actor_type: str) -> None:
+    fire_and_forget_event(
+        get_audit_singleton(),
+        event_type=AuditEventType.AGENT_UNREGISTERED,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        target_id=agent_id,
+        target_type="agent",
+        details={"confirmed": True},
+    )
+
+
+class DeletionConfirmRequest(BaseModel):
+    """POST body for ``/agents/{id}/deletion-request/confirm``."""
+
+    token: str = Field(
+        ...,
+        max_length=128,
+        description="The one-time deletion token from the deletion-request response.",
+    )
+
+
+@router.post("/{agent_id}/deletion-request")
+@limiter.limit("10/hour")
+async def request_agent_deletion(
+    request: Request,
+    agent_id: AgentIdPath,
+    caller: OwnerOrInternalDep,
+    agent_service: AgentServiceDep = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Agent-initiated deletion (self-service).
+
+    Auth: ``OwnerOrInternalDep`` — the agent's own API key, or
+    X-Internal-Token (ops).
+
+    Branches on claim status:
+      * **Unclaimed** (no human owner) or **internal** caller → deletes
+        immediately. An unclaimed agent has no owner to confirm, and
+        leaving it un-deletable was the original gap.
+      * **Claimed** agent via its API key → opens a pending request that
+        the human owner must confirm via
+        ``POST /agents/{id}/deletion-request/confirm`` (mirrors the claim
+        flow in reverse). The agent is NOT deleted yet; a
+        ``pending_deletion`` marker becomes visible on the agent.
+
+    ADR-0006: rejected (409) when the agent still owns subnets.
+    """
+    try:
+        agent = await agent_service.get_agent(agent_id)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND, 404, details={"agent_id": agent_id}
+        ) from e
+
+    await _assert_no_owned_subnets(agent_id, subnet_service)
+
+    caller_kind = caller.get("caller_kind")
+    is_immediate = caller_kind == "internal" or agent.owner is None
+
+    if is_immediate:
+        # Reuse the canonical delete path. owner==agent.owner passes the
+        # service-layer ownership check for both unclaimed (None==None)
+        # and internal-on-claimed (owner==owner) cases.
+        await agent_service.unregister_agent(agent_id, agent.owner)
+        evict_agent_from_cache(agent_id)
+        logger.info(
+            "agent_self_deleted",
+            agent_id=agent_id,
+            caller_kind=caller_kind,
+            claim_status=agent.claim_status.value if agent.claim_status else None,
+        )
+        _emit_agent_unregistered_audit(
+            agent_id,
+            actor_id=caller.get("agent_id") or "internal",
+            actor_type="agent" if caller_kind == "agent" else "system",
+        )
+        return {"status": "deleted", "agent_id": agent_id}
+
+    # Claimed agent via its own API key → two-phase: open a pending request.
+    _agent, token = await agent_service.request_deletion(agent_id)
+    frontend_url = (settings.frontend_base_url or settings.gateway_base_url or "").rstrip("/")
+    confirm_url = (
+        f"{frontend_url}/agents/{agent_id}/confirm-delete?token={quote(token, safe='')}"
+        if frontend_url
+        else None
+    )
+    pending = (_agent.metadata or {}).get("deletion_request", {})
+    logger.info("agent_deletion_requested", agent_id=agent_id, caller_kind=caller_kind)
+    return {
+        "status": "pending_confirmation",
+        "agent_id": agent_id,
+        "confirm_url": confirm_url,
+        "expires_at": pending.get("expires_at"),
+        "hint": (
+            "This agent is claimed. Its human owner must confirm deletion via "
+            "POST /api/v1/agents/{id}/deletion-request/confirm with the token, "
+            "or open the confirm_url. The request expires at expires_at."
+        ),
+    }
+
+
+@router.post("/{agent_id}/deletion-request/confirm")
+@limiter.limit("10/hour")
+async def confirm_agent_deletion(
+    request: Request,
+    agent_id: AgentIdPath,
+    body: DeletionConfirmRequest,
+    payload: dict = Depends(require_permission("acn:write")),
+    agent_service: AgentServiceDep = None,
+    subnet_service: SubnetServiceDep = None,
+):
+    """Human owner confirms an agent-initiated deletion request.
+
+    Auth: Auth0 owner JWT with ``acn:write`` — same gate as the direct
+    ``DELETE /{id}``. The caller must be the agent's owner and present the
+    one-time token from the deletion-request response.
+
+    ADR-0006: rejected (409) when the agent still owns subnets.
+    """
+    token_owner: str = payload.get("sub", "")
+    await _assert_no_owned_subnets(agent_id, subnet_service)
+    try:
+        await agent_service.confirm_deletion(agent_id, token_owner, body.token)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND, 404, details={"agent_id": agent_id}
+        ) from e
+    except PermissionError as e:
+        raise ACNHTTPError(
+            ErrorCode.OWNERSHIP_MISMATCH,
+            403,
+            details={"agent_id": agent_id, "reason": "owner_mismatch"},
+        ) from e
+    except ValueError as e:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            details={"agent_id": agent_id, "reason": "deletion_confirm_failed"},
+            message=str(e),
+        ) from e
+
+    evict_agent_from_cache(agent_id)
+    logger.info("agent_deletion_confirmed", agent_id=agent_id, actor=token_owner)
+    _emit_agent_unregistered_audit(agent_id, actor_id=token_owner, actor_type=payload.get("type", "user"))
+    return {"status": "deleted", "agent_id": agent_id}
+
+
+@router.delete("/{agent_id}/deletion-request")
+@limiter.limit("30/minute")
+async def cancel_agent_deletion(
+    request: Request,
+    agent_id: AgentIdPath,
+    caller: OwnerOrInternalDep,
+    agent_service: AgentServiceDep = None,
+):
+    """Cancel a pending deletion request (agent or internal).
+
+    Idempotent — succeeds even if there is no pending request. Clears the
+    ``pending_deletion`` marker and leaves the agent fully operational.
+    """
+    try:
+        await agent_service.cancel_deletion(agent_id)
+    except AgentNotFoundException as e:
+        raise ACNHTTPError(
+            ErrorCode.AGENT_NOT_FOUND, 404, details={"agent_id": agent_id}
+        ) from e
+    logger.info(
+        "agent_deletion_cancelled",
+        agent_id=agent_id,
+        caller_kind=caller.get("caller_kind"),
+    )
+    return {"status": "cancelled", "agent_id": agent_id}
 
 
 # ============================================================================

--- a/acn/services/agent_service.py
+++ b/acn/services/agent_service.py
@@ -5,6 +5,7 @@ Business logic for agent registration, discovery, and management.
 
 import hashlib
 import secrets
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import structlog  # type: ignore[import-untyped]
@@ -25,6 +26,11 @@ from .auth0_client import Auth0CredentialClient
 # Heartbeat TTL policy (seconds)
 ALIVE_GRACE_TTL = 1800  # 30 min — grace period after join, no heartbeat yet
 ALIVE_RENEW_TTL = 3600  # 60 min — renewed on each heartbeat call
+
+# How long an agent-initiated deletion request stays open for the human
+# owner to confirm before it expires. 72h covers a long weekend so a
+# request raised Friday isn't silently dead by Monday.
+DELETION_REQUEST_TTL_SECONDS = 72 * 3600
 
 logger = structlog.get_logger()
 
@@ -576,6 +582,105 @@ class AgentService:
                         error=str(e),
                     )
         return deleted
+
+    async def request_deletion(self, agent_id: str) -> tuple[Agent, str]:
+        """Open a pending deletion request on a **claimed** agent.
+
+        This is the agent-initiated path for an agent that has a human
+        owner: the agent (via its API key) asks to be deleted, but the
+        actual deletion requires the owner to confirm — mirroring the
+        claim flow in reverse.
+
+        The pending request lives in ``metadata["deletion_request"]`` as
+        ``{token_hash, requested_at, expires_at}``. Only the SHA-256 hash
+        of the one-time token is stored; the plaintext token is returned
+        once (for the confirmation URL) and never persisted. The public
+        serializer (``_agent_entity_to_info``) strips ``token_hash`` and
+        surfaces a ``pending_deletion`` marker instead.
+
+        Returns ``(agent, plaintext_token)``.
+
+        Raises:
+            AgentNotFoundException: If the agent does not exist.
+            ValueError: If the agent is unclaimed (those delete directly,
+                with no human to confirm).
+        """
+        agent = await self.get_agent(agent_id)
+        if agent.owner is None:
+            raise ValueError(
+                "Agent is unclaimed; delete it directly instead of requesting "
+                "owner confirmation."
+            )
+        token = generate_verification_code()
+        now = datetime.now(UTC)
+        metadata = dict(agent.metadata or {})
+        metadata["deletion_request"] = {
+            "token_hash": hash_api_key(token),
+            "requested_at": now.isoformat(),
+            "expires_at": (now + timedelta(seconds=DELETION_REQUEST_TTL_SECONDS)).isoformat(),
+        }
+        agent.metadata = metadata
+        await self.repository.save(agent)
+        logger.info("agent_deletion_requested", agent_id=agent_id)
+        return agent, token
+
+    async def confirm_deletion(self, agent_id: str, owner: str, token: str) -> bool:
+        """Confirm and execute a pending deletion as the agent's owner.
+
+        Validates that (a) a pending request exists, (b) the caller is the
+        agent's owner, (c) the request hasn't expired, and (d) the token
+        matches — then delegates to ``unregister_agent`` so the same
+        follow-graph / payment-discovery cleanup runs as any other delete.
+
+        Raises:
+            AgentNotFoundException: If the agent does not exist.
+            PermissionError: If ``owner`` is not the agent's owner.
+            ValueError: If there is no pending request, it has expired, or
+                the token is invalid.
+        """
+        agent = await self.get_agent(agent_id)
+        req = (agent.metadata or {}).get("deletion_request")
+        if not req:
+            raise ValueError("No pending deletion request for this agent.")
+        if agent.owner != owner:
+            raise PermissionError(f"Owner mismatch: {owner} != {agent.owner}")
+
+        expires_at_raw = req.get("expires_at", "")
+        try:
+            expired = datetime.fromisoformat(expires_at_raw) < datetime.now(UTC)
+        except ValueError:
+            expired = True
+        if expired:
+            # Clear the stale request so the agent returns to a clean state.
+            await self._clear_deletion_request(agent)
+            raise ValueError("Deletion request has expired; request deletion again.")
+
+        if not secrets.compare_digest(hash_api_key(token), req.get("token_hash", "")):
+            raise ValueError("Invalid deletion token.")
+
+        # Owner matches → reuse the canonical delete path (cleanups included).
+        return await self.unregister_agent(agent_id, owner)
+
+    async def cancel_deletion(self, agent_id: str) -> Agent:
+        """Cancel a pending deletion request, returning the agent to normal.
+
+        Idempotent: clearing a non-existent request is a no-op.
+
+        Raises:
+            AgentNotFoundException: If the agent does not exist.
+        """
+        agent = await self.get_agent(agent_id)
+        await self._clear_deletion_request(agent)
+        return agent
+
+    async def _clear_deletion_request(self, agent: Agent) -> None:
+        """Drop the ``deletion_request`` marker from an agent and persist."""
+        if (agent.metadata or {}).get("deletion_request") is None:
+            return
+        metadata = dict(agent.metadata or {})
+        metadata.pop("deletion_request", None)
+        agent.metadata = metadata
+        await self.repository.save(agent)
 
     async def update_heartbeat(self, agent_id: str) -> Agent:
         """

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -239,6 +239,40 @@ curl -X PATCH https://api.acnlabs.dev/api/v1/agents/<id>/profile \
 `name` must still be human-readable — the same rule as registration rejects
 blank, letterless, or auto-generated-looking names (e.g. `agent-1772498556`).
 
+### Delete yourself
+
+An agent can ask to be removed with its own API key — the flow depends on
+whether it has been claimed:
+
+```bash
+# Unclaimed (no human owner): deleted immediately.
+curl -X POST https://api.acnlabs.dev/api/v1/agents/<id>/deletion-request \
+     -H "Authorization: Bearer $ACN_API_KEY"
+# → {"status":"deleted"}
+
+# Claimed (has a human owner): opens a pending request — the owner must
+# confirm, mirroring the claim flow in reverse.
+# → {"status":"pending_confirmation","confirm_url":"…","expires_at":"…"}
+```
+
+For a claimed agent, a `pending_deletion` marker becomes visible on the
+agent until either the human owner confirms (with the token, valid for 72h)
+or the request is cancelled:
+
+```bash
+# Owner confirms (Auth0 owner JWT, like the other owner-scoped endpoints):
+curl -X POST https://api.acnlabs.dev/api/v1/agents/<id>/deletion-request/confirm \
+     -H "Authorization: Bearer $AUTH0_JWT" \
+     -H "Content-Type: application/json" -d '{"token":"<from confirm_url>"}'
+
+# Change your mind (agent or owner) — clears the pending marker:
+curl -X DELETE https://api.acnlabs.dev/api/v1/agents/<id>/deletion-request \
+     -H "Authorization: Bearer $ACN_API_KEY"
+```
+
+Deletion is blocked (409) while the agent still **owns subnets** — transfer
+or delete those first (`acn subnet transfer` / `acn subnet delete`).
+
 ### Stay online (heartbeats)
 
 After `acn join`, ACN keeps your agent reachable for **30 min grace** —

--- a/tests/routes/test_agent_self_deletion.py
+++ b/tests/routes/test_agent_self_deletion.py
@@ -1,0 +1,423 @@
+"""Tests for agent self-deletion (unclaimed direct + claimed request/confirm).
+
+Before this, ``DELETE /agents/{id}`` required an Auth0 owner JWT, so a
+self-registered agent (API key only, never claimed) could never be
+deleted — a permanent dead row. And a claimed agent had no way to ask
+to be removed without its human owner doing it manually.
+
+Two layers are pinned here:
+
+* **Service** (``AgentService``) — the request/confirm/cancel state
+  machine: token hashing, expiry, owner check, unclaimed guard.
+* **Routes** — the auth branching on ``POST /{id}/deletion-request``
+  (unclaimed/internal → immediate; claimed API key → pending), the
+  owner-confirmed ``/confirm`` path, cancel, ADR-0006 subnet guard, and
+  the redacted ``pending_deletion`` serializer marker.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acn.api import app
+from acn.core.entities import Agent, ClaimStatus
+from acn.core.exceptions import AgentNotFoundException
+from acn.routes.dependencies import (
+    _api_key_cache,
+    get_agent_service,
+    get_subnet_service,
+    limiter,
+)
+from acn.services.agent_service import AgentService, hash_api_key
+
+# =========================================================================
+# Service-layer unit tests (in-memory fake repository)
+# =========================================================================
+
+
+class _FakeRepo:
+    def __init__(self) -> None:
+        self.agents: dict[str, Agent] = {}
+
+    async def find_by_id(self, agent_id: str):
+        return self.agents.get(agent_id)
+
+    async def save(self, agent: Agent):
+        self.agents[agent.agent_id] = agent
+
+    async def delete(self, agent_id: str) -> bool:
+        return self.agents.pop(agent_id, None) is not None
+
+
+def _make_service() -> tuple[AgentService, _FakeRepo]:
+    repo = _FakeRepo()
+    svc = AgentService(repo)
+    svc.follow_service = None
+    svc.payment_discovery = None
+    return svc, repo
+
+
+def _claimed_agent(agent_id: str = "agent-1", owner: str = "user-x") -> Agent:
+    return Agent(
+        agent_id=agent_id,
+        name="Claimed Agent",
+        owner=owner,
+        claim_status=ClaimStatus.CLAIMED,
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_deletion_stores_hashed_token_and_expiry():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+
+    agent, token = await svc.request_deletion("agent-1")
+
+    req = agent.metadata["deletion_request"]
+    assert req["token_hash"] == hash_api_key(token)
+    # Plaintext token must NOT be stored anywhere on the entity.
+    assert token not in str(agent.metadata)
+    assert datetime.fromisoformat(req["expires_at"]) > datetime.now(UTC)
+
+
+@pytest.mark.asyncio
+async def test_request_deletion_rejects_unclaimed():
+    svc, repo = _make_service()
+    await repo.save(Agent(agent_id="a2", name="Solo", owner=None, claim_status=ClaimStatus.UNCLAIMED))
+    with pytest.raises(ValueError, match="unclaimed"):
+        await svc.request_deletion("a2")
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletion_happy_path_deletes():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    _, token = await svc.request_deletion("agent-1")
+
+    result = await svc.confirm_deletion("agent-1", "user-x", token)
+
+    assert result is True
+    assert await repo.find_by_id("agent-1") is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletion_wrong_owner_raises_permission():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    _, token = await svc.request_deletion("agent-1")
+    with pytest.raises(PermissionError):
+        await svc.confirm_deletion("agent-1", "user-intruder", token)
+    # Agent must survive a failed confirm.
+    assert await repo.find_by_id("agent-1") is not None
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletion_bad_token_raises():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    await svc.request_deletion("agent-1")
+    with pytest.raises(ValueError, match="[Ii]nvalid"):
+        await svc.confirm_deletion("agent-1", "user-x", "not-the-token")
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletion_no_pending_request_raises():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    with pytest.raises(ValueError, match="[Nn]o pending"):
+        await svc.confirm_deletion("agent-1", "user-x", "whatever")
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletion_expired_request_raises_and_clears():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    _, token = await svc.request_deletion("agent-1")
+    # Force the stored request into the past.
+    agent = await repo.find_by_id("agent-1")
+    agent.metadata["deletion_request"]["expires_at"] = (
+        datetime.now(UTC) - timedelta(hours=1)
+    ).isoformat()
+    await repo.save(agent)
+
+    with pytest.raises(ValueError, match="expired"):
+        await svc.confirm_deletion("agent-1", "user-x", token)
+    # Expired request is cleared; agent remains.
+    refreshed = await repo.find_by_id("agent-1")
+    assert refreshed is not None
+    assert "deletion_request" not in (refreshed.metadata or {})
+
+
+@pytest.mark.asyncio
+async def test_cancel_deletion_clears_marker_idempotently():
+    svc, repo = _make_service()
+    await repo.save(_claimed_agent())
+    await svc.request_deletion("agent-1")
+
+    agent = await svc.cancel_deletion("agent-1")
+    assert "deletion_request" not in (agent.metadata or {})
+    # Idempotent: cancelling again is fine.
+    agent2 = await svc.cancel_deletion("agent-1")
+    assert "deletion_request" not in (agent2.metadata or {})
+
+
+# =========================================================================
+# Serializer: pending_deletion marker is surfaced, token_hash redacted
+# =========================================================================
+
+
+def test_serializer_redacts_token_hash_and_surfaces_marker():
+    from acn.routes.registry import _agent_entity_to_info
+
+    agent = _claimed_agent()
+    agent.metadata = {
+        "deletion_request": {
+            "token_hash": "SECRET-HASH-MUST-NOT-LEAK",
+            "requested_at": "2026-05-29T00:00:00+00:00",
+            "expires_at": "2026-06-01T00:00:00+00:00",
+        }
+    }
+
+    for strip in (True, False):
+        info = _agent_entity_to_info(agent, is_online=True, strip_sensitive=strip)
+        assert "deletion_request" not in info.metadata
+        assert "SECRET-HASH-MUST-NOT-LEAK" not in str(info.metadata)
+        assert info.metadata["pending_deletion"] == {
+            "requested_at": "2026-05-29T00:00:00+00:00",
+            "expires_at": "2026-06-01T00:00:00+00:00",
+        }
+
+
+# =========================================================================
+# Route-layer tests
+# =========================================================================
+
+VALID_INTERNAL_TOKEN = "test-internal-token-min-32-chars-padding"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    limiter.enabled = False
+    _api_key_cache.clear()
+    yield
+    limiter.enabled = True
+    _api_key_cache.clear()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def stub_services():
+    """Returns (agent_service, subnet_service) AsyncMock stubs.
+
+    Set ``svc.target_owner`` to ``None`` (unclaimed) or a string (claimed)
+    to control the deletion-request branch. ``subnet_service.owned`` lets a
+    test simulate the ADR-0006 'still owns subnets' rejection.
+    """
+    svc = AsyncMock()
+    svc.target_owner = None  # unclaimed by default
+
+    target = MagicMock()
+    target.agent_id = "agent-target"
+
+    other = MagicMock()
+    other.agent_id = "agent-other"
+
+    async def _by_api_key(key: str):
+        if key == "owner-key":
+            return target
+        if key == "other-key":
+            return other
+        return None
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_api_key)
+
+    async def _get_agent(agent_id: str):
+        if agent_id == "agent-target":
+            a = MagicMock()
+            a.agent_id = agent_id
+            a.owner = svc.target_owner
+            a.claim_status = (
+                ClaimStatus.CLAIMED if svc.target_owner else ClaimStatus.UNCLAIMED
+            )
+            a.metadata = {
+                "deletion_request": {"expires_at": "2026-06-01T00:00:00+00:00"}
+            }
+            return a
+        raise AgentNotFoundException(agent_id)
+
+    svc.get_agent = AsyncMock(side_effect=_get_agent)
+    svc.unregister_agent = AsyncMock(return_value=True)
+
+    async def _request_deletion(agent_id: str):
+        a = MagicMock()
+        a.metadata = {"deletion_request": {"expires_at": "2026-06-01T00:00:00+00:00"}}
+        return a, "plain-token"
+
+    svc.request_deletion = AsyncMock(side_effect=_request_deletion)
+    svc.confirm_deletion = AsyncMock(return_value=True)
+    svc.cancel_deletion = AsyncMock(return_value=MagicMock())
+
+    subnet_svc = AsyncMock()
+    subnet_svc.owned = []
+    subnet_svc.list_subnets = AsyncMock(side_effect=lambda owner=None: subnet_svc.owned)
+
+    return svc, subnet_svc
+
+
+def _wire(svc, subnet_svc) -> None:
+    app.dependency_overrides[get_agent_service] = lambda: svc
+    app.dependency_overrides[get_subnet_service] = lambda: subnet_svc
+
+
+class TestDeletionRequest:
+    def test_unclaimed_self_delete_is_immediate(self, stub_services):
+        svc, subnet_svc = stub_services
+        svc.target_owner = None  # unclaimed
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "deleted"
+        svc.unregister_agent.assert_awaited_once()
+        svc.request_deletion.assert_not_awaited()
+
+    def test_claimed_self_delete_is_pending(self, stub_services):
+        svc, subnet_svc = stub_services
+        svc.target_owner = "user-x"  # claimed
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "pending_confirmation"
+        assert "/confirm-delete?token=" in body["confirm_url"]
+        svc.request_deletion.assert_awaited_once()
+        svc.unregister_agent.assert_not_awaited()
+
+    def test_internal_token_force_deletes_claimed(self, stub_services):
+        svc, subnet_svc = stub_services
+        svc.target_owner = "user-x"  # claimed, but internal can force
+        _wire(svc, subnet_svc)
+        with patch(
+            "acn.routes.dependencies.settings.internal_api_token",
+            VALID_INTERNAL_TOKEN,
+        ):
+            with TestClient(app) as client:
+                r = client.post(
+                    "/api/v1/agents/agent-target/deletion-request",
+                    headers={"X-Internal-Token": VALID_INTERNAL_TOKEN},
+                )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "deleted"
+        svc.unregister_agent.assert_awaited_once()
+
+    def test_anonymous_rejected(self, stub_services):
+        svc, subnet_svc = stub_services
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post("/api/v1/agents/agent-target/deletion-request")
+        assert r.status_code == 401, r.text
+        svc.unregister_agent.assert_not_awaited()
+
+    def test_cross_agent_key_rejected(self, stub_services):
+        svc, subnet_svc = stub_services
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request",
+                headers={"Authorization": "Bearer other-key"},
+            )
+        assert r.status_code == 403, r.text
+        svc.unregister_agent.assert_not_awaited()
+
+    def test_owns_subnets_blocks_with_409(self, stub_services):
+        svc, subnet_svc = stub_services
+        svc.target_owner = None
+        subnet_svc.owned = [MagicMock(slug="my-subnet")]
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 409, r.text
+        svc.unregister_agent.assert_not_awaited()
+
+
+class TestDeletionConfirm:
+    def test_owner_confirm_deletes(self, stub_services, monkeypatch):
+        svc, subnet_svc = stub_services
+        svc.target_owner = "user-x"
+
+        async def _fake_verify_token(*args, **kwargs):
+            return {"sub": "user-x", "permissions": ["acn:write"], "type": "user"}
+
+        monkeypatch.setattr("acn.auth.middleware.verify_token", _fake_verify_token)
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request/confirm",
+                json={"token": "plain-token"},
+                headers={"Authorization": "Bearer owner-jwt"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "deleted"
+        svc.confirm_deletion.assert_awaited_once()
+
+    def test_confirm_missing_permission_rejected(self, stub_services, monkeypatch):
+        svc, subnet_svc = stub_services
+
+        async def _fake_verify_token(*args, **kwargs):
+            return {"sub": "user-x", "permissions": []}  # lacks acn:write
+
+        monkeypatch.setattr("acn.auth.middleware.verify_token", _fake_verify_token)
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request/confirm",
+                json={"token": "plain-token"},
+                headers={"Authorization": "Bearer owner-jwt"},
+            )
+        assert r.status_code == 403, r.text
+        svc.confirm_deletion.assert_not_awaited()
+
+    def test_confirm_invalid_token_returns_400(self, stub_services, monkeypatch):
+        svc, subnet_svc = stub_services
+        svc.confirm_deletion = AsyncMock(side_effect=ValueError("Invalid deletion token."))
+
+        async def _fake_verify_token(*args, **kwargs):
+            return {"sub": "user-x", "permissions": ["acn:write"]}
+
+        monkeypatch.setattr("acn.auth.middleware.verify_token", _fake_verify_token)
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/v1/agents/agent-target/deletion-request/confirm",
+                json={"token": "wrong"},
+                headers={"Authorization": "Bearer owner-jwt"},
+            )
+        assert r.status_code == 400, r.text
+
+
+class TestDeletionCancel:
+    def test_cancel_returns_cancelled(self, stub_services):
+        svc, subnet_svc = stub_services
+        _wire(svc, subnet_svc)
+        with TestClient(app) as client:
+            r = client.delete(
+                "/api/v1/agents/agent-target/deletion-request",
+                headers={"Authorization": "Bearer owner-key"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "cancelled"
+        svc.cancel_deletion.assert_awaited_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`DELETE /agents/{id}` requires an Auth0 owner JWT (`acn:write`). That left two gaps:

1. A **self-registered, never-claimed** agent (API key only, `owner=None`) could never be deleted via the API — a permanent dead row, removable only by manual DB surgery.
2. A **claimed** agent had no way to initiate its own removal; only the human owner could, manually.

This adds a self-service deletion path **without touching the existing owner/admin `DELETE /{id}` route** (zero risk to the established Auth0 owner flow). The auth model splits on claim status, per the agreed design:

| Initiator | Agent state | Result |
|---|---|---|
| Agent API key | unclaimed | deleted immediately |
| Agent API key | claimed | pending request → human owner confirms |
| `X-Internal-Token` | any | deleted immediately (ops) |
| Owner Auth0 JWT | claimed | `DELETE /{id}` (existing, unchanged) |

## Endpoints

- **`POST /agents/{id}/deletion-request`** (`OwnerOrInternalDep` — agent's own API key or internal token)
  - unclaimed / internal → immediate delete (`{"status":"deleted"}`)
  - claimed via API key → opens a pending request, returns `{"status":"pending_confirmation","confirm_url","expires_at"}`
- **`POST /agents/{id}/deletion-request/confirm`** (Auth0 owner JWT + `{"token"}`) → validates owner + token + expiry, then deletes via the canonical `unregister_agent` path.
- **`DELETE /agents/{id}/deletion-request`** → cancel a pending request (idempotent).

## Design notes

- **Token security**: only the SHA-256 hash of the one-time token is stored (in `metadata["deletion_request"]` with `requested_at` / `expires_at`); the plaintext is returned once for the `confirm_url`. TTL 72h (covers a long weekend).
- **Outward marker**: `_agent_entity_to_info` strips `token_hash` from every read response and surfaces a non-secret `pending_deletion` marker, so consumers can see an agent winding down without the secret leaking. (Active filtering of pending-deletion agents from task-matching/discovery is a deliberate follow-up; this PR surfaces the marker.)
- **ADR-0006**: the subnet-ownership guard (can't delete while owning subnets → 409) is applied on every deletion path via a shared helper.
- **No new storage layer / no repo-interface churn**: pending state lives in the existing `metadata` JSONB; `Agent.endpoint`/`metadata` already exist.

## Tests (19)

- Service state machine: request stores hashed token + future expiry; unclaimed guard; confirm happy path; wrong owner (PermissionError); bad token; no pending request; expired (clears + raises); cancel idempotent.
- Serializer: `token_hash` never leaks, `pending_deletion` marker surfaces (both strip modes).
- Routes: unclaimed→immediate, claimed→pending, internal force-delete, anonymous 401, cross-agent 403, owns-subnets 409, owner-confirm 200, missing-permission 403, invalid-token 400, cancel 200.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Tests

## Related

Part of the agent self-management backlog (sibling to the profile-edit PR #147 and endpoint-relaxation PR #146). Independent branch/PR per the "one concern per PR" discipline, since this is the destructive + auth-sensitive piece.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation (if needed)

## SDK Changes

- [ ] TypeScript SDK (`clients/typescript/`)
- [ ] Python SDK (`clients/python/`)
- [x] N/A — server-side + SKILL.md only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea249f8-0110-4f40-b1be-8b49a0ea670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

