### PR TITLE
feat(ap2): seller webhook delivery + store-settlement bridge (ADR-0009 P1-A)

### DIFF
--- a/acn/core/errors.py
+++ b/acn/core/errors.py
@@ -311,6 +311,12 @@ class ErrorCode(StrEnum):
     PAYMENT_TASK_NOT_FOUND = "payment_task_not_found"
     TOKEN_PRICING_NOT_CONFIGURED = "token_pricing_not_configured"
     BILLING_TRANSACTION_NOT_FOUND = "billing_transaction_not_found"
+    # Store-settlement bridge (ADR-0009 P1-A). Dedicated codes (not the
+    # generic capability/task-not-found above) because they carry a store
+    # ``order_id`` rather than an ``agent_id``/``task_id``, and a distinct
+    # ``details`` shape per the cross-module schema contract.
+    STORE_SETTLEMENT_SELLER_NOT_PAYABLE = "store_settlement_seller_not_payable"
+    STORE_SETTLEMENT_NOT_FOUND = "store_settlement_not_found"
 
     # ===== Cross-module auth/permission/validation (sprint row #2b) =====
     # Shared by ``registry``, ``subnets``, and ``tasks`` routes.
@@ -461,6 +467,13 @@ _DEFAULT_MESSAGES: dict[ErrorCode, str] = {
     ),
     ErrorCode.BILLING_TRANSACTION_NOT_FOUND: (
         "The requested billing transaction could not be found."
+    ),
+    ErrorCode.STORE_SETTLEMENT_SELLER_NOT_PAYABLE: (
+        "The seller agent does not accept platform-credit payments, so the "
+        "store order cannot be mirrored as a payment task."
+    ),
+    ErrorCode.STORE_SETTLEMENT_NOT_FOUND: (
+        "No payment task is recorded for the given store order id."
     ),
     ErrorCode.ALLOWLIST_CAPACITY_EXCEEDED: (
         "The owner's allowlist is at capacity. Remove some entries first."

--- a/acn/protocols/ap2/core.py
+++ b/acn/protocols/ap2/core.py
@@ -313,6 +313,24 @@ class PaymentCapability(BaseModel):
         description="Token-based pricing (per million tokens, OpenAI-style)",
     )
 
+    # Webhook delivery (P1-A): the seller's endpoint that ACN POSTs payment
+    # events to (signed + retried). Until P1-A this was accepted by the API
+    # but never stored (the field did not exist on the model, so it was
+    # silently dropped by Pydantic's extra='ignore').
+    webhook_url: str | None = Field(
+        default=None,
+        description="Seller endpoint ACN delivers payment events to (signed + retried).",
+    )
+    # HMAC-SHA256 signing secret for outgoing deliveries to webhook_url. This is
+    # a SHARED symmetric secret: ACN signs each outgoing request with it and the
+    # seller verifies. ACN must therefore store it *recoverably* (NOT hashed) —
+    # the same way agents.api_key is kept (plaintext behind infra at-rest
+    # encryption), not via a new app-level crypto layer.
+    webhook_secret: str | None = Field(
+        default=None,
+        description="Recoverable HMAC secret used to sign outgoing webhook deliveries.",
+    )
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def supported_methods(self) -> list[SupportedPaymentMethod]:
@@ -804,6 +822,99 @@ class PaymentTaskManager:
 
         return task
 
+    # ------------------------------------------------------------------ #
+    # Store settlement bridge (ADR-0009 P1-A)
+    # ------------------------------------------------------------------ #
+    # The AgentPlanet backend store settles credits in its own ledger (the
+    # source of truth). These helpers let the backend *mirror* a settled store
+    # order as a platform_credits PaymentTask so ACN fires the seller's webhook
+    # and the order joins the agent-commerce event/discovery layer. The task is
+    # an event mirror — never a second ledger. Idempotent on the store order id.
+
+    def _store_order_index_key(self, order_id: str) -> str:
+        return f"{self._prefix}store_order:{order_id}"
+
+    async def record_store_settlement(
+        self,
+        *,
+        order_id: str,
+        seller_agent: str,
+        buyer_agent: str,
+        amount_credits: int,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> PaymentTask:
+        """Mirror a settled store order as a confirmed platform_credits task.
+
+        Idempotent on ``order_id``: a repeat call returns the existing task
+        without re-creating or re-firing. Creating + confirming fires the
+        seller's ``payment_task.payment_confirmed`` webhook (see _send_webhook).
+        """
+        index_key = self._store_order_index_key(order_id)
+        existing_id = await self.redis.get(index_key)
+        if existing_id:
+            if isinstance(existing_id, bytes):
+                existing_id = existing_id.decode()
+            existing_task = await self.get_task(existing_id)
+            if existing_task:
+                return existing_task
+
+        task_metadata = {
+            **(metadata or {}),
+            "order_id": order_id,
+            "source": "store",
+            # Make the single-ledger constraint explicit for any consumer:
+            # money truth lives in the backend wallet, not in this task.
+            "settlement_authority": "backend",
+        }
+        task = await self.create_payment_task(
+            buyer_agent=buyer_agent,
+            seller_agent=seller_agent,
+            task_description=description or f"Store order {order_id}",
+            amount=str(amount_credits),
+            currency=CREDITS,
+            payment_method=SupportedPaymentMethod.PLATFORM_CREDITS,
+            task_type="store_settlement",
+            metadata=task_metadata,
+        )
+        # Settlement already happened in the backend; jump straight to confirmed
+        # (no buyer tx_hash dance). tx_hash carries the store order id.
+        await self.update_task_status(
+            task_id=task.task_id,
+            status=PaymentTaskStatus.PAYMENT_CONFIRMED,
+            tx_hash=order_id,
+        )
+        # Index for idempotency; TTL matches terminal-task retention.
+        await self.redis.set(
+            index_key,
+            task.task_id,
+            ex=_PAYMENT_TASK_TERMINAL_TTL_SECONDS,
+        )
+        return await self.get_task(task.task_id) or task
+
+    async def complete_store_settlement(self, order_id: str) -> PaymentTask | None:
+        """Advance a store-mirror task to ``task_completed`` on seller fulfill (C8).
+
+        Idempotent; returns ``None`` if no mirror task exists for ``order_id``
+        (e.g. the settlement mirror was never recorded — the caller falls back
+        to its reconciliation path).
+        """
+        index_key = self._store_order_index_key(order_id)
+        existing_id = await self.redis.get(index_key)
+        if not existing_id:
+            return None
+        if isinstance(existing_id, bytes):
+            existing_id = existing_id.decode()
+        task = await self.get_task(existing_id)
+        if not task:
+            return None
+        if task.status == PaymentTaskStatus.TASK_COMPLETED:
+            return task
+        return await self.update_task_status(
+            task_id=existing_id,
+            status=PaymentTaskStatus.TASK_COMPLETED,
+        )
+
     async def sweep_stale_tasks(self, stale_after_days: int = 7) -> int:
         """Force-fail in-flight payment tasks that have been stuck too long.
 
@@ -1084,7 +1195,19 @@ class PaymentTaskManager:
         await self.redis.expire(log_key, _PAYMENT_TASK_TERMINAL_TTL_SECONDS)
 
     async def _send_webhook(self, event_type: str, task: PaymentTask):
-        """Send webhook notification to backend"""
+        """Send webhook notification.
+
+        Two delivery targets, both best-effort (correctness is guaranteed by
+        the buyer/seller reconciling against the source-of-truth, e.g. the
+        backend store's fulfillment-queue — ADR-0009 P0, not by this push):
+
+        1. The platform-wide ``default_config`` webhook (the billing backend),
+           preserved from the original behavior.
+        2. **P1-A**: the *seller's* own registered ``webhook_url`` (signed with
+           the seller's per-agent ``webhook_secret``), so seller agents like
+           AgentMother receive payment events directly. Previously the seller
+           webhook was registered but never consumed.
+        """
         if not self.webhook:
             return
 
@@ -1097,16 +1220,55 @@ class PaymentTaskManager:
             # Unknown event type, skip
             return
 
+        payload_data = task.model_dump()
+        payment_method = task.payment_method.value if task.payment_method else None
+
+        # 1) Platform-wide default backend (existing behavior).
         await self.webhook.send_event(
             event=webhook_event,
             task_id=task.task_id,
-            data=task.model_dump(),
+            data=payload_data,
             buyer_agent=task.buyer_agent,
             seller_agent=task.seller_agent,
             amount=task.amount,
             currency=task.currency,
-            payment_method=task.payment_method.value if task.payment_method else None,
+            payment_method=payment_method,
         )
+
+        # 2) Seller's own registered webhook (P1-A). Best-effort: a lookup or
+        # delivery failure must never break the status transition that
+        # triggered it — the seller's reconciliation poll is the guarantee.
+        try:
+            capability = await self.discovery.get_agent_payment_capability(task.seller_agent)
+        except Exception:
+            logger.warning(
+                "seller_webhook_capability_lookup_failed task=%s seller=%s",
+                task.task_id,
+                task.seller_agent,
+            )
+            capability = None
+
+        if capability and capability.webhook_url:
+            try:
+                await self.webhook.send_to(
+                    url=capability.webhook_url,
+                    secret=capability.webhook_secret,
+                    event=webhook_event,
+                    task_id=task.task_id,
+                    data=payload_data,
+                    buyer_agent=task.buyer_agent,
+                    seller_agent=task.seller_agent,
+                    amount=task.amount,
+                    currency=task.currency,
+                    payment_method=payment_method,
+                )
+            except Exception:
+                logger.warning(
+                    "seller_webhook_delivery_failed task=%s seller=%s url=%s",
+                    task.task_id,
+                    task.seller_agent,
+                    capability.webhook_url,
+                )
 
 
 # =============================================================================

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -366,7 +366,7 @@ async def store_settlement(
         task = await payment_tasks.complete_store_settlement(body.order_id)
         if task is None:
             raise ACNHTTPError(
-                ErrorCode.PAYMENT_TASK_NOT_FOUND,
+                ErrorCode.STORE_SETTLEMENT_NOT_FOUND,
                 status_code=404,
                 details={"order_id": body.order_id},
             )
@@ -385,7 +385,7 @@ async def store_settlement(
         # Seller hasn't registered a platform_credits capability — the backend
         # treats this as non-fatal and falls back to its reconciliation path.
         raise ACNHTTPError(
-            ErrorCode.PAYMENT_CAPABILITY_NOT_FOUND,
+            ErrorCode.STORE_SETTLEMENT_SELLER_NOT_PAYABLE,
             status_code=409,
             details={"order_id": body.order_id, "reason": str(exc)},
         ) from exc

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -249,7 +249,11 @@ async def set_payment_capability(
     # again (excluded from GET responses).
     new_secret: str | None = None
     webhook_secret: str | None = None
-    if body.webhook_url:
+    # Only mint a secret when the capability will actually be indexed and
+    # deliver: index_payment_capability is a no-op when accepts_payment is
+    # False, so minting one there would hand back a secret that is never
+    # stored and never used.
+    if body.webhook_url and body.accepts_payment:
         existing = None
         try:
             existing = await payment_discovery.get_agent_payment_capability(agent_id)

--- a/acn/routes/payments.py
+++ b/acn/routes/payments.py
@@ -1,5 +1,8 @@
 """Payment System API Routes"""
 
+import secrets
+from typing import Literal
+
 import structlog  # type: ignore[import-untyped]
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field, field_validator
@@ -51,6 +54,13 @@ class PaymentCapabilityRequest(BaseModel):
     )
     api_endpoint: str | None = Field(default=None, max_length=500)
     webhook_url: str | None = Field(default=None, max_length=500)
+    rotate_webhook_secret: bool = Field(
+        default=False,
+        description=(
+            "Force a new webhook signing secret even if webhook_url is unchanged. "
+            "The new secret is returned once in the response and never again."
+        ),
+    )
 
     @field_validator("token_pricing")
     @classmethod
@@ -78,6 +88,37 @@ class CreatePaymentTaskRequest(BaseModel):
     currency: str = Field(..., max_length=32)
     payment_method: SupportedPaymentMethod
     network: SupportedNetwork
+    description: str | None = Field(default=None, max_length=2_000)
+    metadata: dict | None = None
+
+    @field_validator("metadata")
+    @classmethod
+    def _metadata_size(cls, v: dict | None) -> dict | None:
+        if v is None:
+            return v
+        return check_dict_size_64k("metadata", v)
+
+
+class StoreSettlementRequest(BaseModel):
+    """Internal: mirror a settled AgentPlanet store order as an AP2 task.
+
+    Called by the backend store (X-Internal-Token) so a store payment fires
+    the seller's AP2 webhook and joins the agent-commerce event layer. The
+    backend wallet remains the single ledger; this task is an event mirror.
+    """
+
+    order_id: str = Field(..., max_length=128, description="Store order id (idempotency key)")
+    seller_agent: str = Field(..., max_length=128)
+    buyer_agent: str = Field(
+        ...,
+        max_length=128,
+        description="Buyer agent id; a system pseudo-agent for human buyers",
+    )
+    amount_credits: int = Field(..., ge=0, description="Settled amount in platform credits")
+    event: Literal["paid", "fulfilled"] = Field(
+        default="paid",
+        description="'paid' mirrors+confirms the order; 'fulfilled' completes the task (C8)",
+    )
     description: str | None = Field(default=None, max_length=2_000)
     metadata: dict | None = None
 
@@ -198,6 +239,30 @@ async def set_payment_capability(
         except Exception:
             pass
 
+    # Resolve the webhook signing secret (P1-A). Re-registration is a full
+    # replace, so we look at the *existing* indexed capability to decide:
+    #   - webhook_url unchanged + existing secret + no rotate  -> preserve
+    #     (so a pricing-only update doesn't silently break the seller's verifier)
+    #   - new/changed webhook_url, explicit rotate, or no prior secret -> mint
+    #   - webhook_url cleared -> drop the secret
+    # A freshly minted secret is returned exactly once; it is never readable
+    # again (excluded from GET responses).
+    new_secret: str | None = None
+    webhook_secret: str | None = None
+    if body.webhook_url:
+        existing = None
+        try:
+            existing = await payment_discovery.get_agent_payment_capability(agent_id)
+        except Exception:
+            logger.warning("payment_capability_lookup_failed", agent_id=agent_id, exc_info=True)
+        same_url = bool(existing and existing.webhook_url == body.webhook_url)
+        prior_secret = existing.webhook_secret if existing else None
+        if same_url and prior_secret and not body.rotate_webhook_secret:
+            webhook_secret = prior_secret
+        else:
+            new_secret = secrets.token_urlsafe(32)
+            webhook_secret = new_secret
+
     capability = PaymentCapability(
         agent_id=agent_id,
         accepts_payment=body.accepts_payment,
@@ -208,13 +273,18 @@ async def set_payment_capability(
         token_pricing=token_pricing_obj,
         api_endpoint=body.api_endpoint,
         webhook_url=body.webhook_url,
+        webhook_secret=webhook_secret,
     )
     try:
         await payment_discovery.index_payment_capability(agent_id, capability)
     except Exception:
         logger.warning("payment_discovery_index_failed", agent_id=agent_id, exc_info=True)
 
-    return {"status": "registered", "agent_id": agent_id}
+    response: dict = {"status": "registered", "agent_id": agent_id}
+    if new_secret:
+        # Shown once — the seller must store this to verify webhook signatures.
+        response["webhook_secret"] = new_secret
+    return response
 
 
 @router.get("/{agent_id}/payment-capability")
@@ -243,7 +313,8 @@ async def get_payment_capability(
             status_code=404,
             details={"agent_id": agent_id},
         )
-    return capability
+    # webhook_secret is show-once at registration; never expose it on reads.
+    return capability.model_dump(exclude={"webhook_secret"})
 
 
 @router.get("/discover")
@@ -265,6 +336,61 @@ async def discover_payment_agents(
         network=network,
     )
     return {"agents": agents, "count": len(agents)}
+
+
+@router.post("/internal/store-settlement")
+async def store_settlement(
+    body: StoreSettlementRequest,
+    _: InternalTokenDep,
+    payment_tasks: PaymentTasksDep = None,
+):
+    """Internal: mirror a settled store order into an AP2 payment task.
+
+    Auth: ``X-Internal-Token`` (trusted backend only). Idempotent on
+    ``order_id``.
+
+    - ``event="paid"``: create (if new) + confirm the mirror task, firing the
+      seller's ``payment_task.payment_confirmed`` webhook. Returns the task id.
+    - ``event="fulfilled"``: advance the existing mirror task to
+      ``task_completed`` (C8). Returns ``404`` if no mirror exists for the
+      order (the backend then relies on its own reconciliation).
+
+    Delivery to the seller is best-effort; the backend store's
+    fulfillment-queue (ADR-0009 P0) remains the correctness guarantee.
+    """
+    if body.event == "fulfilled":
+        task = await payment_tasks.complete_store_settlement(body.order_id)
+        if task is None:
+            raise ACNHTTPError(
+                ErrorCode.PAYMENT_TASK_NOT_FOUND,
+                status_code=404,
+                details={"order_id": body.order_id},
+            )
+        return {"status": "completed", "order_id": body.order_id, "task_id": task.task_id}
+
+    try:
+        task = await payment_tasks.record_store_settlement(
+            order_id=body.order_id,
+            seller_agent=body.seller_agent,
+            buyer_agent=body.buyer_agent,
+            amount_credits=body.amount_credits,
+            description=body.description,
+            metadata=body.metadata,
+        )
+    except ValueError as exc:
+        # Seller hasn't registered a platform_credits capability — the backend
+        # treats this as non-fatal and falls back to its reconciliation path.
+        raise ACNHTTPError(
+            ErrorCode.PAYMENT_CAPABILITY_NOT_FOUND,
+            status_code=409,
+            details={"order_id": body.order_id, "reason": str(exc)},
+        ) from exc
+
+    return {
+        "status": "confirmed",
+        "order_id": body.order_id,
+        "task_id": task.task_id,
+    }
 
 
 @router.post("/tasks")

--- a/tests/services/test_ap2_seller_webhook_and_settlement.py
+++ b/tests/services/test_ap2_seller_webhook_and_settlement.py
@@ -1,0 +1,264 @@
+"""Tests for ADR-0009 P1-A: seller webhook delivery + store settlement mirror.
+
+Covers the three behaviors added for ACN #161:
+
+1. ``PaymentCapability`` now persists ``webhook_url`` / ``webhook_secret``
+   round-trip through the Redis-backed discovery index (previously
+   ``webhook_url`` was accepted by the API but silently dropped).
+2. Payment-task status transitions deliver to the *seller's* registered
+   webhook (signed with the seller's per-agent secret) in addition to the
+   platform default backend.
+3. The store-settlement bridge mirrors a settled store order as a confirmed
+   ``platform_credits`` task, idempotent on ``order_id``, and can advance the
+   mirror to ``task_completed`` on fulfill (C8).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis as fakeredis_async
+
+from acn.protocols.ap2.core import (
+    PaymentCapability,
+    PaymentDiscoveryService,
+    PaymentTaskManager,
+    PaymentTaskStatus,
+    SupportedPaymentMethod,
+)
+from acn.protocols.ap2.webhook import WebhookEventType
+
+SELLER = "agentmother"
+BUYER = "system:human-buyer"
+WEBHOOK_URL = "https://agentmother.acnlabs.org/acn/webhooks"
+WEBHOOK_SECRET = "seller-shared-secret"
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncGenerator[fakeredis_async.FakeRedis, None]:
+    client = fakeredis_async.FakeRedis(decode_responses=False)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def discovery(redis_client) -> PaymentDiscoveryService:
+    return PaymentDiscoveryService(redis_client)
+
+
+@pytest_asyncio.fixture
+async def seller_capability(discovery) -> PaymentCapability:
+    cap = PaymentCapability(
+        accepts_payment=True,
+        payment_methods=[SupportedPaymentMethod.PLATFORM_CREDITS],
+        webhook_url=WEBHOOK_URL,
+        webhook_secret=WEBHOOK_SECRET,
+    )
+    await discovery.index_payment_capability(SELLER, cap)
+    return cap
+
+
+def _make_manager(redis_client, discovery) -> tuple[PaymentTaskManager, AsyncMock]:
+    webhook = AsyncMock()
+    webhook.send_event = AsyncMock(return_value=True)
+    webhook.send_to = AsyncMock(return_value=True)
+    mgr = PaymentTaskManager(
+        redis=redis_client,
+        discovery=discovery,
+        webhook_service=webhook,
+    )
+    return mgr, webhook
+
+
+# --------------------------------------------------------------------------- #
+# 1. webhook_url / webhook_secret persistence
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_webhook_fields_round_trip_through_discovery(discovery, seller_capability):
+    """webhook_url + webhook_secret survive the Redis index round-trip."""
+    loaded = await discovery.get_agent_payment_capability(SELLER)
+    assert loaded is not None
+    assert loaded.webhook_url == WEBHOOK_URL
+    assert loaded.webhook_secret == WEBHOOK_SECRET
+
+
+def test_webhook_secret_excluded_from_read_dump():
+    """The model_dump(exclude=...) used by the GET route hides the secret
+    but keeps webhook_url and the computed supported_methods alias."""
+    cap = PaymentCapability(
+        accepts_payment=True,
+        payment_methods=[SupportedPaymentMethod.PLATFORM_CREDITS],
+        webhook_url=WEBHOOK_URL,
+        webhook_secret=WEBHOOK_SECRET,
+    )
+    dumped = cap.model_dump(exclude={"webhook_secret"})
+    assert "webhook_secret" not in dumped
+    assert dumped["webhook_url"] == WEBHOOK_URL
+    assert dumped["supported_methods"] == [SupportedPaymentMethod.PLATFORM_CREDITS]
+
+
+# --------------------------------------------------------------------------- #
+# 2. Per-seller webhook delivery
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_status_change_delivers_to_seller_webhook(
+    redis_client, discovery, seller_capability
+):
+    mgr, webhook = _make_manager(redis_client, discovery)
+
+    task = await mgr.create_payment_task(
+        buyer_agent=BUYER,
+        seller_agent=SELLER,
+        task_description="order",
+        amount="700",
+        currency="credits",
+        payment_method=SupportedPaymentMethod.PLATFORM_CREDITS,
+    )
+    await mgr.update_task_status(task.task_id, PaymentTaskStatus.PAYMENT_CONFIRMED)
+
+    # Seller endpoint received deliveries signed with the seller's secret.
+    assert webhook.send_to.await_count >= 1
+    for call in webhook.send_to.await_args_list:
+        assert call.kwargs["url"] == WEBHOOK_URL
+        assert call.kwargs["secret"] == WEBHOOK_SECRET
+    delivered_events = {call.kwargs["event"] for call in webhook.send_to.await_args_list}
+    assert WebhookEventType.PAYMENT_CONFIRMED in delivered_events
+    # Platform default backend still notified too.
+    assert webhook.send_event.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_no_seller_webhook_when_url_unset(redis_client, discovery):
+    cap = PaymentCapability(
+        accepts_payment=True,
+        payment_methods=[SupportedPaymentMethod.PLATFORM_CREDITS],
+    )
+    await discovery.index_payment_capability(SELLER, cap)
+    mgr, webhook = _make_manager(redis_client, discovery)
+
+    task = await mgr.create_payment_task(
+        buyer_agent=BUYER,
+        seller_agent=SELLER,
+        task_description="order",
+        amount="700",
+        currency="credits",
+        payment_method=SupportedPaymentMethod.PLATFORM_CREDITS,
+    )
+    await mgr.update_task_status(task.task_id, PaymentTaskStatus.PAYMENT_CONFIRMED)
+
+    webhook.send_to.assert_not_awaited()
+    assert webhook.send_event.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_seller_delivery_failure_does_not_break_status_change(
+    redis_client, discovery, seller_capability
+):
+    mgr, webhook = _make_manager(redis_client, discovery)
+    webhook.send_to = AsyncMock(side_effect=RuntimeError("seller down"))
+
+    task = await mgr.create_payment_task(
+        buyer_agent=BUYER,
+        seller_agent=SELLER,
+        task_description="order",
+        amount="700",
+        currency="credits",
+        payment_method=SupportedPaymentMethod.PLATFORM_CREDITS,
+    )
+    # Must not raise despite the seller webhook blowing up.
+    updated = await mgr.update_task_status(task.task_id, PaymentTaskStatus.PAYMENT_CONFIRMED)
+    assert updated.status == PaymentTaskStatus.PAYMENT_CONFIRMED
+
+
+# --------------------------------------------------------------------------- #
+# 3. Store settlement bridge
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_record_store_settlement_creates_confirmed_task(
+    redis_client, discovery, seller_capability
+):
+    mgr, webhook = _make_manager(redis_client, discovery)
+
+    task = await mgr.record_store_settlement(
+        order_id="APORDER-1",
+        seller_agent=SELLER,
+        buyer_agent=BUYER,
+        amount_credits=700,
+    )
+
+    assert task.status == PaymentTaskStatus.PAYMENT_CONFIRMED
+    assert task.payment_method == SupportedPaymentMethod.PLATFORM_CREDITS
+    assert task.currency == "credits"
+    assert task.task_metadata["order_id"] == "APORDER-1"
+    assert task.task_metadata["settlement_authority"] == "backend"
+    assert task.tx_hash == "APORDER-1"
+
+
+@pytest.mark.asyncio
+async def test_record_store_settlement_is_idempotent(
+    redis_client, discovery, seller_capability
+):
+    mgr, _ = _make_manager(redis_client, discovery)
+
+    first = await mgr.record_store_settlement(
+        order_id="APORDER-2", seller_agent=SELLER, buyer_agent=BUYER, amount_credits=500
+    )
+    second = await mgr.record_store_settlement(
+        order_id="APORDER-2", seller_agent=SELLER, buyer_agent=BUYER, amount_credits=500
+    )
+    assert first.task_id == second.task_id
+
+
+@pytest.mark.asyncio
+async def test_complete_store_settlement_advances_to_completed(
+    redis_client, discovery, seller_capability
+):
+    mgr, _ = _make_manager(redis_client, discovery)
+
+    recorded = await mgr.record_store_settlement(
+        order_id="APORDER-3", seller_agent=SELLER, buyer_agent=BUYER, amount_credits=900
+    )
+    completed = await mgr.complete_store_settlement("APORDER-3")
+
+    assert completed is not None
+    assert completed.task_id == recorded.task_id
+    assert completed.status == PaymentTaskStatus.TASK_COMPLETED
+
+    # Idempotent: completing again keeps it completed.
+    again = await mgr.complete_store_settlement("APORDER-3")
+    assert again is not None
+    assert again.status == PaymentTaskStatus.TASK_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_complete_store_settlement_unknown_order_returns_none(
+    redis_client, discovery
+):
+    mgr, _ = _make_manager(redis_client, discovery)
+    assert await mgr.complete_store_settlement("does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_record_store_settlement_rejects_unregistered_seller(redis_client, discovery):
+    """A seller with no platform_credits capability raises ValueError, which the
+    route maps to a non-fatal 409 so the backend falls back to reconciliation."""
+    mgr, _ = _make_manager(redis_client, discovery)
+    with pytest.raises(ValueError, match="does not accept"):
+        await mgr.record_store_settlement(
+            order_id="APORDER-4",
+            seller_agent="unknown-seller",
+            buyer_agent=BUYER,
+            amount_credits=100,
+        )


### PR DESCRIPTION
## Summary

Implements **ACN #161** — the core of ADR-0009 **P1-A**: deliver AP2 payment events to the *seller's* own webhook, and bridge settled AgentPlanet store orders into the AP2 event layer.

Until now the seller `webhook_url` was accepted by the payment-capability API but **silently dropped** (the field did not exist on the `PaymentCapability` model, so Pydantic's `extra='ignore'` discarded it), and `_send_webhook` only ever notified the platform default backend. This PR closes that gap.

### What changed
- **Persist webhook config**: `PaymentCapability` now stores `webhook_url` + `webhook_secret`, round-tripping through the Redis discovery index.
- **Per-agent signing secret**: `set_payment_capability` mints an HMAC secret when a `webhook_url` is set, **preserves** it across re-registrations with the same URL (so a pricing-only update doesn't break the seller's verifier), and rotates on URL change or explicit `rotate_webhook_secret`. Returned **exactly once**; never exposed on `GET`. Stored recoverably (like `agents.api_key`, behind infra at-rest encryption) — not hashed, because ACN signs outgoing requests with it.
- **Per-seller delivery**: `PaymentTaskManager._send_webhook` now also delivers to the seller's registered webhook via `WebhookService.send_to(url, secret, …)`, in addition to the platform default. **Best-effort** — a lookup/delivery failure never breaks the status transition that triggered it (the P0 reconciliation poll remains the correctness guarantee).
- **Store-settlement bridge**: `record_store_settlement` (idempotent on `order_id`; creates + confirms a `platform_credits` mirror task) and `complete_store_settlement` (advance to `task_completed` on fulfill — C8).
- **Internal endpoint**: `POST /api/v1/payments/internal/store-settlement` (`X-Internal-Token`). `event=paid` → mirror+confirm; `event=fulfilled` → complete. Unregistered seller → `409` (non-fatal; backend falls back to reconciliation).

The backend wallet stays the **single ledger**; the AP2 task is an **event mirror**, marked `settlement_authority=backend`.

## Test plan
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on `core.py` + `payments.py`
- [x] New `tests/services/test_ap2_seller_webhook_and_settlement.py` — 10 tests pass (webhook field round-trip, secret excluded from read dump, per-seller delivery + signing secret, no delivery when url unset, delivery failure isolation, settlement create/confirm, idempotency, C8 complete, unknown-order None, unregistered-seller ValueError)
- [x] Existing service-level payment tests still pass (the 13 route-test failures are pre-existing — they require a live Redis at `localhost:6379`)

## Follow-ups (separate issues)
- backend #20 — drive AP2 settled-task from store payment via this endpoint
- backend #21 — AgentMother seller integration (capability registration + webhook receiver + P0 poll backstop)
- ACN #162 — durable webhook outbox (true at-least-once); current retries are in-process

Closes #161

Made with [Cursor](https://cursor.com)