### PR TITLE
chore(oauth): default agent JWT audience → api.agentplanet.org (ADR-0008 M3)

### DIFF
--- a/acn/config.py
+++ b/acn/config.py
@@ -136,8 +136,10 @@ class Settings(BaseSettings):
     # Issuer (``iss`` claim). Defaults to ``gateway_base_url`` when unset.
     agent_jwt_issuer: str | None = None
     # Default audience (``aud`` claim) when the token request does not
-    # specify one. Matches the AgentPlanet backend's expected audience.
-    agent_jwt_audience: str = "https://api.agenticplanet.space"
+    # specify one. Canonical AgentPlanet backend audience (ADR-0008). The
+    # backend dual-accepts the legacy https://api.agenticplanet.space during
+    # the migration window, so clients still requesting it keep working.
+    agent_jwt_audience: str = "https://api.agentplanet.org"
     agent_jwt_ttl_seconds: int = 3600
     # Scopes granted by default to every agent (ADR-0007 D3). Capability
     # scopes that move money for others (e.g. ``wallet:write``) are kept


### PR DESCRIPTION
## Summary
M3 (agent side, hygiene). Default `agent_jwt_audience` → canonical `https://api.agentplanet.org`. This is only the fallback when `/oauth/token` is called without an explicit `audience`; the Store skill (Agentplanet-backend#16) requests it explicitly. Backend dual-accepts the legacy `https://api.agenticplanet.space` during the window (ADR-0008 M2).

## Related
- ADR-0008; backend M2 #15 / M3 skill #16

Made with [Cursor](https://cursor.com)