### PR TITLE
fix(ap2): scope durable outbox to payment webhooks, not join-flow/subnet

### DIFF
--- a/acn/protocols/ap2/webhook.py
+++ b/acn/protocols/ap2/webhook.py
@@ -255,11 +255,15 @@ class WebhookService:
         amount: str | None = None,
         currency: str | None = None,
         payment_method: str | None = None,
+        outbox: bool = True,
     ) -> bool:
         """
         Send a webhook event to configured endpoints.
 
         Returns True if delivered successfully (or no webhook configured).
+
+        ``outbox`` (default True) controls durable at-least-once re-driving; see
+        :meth:`_deliver_webhook`.
         """
         if not self.default_config or not self.default_config.enabled:
             logger.debug(f"Webhook not configured, skipping event: {event}")
@@ -281,7 +285,7 @@ class WebhookService:
             payment_method=payment_method,
         )
 
-        return await self._deliver_webhook(payload, self.default_config)
+        return await self._deliver_webhook(payload, self.default_config, use_outbox=outbox)
 
     async def send_to(
         self,
@@ -299,6 +303,7 @@ class WebhookService:
         timeout: int = 30,
         retry_count: int = 3,
         retry_delay: int = 5,
+        outbox: bool = True,
     ) -> bool:
         """Deliver a webhook payload to an arbitrary URL.
 
@@ -319,6 +324,9 @@ class WebhookService:
             timeout: HTTP timeout in seconds
             retry_count: Number of delivery attempts
             retry_delay: Base delay between retries (exponential backoff)
+            outbox: Durable at-least-once re-driving (default True). Pass False
+                for fire-and-forget callers (e.g. join-flow / Org-Harness
+                lifecycle events) that reconcile out-of-band.
 
         Returns:
             True if delivered successfully, False after exhausting retries.
@@ -346,14 +354,24 @@ class WebhookService:
             enabled=True,
         )
 
-        return await self._deliver_webhook(payload, config)
+        return await self._deliver_webhook(payload, config, use_outbox=outbox)
 
     async def _deliver_webhook(
         self,
         payload: WebhookPayload,
         config: WebhookConfig,
+        *,
+        use_outbox: bool = True,
     ) -> bool:
-        """Deliver webhook with retries"""
+        """Deliver webhook with retries.
+
+        ``use_outbox`` gates the durable outbox (ACN #162). It defaults to True
+        (payment/platform webhooks want at-least-once), but callers whose
+        delivery semantics are "fire-and-forget, reconcile out-of-band" — e.g.
+        subnet / Org-Harness join-flow lifecycle events (ADR-0004) — pass
+        ``False`` to keep the historical "fail fast after in-process retries"
+        behavior and avoid late/out-of-order re-delivery.
+        """
         if not self._http_client:
             self._http_client = httpx.AsyncClient(timeout=config.timeout, trust_env=False)
 
@@ -420,8 +438,9 @@ class WebhookService:
 
         # In-process retries exhausted. Park it in the durable outbox so a
         # background worker keeps re-driving across restarts (at-least-once);
-        # fall back to the old terminal "failed" only when the outbox is off.
-        if self._outbox_enabled:
+        # fall back to the old terminal "failed" when the outbox is off OR the
+        # caller opted out (use_outbox=False).
+        if self._outbox_enabled and use_outbox:
             delivery.status = "queued"
             await self._save_delivery(delivery)
             await self._enqueue_outbox(delivery, config, payload_json)

--- a/acn/routes/_subnet_membership.py
+++ b/acn/routes/_subnet_membership.py
@@ -271,6 +271,7 @@ async def do_join_subnet(
                     "agent_id": agent_id,
                     "parent_slug": parent_slug,
                 },
+                outbox=False,  # membership lifecycle: fire-and-forget, reconcile via GET /allowlist
             )
         except Exception as e:  # noqa: BLE001 - never break join on webhook failure
             logger.warning(
@@ -324,6 +325,7 @@ async def do_leave_subnet(
                         # harnesses get hierarchy on both edges.
                         "parent_slug": _subnet_parent_id(subnet),
                     },
+                    outbox=False,  # membership lifecycle: fire-and-forget, reconcile via GET /allowlist
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -2039,6 +2039,7 @@ class TaskService:
                     event=event,
                     task_id=task.task_id,
                     data=payload,
+                    outbox=False,  # Org-Harness lifecycle: fire-and-forget, reconcile out-of-band
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(
@@ -2096,6 +2097,7 @@ class TaskService:
                     event=event,
                     task_id=task.task_id,
                     data=payload,
+                    outbox=False,  # Org-Harness lifecycle: fire-and-forget, reconcile out-of-band
                 )
             except Exception as e:
                 logger.warning(

--- a/acn/services/webhook_join_flow_event_publisher.py
+++ b/acn/services/webhook_join_flow_event_publisher.py
@@ -161,6 +161,7 @@ class WebhookJoinFlowEventPublisher(IJoinFlowEventPublisher):
                 # directly so this is a transport-only field.
                 task_id=subnet.slug,
                 data=data,
+                outbox=False,  # join-flow lifecycle: fire-and-forget, reconcile via GET /allowlist
             )
         except Exception as exc:  # noqa: BLE001 — see class docstring.
             logger.error(

--- a/tests/services/test_webhook_outbox.py
+++ b/tests/services/test_webhook_outbox.py
@@ -257,6 +257,36 @@ async def test_zrem_claim_is_atomic(redis_client):
 
 
 @pytest.mark.asyncio
+async def test_send_to_outbox_false_does_not_park(redis_client):
+    """Opt-out callers (join-flow / Org-Harness) keep the old fail-fast behavior."""
+    svc = _make_service(redis_client)
+    svc._http_client = _fake_http(ok=False)
+
+    ok = await svc.send_to(
+        URL, SECRET, EVENT, "task1", {"x": 1},
+        retry_count=1, retry_delay=0, outbox=False,
+    )
+
+    assert ok is False
+    assert await redis_client.zcard(_OUTBOX_DUE_ZSET) == 0  # nothing parked
+
+
+@pytest.mark.asyncio
+async def test_send_to_default_parks_on_failure(redis_client):
+    """Payment/default callers (outbox defaults True) DO park on failure."""
+    svc = _make_service(redis_client)
+    svc._http_client = _fake_http(ok=False)
+
+    ok = await svc.send_to(
+        URL, SECRET, EVENT, "task1", {"x": 1},
+        retry_count=1, retry_delay=0,
+    )
+
+    assert ok is False
+    assert await redis_client.zcard(_OUTBOX_DUE_ZSET) == 1  # parked for re-driving
+
+
+@pytest.mark.asyncio
 async def test_secret_never_written_to_history_record(redis_client):
     svc = _make_service(redis_client)
     delivery, payload_json = _payload()


### PR DESCRIPTION
Follow-up to #164 (review finding).

## Problem
The #162 durable outbox was added on the shared `_deliver_webhook` path, so it **unintentionally** also parked-and-retried (24h) the subnet / Org-Harness lifecycle webhooks (ADR-0004) that flow through `send_to`. That changed their "fire-and-forget, reconcile via `GET /allowlist`" semantics and risked **late / out-of-order re-delivery** (e.g. a stale `agent.joined_subnet` arriving after a `leave`). The broadening was out of #162's scope and untested.

## Fix
Add an `outbox` flag to `send_event` / `send_to` (default `True`, threaded to `_deliver_webhook` as `use_outbox`). Payment + platform-default deliveries keep at-least-once; the join-flow / subnet-harness call sites now pass `outbox=False` to preserve their historical fail-fast behavior:
- `task_service`: task + participation Org-Harness webhooks
- `webhook_join_flow_event_publisher`: join-flow lifecycle events
- `_subnet_membership`: `agent.joined_subnet` / `agent.left_subnet`

## Test plan
- [x] New tests: `send_to(outbox=False)` does not park on failure; default `send_to` still parks.
- [x] Regression: seller webhook/settlement + join-flow + org-harness suites (60) unchanged.
- [x] ruff + mypy clean on all changed files.

Made with [Cursor](https://cursor.com)