### PR TITLE
feat(auth): ACN agent JWT issuance — OAuth2 client_credentials + JWKS (ADR-0007)

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -105,6 +105,7 @@ from .routes import (
     gateway_connect,
     manifest,
     monitoring,
+    oauth,
     onchain,
     payments,
     registry,
@@ -1353,6 +1354,10 @@ app.include_router(analytics.router)
 app.include_router(payments.router)
 app.include_router(tasks.router)  # Task Pool API
 app.include_router(websocket.router)
+# ADR-0007: agent JWT issuance (OAuth2 client_credentials) + JWKS / OIDC
+# discovery. ACN mints short-lived agent JWTs that resource servers
+# verify offline; the long-lived acn_* key is the client credential.
+app.include_router(oauth.router)
 
 # Note: onboarding.py removed - functionality migrated to:
 # - /api/v1/agents/join (registry.py)

--- a/acn/config.py
+++ b/acn/config.py
@@ -118,6 +118,33 @@ class Settings(BaseSettings):
             v = f"https://{v}"
         return v.rstrip("/")
 
+    # ------------------------------------------------------------------
+    # Agent JWT issuance (ADR-0007) — ACN as the agent identity authority.
+    # ------------------------------------------------------------------
+    # ACN mints short-lived RS256 JWTs that resource servers (AgentPlanet
+    # backend, future consensus/feed) verify offline against the JWKS
+    # published at ``/.well-known/jwks.json``. The agent's long-lived
+    # ``acn_*`` API key is the client credential exchanged at
+    # ``POST /oauth/token`` (OAuth2 client_credentials) for these JWTs.
+    #
+    # ``AGENT_JWT_PRIVATE_KEY`` is a PEM-encoded RSA private key. When it
+    # is unset the issuer is disabled: ``/oauth/token`` returns 503 and
+    # the JWKS is empty. The public half (for JWKS) is derived from the
+    # private key at runtime — no second env var to keep in sync.
+    agent_jwt_private_key: str | None = None
+    agent_jwt_kid: str = "acn-agent-key-1"
+    # Issuer (``iss`` claim). Defaults to ``gateway_base_url`` when unset.
+    agent_jwt_issuer: str | None = None
+    # Default audience (``aud`` claim) when the token request does not
+    # specify one. Matches the AgentPlanet backend's expected audience.
+    agent_jwt_audience: str = "https://api.agenticplanet.space"
+    agent_jwt_ttl_seconds: int = 3600
+    # Scopes granted by default to every agent (ADR-0007 D3). Capability
+    # scopes that move money for others (e.g. ``wallet:write``) are kept
+    # OUT of the default and must be granted explicitly. ``store:sell`` is
+    # safe to default: it only lets an agent collect to its OWN wallet.
+    agent_jwt_default_scope: str = "acn:read acn:write store:sell"
+
     # PostgreSQL (for future persistent storage)
     database_url: str | None = None
 

--- a/acn/routes/oauth.py
+++ b/acn/routes/oauth.py
@@ -1,0 +1,185 @@
+"""OAuth2 token + OIDC discovery routes (ADR-0007).
+
+ACN issues short-lived agent JWTs here. An agent exchanges its
+long-lived ``acn_*`` API key (the client credential) for a signed RS256
+JWT via the standard OAuth2 ``client_credentials`` grant; resource
+servers then verify that JWT offline against the JWKS published below.
+
+Endpoints
+=========
+- ``POST /oauth/token`` — client_credentials grant. Accepts the
+  credential as form or JSON body (``client_secret``) or HTTP Basic.
+  Mirrors the request shape of an Auth0 ``/oauth/token`` call so a
+  migrating seller (e.g. AgentMother) only swaps the endpoint URL and
+  the credential, not the flow.
+- ``GET /.well-known/jwks.json`` — public verification keys.
+- ``GET /.well-known/openid-configuration`` — minimal OIDC discovery so
+  standards-based verifiers can self-configure.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from functools import lru_cache
+from typing import Any
+
+import structlog  # type: ignore[import-untyped]
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from ..config import get_settings
+from ..services import AgentService
+from ..services.agent_token_service import AgentTokenIssuer
+from .dependencies import get_agent_service, limiter
+
+logger = structlog.get_logger()
+
+router = APIRouter(tags=["oauth"])
+
+
+@lru_cache
+def get_token_issuer() -> AgentTokenIssuer:
+    """Build (and cache) the process-wide agent token issuer from settings."""
+    s = get_settings()
+    issuer = s.agent_jwt_issuer or s.gateway_base_url
+    return AgentTokenIssuer(
+        private_key_pem=s.agent_jwt_private_key,
+        kid=s.agent_jwt_kid,
+        issuer=issuer,
+        default_audience=s.agent_jwt_audience,
+        ttl_seconds=s.agent_jwt_ttl_seconds,
+        default_scope=s.agent_jwt_default_scope,
+    )
+
+
+def _oauth_error(error: str, description: str, status_code: int = 400) -> JSONResponse:
+    """RFC 6749 §5.2 error response."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": error, "error_description": description},
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+def _basic_auth_secret(request: Request) -> tuple[str | None, str | None]:
+    """Extract (client_id, client_secret) from an HTTP Basic header, if present."""
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("basic "):
+        return None, None
+    try:
+        raw = base64.b64decode(header[6:].strip()).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return None, None
+    if ":" not in raw:
+        return None, None
+    cid, secret = raw.split(":", 1)
+    return (cid or None), (secret or None)
+
+
+async def _parse_token_request(request: Request) -> dict[str, Any]:
+    """Read token-request params from JSON or form body (content-type aware)."""
+    ctype = request.headers.get("content-type", "")
+    if "application/json" in ctype:
+        try:
+            data = await request.json()
+            return data if isinstance(data, dict) else {}
+        except Exception:  # noqa: BLE001
+            return {}
+    try:
+        form = await request.form()
+        return dict(form)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+@router.post("/oauth/token")
+@limiter.limit("60/minute")
+async def issue_token(
+    request: Request,
+    agent_service: AgentService = Depends(get_agent_service),
+) -> JSONResponse:
+    """OAuth2 ``client_credentials`` grant: ``acn_*`` key → short-lived JWT."""
+    issuer = get_token_issuer()
+    if not issuer.enabled:
+        return _oauth_error(
+            "temporarily_unavailable",
+            "Token issuance is not configured on this ACN deployment.",
+            status_code=503,
+        )
+
+    body = await _parse_token_request(request)
+    basic_id, basic_secret = _basic_auth_secret(request)
+
+    grant_type = body.get("grant_type")
+    if grant_type != "client_credentials":
+        return _oauth_error(
+            "unsupported_grant_type",
+            "Only 'client_credentials' is supported.",
+        )
+
+    client_id = body.get("client_id") or basic_id
+    client_secret = body.get("client_secret") or basic_secret
+    if not client_secret:
+        return _oauth_error(
+            "invalid_request",
+            "Missing client_secret (your acn_* API key).",
+        )
+
+    agent = await agent_service.get_agent_by_api_key(client_secret)
+    if agent is None:
+        return _oauth_error(
+            "invalid_client",
+            "API key did not resolve to a registered agent.",
+            status_code=401,
+        )
+
+    # If the caller asserted a client_id, it must equal their agent_id —
+    # prevents minting a token under someone else's identity.
+    if client_id and client_id != agent.agent_id:
+        return _oauth_error(
+            "invalid_client",
+            "client_id does not match the agent that owns this credential.",
+            status_code=401,
+        )
+
+    # ``audience`` is honoured if provided (so an Auth0-style call with
+    # the same audience keeps working); scope escalation is NOT honoured —
+    # the issuer always grants the configured default scope set (ADR-0007
+    # D3). Per-agent capability grants are a separate, later feature.
+    audience = body.get("audience") or None
+    tok = issuer.mint(agent.agent_id, audience=audience)
+
+    logger.info("agent_jwt_issued", agent_id=agent.agent_id, scope=tok["scope"])
+    return JSONResponse(
+        content=tok,
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+@router.get("/.well-known/jwks.json")
+async def jwks() -> JSONResponse:
+    """Public JSON Web Key Set for verifying ACN-issued agent JWTs."""
+    issuer = get_token_issuer()
+    return JSONResponse(content=issuer.jwks())
+
+
+@router.get("/.well-known/openid-configuration")
+async def openid_configuration() -> JSONResponse:
+    """Minimal OIDC discovery document for standards-based verifiers."""
+    issuer = get_token_issuer()
+    base = issuer.issuer
+    return JSONResponse(
+        content={
+            "issuer": base,
+            "jwks_uri": f"{base}/.well-known/jwks.json",
+            "token_endpoint": f"{base}/oauth/token",
+            "grant_types_supported": ["client_credentials"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_post",
+                "client_secret_basic",
+            ],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "response_types_supported": ["token"],
+        }
+    )

--- a/acn/services/agent_token_service.py
+++ b/acn/services/agent_token_service.py
@@ -83,11 +83,16 @@ class AgentTokenIssuer:
     @staticmethod
     def _derive_jwk(private_key_pem: str, kid: str) -> dict:
         """Build the public JWK (RSA) from a PEM private key."""
+        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
         from cryptography.hazmat.primitives.serialization import (
             load_pem_private_key,
         )
 
         priv = load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
+        if not isinstance(priv, RSAPrivateKey):
+            # RS256 signing requires an RSA key; reject anything else loudly
+            # so a misconfigured PEM disables the issuer instead of 500ing.
+            raise ValueError("AGENT_JWT_PRIVATE_KEY must be an RSA private key")
         pub_numbers = priv.public_key().public_numbers()
         return {
             "kty": "RSA",

--- a/acn/services/agent_token_service.py
+++ b/acn/services/agent_token_service.py
@@ -1,0 +1,147 @@
+"""Agent JWT issuance (ADR-0007).
+
+ACN is the agent identity authority. This service turns an agent's
+long-lived ``acn_*`` API key (the client credential) into a short-lived,
+standards-compliant RS256 JWT that resource servers verify *offline*
+against the JWKS published at ``/.well-known/jwks.json``.
+
+Design notes
+============
+- **Self-contained identity.** The token carries ``sub = agent_id`` and
+  ``scope`` as signed claims, so resource servers read the agent identity
+  straight from the verified JWT — no shared mapping table, no callback
+  to ACN per request (contrast the legacy ``agent_auth0_credentials``
+  lookup the AgentPlanet backend used to do on every call).
+- **Public key derived from the private key.** JWKS ``n``/``e`` are
+  computed from the PEM private key at construction time, so operators
+  only set one secret (``AGENT_JWT_PRIVATE_KEY``).
+- **Disabled-by-default.** With no private key configured the issuer is
+  inert: ``enabled`` is False, ``jwks()`` returns an empty key set, and
+  the route layer surfaces 503. This keeps self-hosted ACN bootable
+  without standing up issuance.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+import uuid
+
+import structlog  # type: ignore[import-untyped]
+from jose import jwt
+
+logger = structlog.get_logger()
+
+
+def _b64url_uint(val: int) -> str:
+    """Base64url-encode a big-endian unsigned int with no padding (RFC 7518)."""
+    raw = val.to_bytes((val.bit_length() + 7) // 8 or 1, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+class AgentTokenIssuer:
+    """Mints and publishes keys for ACN-issued agent JWTs.
+
+    Construct once (e.g. cached per process). Safe to construct with a
+    ``None`` private key — the resulting instance is ``enabled == False``
+    and refuses to mint.
+    """
+
+    def __init__(
+        self,
+        *,
+        private_key_pem: str | None,
+        kid: str,
+        issuer: str,
+        default_audience: str,
+        ttl_seconds: int,
+        default_scope: str,
+    ) -> None:
+        self._kid = kid
+        self._issuer = issuer.rstrip("/")
+        self._default_audience = default_audience
+        self._ttl = ttl_seconds
+        self._default_scope = default_scope
+        self._private_key_pem = private_key_pem.strip() if private_key_pem else None
+        self._jwks_keys: list[dict] = []
+
+        if self._private_key_pem:
+            try:
+                self._jwks_keys = [self._derive_jwk(self._private_key_pem, kid)]
+            except Exception as exc:  # noqa: BLE001
+                logger.error("agent_jwt_private_key_invalid", error=str(exc))
+                self._private_key_pem = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._private_key_pem is not None
+
+    @property
+    def issuer(self) -> str:
+        return self._issuer
+
+    @staticmethod
+    def _derive_jwk(private_key_pem: str, kid: str) -> dict:
+        """Build the public JWK (RSA) from a PEM private key."""
+        from cryptography.hazmat.primitives.serialization import (
+            load_pem_private_key,
+        )
+
+        priv = load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
+        pub_numbers = priv.public_key().public_numbers()
+        return {
+            "kty": "RSA",
+            "use": "sig",
+            "alg": "RS256",
+            "kid": kid,
+            "n": _b64url_uint(pub_numbers.n),
+            "e": _b64url_uint(pub_numbers.e),
+        }
+
+    def jwks(self) -> dict:
+        """Return the JSON Web Key Set for the public verification key(s)."""
+        return {"keys": list(self._jwks_keys)}
+
+    def mint(
+        self,
+        agent_id: str,
+        *,
+        audience: str | None = None,
+        scope: str | None = None,
+    ) -> dict:
+        """Issue a short-lived JWT for ``agent_id``.
+
+        Returns an OAuth2-style token response dict. Raises
+        ``RuntimeError`` if the issuer is disabled (no signing key).
+        """
+        if not self.enabled:
+            raise RuntimeError("Agent JWT issuer is not configured (no signing key)")
+
+        now = int(time.time())
+        aud = audience or self._default_audience
+        scp = scope if scope is not None else self._default_scope
+        claims = {
+            "iss": self._issuer,
+            "sub": agent_id,
+            "aud": aud,
+            "scope": scp,
+            "iat": now,
+            "nbf": now,
+            "exp": now + self._ttl,
+            "jti": str(uuid.uuid4()),
+            # Marks the principal class so resource servers can branch
+            # agent-direct vs human without sniffing the sub format.
+            "acn_principal": "agent",
+        }
+        token = jwt.encode(
+            claims,
+            self._private_key_pem,
+            algorithm="RS256",
+            headers={"kid": self._kid},
+        )
+        return {
+            "access_token": token,
+            "token_type": "Bearer",
+            "expires_in": self._ttl,
+            "scope": scp,
+        }

--- a/tests/routes/test_oauth_token.py
+++ b/tests/routes/test_oauth_token.py
@@ -1,0 +1,182 @@
+"""Tests for the OAuth2 token + JWKS routes (ADR-0007).
+
+Contract pinned here (route → issuer/service seam):
+
+* **client_credentials** — a valid ``acn_*`` key (``client_secret``)
+  resolves to its agent and mints a verifiable RS256 JWT whose ``sub``
+  is that agent's id.
+* **invalid_client** — an unknown key, or a ``client_id`` that does not
+  match the credential's owner, fails 401 before a token is minted.
+* **unsupported_grant_type** — only ``client_credentials`` is accepted.
+* **JWKS** — the public key set is served and matches the signing kid.
+* **temporarily_unavailable** — with no signing key the endpoint is 503.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from acn.api import app
+from acn.routes import oauth
+from acn.routes.dependencies import get_agent_service, limiter
+from acn.services.agent_token_service import AgentTokenIssuer
+
+
+def _gen_key_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def issuer() -> AgentTokenIssuer:
+    return AgentTokenIssuer(
+        private_key_pem=_gen_key_pem(),
+        kid="acn-agent-key-1",
+        issuer="https://acn.test",
+        default_audience="https://api.test",
+        ttl_seconds=3600,
+        default_scope="acn:read acn:write store:sell",
+    )
+
+
+@pytest.fixture
+def client(issuer, monkeypatch) -> TestClient:
+    monkeypatch.setattr(oauth, "get_token_issuer", lambda: issuer)
+
+    svc = AsyncMock()
+    agent = MagicMock()
+    agent.agent_id = "agent-xyz"
+
+    async def _by_key(key: str):
+        return agent if key == "acn_validkey" else None
+
+    svc.get_agent_by_api_key = AsyncMock(side_effect=_by_key)
+    app.dependency_overrides[get_agent_service] = lambda: svc
+    return TestClient(app)
+
+
+def _verify(token: str, issuer: AgentTokenIssuer) -> dict:
+    key = issuer.jwks()["keys"][0]
+    rsa_key = {k: key[k] for k in ("kty", "kid", "use", "n", "e")}
+    return jwt.decode(
+        token, rsa_key, algorithms=["RS256"],
+        audience="https://api.test", issuer="https://acn.test",
+    )
+
+
+def test_token_success(client, issuer):
+    r = client.post(
+        "/oauth/token",
+        json={"grant_type": "client_credentials", "client_secret": "acn_validkey"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["token_type"] == "Bearer"
+    payload = _verify(body["access_token"], issuer)
+    assert payload["sub"] == "agent-xyz"
+    assert payload["acn_principal"] == "agent"
+
+
+def test_token_success_with_matching_client_id(client):
+    r = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "client_credentials",
+            "client_id": "agent-xyz",
+            "client_secret": "acn_validkey",
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_token_invalid_key(client):
+    r = client.post(
+        "/oauth/token",
+        json={"grant_type": "client_credentials", "client_secret": "acn_wrong"},
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_client"
+
+
+def test_token_client_id_mismatch(client):
+    r = client.post(
+        "/oauth/token",
+        json={
+            "grant_type": "client_credentials",
+            "client_id": "someone-else",
+            "client_secret": "acn_validkey",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_client"
+
+
+def test_token_missing_secret(client):
+    r = client.post("/oauth/token", json={"grant_type": "client_credentials"})
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+def test_unsupported_grant_type(client):
+    r = client.post(
+        "/oauth/token",
+        json={"grant_type": "password", "client_secret": "acn_validkey"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "unsupported_grant_type"
+
+
+def test_basic_auth_credentials(client):
+    import base64
+
+    basic = base64.b64encode(b"agent-xyz:acn_validkey").decode()
+    r = client.post(
+        "/oauth/token",
+        data={"grant_type": "client_credentials"},
+        headers={"Authorization": f"Basic {basic}"},
+    )
+    assert r.status_code == 200
+
+
+def test_jwks_endpoint(client, issuer):
+    r = client.get("/.well-known/jwks.json")
+    assert r.status_code == 200
+    keys = r.json()["keys"]
+    assert len(keys) == 1
+    assert keys[0]["kid"] == "acn-agent-key-1"
+
+
+def test_disabled_issuer_returns_503(client, monkeypatch):
+    disabled = AgentTokenIssuer(
+        private_key_pem=None,
+        kid="acn-agent-key-1",
+        issuer="https://acn.test",
+        default_audience="https://api.test",
+        ttl_seconds=3600,
+        default_scope="acn:read",
+    )
+    monkeypatch.setattr(oauth, "get_token_issuer", lambda: disabled)
+    r = client.post(
+        "/oauth/token",
+        json={"grant_type": "client_credentials", "client_secret": "acn_validkey"},
+    )
+    assert r.status_code == 503
+    assert r.json()["error"] == "temporarily_unavailable"

--- a/tests/services/test_agent_token_service.py
+++ b/tests/services/test_agent_token_service.py
@@ -1,0 +1,94 @@
+"""Unit tests for ``AgentTokenIssuer`` (ADR-0007).
+
+Pure (no app wiring): generate a keypair, mint, verify the round-trip,
+and pin the disabled / scope / JWKS-shape invariants.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import jwt
+
+from acn.services.agent_token_service import AgentTokenIssuer
+
+
+def _gen_key_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _issuer(**overrides) -> AgentTokenIssuer:
+    params = dict(
+        private_key_pem=_gen_key_pem(),
+        kid="acn-agent-key-1",
+        issuer="https://acn.test",
+        default_audience="https://api.test",
+        ttl_seconds=3600,
+        default_scope="acn:read acn:write store:sell",
+    )
+    params.update(overrides)
+    return AgentTokenIssuer(**params)
+
+
+def _verify(token: str, jwks: dict, *, audience="https://api.test", issuer="https://acn.test"):
+    key = jwks["keys"][0]
+    rsa_key = {
+        "kty": key["kty"],
+        "kid": key["kid"],
+        "use": key["use"],
+        "n": key["n"],
+        "e": key["e"],
+    }
+    return jwt.decode(token, rsa_key, algorithms=["RS256"], audience=audience, issuer=issuer)
+
+
+def test_mint_and_verify_roundtrip():
+    iss = _issuer()
+    assert iss.enabled
+    tok = iss.mint("agent-123")
+    assert tok["token_type"] == "Bearer"
+    assert tok["expires_in"] == 3600
+    payload = _verify(tok["access_token"], iss.jwks())
+    assert payload["sub"] == "agent-123"
+    assert payload["iss"] == "https://acn.test"
+    assert payload["aud"] == "https://api.test"
+    assert payload["acn_principal"] == "agent"
+    assert payload["scope"] == "acn:read acn:write store:sell"
+
+
+def test_default_scope_excludes_wallet_write():
+    # ADR-0007 D3: money-movement-for-others is not granted by default.
+    assert "wallet:write" not in _issuer().mint("a")["scope"]
+
+
+def test_custom_audience_is_honoured():
+    tok = _issuer().mint("a", audience="https://other.example")
+    assert jwt.get_unverified_claims(tok["access_token"])["aud"] == "https://other.example"
+
+
+def test_jwks_shape():
+    key = _issuer().jwks()["keys"][0]
+    assert key["kty"] == "RSA"
+    assert key["alg"] == "RS256"
+    assert key["use"] == "sig"
+    assert key["kid"] == "acn-agent-key-1"
+    assert key["n"] and key["e"]
+
+
+def test_disabled_without_key():
+    iss = _issuer(private_key_pem=None)
+    assert iss.enabled is False
+    assert iss.jwks() == {"keys": []}
+    with pytest.raises(RuntimeError):
+        iss.mint("a")
+
+
+def test_invalid_private_key_disables_issuer():
+    iss = _issuer(private_key_pem="-----BEGIN PRIVATE KEY-----\nnot-a-key\n-----END PRIVATE KEY-----")
+    assert iss.enabled is False

--- a/tests/services/test_agent_token_service.py
+++ b/tests/services/test_agent_token_service.py
@@ -24,14 +24,14 @@ def _gen_key_pem() -> str:
 
 
 def _issuer(**overrides) -> AgentTokenIssuer:
-    params = dict(
-        private_key_pem=_gen_key_pem(),
-        kid="acn-agent-key-1",
-        issuer="https://acn.test",
-        default_audience="https://api.test",
-        ttl_seconds=3600,
-        default_scope="acn:read acn:write store:sell",
-    )
+    params = {
+        "private_key_pem": _gen_key_pem(),
+        "kid": "acn-agent-key-1",
+        "issuer": "https://acn.test",
+        "default_audience": "https://api.test",
+        "ttl_seconds": 3600,
+        "default_scope": "acn:read acn:write store:sell",
+    }
     params.update(overrides)
     return AgentTokenIssuer(**params)
 


### PR DESCRIPTION
## Summary

Implements **ADR-0007 Phase 1**: ACN becomes the agent identity authority and a standards-compliant OIDC token issuer.

- Agents exchange their long-lived `acn_*` API key (the client credential) for a short-lived **RS256 JWT** carrying `sub = agent_id` + `scope`.
- Resource servers (AgentPlanet backend, future consensus/feed) verify the JWT **offline** against the published JWKS — no per-request callback to ACN, no shared mapping table.
- **Purely additive**: the existing opaque `acn_*` request path is untouched.

## What's included

- `services/agent_token_service.py` — `AgentTokenIssuer`: RS256 signing, public JWK derived from the PEM private key, **disabled-by-default** when no signing key is set (so self-hosted ACN still boots).
- `routes/oauth.py`:
  - `POST /oauth/token` — OAuth2 `client_credentials` (credential via JSON/form body or HTTP Basic). Mirrors an Auth0 `/oauth/token` call so migrating sellers only swap the endpoint URL + credential.
  - `GET /.well-known/jwks.json`
  - `GET /.well-known/openid-configuration`
- `config.py` — `AGENT_JWT_PRIVATE_KEY` / `_ISSUER` / `_KID` / `_AUDIENCE` / `_TTL_SECONDS` / `AGENT_JWT_DEFAULT_SCOPE`.

## Decisions (per ADR-0007)

- **D1** mint protocol = standard OAuth2 `client_credentials`.
- **D2** RS256 (matches existing JWKS verification on both sides); private key in Railway secret.
- **D3** default scope = `acn:read acn:write store:sell`; `wallet:write` intentionally **excluded** (no default money-movement).

## Config / deploy

`AGENT_JWT_PRIVATE_KEY` + `AGENT_JWT_ISSUER=https://api.acnlabs.dev` already set on the ACN Railway service (skip-deploys; activates on this merge).

## Test plan

- [x] Local crypto round-trip: mint → verify (`sub`/`aud`/`scope` correct); wrong-audience rejected; disabled issuer inert.
- [ ] Post-deploy: `GET https://api.acnlabs.dev/.well-known/jwks.json` returns a key; `POST /oauth/token` with a valid `acn_*` key returns a JWT.
- [ ] End-to-end with backend `/api/store/quotes` (see backend PR).

Follow-ups (later ADR-0007 phases, not in this PR): ACN accepting its own JWT on its request path; A2A `from_agent` middleware JWT support.

Made with [Cursor](https://cursor.com)