### PR TITLE
docs(adr): supersede ADR-0011; mark ADR-0010 fully implemented

### DIFF
--- a/docs/adr/0010-marketplace-buyer-protection-escrow.md
+++ b/docs/adr/0010-marketplace-buyer-protection-escrow.md
@@ -6,22 +6,19 @@
 **Related:** ADR-0009 (Commerce Layered Architecture — single ledger, reconciliation, AP2 events), ~~ADR-0011~~ (Superseded — seller capital layer no longer needed given universal hold), ADR-0007 (Unified Agent Identity); backend PRs #24 #25 #26 (`store_service.py`, `main.py`, `SKILL.md v1.5.0`)
 
 > **Decision:** Buyer protection is provided **per order**, only for the **acute
-> "paid → fulfilled-and-accepted" window**. This ADR uses **two tiers**:
-> - **Unproven seller →** the buyer's payment is **held in escrow**; it releases
->   to the seller only on **buyer acceptance or an acceptance-window timeout**
->   (D3/D13), **never** on the seller's self-attested `fulfill`. Abandonment /
->   dispute refunds the buyer from the hold.
-> - **Proven / trusted seller →** **instant settlement** (today's behavior).
->
-> The *graduated* trust model that refines "proven" into a continuous,
-> capital-backed privilege (earned exposure limit, opt-in deposit, rolling
-> reserve, anomaly step-up) lives in **ADR-0011**.
+> "paid → fulfilled-and-accepted" window**. **Universal escrow — all sellers,
+> no exceptions, no instant-settlement tier:**
+> - The buyer's payment is **held in escrow** at pay time; it releases to the
+>   seller only on **buyer acceptance or an acceptance-window timeout (72 h
+>   default)**, **never** on the seller's self-attested `fulfill`.
+> - Abandonment / refund before release ⇒ refund from hold (seller was never
+>   credited, so no seller balance is drawn).
+> - Contested ⇒ arbitration ruling (Future Work; see ADR-0011).
 >
 > **Post-fulfillment prorated refunds are out of scope** — for providers that
 > refund (Tencent/Aliyun/Huawei) they are self-funded by the upstream refund the
 > seller received; for no-refund rails (AWS pay-as-you-go) the case largely does
-> not arise. Disputes are settled by the **existing arbitration network** (detail
-> + fee model in ADR-0011), not a manual admin path.
+> not arise.
 >
 > Hard constraints (from ADR-0009): **single ledger**; the escrow hold is a
 > wallet-backed sub-account in the backend, never a second money truth.
@@ -33,7 +30,7 @@
 ### Why buyer protection is foundational
 
 AgentMother is a **paid service provider** — it builds & deploys agents *for
-paying customers*; it is itself a (first-party, trusted) seller, **not a charity
+paying customers*; it is itself a (first-party) seller, **not a charity
 and not an underwriter** of the agents it creates. Whether a created agent then
 opens its own shop is **that agent's and its owner's business** — an independent,
 **owner-capitalized** economic actor. So the seller population is a long tail of
@@ -42,16 +39,19 @@ the platform must bootstrap or that AgentMother backstops. Buyer protection is
 still foundational: the marketplace collapses the first time one of these
 independent sellers takes payment and disappears.
 
-### The gap in current code
+Buyer protection is therefore **foundational infrastructure**, built as a
+prerequisite for opening third-party seller onboarding, **not triggered by the
+first bad actor**.
 
-- **Instant settlement, unconditionally.** `pay_order` debits the buyer and
-  credits the seller's wallet in one transaction (`state="fulfilling"`); the
-  seller can spend immediately. (ADR-0009 assumed this for a single trusted
-  seller — this ADR refines it: instant settlement becomes a *trust-tier
-  privilege*.)
-- **Refund has no collateral behind it.** `refund_order` draws from the seller
-  wallet; if the seller spent/cashed-out the proceeds it fails with
-  `409 "Seller cannot cover refund"`. A vanished seller leaves the buyer with no
+### The gap in current code (at design time)
+
+- **Instant settlement, unconditionally.** `pay_order` debited the buyer and
+  credited the seller's wallet in one transaction; the seller could spend
+  immediately. (ADR-0009 assumed this for a single trusted seller; this ADR
+  replaced it with universal escrow.)
+- **Refund had no collateral behind it.** `refund_order` drew from the seller
+  wallet; if the seller had spent the proceeds it failed with
+  `409 "Seller cannot cover refund"`. A vanished seller left the buyer with no
   recourse.
 
 ### The fundamental trade (state it honestly)
@@ -62,16 +62,17 @@ it:
 
 | Mechanism | Whose capital | Cashflow effect on seller | Buyer protection |
 |---|---|---|---|
-| **Escrow the buyer's payment** | the buyer's (already paid) | seller fronts provisioning itself | full, for that order, zero seller collateral |
-| **Seller deposit (collateral)** — see ADR-0011 | the seller's own | seller locks ≈ exposure *plus* funds provisioning | full, bounded by deposit |
-| **Instant settlement (today)** | none held | best (seller has the cash) | none |
+| **Escrow the buyer's payment** ← chosen | the buyer's (already paid) | seller fronts provisioning itself | full, for that order, zero seller collateral |
+| Seller deposit (collateral) | the seller's own | seller locks ≈ exposure *plus* funds provisioning | full, bounded by deposit |
+| Instant settlement (old behavior) | none held | best (seller has the cash) | none |
 
 There is no option that protects the buyer *and* costs the seller no capital
-during provisioning. This ADR assigns the burden by trust: **unproven sellers
-bear it (escrow); proven sellers don't (instant)**. This burden is **the
-seller-owner's responsibility by design** — the platform does not advance startup
-capital, and an agent that cannot fund provisioning under escrow simply **isn't
-ready to sell** (no charity, no bootstrapping).
+during provisioning. Universal escrow places the burden entirely on the buyer's
+own already-paid funds — the seller never received the money to spend, so no
+additional collateral is required. Credits are closed-loop (no withdrawal), so
+the 72-hour delay only affects when credits enter the seller's wallet for
+platform-internal use. There is no cashflow reason for sellers to prefer instant
+settlement.
 
 ### Reusable in-house pattern
 
@@ -83,12 +84,13 @@ cleanly reusable** for a plain store-payment hold. P1 therefore adds a **lightwe
 store-payment hold** (buyer debited at pay time; the amount parked as a recorded
 liability — held order sub-state, settled to the seller only at release) reusing
 the *pattern*, not the task-escrow tables. The **arbitration** path (the
-`ReviewService` jury + Escrow ruling) still resolves contested disputes (it decides;
-the hold pays); its fee model and store-dispute wiring are specified in ADR-0011.
+`ReviewService` jury + Escrow ruling) remains a candidate for resolving contested
+disputes; its fee model and store-dispute wiring are deferred to a future ADR
+(see Future Work in ~~ADR-0011~~).
 
 ### Interaction with ADR-0009 (what P1 must reconcile)
 
-ADR-0009 settles in one transaction (**credit seller wallet + notify seller**) at
+ADR-0009 settled in one transaction (**credit seller wallet + notify seller**) at
 pay time. Escrow-hold breaks that coupling, so P1 must:
 
 - **Split "notify the seller to fulfill" from "settle to the seller wallet."** A
@@ -96,7 +98,7 @@ pay time. Escrow-hold breaks that coupling, so P1 must:
   but the wallet credit happens only at **release** (acceptance window end). The
   AP2/`store.order_paid` notification fires on escrow-lock; ledger settlement to
   the seller fires on release.
-- **Make the *already-shipped* `refund_order` escrow-aware.** It currently debits
+- **Make the *already-shipped* `refund_order` escrow-aware.** It previously debited
   the **seller balance**; a held order's seller was never credited, so a refund
   must come from the **hold**, not the seller wallet (else it wrongly `409`s on
   funds sitting in escrow). ⇒ P1 is **not purely additive**: it modifies the P0
@@ -113,94 +115,97 @@ pay time. Escrow-hold breaks that coupling, so P1 must:
    refund where applicable); the existing `refund_order` handles them best-effort
    against seller balance.
 
-2. **Two tiers (this ADR):** **unproven → escrow-hold**; **proven / D8-trusted →
-   instant settlement** (today's behavior). The classifier here is **binary**
-   (proven vs unproven). The continuous, capital-backed refinement of "proven"
-   (earned limit `L`, opt-in deposit, reserve) is **ADR-0011**.
+2. **Universal escrow — all sellers, no instant-settlement tier.** Every
+   `agent_service` order routes through escrow hold regardless of seller identity
+   or history. No trust classifier is needed; no D8 allowlist exists. This
+   eliminates the bust-out attack surface entirely (there is no "proven tier" to
+   graduate into), removes the need for the ADR-0011 capital subsystem, and
+   eliminates money-flow complexity from credits being closed-loop.
 
 3. **Escrow release / refund trigger.** Seller `fulfill` does **not** release
-   funds by itself — it **starts a buyer-acceptance / dispute window** (D13).
-   Release = **buyer confirms** ∨ **window elapses with no dispute**. Buyer refund
-   before release ⇒ refund from hold. **Contested** ⇒ arbitration ruling.
+   funds by itself — it **starts a buyer-acceptance window (D13)**. Release =
+   **buyer confirms** ∨ **window elapses with no dispute**. Buyer refund before
+   release ⇒ refund from hold (seller never credited; always covered). **Contested**
+   ⇒ arbitration ruling (Future Work).
    Rationale: `fulfill` is seller-self-reported free-text, so releasing on it
    would let a lying seller drain the escrow with a fake fulfillment.
 
 4. **Disputes go to the arbitration network**, not a manual admin button (ruling
-   → release vs refund). Dispute-routing detail and the **juror fee model** are in
-   ADR-0011 (a dependency before that wiring lands).
+   → release vs refund). Dispute-routing detail and juror fee model are **Future
+   Work**, designed when the first real disputed order occurs (see ~~ADR-0011~~).
 
 5. **Single ledger preserved.** The escrow hold is a backend wallet sub-account;
    not mirrored as money truth in ACN/AP2 (ADR-0009).
 
-### Threat model — reputation farming / "bust-out" (where it's handled)
+### Threat model — "bust-out" (fully neutralised)
 
 The classic attack — *farm reputation with small orders, graduate, then take one
-large payment and vanish* — has two halves:
-
-- **Unproven sellers** are **fully escrowed** in this ADR, so a brand-new seller
-  cannot bust out at all (funds are held until buyer acceptance).
-- The **post-graduation** bust-out (a *proven* seller suddenly taking a huge
-  order) is defeated by **ADR-0011's** continuous earned-limit `L`, rolling
-  reserve, and anomaly step-up. This ADR's binary "proven ⇒ instant" is therefore
-  **only safe once ADR-0011 lands**; until then "proven/instant" is restricted to
-  the **D8 trusted-seller allowlist** (i.e. first-party sellers like AgentMother),
-  not earned by volume.
+large payment and vanish* — requires a "large payment to abscond with." Under
+universal hold, funds are **never released to the seller until the buyer accepts or
+the window times out**. The money never arrives before the obligation is checked,
+so there is nothing to abscond with. The attack is structurally impossible.
 
 ### Buyer-side fraud (friendly fraud)
 
 Escrow + buyer-dispute lets a malicious **buyer** take delivery (real cloud value)
-then refuse to confirm / dispute → refund, leaving an unproven seller out the
-cloud cost. Mitigations in P1: contested cases go to **arbitration** (not
-auto-refund); buyers also accrue reputation (a confirm-then-dispute pattern is
-down-weighted/flagged). Full buyer-abuse governance is deferred (ADR-0011 P3).
+then refuse to confirm / dispute → refund, leaving a seller out the cloud cost.
+Mitigations: contested cases go to **arbitration** (not auto-refund); buyers
+accrue a dispute reputation score (confirm-then-dispute pattern down-weighted/
+flagged). Full buyer-abuse governance is **Future Work** (trigger: first pattern
+of suspected buyer abuse).
 
 ---
 
 ## Considered Options
 
-| | A: progressive trust — escrow(unproven)/instant(proven, gated by D8 then ADR-0011) (chosen) | B: universal seller deposit | C: universal escrow-until-fulfill | D: platform underwrites (negative balance) | E: status quo (instant + 409 refund) |
+| | A: progressive trust — escrow(unproven)/instant(proven) | B: universal seller deposit | **C: universal escrow (chosen)** | D: platform underwrites (negative balance) | E: status quo (instant + 409 refund) |
 |---|---|---|---|---|---|
 | Protects buyer from untrusted seller | ✅ (escrow) | ✅ | ✅ | ⚠️ platform bears default | ❌ |
-| Proven seller keeps cashflow | ✅ instant | ⚠️ locks capital | ❌ all held | ✅ | ✅ |
-| Capital burden falls fairly | ✅ on unproven only | ❌ on all sellers | ❌ on all sellers | ❌ on platform | n/a |
+| Proven seller keeps cashflow | ✅ instant | ⚠️ locks capital | ⚠️ 72h delay (credits only, closed-loop) | ✅ | ✅ |
+| Capital burden falls fairly | ✅ on unproven only | ❌ on all sellers | ✅ none (buyer's own payment) | ❌ on platform | n/a |
 | Bounds platform risk | ✅ | ✅ | ✅ | ❌ unbounded | ✅ (no protection) |
-| Build cost (P1) | low (reuse escrow) | medium | low–medium | low | none |
+| Eliminates bust-out | ❌ only unproven | ✅ | ✅ | ❌ | ❌ |
+| Needs trust classifier | ✅ needed | ❌ | ❌ | ❌ | ❌ |
+| Build cost (P1) | medium (classifier + two paths) | medium | **low** (single path) | low | none |
 
-**B** rejected (→ deferred to ADR-0011 as an *opt-in*): over-charges
-thin-margin sellers. **C** rejected: starves proven sellers' cashflow. **D**
-rejected as primary: unbounded liability (kept only as the D8 trusted-seller
-fallback, default off). **E** is the current bug for untrusted sellers. **A** puts
-the cheapest sufficient mechanism on each tier.
+**A** rejected: requires a trust classifier and a "proven" tier that can still bust
+out post-graduation; needs ADR-0011 capital subsystem to be safe.
+**B** rejected: over-charges thin-margin sellers; capital locked even when order
+succeeds.
+**D** rejected as primary: unbounded platform liability.
+**E** is the current bug for untrusted sellers.
+**C** is the simplest sufficient mechanism — one code path, full coverage,
+zero additional collateral, bust-out structurally impossible.
 
 ---
 
 ## Consequences
 
 ### Positive
-- Buyers are protected against the imminent untrusted-seller influx **from P1**,
-  reusing the existing escrow mechanism (low build cost, full acute-window
-  coverage, zero seller collateral).
-- No new bespoke trust machinery in P1; the heavier staking/deposit subsystem is
-  cleanly deferred to ADR-0011.
+- Buyers are protected for **every** order from **day one of third-party
+  onboarding**, with no per-seller classification logic.
+- No trust classifier, no D8 allowlist, no capital mechanics — the escrow path is
+  the only path.
+- Bust-out attack is structurally impossible (no instant-settlement tier to
+  graduate into).
+- No ADR-0011 capital layer to build: universal hold made it unnecessary.
 
 ### Negative / costs
 - Adds an **escrow-hold order sub-state** to `pay_order`/`fulfill` and makes
   `refund_order` escrow-aware (settlement-adjacent → transaction-safe + tested
   like wallet paths). **Not purely additive** (see Interaction with ADR-0009).
-- Under escrow a seller funds its own provisioning during the hold — **by design,
-  the seller-owner's responsibility** (no platform advance).
-- A binary proven/unproven classifier is needed; until ADR-0011, "proven/instant"
-  is the **D8 allowlist only** (not earned), to avoid an unguarded bust-out.
-- **Depends on a sufficiently neutral arbitration jury** for disputes (validated
-  in ADR-0011).
+- All sellers (including first-party) wait up to 72 hours for credits to settle.
+  Accepted: credits are closed-loop, so the delay has no real-money cashflow
+  impact.
+- **Depends on a neutral arbitration mechanism** for contested holds (Future Work;
+  trigger: first real disputed order).
 
 ### Neutral
 - The shipped refund API surface is unchanged for callers; for held orders the
-  funding source becomes the escrow (always covered for the acute window).
-- **The original "seller won't top up" gap is only *partly* closed:** solved for
-  the acute window (escrow); post-fulfillment prorated refunds by an instant
-  seller remain best-effort against seller balance (the P0 `409`), backstopped by
-  ADR-0011's rolling reserve. Accepted scope limit, not a regression.
+  funding source is always the hold (always covered for the acute window).
+- **The original "seller won't top up" gap is fully closed** for the acute window.
+  Post-fulfillment prorated refunds remain best-effort against seller balance
+  (the P0 `409`); this is an accepted scope limit, not a regression.
 
 ---
 
@@ -208,19 +213,15 @@ the cheapest sufficient mechanism on each tier.
 
 - **P0 — done:** refund API (`POST /orders/{id}/refund`) — full/partial refund
   from seller balance, terminal `refunded`, blocks re-fulfill; `409` if seller
-  can't cover (the gap this ADR closes for untrusted sellers).
-- **P1 — acute-window escrow for unproven sellers (highest protection / lowest
-  build):** classify trust (binary); for **unproven** sellers `pay_order` routes
-  the payment into an **escrow hold** instead of crediting the seller; `fulfill`
-  opens a buyer-acceptance / dispute window (D3/D13); release on buyer confirm or
-  window timeout; abandonment/refund refunds the buyer from the hold. Proven /
-  D8-trusted sellers keep instant settlement. **Routing is binary** — the
-  continuous limit `L` is ADR-0011.
-- **P2 / P3 → Superseded.** The seller capital layer (deposit, L, reserve) is no longer
-  needed — universal hold already provides full buyer protection with no instant-settlement
-  tier to protect against. Dispute arbitration and buyer-reputation are noted as Future Work
-  in the now-superseded ADR-0011; they will be designed when the first real disputed order
-  occurs.
+  can't cover.
+- **P1 — done:** universal acute-window escrow for **all** sellers. `pay_order`
+  debits the buyer and parks the full amount as a hold (seller not credited);
+  `fulfill` opens a 72-hour buyer-acceptance window; release on buyer confirm
+  (`POST /orders/{id}/accept`) or window timeout (background
+  `release_expired_holds`); refund before release draws from hold, never from
+  seller balance.
+- **Future Work (not scheduled):** dispute arbitration wiring; buyer-side fraud
+  detection. Both designed as new standalone ADRs at their respective trigger events.
 
 > Blast radius: P0/P1 backend-only.
 
@@ -228,16 +229,18 @@ the cheapest sufficient mechanism on each tier.
 
 ## Open Sub-Decisions (this ADR's scope)
 
-| # | Decision | Proposed |
+| # | Decision | Status |
 |---|---|---|
-| D1 | Trust classifier (this ADR = binary) | **Decided:** binary proven/unproven. Unproven ⇒ escrow. "Proven ⇒ instant" is, until ADR-0011 lands, the **D8 trusted-seller allowlist only** (first-party sellers); earned/graduated "proven" is ADR-0011. |
-| D2 | Acute window = escrow-hold scope | Hold the **full order amount**; release **after the buyer-acceptance / dispute window (D3/D13)**, *not* on the seller's `completed` flag; refundable to buyer until release. P1 = **all-or-nothing** release (partial fulfillment out of scope). |
-| D3 | Escrow release / refund trigger | **Decided:** release = buyer confirm ∨ window timeout; **never** seller self-attested `fulfill`; contested ⇒ arbitration. |
-| D4 | Abandonment trigger | **Decided:** **both** a buyer dispute **and** a fulfillment-SLA timeout (uses existing order timestamps) ⇒ buyer may reclaim from the hold. (A silently-vanished seller means the buyer may never dispute, so the SLA auto-path is required in P1.) |
-| D8 | Trusted-seller fallback | Per-seller flag, **default off**: instant settlement (+ optional negative-balance underwrite) for explicitly trusted first-party sellers (e.g. AgentMother). **Not** transitively granted to agents a trusted seller creates. |
-| D13 | Acceptance-window length & buyer-no-response default | **Decided:** two timers — (a) **fulfillment SLA** (seller fulfills within X or buyer reclaims, D4); (b) **post-fulfill acceptance window** of **Y (default 72h, configurable)** — buyer neither confirms nor disputes within Y ⇒ hold **auto-releases to seller** (an absent buyer cannot freeze seller funds). Tunable per product class. |
-| D14 | Buyer-side fraud (friendly fraud) | **Acknowledged:** contested ⇒ arbitration (not auto-refund); buyers accrue reputation (confirm-then-dispute pattern down-weighted). Full governance → ADR-0011 P3. |
+| D2 | Acute window = escrow-hold scope | **Decided:** hold the full order amount; release after the buyer-acceptance window (D13), *not* on the seller's `completed` flag; refundable to buyer until release. All-or-nothing release (partial fulfillment out of scope). |
+| D3 | Escrow release / refund trigger | **Decided:** release = buyer confirm ∨ window timeout; **never** seller self-attested `fulfill`; contested ⇒ arbitration (Future Work). |
+| D4 | Abandonment / auto-release | **Decided:** fulfillment-SLA timeout ⇒ buyer may reclaim from hold; post-fulfill acceptance-window timeout ⇒ hold auto-releases to seller. Background task `release_expired_holds` runs on a 5-minute loop. |
+| D13 | Acceptance-window length & buyer-no-response default | **Decided:** 72-hour post-fulfill acceptance window (configurable per product class). Buyer neither confirms nor disputes within 72h ⇒ hold auto-releases to seller (an absent buyer cannot freeze seller funds indefinitely). |
+| D14 | Buyer-side fraud (friendly fraud) | **Acknowledged:** contested ⇒ arbitration (not auto-refund); buyers accumulate dispute reputation. Full governance → Future Work (new ADR at trigger event). |
 
+> ~~D1 (trust classifier) and D8 (trusted-seller D8 allowlist) are withdrawn~~
+> — universal escrow requires no classifier and no per-seller instant-settlement
+> flag.
+>
 > Deposit sizing, forfeit semantics, `ap_points` role, reviewer-stake migration,
-> unified bond, rolling reserve, anomaly step-up, and the arbitration fee model
-> are **ADR-0011** sub-decisions.
+> rolling reserve, and the arbitration fee model were **ADR-0011** sub-decisions;
+> ADR-0011 is now superseded.

--- a/docs/adr/0010-marketplace-buyer-protection-escrow.md
+++ b/docs/adr/0010-marketplace-buyer-protection-escrow.md
@@ -1,9 +1,9 @@
 # ADR-0010: Marketplace Buyer Protection — Acute-Window Escrow
 
-**Status:** Accepted (direction) — P0 done; **P1 is foundational infrastructure and a hard prerequisite for enabling third-party (non-first-party) seller onboarding** — it is built *before* the marketplace opens to untrusted sellers, **not** deferred until one appears (that would leave the first such seller's buyers unprotected). Until P1 ships, third-party seller registration stays closed and only D8 first-party sellers (e.g. AgentMother) sell, on the trusted-instant path. Release *mechanism* decided (D3); window length (D13) set during P1 build. The graduated staking/deposit/reputation layer is split into **ADR-0011**.
+**Status:** Accepted — **P0 and P1 fully implemented** (backend PRs #24, #25, #26). Universal escrow hold: all orders, all sellers, no instant-settlement tier. The graduated staking/deposit/reputation layer (originally split into ADR-0011) is **superseded** — it was only needed to safely allow sellers to skip escrow, a tier that no longer exists.
 **Date:** 2026-06-01
 **Deciders:** AgentPlanet platform owner + ACN core team + backend
-**Related:** ADR-0009 (Commerce Layered Architecture — single ledger, reconciliation, AP2 events; this ADR *refines* its instant-settlement assumption), **ADR-0011** (Seller Staking / Deposit / Graduated Reputation — the capital-backed refinement of this ADR's "proven seller" tier), ADR-0007 (Unified Agent Identity); backend store (`backend/app/services/store_service.py`), refund API (`POST /api/store/orders/{order_id}/refund`), escrow (`backend/app/services/escrow_service.py`)
+**Related:** ADR-0009 (Commerce Layered Architecture — single ledger, reconciliation, AP2 events), ~~ADR-0011~~ (Superseded — seller capital layer no longer needed given universal hold), ADR-0007 (Unified Agent Identity); backend PRs #24 #25 #26 (`store_service.py`, `main.py`, `SKILL.md v1.5.0`)
 
 > **Decision:** Buyer protection is provided **per order**, only for the **acute
 > "paid → fulfilled-and-accepted" window**. This ADR uses **two tiers**:
@@ -216,16 +216,11 @@ the cheapest sufficient mechanism on each tier.
   window timeout; abandonment/refund refunds the buyer from the hold. Proven /
   D8-trusted sellers keep instant settlement. **Routing is binary** — the
   continuous limit `L` is ADR-0011.
-- **P2 / P3 → ADR-0011:** seller deposit (`agent_stakes`), earned exposure limit
-  `L`, rolling reserve, anomaly step-up, arbitration integration + fee model,
-  reviewer-stake migration, optional unified bond.
-
-> Sequencing: P1 is **build-ahead infrastructure** — it gates the *opening* of
-> third-party seller onboarding (you flip third-party registration on only once
-> the hold path exists), so buyers are never exposed by a seller arriving before
-> protection does. By contrast the ADR-0011 capital subsystem is genuinely
-> demand-gated: it waits for real proven-seller volume / a deposit-demand signal,
-> because escrow already fully protects unproven sellers' buyers in the interim.
+- **P2 / P3 → Superseded.** The seller capital layer (deposit, L, reserve) is no longer
+  needed — universal hold already provides full buyer protection with no instant-settlement
+  tier to protect against. Dispute arbitration and buyer-reputation are noted as Future Work
+  in the now-superseded ADR-0011; they will be designed when the first real disputed order
+  occurs.
 
 > Blast radius: P0/P1 backend-only.
 

--- a/docs/adr/0011-seller-staking-deposit-graduated-reputation.md
+++ b/docs/adr/0011-seller-staking-deposit-graduated-reputation.md
@@ -1,131 +1,53 @@
 # ADR-0011: Seller Staking, Deposit & Graduated Reputation (Marketplace Trust v2)
 
-**Status:** Proposed — **trigger-gated**: build when there is real proven-seller volume or demand for early instant settlement (a deposit-demand signal). Extends ADR-0010.
-**Date:** 2026-06-01
+**Status:** Superseded — the capital subsystem (deposit / exposure-limit L / rolling reserve / anomaly step-up) is **no longer needed** given the P1 universal-escrow decision. All residual work is noted as Future Work.
+**Date:** 2026-06-01 (superseded 2026-06-02)
 **Deciders:** AgentPlanet platform owner + ACN core team + backend
-**Related:** **ADR-0010** (Acute-Window Escrow — this ADR refines its binary "proven ⇒ instant" tier into a continuous, capital-backed privilege), ADR-0009 (single ledger), ADR-0007 (Unified Agent Identity); consensus/arbitration (`backend/app/services/review_service.py`, `ReviewerStats`), escrow (`escrow_service.py`)
-
-> **Decision:** Refine ADR-0010's "proven seller → instant settlement" tier from a
-> binary **D8 allowlist** into a **continuous, earned, capital-backed** privilege:
-> - **Earned exposure limit `L`** — a seller's uncollateralized instant-settlement
->   limit = its accumulated **cleared value** (orders completed *and* past their
->   dispute window), **time-decayed** and **buyer-diversity-weighted** (not order
->   count). Instant only while `order_amount + uninsured_in_flight ≤ L`; above ⇒
->   escrow (ADR-0010) or deposit.
-> - **Opt-in seller deposit** — an **exposure-linked** collateral lets a
->   not-yet-proven seller *buy* instant settlement early. **Total instant capacity
->   = `L` + free deposit.**
-> - **Rolling reserve, anomaly step-up, anti-self-deal** — defeat post-graduation
->   bust-out.
-> - **Arbitration integration** — route store disputes to the existing jury /
->   Escrow-ruling network, with a defined **juror fee model**.
->
-> The deposit reuses the **consensus reviewer-staking *pattern*** (`balance ↓` →
-> segregated side-ledger → release/forfeit) in a **new generic
-> `agent_stakes(purpose)` table** — **not** consensus's reviewer-bound tables —
-> with **earmarked buckets** (a review slash must never deplete refund coverage,
-> nor vice versa; **no shared pool**). **Single ledger** (ADR-0009).
+**Related:** **ADR-0010** (Acute-Window Escrow — the implemented buyer-protection layer that supersedes the need for this ADR), ADR-0009 (single ledger), ADR-0007 (Unified Agent Identity)
 
 ---
 
-## Context
+## Why superseded
 
-ADR-0010 ships buyer protection for the acute window with a **binary** classifier:
-unproven ⇒ escrow, and "proven ⇒ instant" restricted to the **D8 trusted-seller
-allowlist** (first-party sellers). That is deliberately un-scalable: it does not
-let an independent third-party seller *earn* instant settlement, and ADR-0010's
-own threat model notes that an *earned* "proven ⇒ instant" is only safe once a
-graduated, capital-backed limit exists. This ADR supplies that layer.
+ADR-0011 was designed to answer one question:
 
-It also answers two questions ADR-0010 explicitly deferred:
-1. **Post-graduation bust-out** (farm small, graduate, take one big order, vanish).
-2. **The post-fulfillment "seller won't top up" residue** — instant sellers whose
-   later prorated refunds aren't covered by escrow; the **rolling reserve**
-   backstops this.
+> *How do we safely allow a proven seller to skip the escrow hold and receive instant settlement?*
 
-### Reusable in-house pattern (staking)
+The answer was a capital-backed privilege: earn an exposure limit `L` through track record, optionally top it up with a seller deposit, back it with a rolling reserve, and gate large anomalous orders with a step-up.
 
-Consensus `ReviewService` + `ReviewerStats`: `REVIEW_STAKE`/`UNSTAKE`/`PENALTY`,
-`staked_amount`, `reviewer_min_stake=50`, **no `wallet.locked` column** (debit
-`balance`, record in a side-ledger). `ap_points` is non-transferable reputation,
-**never** collateral. The **pattern** (not the tables) is reused for the seller
-deposit; the **arbitration jury** is reused for store disputes.
+**That question no longer exists.**
 
----
+The P1 implementation (backend PR #25) adopted **universal escrow for all sellers** — no instant-settlement tier, no exceptions, no trust classifier. The hold mechanism fully protects buyers for every order. Without an instant-settlement tier to earn, there is nothing for a deposit or exposure limit to unlock.
 
-## Decision
+Specifically:
 
-1. **Earned exposure limit `L` (continuous, not a tier).** `L` = time-decayed,
-   buyer-diversity-weighted **cleared value**. Instant only while
-   `order_amount + uninsured_in_flight ≤ L`; above ⇒ escrow (ADR-0010) or deposit.
-   New seller `L=0` ⇒ fully escrowed. Bounds net platform/buyer exposure to value
-   the seller genuinely earned.
-
-2. **Opt-in exposure-linked deposit.** New generic `agent_stakes(agent_id,
-   purpose, amount_mc, …)` with `purpose ∈ {reviewer, seller_deposit}` + a generic
-   stake service (`lock`/`release`/`forfeit`) + transaction types
-   `seller_deposit` / `seller_deposit_release` / `seller_deposit_forfeit`. Logic
-   mirrors `register_reviewer` / `withdraw_stake` / `penalize_timeout_voters`,
-   reusing `WalletService.deduct_balance` (pessimistic-locked). **Total instant
-   capacity = `L` + free deposit.**
-
-3. **Earmarked buckets, unified identity.** One agent can review *and* sell; one
-   "stake center" surface shows both buckets, **accounted separately** (no shared
-   pool — a review slash and a refund draw are independent risks).
-
-4. **Rolling reserve** even for instant sellers: hold a configurable % of recent
-   settled volume for N days; pre-covers a post-graduation refund/abuse spike.
-   Reserve grows with volume ⇒ bigger sellers keep more skin in the game.
-
-5. **Anomaly step-up + anti-self-deal.** An order far above a seller's historical
-   magnitude forces escrow for that order; `L` only accrues from orders with
-   **distinct, reputable buyers sharing no owner/funding/ACN lineage** with the
-   seller (generic sybil / self-dealing resistance).
-
-6. **Arbitration integration + fee model.** Route store disputes to the jury /
-   Escrow-ruling path (ruling → release / refund / forfeit-from-deposit-to-buyer).
-   Define who funds jurors (loser-pays / order fee / early platform subsidy),
-   aligned with the existing consensus fee mechanism.
-
-7. **Forfeit is compensatory (transfer to buyer), not a burn.** Burning is
-   reserved for true penalties (none defined for sellers yet).
-
-8. **Single ledger** (ADR-0009): deposits/reserve are backend wallet sub-accounts.
-
-### Threat model — post-graduation bust-out
-
-`L` (value/time/diversity-weighted) means small orders cannot earn the limit for a
-big bust-out; an over-limit order is forced into escrow/deposit; the rolling
-reserve pre-covers in-limit spikes; anomaly step-up + anti-self-deal block fast
-farming and same-lineage cross-trading. Net: structurally unprofitable.
-
----
-
-## Phased Plan
-
-- **P2 — deposit opt-in for early instant settlement:** `agent_stakes` + stake
-  service + `seller_deposit*` txn types; exposure-linked deposit backs
-  refund/forced-refund; introduce `L` accounting + the rolling reserve.
-- **P3 — arbitration integration & consolidation:** wire store disputes into the
-  jury/Escrow-ruling network (+ fee model); dynamic exposure accounting +
-  auto-gating of over-exposed new orders; **migrate reviewer staking onto
-  `agent_stakes`** (behind a migration runbook, like the microcredits migration);
-  optional **unified bond** with a combined-exposure cap for dual-role agents.
-
-> Blast radius: P2 backend-only. P3 touches consensus (reviewer-stake migration).
-
----
-
-## Open Sub-Decisions
-
-| # | Decision | Proposed |
+| ADR-0011 mechanism | Original purpose | Status |
 |---|---|---|
-| D5 | Deposit sizing | **Exposure-linked**: free deposit ≥ outstanding in-flight liability to allow instant settlement. Any flat minimum is an anti-sybil fee only (label as such), not protection. |
-| D6 | Deposit forfeit semantics | **Transfer to buyer** (compensatory), recorded as `seller_deposit_forfeit`; burning reserved for true penalties. |
-| D7 | `ap_points` role | Reputation **gate/graduation lever** (can lower required deposit / raise `L`); **not** collateral (non-transferable). |
-| D9 | Reviewer-stake migration | **P3**; do not touch production `ReviewerStats` stake before then. |
-| D10 | Capital-efficiency unified bond | **P3+**, only if dual-role agents show demand; requires combined-exposure accounting + two-sided gating. |
-| D11 | Rolling reserve | **Decided (anti-bust-out):** hold a configurable % of recent settled volume for N days, even for instant sellers. Sizing tuned from data. |
-| D12 | Anomaly step-up & anti-self-deal | **Decided:** anomalous-magnitude order ⇒ escrow that order; `L` only accrues from distinct, reputable, non-lineage buyers. |
-| D15 | Who funds arbitration of a store dispute | **Open (dependency on consensus fee model):** loser-pays / small order fee / early platform subsidy — align with the existing consensus/Escrow-ruling fee mechanism. |
-| D16 | Exact `L` formula | **Open:** functional form (decay half-life, diversity weighting, cap) tuned from data; conservative start (slow accrual). |
+| Seller deposit (`agent_stakes`) | Buy early instant settlement | ❌ No instant settlement exists |
+| Earned exposure limit `L` | Cap uncollateralized instant volume | ❌ Not applicable |
+| Rolling reserve | Pre-cover post-graduation bust-out | ❌ Universal hold prevents bust-out |
+| Anomaly step-up | Force escrow on outlier orders | ❌ All orders are already escrowed |
+| Anti-self-deal / sybil resistance | Prevent L-farming | ❌ No L to farm |
+| Reviewer-stake migration | Unified `agent_stakes` table | ⏸ Deferred independently of this ADR |
+
+---
+
+## Why universal hold made the capital layer unnecessary
+
+The classic bust-out attack requires two phases: (1) farm reputation with small honest orders, (2) take one large payment and vanish. Universal hold defeats phase 2 entirely — funds are never released to the seller until the buyer accepts or the window times out. There is no "large payment to abscond with" because the money never arrives before the obligation is checked.
+
+Credits are also closed-loop (no withdrawal). The 72-hour delay only affects when credits enter the seller's wallet for use within the platform. There is no cashflow reason for sellers to prefer instant settlement over held settlement.
+
+---
+
+## Future Work (not this ADR)
+
+Two concerns from the original ADR-0011 remain relevant but are standalone features, **not capital mechanics**:
+
+### 1. Dispute arbitration
+When a buyer disputes delivery ("seller claims fulfilled but I received nothing"), the hold must be resolved by a neutral party rather than auto-released. The existing `ReviewService` jury + `EscrowService` ruling path is a candidate. **Trigger: first real disputed store order.**
+
+### 2. Buyer-side fraud (friendly fraud)
+A malicious buyer could accept delivery then dispute to reclaim credits. Mitigations: contested disputes go to arbitration (not auto-refund); buyers accumulate a dispute reputation score. **Trigger: first pattern of suspected buyer abuse.**
+
+Both will be designed as new ADRs at the time of their trigger event, informed by real data rather than preemptive architecture.


### PR DESCRIPTION
## What

**ADR-0011 → Superseded**

The seller capital layer (deposit / exposure-limit L / rolling reserve / anomaly step-up) is no longer needed. It was designed to safely allow sellers to skip the escrow hold (instant-settlement tier). P1 adopted **universal hold for all sellers** — no instant-settlement tier exists, so there is nothing for a deposit or exposure limit to unlock. Universal hold defeats bust-out at the mechanism level; closed-loop credits remove cashflow pressure for instant settlement.

Two residual concerns remain as Future Work in ADR-0011 (not this ADR):
- **Dispute arbitration** — resolve contested holds (buyer vs seller on delivery)
- **Buyer-side fraud** — prevent malicious buyers from disputing valid deliveries

Both will be designed as standalone ADRs when triggered by the first real disputed order.

**ADR-0010 → Accepted (fully implemented)**

Status updated from "Accepted direction / P1 pending" to "Accepted — P0 and P1 fully implemented" (backend PRs #24 #25 #26). References to ADR-0011 as a pending dependency removed.

## No code changes — doc only

Made with [Cursor](https://cursor.com)