### PR TITLE
fix(org-harness): private-Org read ACL + atomic Redis fence binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   P1 polish: `PATCH /orgs/{id}`; members view with subnet `degraded`;
   create-time optional `harness_url`; CLI `update` / `dissolve` /
   `--join-policy` / `--harness-url`.
+- **Org Harness hardening (review follow-up)** — private-fence Orgs now
+  redact `GET /orgs/{id}` for unentitled readers and gate `…/members` /
+  `…/work` with 403 (`private_org`), mirroring subnet ACL V6; entitled =
+  owner / created_by / steward / subnet owner-member / active OrgMembership /
+  steward-owner human / `acn:admin` / internal. Redis fence binding
+  (`acn:orgs:by_subnet`) claimed via `SET NX` with dissolved/dangling-holder
+  eviction and guarded release; Postgres maps `uq_orgs_subnet_id` violations
+  to `OrgSubnetBindingConflictError` → 409 `subnet_already_bound`. New
+  repository-layer tests (fakeredis + mock-session).
 
 ### Docs
 

--- a/acn/core/exceptions/__init__.py
+++ b/acn/core/exceptions/__init__.py
@@ -22,6 +22,28 @@ class SubnetNotFoundException(ACNException):
     pass
 
 
+class OrgSubnetBindingConflictError(ACNException):
+    """The subnet is already bound to another (non-dissolved) Org.
+
+    Raised by ``IOrgRepository.save_org`` implementations when the
+    one-Org-per-subnet fence invariant (ADR-0014) would be violated:
+
+    - Postgres: mapped from the ``uq_orgs_subnet_id`` unique-constraint
+      violation.
+    - Redis: raised when the ``acn:orgs:by_subnet:{slug}`` index claim
+      (``SET NX``) loses to a concurrent create whose Org is still
+      active. The pre-check in ``OrgService.create_org`` cannot close
+      this window on its own — Redis has no unique constraint.
+    """
+
+    def __init__(self, subnet_id: str, bound_org_id: str) -> None:
+        self.subnet_id = subnet_id
+        self.bound_org_id = bound_org_id
+        super().__init__(
+            f"subnet '{subnet_id}' is already bound to org {bound_org_id}"
+        )
+
+
 class PolicyRejected(ACNException):
     """Inbound message was rejected by the recipient's communication_policy.
 

--- a/acn/infrastructure/persistence/postgres/org_repository.py
+++ b/acn/infrastructure/persistence/postgres/org_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from ....core.entities.org import (
@@ -12,6 +13,7 @@ from ....core.entities.org import (
     OrgPrincipal,
     OrgWorkItem,
 )
+from ....core.exceptions import OrgSubnetBindingConflictError
 from ....core.interfaces.org_repository import IOrgRepository
 from .models import OrgMembershipModel, OrgModel, OrgWorkItemModel
 
@@ -69,7 +71,24 @@ class PostgresOrgRepository(IOrgRepository):
                 )
             else:
                 session.add(OrgModel(**values))
-            await session.commit()
+            try:
+                await session.commit()
+            except IntegrityError as e:
+                # ``uq_orgs_subnet_id`` (one Org per fence, ADR-0014):
+                # surface as the domain conflict instead of a bare 500 so
+                # a create that loses the pre-check race gets a 409.
+                await session.rollback()
+                if "uq_orgs_subnet_id" not in str(e.orig or e):
+                    raise
+                holder = await session.execute(
+                    select(OrgModel.org_id)
+                    .where(OrgModel.subnet_id == org.subnet_id)
+                    .limit(1)
+                )
+                bound_org_id = holder.scalar_one_or_none() or "(unknown)"
+                raise OrgSubnetBindingConflictError(
+                    org.subnet_id, bound_org_id
+                ) from e
 
     async def find_org(self, org_id: str) -> Org | None:
         async with self._session_factory() as session:

--- a/acn/infrastructure/persistence/redis/org_repository.py
+++ b/acn/infrastructure/persistence/redis/org_repository.py
@@ -1,4 +1,36 @@
-"""Redis implementation of IOrgRepository."""
+"""Redis implementation of IOrgRepository.
+
+Assumes the shared production client is created with
+``decode_responses=True`` (see ``acn/api.py`` lifespan) — all reads
+below compare/compose raw ``str`` values.
+
+Fence-binding atomicity (ADR-0014 "one Org per subnet")
+-------------------------------------------------------
+Postgres enforces the invariant with a unique index; Redis has no
+unique constraint, so the ``acn:orgs:by_subnet:{slug}`` pointer is
+claimed with ``SET NX`` inside :meth:`save_org`. A plain ``SET`` here
+(the original implementation) let two concurrent ``create_org`` calls
+both pass the service-level pre-check and both bind the same subnet —
+last writer silently won.
+
+Rules:
+
+- New binding (new org, or ``subnet_id`` changed): ``SET NX``. On
+  failure the current holder is inspected — a **dangling** pointer
+  (org payload deleted) or a **dissolved** holder is released and the
+  claim retried once; an active holder raises
+  :class:`OrgSubnetBindingConflictError`.
+- ``status="dissolved"`` saves release the pointer (only when it still
+  points at this org), so a dissolved Org's subnet is immediately
+  rebindable — mirroring the Postgres partial-unique-index semantics.
+- :meth:`delete_org` only deletes the pointer when it points at the
+  org being deleted (a stale-takeover may have re-pointed it).
+
+The release-then-retry window on stale/dissolved takeover is not
+atomic (no Lua — fakeredis in CI has no interpreter), but it can only
+race another *takeover of an already-dead binding*; the fresh-create
+vs fresh-create race that mattered is closed by ``SET NX``.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +40,7 @@ from typing import Any
 import redis.asyncio as redis  # type: ignore[import-untyped]
 
 from ....core.entities.org import Org, OrgMembership, OrgWorkItem
+from ....core.exceptions import OrgSubnetBindingConflictError
 from ....core.interfaces.org_repository import IOrgRepository
 
 
@@ -43,8 +76,43 @@ class RedisOrgRepository(IOrgRepository):
     def __init__(self, redis_client: redis.Redis) -> None:
         self.redis = redis_client
 
+    async def _claim_subnet_binding(self, org: Org) -> None:
+        """Claim ``acn:orgs:by_subnet`` for ``org`` with SET NX semantics.
+
+        Raises ``OrgSubnetBindingConflictError`` when another **active**
+        Org already holds the pointer. Dangling (payload gone) and
+        dissolved holders are evicted, then the claim is retried once.
+        """
+        idx_key = _org_subnet_idx(org.subnet_id)
+        for _ in range(2):
+            claimed = await self.redis.set(idx_key, org.org_id, nx=True)
+            if claimed:
+                return
+            holder_id = await self.redis.get(idx_key)
+            if holder_id is None:
+                continue  # holder vanished between SET NX and GET — retry
+            if holder_id == org.org_id:
+                return  # already ours (idempotent re-save)
+            holder = await self.find_org(holder_id)
+            if holder is None or holder.status == "dissolved":
+                # Dead binding — release and retry the NX claim once.
+                await self.redis.delete(idx_key)
+                continue
+            raise OrgSubnetBindingConflictError(org.subnet_id, holder_id)
+        # Second NX attempt also lost: a concurrent claimer won the race.
+        holder_id = await self.redis.get(idx_key)
+        if holder_id and holder_id != org.org_id:
+            raise OrgSubnetBindingConflictError(org.subnet_id, holder_id)
+
     async def save_org(self, org: Org) -> None:
         old = await self.find_org(org.org_id)
+
+        # Claim the fence pointer BEFORE persisting the org payload so a
+        # lost race leaves no orphan org row behind.
+        binding_is_new = old is None or old.subnet_id != org.subnet_id
+        if binding_is_new and org.status != "dissolved":
+            await self._claim_subnet_binding(org)
+
         payload = json.dumps(org.to_dict())
         await self.redis.set(_org_key(org.org_id), payload)
         if old and old.steward_agent_id != org.steward_agent_id:
@@ -53,8 +121,18 @@ class RedisOrgRepository(IOrgRepository):
             )
         await self.redis.sadd(_org_steward_idx(org.steward_agent_id), org.org_id)
         if old and old.subnet_id != org.subnet_id:
-            await self.redis.delete(_org_subnet_idx(old.subnet_id))
-        await self.redis.set(_org_subnet_idx(org.subnet_id), org.org_id)
+            await self._release_subnet_binding(old.subnet_id, org.org_id)
+        if org.status == "dissolved":
+            # Dissolution releases the fence immediately so the subnet can
+            # be rebound (service allows rebinding over dissolved orgs).
+            await self._release_subnet_binding(org.subnet_id, org.org_id)
+
+    async def _release_subnet_binding(self, subnet_id: str, org_id: str) -> None:
+        """Delete the subnet pointer only if it still points at ``org_id``."""
+        idx_key = _org_subnet_idx(subnet_id)
+        holder = await self.redis.get(idx_key)
+        if holder == org_id:
+            await self.redis.delete(idx_key)
 
     async def find_org(self, org_id: str) -> Org | None:
         raw = await self.redis.get(_org_key(org_id))
@@ -69,7 +147,9 @@ class RedisOrgRepository(IOrgRepository):
             return False
         await self.redis.delete(_org_key(org_id))
         await self.redis.srem(_org_steward_idx(org.steward_agent_id), org_id)
-        await self.redis.delete(_org_subnet_idx(org.subnet_id))
+        # Guarded release — the pointer may have been legitimately taken
+        # over by another org after this one dissolved.
+        await self._release_subnet_binding(org.subnet_id, org_id)
         return True
 
     async def list_orgs_by_steward(self, steward_agent_id: str) -> list[Org]:

--- a/acn/infrastructure/persistence/redis/org_repository.py
+++ b/acn/infrastructure/persistence/redis/org_repository.py
@@ -15,21 +15,32 @@ last writer silently won.
 
 Rules:
 
-- New binding (new org, or ``subnet_id`` changed): ``SET NX``. On
-  failure the current holder is inspected — a **dangling** pointer
-  (org payload deleted) or a **dissolved** holder is released and the
-  claim retried once; an active holder raises
+- **Fresh create** (no payload row yet): the org payload is written
+  BEFORE the ``SET NX`` claim, and a lost claim deletes the just-written
+  payload (loser leaves no row). Ordering is load-bearing: the dangling
+  eviction below treats "pointer without payload" as a dead binding, so
+  a claim-before-write order would let a concurrent create misread a
+  freshly claimed pointer as dangling, evict it, and double-bind the
+  subnet (review finding on #177).
+- **Rebind** (existing org, ``subnet_id`` changed): claim first — the
+  org's payload already exists, so no concurrent claimer can misread
+  the pointer as dangling; the payload write follows the claim.
+- On claim failure the current holder is inspected — a **dangling**
+  pointer (org payload deleted) or a **dissolved** holder is released
+  and the claim retried once; an active holder raises
   :class:`OrgSubnetBindingConflictError`.
 - ``status="dissolved"`` saves release the pointer (only when it still
   points at this org), so a dissolved Org's subnet is immediately
-  rebindable — mirroring the Postgres partial-unique-index semantics.
+  rebindable — mirroring the Postgres unique-constraint semantics.
 - :meth:`delete_org` only deletes the pointer when it points at the
   org being deleted (a stale-takeover may have re-pointed it).
 
 The release-then-retry window on stale/dissolved takeover is not
-atomic (no Lua — fakeredis in CI has no interpreter), but it can only
-race another *takeover of an already-dead binding*; the fresh-create
-vs fresh-create race that mattered is closed by ``SET NX``.
+atomic (no Lua — fakeredis in CI has no interpreter), but with the
+write-before-claim ordering a "pointer without payload" state can only
+arise from a genuinely dead binding (e.g. crash inside ``delete_org``
+between payload delete and pointer release) — never from an in-flight
+create. See BACKLOG ``DEF-ORG-LUA``.
 """
 
 from __future__ import annotations
@@ -104,15 +115,7 @@ class RedisOrgRepository(IOrgRepository):
         if holder_id and holder_id != org.org_id:
             raise OrgSubnetBindingConflictError(org.subnet_id, holder_id)
 
-    async def save_org(self, org: Org) -> None:
-        old = await self.find_org(org.org_id)
-
-        # Claim the fence pointer BEFORE persisting the org payload so a
-        # lost race leaves no orphan org row behind.
-        binding_is_new = old is None or old.subnet_id != org.subnet_id
-        if binding_is_new and org.status != "dissolved":
-            await self._claim_subnet_binding(org)
-
+    async def _write_payload(self, org: Org, old: Org | None) -> None:
         payload = json.dumps(org.to_dict())
         await self.redis.set(_org_key(org.org_id), payload)
         if old and old.steward_agent_id != org.steward_agent_id:
@@ -120,6 +123,35 @@ class RedisOrgRepository(IOrgRepository):
                 _org_steward_idx(old.steward_agent_id), org.org_id
             )
         await self.redis.sadd(_org_steward_idx(org.steward_agent_id), org.org_id)
+
+    async def save_org(self, org: Org) -> None:
+        old = await self.find_org(org.org_id)
+        binding_is_new = old is None or old.subnet_id != org.subnet_id
+        claim_needed = binding_is_new and org.status != "dissolved"
+
+        if claim_needed and old is None:
+            # Fresh create: payload BEFORE claim (see module docstring —
+            # claim-first would let a concurrent create misread our
+            # freshly claimed pointer as dangling and double-bind).
+            await self._write_payload(org, old=None)
+            try:
+                await self._claim_subnet_binding(org)
+            except OrgSubnetBindingConflictError:
+                # Loser leaves no row behind.
+                await self.redis.delete(_org_key(org.org_id))
+                await self.redis.srem(
+                    _org_steward_idx(org.steward_agent_id), org.org_id
+                )
+                raise
+            return
+
+        if claim_needed:
+            # Rebind of an existing org: its payload is already visible,
+            # so concurrent claimers cannot misread the pointer as
+            # dangling; claim first, then persist the new binding.
+            await self._claim_subnet_binding(org)
+
+        await self._write_payload(org, old)
         if old and old.subnet_id != org.subnet_id:
             await self._release_subnet_binding(old.subnet_id, org.org_id)
         if org.status == "dissolved":

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -126,12 +126,104 @@ def require_org_auth():
 OrgAuthDep = Depends(require_org_auth())
 
 
+# ---------------------------------------------------------------------------
+# Optional read-path auth: never rejects — anonymous / invalid credentials
+# resolve to ``None`` so private-Org reads degrade to a redacted view
+# (mirrors GET /subnets/{slug}: invalid token → treated as anonymous).
+# ---------------------------------------------------------------------------
+
+
+def resolve_org_reader():
+    async def checker(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+        x_internal_token: str | None = Header(default=None),
+        agent_service: AgentService = Depends(get_agent_service),
+    ) -> dict | None:
+        s = get_settings()
+        if s.dev_mode:
+            if credentials and credentials.credentials.startswith("acn_"):
+                agent = await agent_service.get_agent_by_api_key(
+                    credentials.credentials
+                )
+                if agent:
+                    _schedule_alive_renewal(
+                        background_tasks, agent_service, agent.agent_id
+                    )
+                    return {
+                        "sub": agent.agent_id,
+                        "type": "agent",
+                        "permissions": ["acn:read", "acn:write"],
+                    }
+            sub = credentials.credentials if credentials else "dev@clients"
+            return {
+                "sub": sub,
+                "type": "human",
+                "permissions": ["acn:read", "acn:write", "acn:admin"],
+            }
+
+        if (
+            x_internal_token
+            and s.internal_api_token
+            and secrets.compare_digest(x_internal_token, s.internal_api_token)
+        ):
+            return {
+                "sub": "backend@internal",
+                "type": "internal",
+                "permissions": ["acn:read", "acn:write", "acn:admin"],
+            }
+
+        if not credentials:
+            return None
+
+        if credentials.credentials.startswith("acn_"):
+            agent = await agent_service.get_agent_by_api_key(credentials.credentials)
+            if not agent:
+                return None  # invalid key → anonymous (read path never 401s)
+            _schedule_alive_renewal(background_tasks, agent_service, agent.agent_id)
+            return {
+                "sub": agent.agent_id,
+                "type": "agent",
+                "permissions": ["acn:read", "acn:write"],
+            }
+
+        try:
+            payload = await verify_token(request, credentials)
+        except Exception:  # noqa: BLE001 — invalid JWT → anonymous
+            return None
+        return {
+            "sub": payload.get("sub", ""),
+            "type": "human",
+            "permissions": payload.get("permissions", []),
+        }
+
+    return checker
+
+
+OrgReaderDep = Depends(resolve_org_reader())
+
+
 def _caller(payload: dict) -> tuple[Literal["human", "agent"], str]:
     ptype = payload.get("type", "human")
     if ptype == "agent":
         return "agent", payload["sub"]
     # internal / human / dev → treat as human principal for created_by
     return "human", payload.get("sub", "")
+
+
+def _reader_ctx(
+    payload: dict | None,
+) -> tuple[Literal["human", "agent"] | None, str | None, bool]:
+    """(caller_type, caller_sub, admin) for optional read-path payloads."""
+    if not payload:
+        return None, None, False
+    admin = (
+        payload.get("type") == "internal"
+        or "acn:admin" in payload.get("permissions", [])
+    )
+    caller_type, caller_sub = _caller(payload)
+    return caller_type, caller_sub, admin
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +297,7 @@ def _map_permission(exc: OrgPermissionError, org_id: str) -> ACNHTTPError:
         "owner_subject_mismatch",
         "owner_agent_not_owned",
         "cannot_remove_steward",
+        "private_org",
     }
     code = (
         ErrorCode.OWNERSHIP_MISMATCH
@@ -245,7 +338,10 @@ async def create_org(
             harness_url=body.harness_url,
             harness_secret=body.harness_secret,
         )
-        return await org_service.get_org_view(org.org_id)
+        # Creator is trivially entitled to the full view of its new Org.
+        return await org_service.get_org_view(
+            org.org_id, caller_type=caller_type, caller_sub=caller_sub
+        )
     except OrgPermissionError as e:
         raise _map_permission(e, org_id="(new)") from e
     except ValueError as e:
@@ -265,10 +361,23 @@ async def create_org(
 @router.get("/{org_id}")
 async def get_org(
     org_id: OrgIdPath,
+    reader: dict | None = OrgReaderDep,
     org_service: OrgService = Depends(get_org_service),
 ):
+    """Get an Org.
+
+    Orgs fenced by a **private** subnet are redacted for anonymous /
+    unentitled callers (same philosophy as ``GET /subnets/{slug}``
+    returning a ``SubnetStub``); public-fence Orgs are fully visible.
+    """
+    caller_type, caller_sub, admin = _reader_ctx(reader)
     try:
-        return await org_service.get_org_view(org_id)
+        return await org_service.get_org_view(
+            org_id,
+            caller_type=caller_type,
+            caller_sub=caller_sub,
+            admin=admin,
+        )
     except OrgNotFoundError as e:
         raise ACNHTTPError(
             ErrorCode.ORG_NOT_FOUND,
@@ -302,7 +411,10 @@ async def update_org(
             charter=body.charter,
             plugins=body.plugins,
         )
-        return await org_service.get_org_view(org_id)
+        # update_org already enforced governance; return the full view.
+        return await org_service.get_org_view(
+            org_id, caller_type=caller_type, caller_sub=caller_sub
+        )
     except OrgNotFoundError as e:
         raise ACNHTTPError(
             ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
@@ -432,14 +544,25 @@ async def dissolve_org(
 @router.get("/{org_id}/members")
 async def list_members(
     org_id: OrgIdPath,
+    reader: dict | None = OrgReaderDep,
     org_service: OrgService = Depends(get_org_service),
 ):
+    """List members. Private-fence Orgs require an entitled reader (403)."""
+    caller_type, caller_sub, admin = _reader_ctx(reader)
     try:
+        await org_service.ensure_private_readable(
+            org_id,
+            caller_type=caller_type,
+            caller_sub=caller_sub,
+            admin=admin,
+        )
         return await org_service.list_members_view(org_id)
     except OrgNotFoundError as e:
         raise ACNHTTPError(
             ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
         ) from e
+    except OrgPermissionError as e:
+        raise _map_permission(e, org_id) from e
 
 
 @router.post("/{org_id}/members")
@@ -544,9 +667,18 @@ async def create_work(
 async def list_work(
     org_id: OrgIdPath,
     open_only: bool = False,
+    reader: dict | None = OrgReaderDep,
     org_service: OrgService = Depends(get_org_service),
 ):
+    """List work items. Private-fence Orgs require an entitled reader (403)."""
+    caller_type, caller_sub, admin = _reader_ctx(reader)
     try:
+        await org_service.ensure_private_readable(
+            org_id,
+            caller_type=caller_type,
+            caller_sub=caller_sub,
+            admin=admin,
+        )
         items = await org_service.list_work(org_id, open_only=open_only)
         return {
             "org_id": org_id,
@@ -557,6 +689,8 @@ async def list_work(
         raise ACNHTTPError(
             ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
         ) from e
+    except OrgPermissionError as e:
+        raise _map_permission(e, org_id) from e
 
 
 @router.patch("/{org_id}/work/{work_id}")

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -380,6 +380,12 @@ class OrgService:
         - any agent holding an **active** OrgMembership (covers degraded
           members not yet propagated into the fence)
         - a human who owns the steward agent (ownership-chain bridge)
+
+        Deliberately narrow, matching subnet ACL V6 § 2: a human who owns
+        a mere *member* (worker) agent is NOT entitled — membership is a
+        collaboration edge and does not extend read trust upward to the
+        member agent's holder. Such humans read via their agent's own
+        API key.
         """
         if admin:
             return True

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -18,7 +18,12 @@ from ..core.entities.org import (
     OrgWorkItem,
     WorkStatus,
 )
-from ..core.exceptions import AgentNotFoundException, SubnetNotFoundException
+from ..core.entities.subnet import Subnet
+from ..core.exceptions import (
+    AgentNotFoundException,
+    OrgSubnetBindingConflictError,
+    SubnetNotFoundException,
+)
 from ..core.interfaces.org_repository import IOrgRepository
 from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
@@ -289,7 +294,7 @@ class OrgService:
                     status="active",
                 )
             )
-        except Exception:
+        except Exception as save_exc:
             if created_subnet:
                 try:
                     await self.subnet_service.delete_subnet(subnet.slug, steward)
@@ -309,6 +314,13 @@ class OrgService:
                     org_id=org_id,
                     exc_info=True,
                 )
+            if isinstance(save_exc, OrgSubnetBindingConflictError):
+                # Concurrent create won the fence claim after our
+                # pre-check — same 409 surface as the pre-check path.
+                raise OrgConflictError(
+                    "subnet_already_bound",
+                    str(save_exc),
+                ) from save_exc
             raise
 
         if harness_url:
@@ -344,24 +356,141 @@ class OrgService:
             raise OrgNotFoundError(org_id)
         return org
 
-    async def get_org_view(self, org_id: str) -> dict[str, Any]:
-        """Org dict enriched with live fence / harness fields."""
+    # ------------------------------------------------------------------
+    # Private-Org read ACL (aligned with subnet ACL V6 / issue #114)
+    # ------------------------------------------------------------------
+
+    async def _is_entitled_private_reader(
+        self,
+        org: Org,
+        subnet: Subnet | None,
+        caller_type: CallerType | None,
+        caller_sub: str | None,
+        *,
+        admin: bool = False,
+    ) -> bool:
+        """True when the caller may read a private Org in full.
+
+        Entitled principals (mirrors ``routes/subnets.py``
+        ``_resolve_caller_access`` plus Org-native relationships):
+
+        - internal token / ``acn:admin``
+        - Org owner or ``created_by`` (human or agent)
+        - the steward agent, the fence subnet owner, or any subnet member
+        - any agent holding an **active** OrgMembership (covers degraded
+          members not yet propagated into the fence)
+        - a human who owns the steward agent (ownership-chain bridge)
+        """
+        if admin:
+            return True
+        if caller_type is None or not caller_sub:
+            return False
+        if self._is_owner(org, caller_type, caller_sub):
+            return True
+        if self._is_created_by(org, caller_type, caller_sub):
+            return True
+        if caller_type == "agent":
+            if caller_sub == org.steward_agent_id:
+                return True
+            if subnet is not None and (
+                caller_sub == subnet.owner or subnet.has_member(caller_sub)
+            ):
+                return True
+            membership = await self.repository.find_membership(
+                org.org_id, caller_sub
+            )
+            return membership is not None and membership.status == "active"
+        # Human ownership-chain bridge: owning the steward agent grants read.
+        try:
+            steward = await self.agent_service.get_agent(org.steward_agent_id)
+        except AgentNotFoundException:
+            return False
+        return steward.owner == caller_sub
+
+    @staticmethod
+    def _redacted_org_view(org: Org, *, fence_missing: bool) -> dict[str, Any]:
+        """Minimal public projection of a private Org.
+
+        Mirrors the ``SubnetStub`` philosophy: existence is not hidden
+        (org_id is required to query at all), but ``charter``, ``plugins``,
+        ``created_by``, owner subject, steward, subnet slug, and harness
+        details are withheld from unauthorised readers.
+        """
+        return {
+            "org_id": org.org_id,
+            "status": org.status,
+            "owner": {"kind": org.owner.kind},
+            "private": True,
+            "fencing": {"is_private": True, "missing": fence_missing},
+        }
+
+    async def ensure_private_readable(
+        self,
+        org_id: str,
+        *,
+        caller_type: CallerType | None = None,
+        caller_sub: str | None = None,
+        admin: bool = False,
+    ) -> Org:
+        """Gate member/work listings of a private Org.
+
+        Raises ``OrgPermissionError("private_org")`` for unauthorised
+        readers. A missing fence subnet is treated as private
+        (conservative: we can no longer prove the fence was public).
+        """
+        org = await self.get_org(org_id)
+        subnet: Subnet | None
+        try:
+            subnet = await self.subnet_service.get_subnet(org.subnet_id)
+        except SubnetNotFoundException:
+            subnet = None
+        is_private = subnet.is_private if subnet is not None else True
+        if not is_private:
+            return org
+        if await self._is_entitled_private_reader(
+            org, subnet, caller_type, caller_sub, admin=admin
+        ):
+            return org
+        raise OrgPermissionError(
+            "private_org",
+            "Org is bound to a private subnet; caller is not entitled to read it",
+        )
+
+    async def get_org_view(
+        self,
+        org_id: str,
+        *,
+        caller_type: CallerType | None = None,
+        caller_sub: str | None = None,
+        admin: bool = False,
+    ) -> dict[str, Any]:
+        """Org dict enriched with live fence / harness fields.
+
+        Private-fence Orgs are redacted for unauthorised viewers (see
+        ``_redacted_org_view``); public-fence Orgs are fully visible.
+        """
         org = await self.get_org(org_id)
         view = org.to_dict()
         try:
             subnet = await self.subnet_service.get_subnet(org.subnet_id)
         except SubnetNotFoundException:
+            if org.status == "active":
+                org.status = "fence_missing"
+                org.updated_at = datetime.now(UTC)
+                await self.repository.save_org(org)
+            # Fence gone → privacy no longer provable; restrict to
+            # entitled readers (conservative default).
+            if not await self._is_entitled_private_reader(
+                org, None, caller_type, caller_sub, admin=admin
+            ):
+                return self._redacted_org_view(org, fence_missing=True)
+            view["status"] = org.status
             view["harness_webhook"] = {"url": None, "registered": False}
             view["fencing"] = {
                 **(view.get("fencing") or {}),
                 "subnet_id": org.subnet_id,
                 "missing": True,
             }
-            if org.status == "active":
-                org.status = "fence_missing"
-                org.updated_at = datetime.now(UTC)
-                await self.repository.save_org(org)
-                view["status"] = "fence_missing"
             return view
 
         if org.status == "fence_missing":
@@ -369,6 +498,11 @@ class OrgService:
             org.updated_at = datetime.now(UTC)
             await self.repository.save_org(org)
             view["status"] = "active"
+
+        if subnet.is_private and not await self._is_entitled_private_reader(
+            org, subnet, caller_type, caller_sub, admin=admin
+        ):
+            return self._redacted_org_view(org, fence_missing=False)
 
         view["harness_webhook"] = {
             "url": subnet.harness_url,
@@ -796,6 +930,15 @@ class OrgService:
         caller_type: CallerType,
         caller_sub: str,
     ) -> Org:
+        """Soft-dissolve: status flip only, by design.
+
+        Memberships, work items, and the fence subnet are intentionally
+        NOT cleaned up here — the subnet (and its members) survive so the
+        same steward can rebind it to a new Org (``create_org`` accepts a
+        subnet whose bound Org is dissolved), and rows stay for audit.
+        Hard cleanup is the operator-path ``delete_org`` +
+        ``delete_memberships_for_org`` / ``delete_work_for_org``.
+        """
         org = await self.get_org(org_id)
         self._require_governance(org, caller_type, caller_sub)
         org.status = "dissolved"

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -897,5 +897,13 @@ Still deferred (Phase 2+):
 - **DEF-ORGC** — Portable `/orgs/*` Core API (only if multi-Pattern discovery needs it)
 - **DEF-SAGA** — Settlement saga v1 (Gated v0 atomicity)
 - **DEF-RAILS** — Agentic payment rails (ADR-0009 P2)
+- **DEF-ORG-ACL** — Org read ACL v1 ships a **redacted view** for private-fence
+  Orgs (`get_org_view` + `ensure_private_readable`, mirroring subnet ACL V6
+  Stub). Deferred: full V6 alignment — opaque-UUID stubs, per-row rendering in
+  future list endpoints, invite-to-read tokens.
+- **DEF-ORG-LUA** — Redis fence claim uses `SET NX` + guarded release; the
+  stale/dissolved-takeover retry window is not atomic (no Lua — fakeredis in CI
+  lacks an interpreter). Promote to a Lua script if takeover races are ever
+  observed in production.
 
 Details: [`org-harness/org-pattern-adapter-spec-v0.md` § Deferred](org-harness/org-pattern-adapter-spec-v0.md#7-deferred-enhancements).

--- a/tests/infrastructure/test_org_repository_postgres.py
+++ b/tests/infrastructure/test_org_repository_postgres.py
@@ -1,0 +1,78 @@
+"""PostgresOrgRepository regressions — unique-fence conflict mapping.
+
+``uq_orgs_subnet_id`` (alembic ``e4f5a6b7c8d9``) enforces one Org per
+subnet at the database level; ``save_org`` must translate that
+IntegrityError into the domain ``OrgSubnetBindingConflictError`` so a
+create that loses the pre-check race surfaces as a 409, not a bare 500.
+
+Mock-session style mirrors ``test_postgres_subnet_repository_nesting.py``
+— no live PostgreSQL needed; schema correctness lives in alembic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from acn.core.entities.org import Org, OrgPrincipal
+from acn.core.exceptions import OrgSubnetBindingConflictError
+from acn.infrastructure.persistence.postgres.org_repository import (
+    PostgresOrgRepository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_session_factory():
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+def _org(org_id: str = "org_a", subnet_id: str = "fence-1") -> Org:
+    return Org(
+        org_id=org_id,
+        display_name="Test",
+        created_by=OrgPrincipal(kind="agent", subject="agt_steward"),
+        subnet_id=subnet_id,
+        steward_agent_id="agt_steward",
+    )
+
+
+def _integrity_error(message: str) -> IntegrityError:
+    return IntegrityError("INSERT INTO orgs ...", {}, Exception(message))
+
+
+async def test_unique_subnet_violation_maps_to_domain_conflict():
+    factory, session = _make_session_factory()
+    session.get.return_value = None  # INSERT branch
+    session.commit.side_effect = _integrity_error(
+        'duplicate key value violates unique constraint "uq_orgs_subnet_id"'
+    )
+    holder_result = MagicMock()
+    holder_result.scalar_one_or_none.return_value = "org_winner"
+    session.execute.return_value = holder_result
+
+    repo = PostgresOrgRepository(factory)
+    with pytest.raises(OrgSubnetBindingConflictError) as ei:
+        await repo.save_org(_org("org_loser"))
+
+    assert ei.value.subnet_id == "fence-1"
+    assert ei.value.bound_org_id == "org_winner"
+    session.rollback.assert_awaited_once()
+
+
+async def test_unrelated_integrity_error_is_not_swallowed():
+    factory, session = _make_session_factory()
+    session.get.return_value = None
+    session.commit.side_effect = _integrity_error(
+        'null value in column "display_name" violates not-null constraint'
+    )
+
+    repo = PostgresOrgRepository(factory)
+    with pytest.raises(IntegrityError):
+        await repo.save_org(_org())

--- a/tests/infrastructure/test_org_repository_redis.py
+++ b/tests/infrastructure/test_org_repository_redis.py
@@ -1,0 +1,178 @@
+"""RedisOrgRepository regressions — fence-binding atomicity (ADR-0014).
+
+Postgres enforces "one Org per subnet" with ``uq_orgs_subnet_id``; Redis
+has no unique constraint, so ``save_org`` must claim the
+``acn:orgs:by_subnet:{slug}`` pointer with ``SET NX``. These tests pin:
+
+- fresh-create vs fresh-create on the same subnet → second save raises
+  ``OrgSubnetBindingConflictError`` (the race the service pre-check
+  cannot close);
+- a **dissolved** holder releases the pointer and a new Org may rebind;
+- a **dangling** pointer (org payload deleted out-of-band) is evicted;
+- ``delete_org`` releases the pointer only when it still points at the
+  deleted org (guarded release);
+- basic round-trips (org / membership / work) against the real key
+  layout, exercised end-to-end on fakeredis.
+
+fakeredis runs in bytes mode by default; production composes the client
+with ``decode_responses=True`` (see ``acn/api.py``), so the fixture
+mirrors that.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fakeredis import aioredis as fakeredis_async
+
+from acn.core.entities.org import Org, OrgMembership, OrgPrincipal, OrgWorkItem
+from acn.core.exceptions import OrgSubnetBindingConflictError
+from acn.infrastructure.persistence.redis.org_repository import (
+    RedisOrgRepository,
+    _org_key,
+    _org_subnet_idx,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def fake_redis():
+    client = fakeredis_async.FakeRedis(decode_responses=True)
+    await client.flushdb()
+    try:
+        yield client
+    finally:
+        await client.flushdb()
+
+
+@pytest.fixture
+def repo(fake_redis):
+    return RedisOrgRepository(fake_redis)
+
+
+def _org(org_id: str, subnet_id: str, **overrides) -> Org:
+    defaults = {
+        "org_id": org_id,
+        "display_name": f"Org {org_id}",
+        "created_by": OrgPrincipal(kind="agent", subject="agt_steward"),
+        "subnet_id": subnet_id,
+        "steward_agent_id": "agt_steward",
+    }
+    defaults.update(overrides)
+    return Org(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fence-binding claim (SET NX)
+# ---------------------------------------------------------------------------
+
+
+async def test_second_org_on_same_subnet_conflicts(repo):
+    await repo.save_org(_org("org_a", "fence-1"))
+    with pytest.raises(OrgSubnetBindingConflictError) as ei:
+        await repo.save_org(_org("org_b", "fence-1"))
+    assert ei.value.subnet_id == "fence-1"
+    assert ei.value.bound_org_id == "org_a"
+    # Loser must leave no payload row behind when raised before SET —
+    # the claim happens before the payload write.
+    assert await repo.find_org("org_b") is None
+
+
+async def test_resave_same_org_is_idempotent(repo):
+    org = _org("org_a", "fence-1")
+    await repo.save_org(org)
+    org.display_name = "Renamed"
+    await repo.save_org(org)  # must not raise
+    loaded = await repo.find_org("org_a")
+    assert loaded is not None
+    assert loaded.display_name == "Renamed"
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_a"
+
+
+async def test_dissolved_holder_releases_fence_for_rebind(repo):
+    org_a = _org("org_a", "fence-1")
+    await repo.save_org(org_a)
+    org_a.status = "dissolved"
+    await repo.save_org(org_a)  # dissolution releases the pointer
+    assert await repo.find_org_by_subnet("fence-1") is None
+
+    await repo.save_org(_org("org_b", "fence-1"))  # rebind succeeds
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_b"
+    # The dissolved org row itself survives (soft-dissolve, audit trail).
+    assert (await repo.find_org("org_a")).status == "dissolved"
+
+
+async def test_stale_pointer_to_dissolved_org_is_evicted(repo, fake_redis):
+    """Pointer still present but holder is dissolved (pre-fix rows)."""
+    org_a = _org("org_a", "fence-1", status="dissolved")
+    # Simulate legacy state: payload says dissolved but pointer remains.
+    import json
+
+    await fake_redis.set(_org_key("org_a"), json.dumps(org_a.to_dict()))
+    await fake_redis.set(_org_subnet_idx("fence-1"), "org_a")
+
+    await repo.save_org(_org("org_b", "fence-1"))
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_b"
+
+
+async def test_dangling_pointer_is_evicted(repo, fake_redis):
+    await fake_redis.set(_org_subnet_idx("fence-1"), "org_ghost")  # no payload
+    await repo.save_org(_org("org_b", "fence-1"))
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_b"
+
+
+async def test_delete_org_releases_only_own_pointer(repo):
+    org_a = _org("org_a", "fence-1")
+    await repo.save_org(org_a)
+    org_a.status = "dissolved"
+    await repo.save_org(org_a)
+    await repo.save_org(_org("org_b", "fence-1"))  # took over the fence
+
+    # Deleting the dissolved predecessor must NOT clobber org_b's binding.
+    assert await repo.delete_org("org_a") is True
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_b"
+
+
+# ---------------------------------------------------------------------------
+# Round-trips on the real key layout
+# ---------------------------------------------------------------------------
+
+
+async def test_org_round_trip_and_steward_index(repo):
+    await repo.save_org(_org("org_a", "fence-1"))
+    loaded = await repo.find_org("org_a")
+    assert loaded is not None
+    assert loaded.subnet_id == "fence-1"
+    assert loaded.created_by.subject == "agt_steward"
+    stewarded = await repo.list_orgs_by_steward("agt_steward")
+    assert [o.org_id for o in stewarded] == ["org_a"]
+
+
+async def test_membership_round_trip_and_active_filter(repo):
+    await repo.save_org(_org("org_a", "fence-1"))
+    await repo.upsert_membership(
+        OrgMembership(org_id="org_a", agent_id="agt_w", role="worker")
+    )
+    inactive = OrgMembership(
+        org_id="org_a", agent_id="agt_gone", role="worker", status="inactive"
+    )
+    await repo.upsert_membership(inactive)
+
+    active = await repo.list_memberships("org_a", active_only=True)
+    assert [m.agent_id for m in active] == ["agt_w"]
+    everyone = await repo.list_memberships("org_a", active_only=False)
+    assert {m.agent_id for m in everyone} == {"agt_w", "agt_gone"}
+    assert await repo.delete_memberships_for_org("org_a") == 2
+
+
+async def test_work_round_trip_and_open_filter(repo):
+    await repo.save_org(_org("org_a", "fence-1"))
+    await repo.save_work(OrgWorkItem(work_id="w1", org_id="org_a", title="todo A"))
+    done = OrgWorkItem(work_id="w2", org_id="org_a", title="done B", status="done")
+    await repo.save_work(done)
+
+    open_items = await repo.list_work("org_a", open_only=True)
+    assert [w.work_id for w in open_items] == ["w1"]
+    all_items = await repo.list_work("org_a", open_only=False)
+    assert {w.work_id for w in all_items} == {"w1", "w2"}
+    assert await repo.delete_work_for_org("org_a") == 2

--- a/tests/infrastructure/test_org_repository_redis.py
+++ b/tests/infrastructure/test_org_repository_redis.py
@@ -73,9 +73,63 @@ async def test_second_org_on_same_subnet_conflicts(repo):
         await repo.save_org(_org("org_b", "fence-1"))
     assert ei.value.subnet_id == "fence-1"
     assert ei.value.bound_org_id == "org_a"
-    # Loser must leave no payload row behind when raised before SET —
-    # the claim happens before the payload write.
+    # Loser leaves no row behind: payload is written before the claim,
+    # and deleted again when the claim is lost.
     assert await repo.find_org("org_b") is None
+    stewarded = await repo.list_orgs_by_steward("agt_steward")
+    assert [o.org_id for o in stewarded] == ["org_a"]
+
+
+async def test_fresh_create_writes_payload_before_claim(repo, fake_redis):
+    """Ordering contract (#177 review): payload BEFORE pointer claim.
+
+    The dangling eviction treats "pointer without payload" as a dead
+    binding. If a fresh create claimed the pointer first, a concurrent
+    create could observe exactly that state, evict the pointer, and
+    double-bind the subnet. Pinning the write order closes the race.
+    """
+    order: list[str] = []
+    real_set = fake_redis.set
+
+    async def spy_set(key, *args, **kwargs):
+        order.append(key)
+        return await real_set(key, *args, **kwargs)
+
+    fake_redis.set = spy_set
+    try:
+        await repo.save_org(_org("org_a", "fence-1"))
+    finally:
+        fake_redis.set = real_set
+
+    assert order.index(_org_key("org_a")) < order.index(
+        _org_subnet_idx("fence-1")
+    )
+
+
+async def test_interleaved_fresh_creates_keep_single_binding(repo, fake_redis):
+    """Regression for the claim-before-write × dangling-eviction race.
+
+    Simulates T1 suspended mid-create (payload written, pointer not yet
+    claimed) while T2 completes a full create for the same subnet. When
+    T1 resumes its claim it must lose with a conflict — T2's binding
+    must NOT be evicted as dangling, and the pointer must keep exactly
+    one holder.
+    """
+    import json
+
+    t1 = _org("org_t1", "fence-1")
+    # T1 mid-flight: payload persisted, claim not yet attempted.
+    await fake_redis.set(_org_key("org_t1"), json.dumps(t1.to_dict()))
+
+    # T2 runs to completion and wins the fence.
+    await repo.save_org(_org("org_t2", "fence-1"))
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_t2"
+
+    # T1 resumes: its claim must observe an ACTIVE holder and back off.
+    with pytest.raises(OrgSubnetBindingConflictError) as ei:
+        await repo._claim_subnet_binding(t1)
+    assert ei.value.bound_org_id == "org_t2"
+    assert (await repo.find_org_by_subnet("fence-1")).org_id == "org_t2"
 
 
 async def test_resave_same_org_is_idempotent(repo):

--- a/tests/routes/test_orgs_auth.py
+++ b/tests/routes/test_orgs_auth.py
@@ -1,4 +1,4 @@
-"""Route-level auth gate for Org Harness write paths."""
+"""Route-level auth gate for Org Harness write paths + optional reader."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from fastapi import BackgroundTasks, Request
 from starlette.datastructures import Headers
 
 from acn.core.errors import ACNHTTPError, ErrorCode
-from acn.routes.orgs import require_org_auth
+from acn.routes.orgs import require_org_auth, resolve_org_reader
 
 
 @pytest.mark.asyncio
@@ -67,3 +67,100 @@ async def test_jwt_write_accepted_by_org_auth():
         )
     assert payload["sub"] == "auth0|writer"
     assert payload["type"] == "human"
+
+
+# ---------------------------------------------------------------------------
+# Optional reader dependency (private-Org read ACL) — never 401s;
+# anonymous / invalid credentials resolve to None.
+# ---------------------------------------------------------------------------
+
+
+def _request() -> MagicMock:
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.headers = Headers({})
+    return request
+
+
+@pytest.mark.asyncio
+async def test_org_reader_anonymous_resolves_to_none():
+    checker = resolve_org_reader()
+    with patch("acn.routes.orgs.get_settings") as gs:
+        gs.return_value = MagicMock(dev_mode=False, internal_api_token="tok")
+        payload = await checker(
+            request=_request(),
+            background_tasks=BackgroundTasks(),
+            credentials=None,
+            x_internal_token=None,
+            agent_service=AsyncMock(),
+        )
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_org_reader_invalid_jwt_resolves_to_none():
+    checker = resolve_org_reader()
+    credentials = MagicMock()
+    credentials.credentials = "not-a-valid-jwt"
+
+    async def boom(req, creds):
+        raise RuntimeError("bad token")
+
+    with patch("acn.routes.orgs.verify_token", new=boom), patch(
+        "acn.routes.orgs.get_settings"
+    ) as gs:
+        gs.return_value = MagicMock(dev_mode=False, internal_api_token="tok")
+        payload = await checker(
+            request=_request(),
+            background_tasks=BackgroundTasks(),
+            credentials=credentials,
+            x_internal_token=None,
+            agent_service=AsyncMock(),
+        )
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_org_reader_invalid_agent_key_resolves_to_none():
+    checker = resolve_org_reader()
+    credentials = MagicMock()
+    credentials.credentials = "acn_deadbeef"
+    agent_service = AsyncMock()
+    agent_service.get_agent_by_api_key.return_value = None
+
+    with patch("acn.routes.orgs.get_settings") as gs:
+        gs.return_value = MagicMock(dev_mode=False, internal_api_token="tok")
+        payload = await checker(
+            request=_request(),
+            background_tasks=BackgroundTasks(),
+            credentials=credentials,
+            x_internal_token=None,
+            agent_service=agent_service,
+        )
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_org_reader_agent_key_resolves_to_agent_payload():
+    checker = resolve_org_reader()
+    credentials = MagicMock()
+    credentials.credentials = "acn_goodkey"
+    agent = MagicMock()
+    agent.agent_id = "agt_reader"
+    agent_service = AsyncMock()
+    agent_service.get_agent_by_api_key.return_value = agent
+
+    with patch("acn.routes.orgs.get_settings") as gs:
+        gs.return_value = MagicMock(dev_mode=False, internal_api_token="tok")
+        payload = await checker(
+            request=_request(),
+            background_tasks=BackgroundTasks(),
+            credentials=credentials,
+            x_internal_token=None,
+            agent_service=agent_service,
+        )
+    assert payload == {
+        "sub": "agt_reader",
+        "type": "agent",
+        "permissions": ["acn:read", "acn:write"],
+    }

--- a/tests/services/test_org_service.py
+++ b/tests/services/test_org_service.py
@@ -9,7 +9,10 @@ import pytest
 from acn.core.entities.agent import Agent
 from acn.core.entities.org import Org, OrgMembership, OrgOwner, OrgPrincipal
 from acn.core.entities.subnet import Subnet
-from acn.core.exceptions import SubnetNotFoundException
+from acn.core.exceptions import (
+    OrgSubnetBindingConflictError,
+    SubnetNotFoundException,
+)
 from acn.core.interfaces.org_repository import IOrgRepository
 from acn.protocols.ap2 import WebhookEventType
 from acn.services.org_service import (
@@ -477,6 +480,194 @@ class TestUpdateAndMembersView:
             harness_secret="s3cret",
         )
         mock_subnet_service.update_harness.assert_awaited_once()
+
+
+class TestPrivateOrgReadACL:
+    """Private-fence Orgs are redacted / gated for unentitled readers."""
+
+    def _private_subnet(self, org, members=None):
+        return Subnet(
+            slug=org.subnet_id,
+            name="P",
+            owner="agt_steward",
+            is_private=True,
+            join_policy="approval",
+            member_agent_ids=set(members or {"agt_steward"}),
+        )
+
+    async def test_anonymous_gets_redacted_view(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org(charter={"mission": "secret"})
+        mock_org_repo.find_org.return_value = org
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=self._private_subnet(org)
+        )
+
+        view = await org_service.get_org_view(org.org_id)
+        assert view["private"] is True
+        assert view["org_id"] == org.org_id
+        # Sensitive fields withheld
+        for field in ("charter", "created_by", "steward_agent_id", "plugins"):
+            assert field not in view
+        assert view["owner"] == {"kind": "none"}
+        assert "subnet_id" not in view["fencing"]
+
+    async def test_member_agent_gets_full_view(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org(charter={"mission": "secret"})
+        mock_org_repo.find_org.return_value = org
+        mock_org_repo.find_membership.return_value = OrgMembership(
+            org_id=org.org_id, agent_id="agt_worker", status="active"
+        )
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=self._private_subnet(org, {"agt_steward", "agt_worker"})
+        )
+
+        view = await org_service.get_org_view(
+            org.org_id, caller_type="agent", caller_sub="agt_worker"
+        )
+        assert view["charter"] == {"mission": "secret"}
+        assert view["steward_agent_id"] == "agt_steward"
+
+    async def test_steward_owner_human_gets_full_view(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        """Ownership-chain bridge: human owning the steward agent may read."""
+        org = _stored_org(created_by=OrgPrincipal(kind="human", subject="auth0|u"))
+        mock_org_repo.find_org.return_value = org
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=self._private_subnet(org)
+        )
+
+        # mock_agent_service maps agt_steward → owner "auth0|u"
+        view = await org_service.get_org_view(
+            org.org_id, caller_type="human", caller_sub="auth0|u"
+        )
+        assert view["steward_agent_id"] == "agt_steward"
+
+    async def test_unrelated_human_gets_redacted_view(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        mock_org_repo.find_membership.return_value = None
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=self._private_subnet(org)
+        )
+
+        view = await org_service.get_org_view(
+            org.org_id, caller_type="human", caller_sub="auth0|stranger"
+        )
+        assert view.get("private") is True
+        assert "charter" not in view
+
+    async def test_public_org_stays_fully_visible_to_anonymous(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org(charter={"mission": "open"})
+        mock_org_repo.find_org.return_value = org
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=Subnet(
+                slug=org.subnet_id,
+                name="Pub",
+                owner="agt_steward",
+                member_agent_ids={"agt_steward"},
+            )
+        )
+
+        view = await org_service.get_org_view(org.org_id)
+        assert view["charter"] == {"mission": "open"}
+        assert view["fencing"]["is_private"] is False
+
+    async def test_fence_missing_is_treated_as_private(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org(charter={"mission": "secret"})
+        mock_org_repo.find_org.return_value = org
+        mock_org_repo.find_membership.return_value = None
+        mock_subnet_service.get_subnet = AsyncMock(
+            side_effect=SubnetNotFoundException("gone")
+        )
+
+        anon = await org_service.get_org_view(org.org_id)
+        assert anon.get("private") is True
+        assert anon["fencing"]["missing"] is True
+        assert "charter" not in anon
+
+        # created_by (agent) still sees the degraded-but-full view
+        entitled = await org_service.get_org_view(
+            org.org_id, caller_type="agent", caller_sub="agt_steward"
+        )
+        assert entitled["charter"] == {"mission": "secret"}
+        assert entitled["fencing"]["missing"] is True
+
+    async def test_members_listing_gated_for_strangers(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        mock_org_repo.find_membership.return_value = None
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=self._private_subnet(org)
+        )
+
+        with pytest.raises(OrgPermissionError) as ei:
+            await org_service.ensure_private_readable(
+                org.org_id, caller_type="agent", caller_sub="agt_stranger"
+            )
+        assert ei.value.reason == "private_org"
+
+        with pytest.raises(OrgPermissionError):
+            await org_service.ensure_private_readable(org.org_id)  # anonymous
+
+        # Steward passes; admin bypasses without identity.
+        await org_service.ensure_private_readable(
+            org.org_id, caller_type="agent", caller_sub="agt_steward"
+        )
+        await org_service.ensure_private_readable(org.org_id, admin=True)
+
+    async def test_public_org_members_listing_open(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=Subnet(
+                slug=org.subnet_id, name="Pub", owner="agt_steward"
+            )
+        )
+        await org_service.ensure_private_readable(org.org_id)  # no raise
+
+
+class TestSubnetBindingConflict:
+    async def test_create_maps_repo_binding_conflict_to_409_reason(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        """A save-time fence conflict (lost race) surfaces as
+        ``subnet_already_bound`` — same contract as the pre-check path."""
+        subnet = Subnet(slug="org-race", name="R", owner="agt_steward")
+        mock_subnet_service.get_subnet = AsyncMock(
+            side_effect=SubnetNotFoundException("x")
+        )
+        mock_subnet_service.create_subnet = AsyncMock(return_value=subnet)
+        mock_org_repo.save_org.side_effect = OrgSubnetBindingConflictError(
+            "org-race", "org_winner"
+        )
+
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.create_org(
+                display_name="Race",
+                caller_type="agent",
+                caller_sub="agt_steward",
+                subnet_id="org-race",
+            )
+        assert ei.value.reason == "subnet_already_bound"
+        # Newly created subnet is still rolled back on this path.
+        mock_subnet_service.delete_subnet.assert_awaited_once_with(
+            "org-race", "agt_steward"
+        )
 
 
 class TestGovernanceGate:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #176 审阅跟进,修复两个发现(stacked 在 `feat/org-harness-phase1` 上,合入后随 #176 一起进 main):

**1. 私有 Org 读接口无 ACL**
`GET /orgs/{id}`、`/members`、`/work` 原先完全无鉴权,即使 Org 绑定的是 `is_private=true` 的私有 subnet,任何匿名调用者也能拿到 `charter`、`created_by`、`steward_agent_id`、成员列表和工单——与 subnet ACL V6(#114,私有 subnet 未授权只返回 Stub)的既有承诺冲突。现在:

- `GET /orgs/{id}`:未授权读者得到最小化 redacted 视图(仅 `org_id`/`status`/`owner.kind`/`private` 标记),对齐 `SubnetStub` 哲学(不藏存在性、藏敏感字段)
- `GET /orgs/{id}/members`、`/work`:未授权读者 403(`reason=private_org`)
- 授权者 = Org owner / created_by / steward / subnet owner 或 member / 持有 active OrgMembership 的 agent / 拥有 steward agent 的人类(ownership-chain bridge)/ `acn:admin` / internal token;桥有意收窄——拥有 worker agent 的人类不可读(对齐 V6 § 2,已写入 docstring)
- fence subnet 丢失时保守按私有处理;公开 fence 的 Org 行为完全不变
- 新增 `resolve_org_reader` 可选鉴权依赖:读路径永不 401,无效凭证按匿名处理(与 `GET /subnets/{slug}` 一致)

**2. Redis 后端「一 subnet 一 Org」无原子保证**
Postgres 有 `uq_orgs_subnet_id` 唯一约束,但默认后端 Redis 的 `acn:orgs:by_subnet` 指针是普通 `SET`,两个并发 create 都能通过 service 预检查、都绑定成功。现在:

- 指针改为 `SET NX` 抢占;**fresh create 先写 payload、后抢指针**,输家删除自己刚写的行(review 修正:claim-before-write 会让并发 create 把刚抢到的指针误判为 dangling 并驱逐,导致双绑定——该竞态已由「写序 spy」和「精确交错」两个回归测试钉死)
- rebind(payload 已存在、不会被误判)保持 claim-first;dissolved / dangling 持有者驱逐后重试一次,活跃持有者抛新增领域异常 `OrgSubnetBindingConflictError`
- dissolve / delete 时只在指针仍指向自己时释放(guarded release)
- Postgres 侧把 `uq_orgs_subnet_id` 的 IntegrityError 映射为同一领域异常;`create_org` 统一转为与预检查路径相同的 409 `subnet_already_bound`,并保持 subnet 回滚语义
- 未用 Lua(CI 的 fakeredis 无解释器);写序修正后「指针无 payload」只可能来自真正死绑定(如 `delete_org` 中途崩溃),残留窗口记录为 BACKLOG `DEF-ORG-LUA`

**其他**
- `dissolve()` 补充软删除设计意图 docstring(subnet/成员/工单有意保留,供重绑与审计)
- BACKLOG 新增 `DEF-ORG-ACL` / `DEF-ORG-LUA` 待办,补末尾换行
- 补齐两个后端缺失的仓储层测试(fakeredis 端到端 + mock-session),这是 #176 审阅指出的空白

## Test plan

- [x] 新增 26 个测试:私有 Org 读 ACL(匿名 redacted / member 全量 / ownership-chain bridge / fence-missing 保守私有 / members 403)、Redis NX 抢占(并发冲突 / dissolved 重绑 / dangling 驱逐 / guarded release / **payload-before-claim 写序** / **T1-T2 交错双绑定回归**)、Postgres IntegrityError 映射、reader 依赖(匿名与无效凭证 → None)
- [x] 全量测试套件 2404 passed, 7 skipped(本地真实 Redis)
- [x] `ruff check acn/` 全过
- [ ] #176 合入 main 后 retarget 本 PR 至 main,以 CI 为最终门禁
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08d2dfc-9004-4a76-90ca-cf8ac2560d21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08d2dfc-9004-4a76-90ca-cf8ac2560d21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

