### PR TITLE
feat(ap2): durable webhook outbox for at-least-once delivery (ADR-0009 C7, #162)

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -517,7 +517,14 @@ async def lifespan(app: FastAPI):
 
     # Initialize payment services
     webhook_config = create_webhook_config_from_settings(settings)
-    webhook_service_instance = WebhookService(redis_client, webhook_config)
+    webhook_service_instance = WebhookService(
+        redis_client,
+        webhook_config,
+        outbox_enabled=settings.webhook_outbox_enabled,
+        outbox_poll_interval=settings.webhook_outbox_poll_interval,
+        outbox_max_age_seconds=settings.webhook_outbox_max_age_seconds,
+        outbox_max_backoff=settings.webhook_outbox_max_backoff,
+    )
 
     # ADR-0004 Slice 2.4 — swap the no-op join-flow publisher used by
     # ``SubnetService`` + ``JoinFlowService`` for a real

--- a/acn/config.py
+++ b/acn/config.py
@@ -98,6 +98,16 @@ class Settings(BaseSettings):
     webhook_retry_count: int = 3
     webhook_retry_delay: int = 5  # seconds
 
+    # Durable webhook outbox (ADR-0009 C7 / ACN #162): after in-process retries
+    # are exhausted, the delivery is parked in Redis and re-driven by a background
+    # worker until delivered or aged out — giving at-least-once delivery across
+    # process restarts. P0 reconciliation (seller fulfillment-queue poll) remains
+    # the correctness backstop; this only shortens the window the seller relies on it.
+    webhook_outbox_enabled: bool = True
+    webhook_outbox_poll_interval: int = 5  # seconds between worker sweeps
+    webhook_outbox_max_age_seconds: int = 86400  # give up (dead-letter) after 24h
+    webhook_outbox_max_backoff: int = 600  # cap per-attempt backoff at 10 min
+
     # Billing webhook
     billing_webhook_url: str | None = None  # e.g., "https://your-backend.com/api/billing/webhook"
 

--- a/acn/protocols/ap2/webhook.py
+++ b/acn/protocols/ap2/webhook.py
@@ -19,6 +19,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import time
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
@@ -28,6 +29,11 @@ from pydantic import BaseModel, Field
 from redis.asyncio import Redis
 
 logger = logging.getLogger(__name__)
+
+# Durable outbox (ACN #162) Redis keys.
+_OUTBOX_DUE_ZSET = "acn:webhooks:outbox:due"  # score = next-attempt epoch, member = delivery_id
+_OUTBOX_ITEM_PREFIX = "acn:webhooks:outbox:item:"  # per-delivery re-drive payload
+_OUTBOX_METRIC_PREFIX = "acn:webhooks:metrics:"  # {outcome}:{event} counters
 
 
 class WebhookEventType(StrEnum):
@@ -143,6 +149,29 @@ class WebhookDelivery(BaseModel):
     last_error: str | None = None
 
 
+class OutboxItem(BaseModel):
+    """A durable, re-drivable webhook delivery parked in Redis (ACN #162).
+
+    Holds everything needed to re-POST the *exact* original body (so the HMAC
+    signature still matches and the receiver can dedupe on ``delivery_id``),
+    including the target ``secret``. This lives only in the internal Redis store
+    — the same trust boundary that already holds the signed payloads and seller
+    capabilities — and is never copied into the secret-free delivery history.
+    """
+
+    delivery_id: str
+    url: str
+    secret: str | None = None
+    payload: str  # the exact JSON body that was signed/sent
+    event: str  # WebhookEventType value, for the X-ACN-Event header
+    timestamp: str  # original payload timestamp, for the X-ACN-Timestamp header
+    task_id: str
+    attempts: int = 0
+    first_enqueued_at: float
+    next_attempt_at: float
+    last_error: str | None = None
+
+
 class WebhookConfig(BaseModel):
     """Webhook configuration"""
 
@@ -168,18 +197,42 @@ class WebhookService:
     - Multiple webhook endpoints support
     """
 
-    def __init__(self, redis: Redis, default_config: WebhookConfig | None = None):
+    def __init__(
+        self,
+        redis: Redis,
+        default_config: WebhookConfig | None = None,
+        *,
+        outbox_enabled: bool = True,
+        outbox_poll_interval: int = 5,
+        outbox_max_age_seconds: int = 86400,
+        outbox_max_backoff: int = 600,
+    ):
         self.redis = redis
         self.default_config = default_config
         self._http_client: httpx.AsyncClient | None = None
+        # Durable outbox (ACN #162)
+        self._outbox_enabled = outbox_enabled
+        self._outbox_poll_interval = max(1, outbox_poll_interval)
+        self._outbox_max_age_seconds = outbox_max_age_seconds
+        self._outbox_max_backoff = max(1, outbox_max_backoff)
+        self._outbox_task: asyncio.Task[None] | None = None
 
     async def start(self):
-        """Start the webhook service"""
+        """Start the webhook service (and the durable-outbox worker)."""
         self._http_client = httpx.AsyncClient(timeout=30, trust_env=False)
-        logger.info("WebhookService started")
+        if self._outbox_enabled and self._outbox_task is None:
+            self._outbox_task = asyncio.create_task(self._outbox_worker())
+        logger.info("WebhookService started (outbox=%s)", self._outbox_enabled)
 
     async def stop(self):
-        """Stop the webhook service"""
+        """Stop the webhook service and gracefully cancel the outbox worker."""
+        if self._outbox_task is not None:
+            self._outbox_task.cancel()
+            try:
+                await self._outbox_task
+            except asyncio.CancelledError:
+                pass
+            self._outbox_task = None
         if self._http_client:
             await self._http_client.aclose()
         logger.info("WebhookService stopped")
@@ -365,11 +418,188 @@ class WebhookService:
                 delay = config.retry_delay * (2**attempt)
                 await asyncio.sleep(delay)
 
-        # All retries failed
-        delivery.status = "failed"
-        await self._save_delivery(delivery)
-        logger.error(f"Webhook failed after {config.retry_count} attempts: {delivery_id}")
+        # In-process retries exhausted. Park it in the durable outbox so a
+        # background worker keeps re-driving across restarts (at-least-once);
+        # fall back to the old terminal "failed" only when the outbox is off.
+        if self._outbox_enabled:
+            delivery.status = "queued"
+            await self._save_delivery(delivery)
+            await self._enqueue_outbox(delivery, config, payload_json)
+            logger.warning(
+                "Webhook queued to durable outbox after %d attempts: %s -> %s",
+                config.retry_count,
+                delivery_id,
+                config.url,
+            )
+        else:
+            delivery.status = "failed"
+            await self._save_delivery(delivery)
+            logger.error(f"Webhook failed after {config.retry_count} attempts: {delivery_id}")
         return False
+
+    # ------------------------------------------------------------------ #
+    # Durable outbox (ACN #162)                                          #
+    # ------------------------------------------------------------------ #
+
+    async def _enqueue_outbox(
+        self,
+        delivery: WebhookDelivery,
+        config: WebhookConfig,
+        payload_json: str,
+    ) -> None:
+        """Park a failed delivery in Redis for durable, background re-driving."""
+        now = time.time()
+        base = max(1, config.retry_delay)
+        next_at = now + min(self._outbox_max_backoff, base * 2)
+        item = OutboxItem(
+            delivery_id=delivery.id,
+            url=config.url,
+            secret=config.secret,
+            payload=payload_json,
+            event=delivery.payload.event.value,
+            timestamp=delivery.payload.timestamp,
+            task_id=delivery.payload.task_id,
+            attempts=delivery.attempts,
+            first_enqueued_at=now,
+            next_attempt_at=next_at,
+            last_error=delivery.last_error,
+        )
+        await self._save_outbox_item(item)
+        await self.redis.zadd(_OUTBOX_DUE_ZSET, {item.delivery_id: next_at})
+
+    async def _save_outbox_item(self, item: OutboxItem) -> None:
+        # Live a bit longer than the max age so a final dead-letter pass can read it.
+        ttl = self._outbox_max_age_seconds + 3600
+        await self.redis.set(
+            f"{_OUTBOX_ITEM_PREFIX}{item.delivery_id}",
+            item.model_dump_json(),
+            ex=ttl,
+        )
+
+    async def _load_outbox_item(self, delivery_id: str) -> OutboxItem | None:
+        data = await self.redis.get(f"{_OUTBOX_ITEM_PREFIX}{delivery_id}")
+        if not data:
+            return None
+        return OutboxItem.model_validate_json(data)
+
+    async def _remove_outbox_item(self, delivery_id: str) -> None:
+        await self.redis.zrem(_OUTBOX_DUE_ZSET, delivery_id)
+        await self.redis.delete(f"{_OUTBOX_ITEM_PREFIX}{delivery_id}")
+
+    async def _incr_metric(self, outcome: str, event: str) -> None:
+        try:
+            await self.redis.incr(f"{_OUTBOX_METRIC_PREFIX}{outcome}:{event}")
+        except Exception:  # metrics are best-effort, never block delivery
+            pass
+
+    async def _post_once(self, item: OutboxItem) -> bool:
+        """One signed POST of the parked body. Returns True on 2xx."""
+        if not self._http_client:
+            self._http_client = httpx.AsyncClient(timeout=30, trust_env=False)
+        headers = {
+            "Content-Type": "application/json",
+            "X-ACN-Webhook-ID": item.delivery_id,
+            "X-ACN-Event": item.event,
+            "X-ACN-Timestamp": item.timestamp,
+        }
+        if item.secret:
+            headers["X-ACN-Signature"] = f"sha256={self._sign_payload(item.payload, item.secret)}"
+        try:
+            resp = await self._http_client.post(
+                item.url, content=item.payload, headers=headers, timeout=30
+            )
+            if resp.is_success:
+                return True
+            item.last_error = f"HTTP {resp.status_code}: {resp.text[:200]}"
+            return False
+        except httpx.TimeoutException:
+            item.last_error = "Request timeout"
+            return False
+        except httpx.RequestError as e:
+            item.last_error = str(e)
+            return False
+
+    async def _mark_delivery_status(
+        self, delivery_id: str, status: str, attempts: int, last_error: str | None
+    ) -> None:
+        """Update the (secret-free) history record's terminal status in place."""
+        key = f"acn:webhooks:deliveries:{delivery_id}"
+        data = await self.redis.get(key)
+        if not data:
+            return
+        delivery = WebhookDelivery.model_validate_json(data)
+        delivery.status = status
+        delivery.attempts = attempts
+        if last_error:
+            delivery.last_error = last_error
+        if status == "delivered":
+            delivery.delivered_at = datetime.now(UTC).isoformat()
+        await self.redis.set(key, delivery.model_dump_json(), ex=86400 * 7)
+
+    async def _process_outbox_item(self, item: OutboxItem) -> None:
+        """Attempt one re-drive of a claimed outbox item, then settle its fate."""
+        item.attempts += 1
+        if await self._post_once(item):
+            await self._remove_outbox_item(item.delivery_id)
+            await self._mark_delivery_status(
+                item.delivery_id, "delivered", item.attempts, None
+            )
+            await self._incr_metric("delivered", item.event)
+            logger.info("Webhook outbox delivered: %s -> %s", item.delivery_id, item.url)
+            return
+
+        now = time.time()
+        if now - item.first_enqueued_at >= self._outbox_max_age_seconds:
+            await self._remove_outbox_item(item.delivery_id)
+            await self._mark_delivery_status(
+                item.delivery_id, "dead", item.attempts, item.last_error
+            )
+            await self._incr_metric("dead", item.event)
+            logger.error(
+                "Webhook outbox dead-lettered after %d attempts (P0 queue remains the "
+                "backstop): %s -> %s (%s)",
+                item.attempts,
+                item.delivery_id,
+                item.url,
+                item.last_error,
+            )
+            return
+
+        backoff = min(self._outbox_max_backoff, self._outbox_poll_interval * (2**item.attempts))
+        item.next_attempt_at = now + backoff
+        await self._save_outbox_item(item)
+        await self.redis.zadd(_OUTBOX_DUE_ZSET, {item.delivery_id: item.next_attempt_at})
+        await self._incr_metric("failed", item.event)
+
+    async def _drain_outbox_once(self) -> int:
+        """Claim and process all currently-due outbox items. Returns count processed."""
+        now = time.time()
+        due_ids = await self.redis.zrangebyscore(_OUTBOX_DUE_ZSET, 0, now, start=0, num=100)
+        processed = 0
+        for raw in due_ids:
+            delivery_id = raw.decode() if isinstance(raw, bytes) else raw
+            # Atomic claim across replicas: only the worker whose ZREM removes
+            # the member owns this attempt. Re-add happens on retry/reschedule.
+            if not await self.redis.zrem(_OUTBOX_DUE_ZSET, delivery_id):
+                continue
+            item = await self._load_outbox_item(delivery_id)
+            if item is None:
+                continue  # item expired/cleaned; nothing to re-drive
+            await self._process_outbox_item(item)
+            processed += 1
+        return processed
+
+    async def _outbox_worker(self) -> None:
+        """Background loop that re-drives parked webhook deliveries."""
+        logger.info("Webhook outbox worker started (interval=%ss)", self._outbox_poll_interval)
+        while True:
+            try:
+                await self._drain_outbox_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # never let the worker die on a transient error
+                logger.error("Webhook outbox sweep failed: %s", e)
+            await asyncio.sleep(self._outbox_poll_interval)
 
     async def _save_delivery(self, delivery: WebhookDelivery):
         """Save delivery record to Redis"""

--- a/tests/services/test_webhook_outbox.py
+++ b/tests/services/test_webhook_outbox.py
@@ -1,0 +1,274 @@
+"""Tests for ACN #162: durable webhook outbox (ADR-0009 C7).
+
+After in-process retries are exhausted, ``WebhookService`` parks the delivery in
+Redis and a background worker re-drives it until delivered or aged out
+(at-least-once). These tests drive ``_drain_outbox_once`` directly (instead of
+the background loop) for determinism, and assert:
+
+- enqueue parks the exact body + secret and schedules it on the due ZSET;
+- a successful sweep delivers, removes the item, marks history ``delivered``;
+- a failed sweep reschedules with a later score and bumps attempts;
+- past ``max_age`` the item is dead-lettered (history ``dead``), not retried;
+- the ZSET ``ZREM`` claim is atomic (only one owner per due item);
+- the secret lives in the outbox item but never in the history record;
+- the re-driven body is signed with the original secret so HMAC still matches.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis as fakeredis_async
+
+from acn.protocols.ap2.webhook import (
+    _OUTBOX_DUE_ZSET,
+    _OUTBOX_ITEM_PREFIX,
+    _OUTBOX_METRIC_PREFIX,
+    OutboxItem,
+    WebhookConfig,
+    WebhookDelivery,
+    WebhookEventType,
+    WebhookPayload,
+    WebhookService,
+)
+
+URL = "https://seller.example/acn/webhooks"
+SECRET = "seller-shared-secret"
+EVENT = WebhookEventType.PAYMENT_CONFIRMED
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncGenerator[fakeredis_async.FakeRedis, None]:
+    client = fakeredis_async.FakeRedis(decode_responses=False)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+def _make_service(redis_client, **kw) -> WebhookService:
+    # Worker is NOT started; tests call _drain_outbox_once() directly.
+    return WebhookService(
+        redis_client,
+        WebhookConfig(url="https://platform.example/wh", secret="platform"),
+        outbox_enabled=True,
+        outbox_poll_interval=1,
+        outbox_max_age_seconds=kw.get("max_age", 86400),
+        outbox_max_backoff=kw.get("max_backoff", 600),
+    )
+
+
+def _payload(delivery_id="wh_task1_pc") -> tuple[WebhookDelivery, str]:
+    payload = WebhookPayload(
+        event=EVENT,
+        task_id="task1",
+        data={"task_metadata": {"order_id": "ord-1"}},
+        seller_agent="seller-agent",
+    )
+    delivery = WebhookDelivery(id=delivery_id, payload=payload, url=URL, attempts=3)
+    return delivery, payload.model_dump_json()
+
+
+def _fake_http(*, ok: bool):
+    """A stand-in httpx.AsyncClient whose post() returns a 2xx/5xx response."""
+    client = MagicMock()
+    resp = MagicMock()
+    resp.is_success = ok
+    resp.status_code = 200 if ok else 503
+    resp.text = "ok" if ok else "nope"
+
+    async def _post(*a, **k):
+        _post.calls.append(k)
+        return resp
+
+    _post.calls = []
+    client.post = _post
+    return client
+
+
+async def _park_now(svc: WebhookService, item: OutboxItem) -> None:
+    """Persist an outbox item and mark it due now (score in the past)."""
+    await svc._save_outbox_item(item)
+    await svc.redis.zadd(_OUTBOX_DUE_ZSET, {item.delivery_id: time.time() - 1})
+
+
+def _item(delivery_id="wh_task1_pc", payload_json=None, **kw) -> OutboxItem:
+    now = time.time()
+    return OutboxItem(
+        delivery_id=delivery_id,
+        url=URL,
+        secret=SECRET,
+        payload=payload_json or _payload(delivery_id)[1],
+        event=EVENT.value,
+        timestamp="2026-06-01T00:00:00+00:00",
+        task_id="task1",
+        attempts=kw.get("attempts", 3),
+        first_enqueued_at=kw.get("first_enqueued_at", now),
+        next_attempt_at=now,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# enqueue
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_enqueue_parks_body_secret_and_schedules(redis_client):
+    svc = _make_service(redis_client)
+    delivery, payload_json = _payload()
+    cfg = WebhookConfig(url=URL, secret=SECRET, retry_delay=5)
+
+    await svc._enqueue_outbox(delivery, cfg, payload_json)
+
+    stored = await redis_client.get(f"{_OUTBOX_ITEM_PREFIX}{delivery.id}")
+    assert stored is not None
+    parsed = OutboxItem.model_validate_json(stored)
+    assert parsed.url == URL
+    assert parsed.secret == SECRET  # outbox keeps the secret to re-sign
+    assert parsed.payload == payload_json  # exact body preserved for HMAC + dedupe
+    # scheduled on the due ZSET
+    assert await redis_client.zscore(_OUTBOX_DUE_ZSET, delivery.id) is not None
+
+
+# --------------------------------------------------------------------------- #
+# successful drain
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_drain_delivers_removes_and_marks_history(redis_client):
+    svc = _make_service(redis_client)
+    svc._http_client = _fake_http(ok=True)
+    delivery, payload_json = _payload()
+    await svc._save_delivery(delivery)  # history record exists (status updated in place)
+    await _park_now(svc, _item())
+
+    processed = await svc._drain_outbox_once()
+
+    assert processed == 1
+    assert await redis_client.zscore(_OUTBOX_DUE_ZSET, delivery.id) is None
+    assert await redis_client.get(f"{_OUTBOX_ITEM_PREFIX}{delivery.id}") is None
+    hist = WebhookDelivery.model_validate_json(
+        await redis_client.get(f"acn:webhooks:deliveries:{delivery.id}")
+    )
+    assert hist.status == "delivered"
+    assert hist.delivered_at is not None
+    assert await redis_client.get(f"{_OUTBOX_METRIC_PREFIX}delivered:{EVENT.value}") == b"1"
+
+
+@pytest.mark.asyncio
+async def test_redriven_body_is_signed_with_original_secret(redis_client):
+    svc = _make_service(redis_client)
+    http = _fake_http(ok=True)
+    svc._http_client = http
+    _, payload_json = _payload()
+    await _park_now(svc, _item(payload_json=payload_json))
+
+    await svc._drain_outbox_once()
+
+    sent = http.post.calls[-1]
+    expected = "sha256=" + hmac.new(
+        SECRET.encode(), payload_json.encode(), hashlib.sha256
+    ).hexdigest()
+    assert sent["headers"]["X-ACN-Signature"] == expected
+    assert sent["headers"]["X-ACN-Event"] == EVENT.value
+    assert sent["content"] == payload_json
+
+
+# --------------------------------------------------------------------------- #
+# failure -> reschedule
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_drain_failure_reschedules_with_later_score(redis_client):
+    svc = _make_service(redis_client)
+    svc._http_client = _fake_http(ok=False)
+    delivery, _ = _payload()
+    delivery.status = "queued"  # mirrors _deliver_webhook before enqueue
+    await svc._save_delivery(delivery)
+    await _park_now(svc, _item(attempts=3))
+
+    before = time.time()
+    await svc._drain_outbox_once()
+
+    score = await redis_client.zscore(_OUTBOX_DUE_ZSET, delivery.id)
+    assert score is not None and score > before  # re-queued for the future
+    item = OutboxItem.model_validate_json(
+        await redis_client.get(f"{_OUTBOX_ITEM_PREFIX}{delivery.id}")
+    )
+    assert item.attempts == 4  # bumped
+    assert item.last_error
+    assert await redis_client.get(f"{_OUTBOX_METRIC_PREFIX}failed:{EVENT.value}") == b"1"
+    # not yet terminal
+    hist = WebhookDelivery.model_validate_json(
+        await redis_client.get(f"acn:webhooks:deliveries:{delivery.id}")
+    )
+    assert hist.status == "queued"
+
+
+# --------------------------------------------------------------------------- #
+# dead-letter past max_age
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_after_max_age(redis_client):
+    svc = _make_service(redis_client, max_age=0)  # any failed attempt ages out
+    svc._http_client = _fake_http(ok=False)
+    delivery, _ = _payload()
+    await svc._save_delivery(delivery)
+    await _park_now(svc, _item(first_enqueued_at=time.time() - 10))
+
+    await svc._drain_outbox_once()
+
+    assert await redis_client.zscore(_OUTBOX_DUE_ZSET, delivery.id) is None
+    assert await redis_client.get(f"{_OUTBOX_ITEM_PREFIX}{delivery.id}") is None
+    hist = WebhookDelivery.model_validate_json(
+        await redis_client.get(f"acn:webhooks:deliveries:{delivery.id}")
+    )
+    assert hist.status == "dead"
+    assert await redis_client.get(f"{_OUTBOX_METRIC_PREFIX}dead:{EVENT.value}") == b"1"
+
+
+# --------------------------------------------------------------------------- #
+# atomic claim + secret hygiene
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_zrem_claim_is_atomic(redis_client):
+    svc = _make_service(redis_client)
+    await redis_client.zadd(_OUTBOX_DUE_ZSET, {"wh_x": time.time() - 1})
+    # First claim wins, second sees nothing.
+    assert await redis_client.zrem(_OUTBOX_DUE_ZSET, "wh_x") == 1
+    assert await redis_client.zrem(_OUTBOX_DUE_ZSET, "wh_x") == 0
+    # An empty due set processes nothing.
+    assert await svc._drain_outbox_once() == 0
+
+
+@pytest.mark.asyncio
+async def test_secret_never_written_to_history_record(redis_client):
+    svc = _make_service(redis_client)
+    delivery, payload_json = _payload()
+    cfg = WebhookConfig(url=URL, secret=SECRET, retry_delay=5)
+
+    delivery.status = "queued"
+    await svc._save_delivery(delivery)
+    await svc._enqueue_outbox(delivery, cfg, payload_json)
+
+    raw_hist = await redis_client.get(f"acn:webhooks:deliveries:{delivery.id}")
+    assert SECRET.encode() not in raw_hist  # history is secret-free
+    # ...but the outbox item retains it (internal Redis only).
+    raw_item = await redis_client.get(f"{_OUTBOX_ITEM_PREFIX}{delivery.id}")
+    assert SECRET.encode() in raw_item
+    assert json.loads(raw_hist)["status"] == "queued"


### PR DESCRIPTION
Closes #162.

## Problem
`WebhookService` retried deliveries **in-process** (3×, ~15s) and persisted records to Redis as *history*, not a work queue. A process crash mid-retry dropped the push — so even after P1-A, seller webhooks were "best-effort with short retries", not at-least-once.

## Change (purely additive — `send_to`/`send_event` signing + event enum unchanged)
- On in-process exhaustion, park the delivery in a **durable Redis outbox**: an `OutboxItem` (`acn:webhooks:outbox:item:{id}`) holding the exact signed body + target url/secret, scheduled on a due ZSET (`acn:webhooks:outbox:due`).
- A background worker (started in `start()`, cancelled in `stop()`) sweeps due items, **claims each atomically via `ZREM`** (safe across replicas; duplicate sends are fine — receivers dedupe on `delivery_id`), re-POSTs with the original secret so the **HMAC still matches**, and on failure reschedules with capped exponential backoff.
- Past `max_age` it **dead-letters** (history `status="dead"` + error log) and leaves recovery to the P0 fulfillment-queue poll, which remains the correctness backstop.
- Idempotent on the unique `delivery_id`; success/failure/dead counters under `acn:webhooks:metrics:{outcome}:{event}`.
- **Secret hygiene:** the secret lives only in the internal outbox item, never in the secret-free delivery-history record.

## Config (settings, all defaulted)
`webhook_outbox_enabled` (True), `webhook_outbox_poll_interval` (5s), `webhook_outbox_max_age_seconds` (24h), `webhook_outbox_max_backoff` (10m).

## Test plan
- [x] New `tests/services/test_webhook_outbox.py` (7 tests, fakeredis): enqueue parks body+secret+schedule; successful sweep delivers/removes/marks history; failed sweep reschedules + bumps attempts; dead-letter past max_age; ZREM claim atomic; re-driven body signed with original secret; secret never in history record.
- [x] Regression: `test_ap2_seller_webhook_and_settlement.py` (10) still pass.
- [x] ruff + mypy clean on changed files.

Made with [Cursor](https://cursor.com)