### PR TITLE
feat(org-harness): Phase 2a Work Port (builtin_work)

### DIFF
--- a/acn/core/entities/org.py
+++ b/acn/core/entities/org.py
@@ -85,8 +85,8 @@ class Org:
     charter: dict[str, Any] = field(default_factory=dict)
     plugins: dict[str, str] = field(
         default_factory=lambda: {
-            "work": "minimal",
-            "loop": "thin",
+            "work": "builtin_work",
+            "loop": "heartbeat",
             "memory": "noop",
         }
     )
@@ -144,7 +144,11 @@ class Org:
             owner=OrgOwner.from_dict(data.get("owner")),
             charter=data.get("charter") or {},
             plugins=data.get("plugins")
-            or {"work": "minimal", "loop": "thin", "memory": "noop"},
+            or {
+                "work": "builtin_work",
+                "loop": "heartbeat",
+                "memory": "noop",
+            },
             roles=list(data.get("roles") or _DEFAULT_ROLES),
             status=data.get("status") or "active",
             steward_agent_id=data.get("steward_agent_id") or "",

--- a/acn/core/exceptions/__init__.py
+++ b/acn/core/exceptions/__init__.py
@@ -44,6 +44,18 @@ class OrgSubnetBindingConflictError(ACNException):
         )
 
 
+class OrgConflictError(ACNException):
+    """Org-domain conflict (ownership, membership, plugin resolve, …).
+
+    ``reason`` is a stable machine code for HTTP ``RESOURCE_CONFLICT``
+    details (e.g. ``plugin_unavailable``, ``already_member``).
+    """
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        self.reason = reason
+        super().__init__(message or reason)
+
+
 class PolicyRejected(ACNException):
     """Inbound message was rejected by the recipient's communication_policy.
 

--- a/acn/core/interfaces/__init__.py
+++ b/acn/core/interfaces/__init__.py
@@ -24,12 +24,12 @@ from .settlement_outbox_repository import (
     ISettlementOutboxRepository,
     SettlementEvent,
 )
-from .work_pattern import IWorkPattern
 from .subnet_allowlist_repository import ISubnetAllowlistRepository
 from .subnet_join_request_repository import ISubnetJoinRequestRepository
 from .subnet_repository import ISubnetRepository
 from .task_repository import ITaskRepository
 from .unit_of_work import IUnitOfWork
+from .work_pattern import IWorkPattern
 
 # IActivityRepository and IBillingRepository are imported directly from their
 # modules to avoid circular imports (they reference service-layer types).

--- a/acn/core/interfaces/__init__.py
+++ b/acn/core/interfaces/__init__.py
@@ -24,6 +24,7 @@ from .settlement_outbox_repository import (
     ISettlementOutboxRepository,
     SettlementEvent,
 )
+from .work_pattern import IWorkPattern
 from .subnet_allowlist_repository import ISubnetAllowlistRepository
 from .subnet_join_request_repository import ISubnetJoinRequestRepository
 from .subnet_repository import ISubnetRepository
@@ -49,6 +50,7 @@ __all__ = [
     "ISubnetRepository",
     "ITaskRepository",
     "IUnitOfWork",
+    "IWorkPattern",
     "IEscrowProvider",
     "ReleaseResult",
     "EscrowResult",

--- a/acn/core/interfaces/work_pattern.py
+++ b/acn/core/interfaces/work_pattern.py
@@ -1,0 +1,48 @@
+"""IWorkPattern — Org Harness Work Graph port (Phase 2 / ADR-0014 D7)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..entities.org import OrgWorkItem, WorkStatus
+
+
+class IWorkPattern(ABC):
+    """How an Org models and mutates work items.
+
+    Control Loop (``IOrgLoop`` / thin tick) **reads** via this port; it never
+    executes L1 tools. Kernel identity / membership stay outside.
+    """
+
+    #: Canonical plugin id (e.g. ``builtin_work``).
+    plugin_id: str
+
+    @abstractmethod
+    async def create_work(
+        self,
+        org_id: str,
+        *,
+        title: str,
+        assignee_agent_id: str | None = None,
+    ) -> OrgWorkItem:
+        """Create a work item in ``todo`` status."""
+
+    @abstractmethod
+    async def update_work(
+        self,
+        org_id: str,
+        work_id: str,
+        *,
+        status: WorkStatus,
+        assignee_agent_id: str | None = None,
+    ) -> OrgWorkItem:
+        """Update status and optional assignee."""
+
+    @abstractmethod
+    async def list_work(
+        self,
+        org_id: str,
+        *,
+        open_only: bool = False,
+    ) -> list[OrgWorkItem]:
+        """List work items; ``open_only`` → todo / in_progress."""

--- a/acn/infrastructure/persistence/postgres/org_repository.py
+++ b/acn/infrastructure/persistence/postgres/org_repository.py
@@ -34,7 +34,8 @@ class PostgresOrgRepository(IOrgRepository):
             ),
             subnet_id=row.subnet_id,
             steward_agent_id=row.steward_agent_id,
-            plugins=row.plugins or {"work": "minimal", "loop": "thin", "memory": "noop"},
+            plugins=row.plugins
+            or {"work": "builtin_work", "loop": "heartbeat", "memory": "noop"},
             roles=list(row.roles or ["manager", "worker", "reviewer"]),
             status=row.status,  # type: ignore[arg-type]
             created_at=row.created_at,

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -249,6 +249,13 @@ class OrgCreateRequest(BaseModel):
         default=None,
         description="HMAC secret for harness_url (optional)",
     )
+    plugins: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Org plugin map; work defaults to builtin_work. "
+            "Legacy aliases minimal→builtin_work, thin→heartbeat."
+        ),
+    )
 
 
 class OrgUpdateRequest(BaseModel):
@@ -335,6 +342,7 @@ async def create_org(
             subnet_id=body.subnet_id,
             join_policy=body.join_policy,
             is_private=body.is_private,
+            plugins=body.plugins,
             harness_url=body.harness_url,
             harness_secret=body.harness_secret,
         )
@@ -421,6 +429,12 @@ async def update_org(
         ) from e
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        raise ACNHTTPError(
+            ErrorCode.RESOURCE_CONFLICT,
+            409,
+            details={"org_id": org_id, "reason": e.reason},
+        ) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST, 400, details={"reason": str(e)}

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -433,7 +433,7 @@ async def update_org(
         raise ACNHTTPError(
             ErrorCode.RESOURCE_CONFLICT,
             409,
-            details={"org_id": org_id, "reason": e.reason},
+            details={"reason": e.reason},
         ) from e
     except ValueError as e:
         raise ACNHTTPError(
@@ -675,6 +675,13 @@ async def create_work(
         ) from e
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        # Legacy Phase 1 Orgs may store unavailable work plugins.
+        raise ACNHTTPError(
+            ErrorCode.RESOURCE_CONFLICT,
+            409,
+            details={"reason": e.reason},
+        ) from e
 
 
 @router.get("/{org_id}/work")
@@ -705,6 +712,12 @@ async def list_work(
         ) from e
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        raise ACNHTTPError(
+            ErrorCode.RESOURCE_CONFLICT,
+            409,
+            details={"reason": e.reason},
+        ) from e
 
 
 @router.patch("/{org_id}/work/{work_id}")
@@ -740,6 +753,12 @@ async def update_work(
         ) from e
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        raise ACNHTTPError(
+            ErrorCode.RESOURCE_CONFLICT,
+            409,
+            details={"reason": e.reason},
+        ) from e
 
 
 @router.post("/{org_id}/loop/tick")
@@ -762,3 +781,9 @@ async def tick_loop(
         ) from e
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        raise ACNHTTPError(
+            ErrorCode.RESOURCE_CONFLICT,
+            409,
+            details={"reason": e.reason},
+        ) from e

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -21,6 +21,7 @@ from ..core.entities.org import (
 from ..core.entities.subnet import Subnet
 from ..core.exceptions import (
     AgentNotFoundException,
+    OrgConflictError,
     OrgSubnetBindingConflictError,
     SubnetNotFoundException,
 )
@@ -47,12 +48,6 @@ class OrgNotFoundError(Exception):
 
 
 class OrgPermissionError(Exception):
-    def __init__(self, reason: str, message: str = "") -> None:
-        self.reason = reason
-        super().__init__(message or reason)
-
-
-class OrgConflictError(Exception):
     def __init__(self, reason: str, message: str = "") -> None:
         self.reason = reason
         super().__init__(message or reason)

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -1,4 +1,4 @@
-"""Org Harness service — Kernel + minimal work + thin Loop (ADR-0014)."""
+"""Org Harness service — Kernel + Work Port + thin Loop (ADR-0014 / Phase 2a)."""
 
 from __future__ import annotations
 
@@ -29,6 +29,11 @@ from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
 from .agent_service import AgentService
 from .subnet_service import SubnetService
+from .work_patterns import (
+    normalize_org_plugins,
+    resolve_work_pattern,
+    validate_org_plugins,
+)
 
 logger = structlog.get_logger()
 
@@ -79,6 +84,11 @@ class OrgService:
         self.subnet_service = subnet_service
         self.agent_service = agent_service
         self.webhook_service = webhook_service
+
+    def _work_pattern_for(self, org: Org):
+        """Resolve ``IWorkPattern`` from ``org.plugins.work`` (aliases allowed)."""
+        plugin_id = (org.plugins or {}).get("work", "builtin_work")
+        return resolve_work_pattern(plugin_id, self.repository)
 
     # ------------------------------------------------------------------
     # Auth helpers
@@ -229,6 +239,10 @@ class OrgService:
         if is_private and join_policy == "open":
             join_policy = "approval"
 
+        # Validate plugins before creating a fence subnet (avoid orphans).
+        resolved_plugins = normalize_org_plugins(plugins)
+        validate_org_plugins(resolved_plugins)
+
         slug = subnet_id or self._generate_subnet_slug(display_name)
         try:
             existing = await self.subnet_service.get_subnet(slug)
@@ -279,8 +293,7 @@ class OrgService:
             steward_agent_id=steward,
             owner=OrgOwner(kind="none"),
             charter=charter or {},
-            plugins=plugins
-            or {"work": "minimal", "loop": "thin", "memory": "noop"},
+            plugins=resolved_plugins,
             created_at=now,
             updated_at=now,
         )
@@ -541,8 +554,8 @@ class OrgService:
         if charter is not None:
             org.charter = charter
         if plugins is not None:
-            merged = dict(org.plugins)
-            merged.update(plugins)
+            merged = normalize_org_plugins({**org.plugins, **plugins})
+            validate_org_plugins(merged)
             org.plugins = merged
         org.updated_at = datetime.now(UTC)
         await self.repository.save_org(org)
@@ -954,7 +967,7 @@ class OrgService:
         return org
 
     # ------------------------------------------------------------------
-    # Minimal work + thin Loop
+    # Work Port + thin Loop
     # ------------------------------------------------------------------
 
     async def create_work(
@@ -968,17 +981,11 @@ class OrgService:
     ) -> OrgWorkItem:
         org = await self.get_org(org_id)
         self._require_governance(org, caller_type, caller_sub)
-        now = datetime.now(UTC)
-        work = OrgWorkItem(
-            work_id=f"work_{uuid4().hex[:16]}",
-            org_id=org_id,
+        work = await self._work_pattern_for(org).create_work(
+            org_id,
             title=title,
             assignee_agent_id=assignee_agent_id,
-            status="todo",
-            created_at=now,
-            updated_at=now,
         )
-        await self.repository.save_work(work)
         await self._emit(
             org,
             WebhookEventType.ORG_WORK_CREATED,
@@ -998,14 +1005,12 @@ class OrgService:
     ) -> OrgWorkItem:
         org = await self.get_org(org_id)
         self._require_governance(org, caller_type, caller_sub)
-        work = await self.repository.find_work(org_id, work_id)
-        if not work:
-            raise OrgWorkNotFoundError(org_id, work_id)
-        work.status = status
-        if assignee_agent_id is not None:
-            work.assignee_agent_id = assignee_agent_id
-        work.updated_at = datetime.now(UTC)
-        await self.repository.save_work(work)
+        work = await self._work_pattern_for(org).update_work(
+            org_id,
+            work_id,
+            status=status,
+            assignee_agent_id=assignee_agent_id,
+        )
         await self._emit(
             org,
             WebhookEventType.ORG_WORK_UPDATED,
@@ -1016,8 +1021,10 @@ class OrgService:
     async def list_work(
         self, org_id: str, *, open_only: bool = False
     ) -> list[OrgWorkItem]:
-        await self.get_org(org_id)
-        return await self.repository.list_work(org_id, open_only=open_only)
+        org = await self.get_org(org_id)
+        return await self._work_pattern_for(org).list_work(
+            org_id, open_only=open_only
+        )
 
     async def tick_loop(
         self,
@@ -1026,13 +1033,15 @@ class OrgService:
         caller_type: CallerType,
         caller_sub: str,
     ) -> dict[str, Any]:
-        """Thin Loop tick: list open work and emit org.loop_tick."""
+        """Thin Loop tick: list open work via Work Port and emit org.loop_tick."""
         org = await self.get_org(org_id)
         self._require_governance(org, caller_type, caller_sub)
         if org.status != "active":
             raise OrgPermissionError("org_not_active", "Org Loop requires active status")
 
-        open_work = await self.repository.list_work(org_id, open_only=True)
+        open_work = await self._work_pattern_for(org).list_work(
+            org_id, open_only=True
+        )
         payload = {
             "open_count": len(open_work),
             "work_ids": [w.work_id for w in open_work],

--- a/acn/services/work_patterns/__init__.py
+++ b/acn/services/work_patterns/__init__.py
@@ -1,0 +1,23 @@
+"""Org Harness work-pattern plugins (Phase 2a)."""
+
+from __future__ import annotations
+
+from ...core.interfaces.work_pattern import IWorkPattern
+from .builtin import BuiltinWorkPattern
+from .registry import (
+    DEFAULT_ORG_PLUGINS,
+    canonicalize_work_plugin,
+    normalize_org_plugins,
+    resolve_work_pattern,
+    validate_org_plugins,
+)
+
+__all__ = [
+    "BuiltinWorkPattern",
+    "DEFAULT_ORG_PLUGINS",
+    "IWorkPattern",
+    "canonicalize_work_plugin",
+    "normalize_org_plugins",
+    "resolve_work_pattern",
+    "validate_org_plugins",
+]

--- a/acn/services/work_patterns/builtin.py
+++ b/acn/services/work_patterns/builtin.py
@@ -1,0 +1,68 @@
+"""builtin_work — Phase 1 OrgWorkItem storage behind IWorkPattern."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from ...core.entities.org import OrgWorkItem, WorkStatus
+from ...core.interfaces.org_repository import IOrgRepository
+from ...core.interfaces.work_pattern import IWorkPattern
+
+
+class BuiltinWorkPattern(IWorkPattern):
+    """Default Work Graph: Org-local work items (Redis / Postgres org repos)."""
+
+    plugin_id = "builtin_work"
+
+    def __init__(self, repository: IOrgRepository) -> None:
+        self._repo = repository
+
+    async def create_work(
+        self,
+        org_id: str,
+        *,
+        title: str,
+        assignee_agent_id: str | None = None,
+    ) -> OrgWorkItem:
+        now = datetime.now(UTC)
+        work = OrgWorkItem(
+            work_id=f"work_{uuid4().hex[:16]}",
+            org_id=org_id,
+            title=title,
+            assignee_agent_id=assignee_agent_id,
+            status="todo",
+            created_at=now,
+            updated_at=now,
+        )
+        await self._repo.save_work(work)
+        return work
+
+    async def update_work(
+        self,
+        org_id: str,
+        work_id: str,
+        *,
+        status: WorkStatus,
+        assignee_agent_id: str | None = None,
+    ) -> OrgWorkItem:
+        # Local import avoids circular import with OrgService.
+        from ..org_service import OrgWorkNotFoundError
+
+        work = await self._repo.find_work(org_id, work_id)
+        if not work:
+            raise OrgWorkNotFoundError(org_id, work_id)
+        work.status = status
+        if assignee_agent_id is not None:
+            work.assignee_agent_id = assignee_agent_id
+        work.updated_at = datetime.now(UTC)
+        await self._repo.save_work(work)
+        return work
+
+    async def list_work(
+        self,
+        org_id: str,
+        *,
+        open_only: bool = False,
+    ) -> list[OrgWorkItem]:
+        return await self._repo.list_work(org_id, open_only=open_only)

--- a/acn/services/work_patterns/registry.py
+++ b/acn/services/work_patterns/registry.py
@@ -1,0 +1,114 @@
+"""Resolve ``org.plugins.work`` / normalize plugin maps (Phase 2a)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...core.interfaces.org_repository import IOrgRepository
+from ...core.interfaces.work_pattern import IWorkPattern
+from .builtin import BuiltinWorkPattern
+
+if TYPE_CHECKING:
+    pass
+
+# Canonical defaults (phase2-work-port-v0).
+DEFAULT_ORG_PLUGINS: dict[str, str] = {
+    "work": "builtin_work",
+    "loop": "heartbeat",
+    "memory": "noop",
+}
+
+# Legacy Phase 1 ids still accepted when reading stored Orgs.
+_WORK_ALIASES: dict[str, str] = {
+    "minimal": "builtin_work",
+    "builtin_work": "builtin_work",
+}
+
+_LOOP_ALIASES: dict[str, str] = {
+    "thin": "heartbeat",
+    "heartbeat": "heartbeat",
+}
+
+# Implemented work plugins in this release.
+_WORK_IMPLEMENTED: frozenset[str] = frozenset({"builtin_work"})
+
+# Known but not yet wired (P2b+) — rejected with a clear reason.
+_WORK_KNOWN_UNAVAILABLE: frozenset[str] = frozenset({"task_pool", "paperclip"})
+
+_LOOP_KNOWN: frozenset[str] = frozenset({"heartbeat"})
+_MEMORY_KNOWN: frozenset[str] = frozenset({"noop"})
+
+
+def canonicalize_work_plugin(plugin_id: str) -> str:
+    return _WORK_ALIASES.get(plugin_id, plugin_id)
+
+
+def canonicalize_loop_plugin(plugin_id: str) -> str:
+    return _LOOP_ALIASES.get(plugin_id, plugin_id)
+
+
+def normalize_org_plugins(plugins: dict[str, str] | None) -> dict[str, str]:
+    """Merge with defaults and canonicalize known aliases."""
+    merged = dict(DEFAULT_ORG_PLUGINS)
+    if plugins:
+        merged.update(plugins)
+    merged["work"] = canonicalize_work_plugin(merged.get("work", "builtin_work"))
+    merged["loop"] = canonicalize_loop_plugin(merged.get("loop", "heartbeat"))
+    if "memory" not in merged or not merged["memory"]:
+        merged["memory"] = "noop"
+    return merged
+
+
+def validate_org_plugins(plugins: dict[str, str]) -> None:
+    """Raise ``OrgConflictError`` for unknown / unavailable plugin ids."""
+    # Imported here to keep registry free of service-module cycles at import time.
+    from ..org_service import OrgConflictError
+
+    work = canonicalize_work_plugin(plugins.get("work", "builtin_work"))
+    if work in _WORK_IMPLEMENTED:
+        pass
+    elif work in _WORK_KNOWN_UNAVAILABLE:
+        raise OrgConflictError(
+            "plugin_unavailable",
+            f"work plugin '{work}' is not available yet (Phase 2b+)",
+        )
+    else:
+        raise OrgConflictError(
+            "unknown_plugin",
+            f"unknown work plugin: {plugins.get('work')!r}",
+        )
+
+    loop = canonicalize_loop_plugin(plugins.get("loop", "heartbeat"))
+    if loop not in _LOOP_KNOWN:
+        raise OrgConflictError(
+            "unknown_plugin",
+            f"unknown loop plugin: {plugins.get('loop')!r}",
+        )
+
+    memory = plugins.get("memory", "noop")
+    if memory not in _MEMORY_KNOWN:
+        raise OrgConflictError(
+            "unknown_plugin",
+            f"unknown memory plugin: {memory!r}",
+        )
+
+
+def resolve_work_pattern(
+    plugin_id: str,
+    repository: IOrgRepository,
+) -> IWorkPattern:
+    """Return an ``IWorkPattern`` for ``plugin_id`` (after alias canonicalize)."""
+    from ..org_service import OrgConflictError
+
+    canonical = canonicalize_work_plugin(plugin_id)
+    if canonical == "builtin_work":
+        return BuiltinWorkPattern(repository)
+    if canonical in _WORK_KNOWN_UNAVAILABLE:
+        raise OrgConflictError(
+            "plugin_unavailable",
+            f"work plugin '{canonical}' is not available yet (Phase 2b+)",
+        )
+    raise OrgConflictError(
+        "unknown_plugin",
+        f"unknown work plugin: {plugin_id!r}",
+    )

--- a/acn/services/work_patterns/registry.py
+++ b/acn/services/work_patterns/registry.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from ...core.exceptions import OrgConflictError
 from ...core.interfaces.org_repository import IOrgRepository
 from ...core.interfaces.work_pattern import IWorkPattern
 from .builtin import BuiltinWorkPattern
-
-if TYPE_CHECKING:
-    pass
 
 # Canonical defaults (phase2-work-port-v0).
 DEFAULT_ORG_PLUGINS: dict[str, str] = {
@@ -61,9 +57,6 @@ def normalize_org_plugins(plugins: dict[str, str] | None) -> dict[str, str]:
 
 def validate_org_plugins(plugins: dict[str, str]) -> None:
     """Raise ``OrgConflictError`` for unknown / unavailable plugin ids."""
-    # Imported here to keep registry free of service-module cycles at import time.
-    from ..org_service import OrgConflictError
-
     work = canonicalize_work_plugin(plugins.get("work", "builtin_work"))
     if work in _WORK_IMPLEMENTED:
         pass
@@ -98,8 +91,6 @@ def resolve_work_pattern(
     repository: IOrgRepository,
 ) -> IWorkPattern:
     """Return an ``IWorkPattern`` for ``plugin_id`` (after alias canonicalize)."""
-    from ..org_service import OrgConflictError
-
     canonical = canonicalize_work_plugin(plugin_id)
     if canonical == "builtin_work":
         return BuiltinWorkPattern(repository)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -889,7 +889,7 @@ minimal work + thin Loop. Design: [`docs/org-harness/`](org-harness/README.md).
 
 Still deferred (Phase 2+):
 
-- **DEF-WORK-PLUGIN** — Task Pool as full `IWorkPattern` plugin host
+- **DEF-WORK-PLUGIN** — Phase 2 Work Port：见 [`org-harness/phase2-work-port-v0.md`](org-harness/phase2-work-port-v0.md)（P2a 默认 `builtin_work`；Task Pool 为可选 Builtin）
 - **DEF-MEM** — Org Memory / SOPs (Pattern-local; Mem0/Zep/PG+vector)
 - **DEF-ORGREP** — Cross-org reputation (beyond per-agent ERC-8004 reads)
 - **DEF-DISPUTE** — Dispute / jury after escrow window (ADR-0010 Future)

--- a/docs/adr/0014-org-harness-module.md
+++ b/docs/adr/0014-org-harness-module.md
@@ -136,7 +136,7 @@ Operations: `claim` / `transfer` / `release` mirror agent ownership semantics (e
 | Thin Loop | Tick: list open work → noop or invoke configured wakeup hook (v0 may only emit events) |
 | EventSink | Reuse subnet harness webhook; add `org.*` event types |
 
-Full Task Pool as `IWorkPattern` plugin moves to **Phase 2** (can migrate minimal work → Task Pool or keep parallel).
+Full Task Pool as an **optional** `IWorkPattern` moves to **Phase 2** ([phase2-work-port-v0.md](../org-harness/phase2-work-port-v0.md)): default remains Phase 1 minimal work as `builtin_work`; Task Pool is opt-in via `plugins.work=task_pool`.
 
 **Rejected:** Phase 1 Loop with zero work model (empty ticker).
 
@@ -212,4 +212,5 @@ Exact HTTP status codes follow ACN flat error schema (`OWNERSHIP_MISMATCH`, `AUT
 
 ## Changelog
 
+- 2026-07-21: Phase 2 sequencing locked in [phase2-work-port-v0.md](../org-harness/phase2-work-port-v0.md) — default `builtin_work`, Task Pool optional.
 - 2026-07-19: Proposed — resolves design review P0/P1 for Org Harness Module.

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -17,6 +17,7 @@
 | [org-model-v0.md](./org-model-v0.md) | Org / Membership 数据模型 |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core 消费契约（外部 Pattern 用） |
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（过渡期 Task 镜像）；服从 design-v0 + ADR |
+| **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · 切片 P2a/b/c）** |
 
 理论草稿（隐喻 / 协议史）：
 
@@ -39,4 +40,4 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 ## 下一步
 
-Phase 1 Kernel + P1 polish 已落地。Phase 2：Task Pool 收编为 `IWorkPattern`、Paperclip 迁到 Org work ports。详见 [design-v0.md §10](./design-v0.md#10-分阶段落地)。
+Phase 1 Kernel + 加固已落地。Phase 2 见 **[phase2-work-port-v0.md](./phase2-work-port-v0.md)**（先 P2a 插座 + 默认小工单）。

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -150,7 +150,7 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 
 | Port | 问题 | v0 默认 | 可替换示例 |
 |---|---|---|---|
-| **`IWorkPattern`** | 活怎么建模、认领、状态 | Builtin TaskPool（轻量） | Paperclip Issues、自研 DAG |
+| **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选）、Paperclip Issues、自研 DAG |
 | **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | ClawTeam 适配、自定义巡检 |
 | **`ICapabilityPool`** | 组织能力目录 | 聚合成员 ACN skills（可先内置非插件） | 外挂 MCP catalog |
 | **`IOrgMemory`** | 集体记忆 / SOP | `noop` | Mem0、PG+vector、Skills 包 |
@@ -189,9 +189,9 @@ Work Graph（IWorkPattern 策略，易变）:
 按 **Org** 配置插件组合，而非全局唯一：
 
 ```text
-Org A → Work=task_pool     Loop=heartbeat      Memory=noop
-Org B → Work=paperclip     Loop=paperclip_wake Memory=vector
-Org C → Work=swarm_handoff Loop=heartbeat      Memory=noop
+Org A → Work=builtin_work  Loop=heartbeat      Memory=noop
+Org B → Work=task_pool     Loop=heartbeat      Memory=noop
+Org C → Work=paperclip     Loop=paperclip_wake Memory=vector
 ```
 
 ---
@@ -257,7 +257,7 @@ Org Harness **消费** Core，不重新实现：
     "subnet_id": "acme-agent-co"
   },
   "plugins": {
-    "work": "task_pool",
+    "work": "builtin_work",
     "loop": "heartbeat",
     "memory": "noop"
   },
@@ -314,15 +314,17 @@ Org Harness **消费** Core，不重新实现：
 
 ### Phase 2 — Work Port
 
-1. 将 Task Pool 收编为默认 `IWorkPattern` 插件
-2. Plugin 配置按 org 切换
-3. 与 `paperclip-acn-plugin` 对齐：Issues ↔ WorkPort（逐步弱化「仅 Task 镜像」）
+> **短方案（实施准绳）：** [phase2-work-port-v0.md](./phase2-work-port-v0.md)
+
+1. **P2a（必做）** 最小 Port 插座 + 默认 `builtin_work`（现有 `OrgWorkItem`）；`smoke_org_kernel.sh` 行为不变  
+2. **P2b（按需）** `plugins.work=task_pool` 进程内可选适配（非默认；外部 Pattern 仍禁绑 `/tasks/*`）  
+3. **P2c（可并行）** `paperclip-acn-plugin`：Issues ↔ Org work + `org.*`，弱化 Task 镜像  
 
 ### Phase 3 — 增强 Port
 
 - Policy/Budget、Memory、Capability 真插件化  
 - ClawTeam / Swarm 适配器实验  
-- 统一 Plugin 宿主  
+- 统一 Plugin 宿主（发现 / 版本 / 热加载；Phase 2 仅最小 resolve）  
 
 ### 明确后置
 

--- a/docs/org-harness/org-model-v0.md
+++ b/docs/org-harness/org-model-v0.md
@@ -45,7 +45,7 @@
     "join_policy": "approval"
   },
   "plugins": {
-    "work": "task_pool",
+    "work": "builtin_work",
     "loop": "heartbeat",
     "memory": "noop"
   },

--- a/docs/org-harness/phase2-work-port-v0.md
+++ b/docs/org-harness/phase2-work-port-v0.md
@@ -1,0 +1,76 @@
+# Phase 2 — Work Port（短方案）
+
+**Status:** Agreed for implementation sequencing（2026-07-21）  
+**Depends on:** [design-v0.md](./design-v0.md) §5 / §10, [ADR-0014](../adr/0014-org-harness-module.md) D5–D7  
+**Audience:** 实施与审阅；先定边界，再写代码
+
+---
+
+## 一句话
+
+Phase 1 盖好了「组织」这栋房子。  
+Phase 2 给「怎么派活」装**可换插座**——先把**现在这套小工单**插上当默认，再按需接 Task Pool / Paperclip，不拆房重建。
+
+---
+
+## 已锁定的选择
+
+| 题 | 决定 |
+|---|---|
+| 默认 Work 实现 | **`builtin_work`** = 现有 `OrgWorkItem` + `/api/v1/orgs/{id}/work*`（不是一上来换成 Task Pool） |
+| Task Pool | **可选** Builtin：`plugins.work = task_pool`，仅 **进程内**调用（ADR-0014 D5）；外部 Pattern 仍 **禁止**依赖 `/api/v1/tasks/*` |
+| Paperclip | 迁到 Org work + `org.*` 事件；Task 镜像标为 legacy，逐步停写 |
+| Plugin 宿主 | Phase 2 只要**最小 resolve**（按 `org.plugins` 找实现 + 未知 id 报错）；完整发现/版本/热加载 → Phase 3 |
+| 短命子代理 | ≠ `OrgMembership`；WorkPort 若以后支持，也不自动进成员表 |
+| 现网 CN | Redis-only；默认路径不得强依赖 Postgres Task 表 |
+
+---
+
+## 切片（按序）
+
+### P2a — 插座 + 默认插件（必做）
+
+1. 定义 `IWorkPattern`（及 Loop 侧对 Port 的只读依赖）。
+2. `builtin_work` 包装现有 create/list/update work。
+3. `org.plugins.work` 默认 `builtin_work`；create/update 可改，非法 id → 明确错误。
+4. `loop/tick` 只通过 Port 读 open work（对外行为与今日一致）。
+5. **验收：** `scripts/smoke_org_kernel.sh` 零改动仍绿；相关单测绿。
+
+### P2b — Task Pool 可选适配（按需）
+
+6. `plugins.work=task_pool` → in-process 适配器。  
+7. 文档写清：选用 Task Pool ≠ 外部 Pattern 可以绑 `/tasks/*`。  
+8. 若需双写/迁移，另开附录，不阻塞 P2a。
+
+### P2c — Paperclip WorkPort（可并行）
+
+9. Adapter 读写 Org work + 消费 `org.work_*` / `org.loop_tick`。  
+10. Issue ↔ `OrgWorkItem` 映射；**新链路不写 Task 镜像**。  
+11. 更新 [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)：bootstrap 以 `POST /orgs` 为准；验收「issue → agent run」不经 Task Pool。
+
+---
+
+## 明确不进 Phase 2
+
+- Memory / Policy / Capability 真插件化  
+- ClawTeam / Swarm 适配器  
+- 完整 Plugin 宿主（市场、版本、热加载）  
+- DEF-ORG-LUA、Federation、Dispute、跨 Org 信誉  
+
+---
+
+## 验收清单
+
+| 项 | 通过标准 |
+|---|---|
+| 默认路径 | `smoke_org_kernel.sh` 通过 |
+| 切换 | 两 Org 可配不同 `plugins.work`，互不影响（P2b 落地后含 task_pool） |
+| 外部契约 | Paperclip 新路径不调用 `/api/v1/tasks/*`（P2c） |
+| 回归 | 私有 Org ACL、Redis fence NX 相关测试仍绿 |
+
+---
+
+## 和旧文案的关系
+
+design-v0 §10 原写「Task Pool 收编为默认」——**收编仍做，但默认实现改为 `builtin_work`**；Task Pool 是可选 Builtin，不是默认。  
+详见本页「已锁定的选择」。

--- a/tests/services/test_org_service.py
+++ b/tests/services/test_org_service.py
@@ -761,3 +761,47 @@ class TestOrgPluginResolve:
             )
         assert ei.value.reason == "plugin_unavailable"
         mock_org_repo.save_org.assert_not_called()
+
+    async def test_work_paths_reject_legacy_unavailable_plugin(
+        self, org_service, mock_org_repo
+    ):
+        """Phase 1 could store plugins.work=task_pool; work paths must raise, not 500."""
+        org = _stored_org(
+            plugins={
+                "work": "task_pool",
+                "loop": "heartbeat",
+                "memory": "noop",
+            }
+        )
+        mock_org_repo.find_org.return_value = org
+
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.list_work(org.org_id)
+        assert ei.value.reason == "plugin_unavailable"
+
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.create_work(
+                org.org_id,
+                title="x",
+                caller_type="agent",
+                caller_sub="agt_steward",
+            )
+        assert ei.value.reason == "plugin_unavailable"
+
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.update_work_status(
+                org.org_id,
+                "work_x",
+                status="todo",
+                caller_type="agent",
+                caller_sub="agt_steward",
+            )
+        assert ei.value.reason == "plugin_unavailable"
+
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.tick_loop(
+                org.org_id,
+                caller_type="agent",
+                caller_sub="agt_steward",
+            )
+        assert ei.value.reason == "plugin_unavailable"

--- a/tests/services/test_org_service.py
+++ b/tests/services/test_org_service.py
@@ -425,7 +425,7 @@ class TestUpdateAndMembersView:
         assert updated.display_name == "Renamed"
         assert updated.charter["mission"] == "ship"
         assert updated.plugins["loop"] == "heartbeat"
-        assert updated.plugins["work"] == "minimal"
+        assert updated.plugins["work"] == "builtin_work"
         mock_org_repo.save_org.assert_awaited()
 
     async def test_list_members_marks_degraded(
@@ -697,3 +697,67 @@ class TestGovernanceGate:
                 caller_type="agent",
                 caller_sub="agt_steward",
             )
+
+
+class TestOrgPluginResolve:
+    async def test_create_rejects_unknown_plugin(self, org_service, mock_org_repo):
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.create_org(
+                display_name="Bad Plugins",
+                caller_type="agent",
+                caller_sub="agt_steward",
+                plugins={"work": "no_such_plugin"},
+            )
+        assert ei.value.reason == "unknown_plugin"
+        mock_org_repo.save_org.assert_not_called()
+
+    async def test_create_rejects_unavailable_task_pool(
+        self, org_service, mock_org_repo
+    ):
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.create_org(
+                display_name="Bad Plugins",
+                caller_type="agent",
+                caller_sub="agt_steward",
+                plugins={"work": "task_pool"},
+            )
+        assert ei.value.reason == "plugin_unavailable"
+        mock_org_repo.save_org.assert_not_called()
+
+    async def test_create_normalizes_legacy_aliases(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        subnet = Subnet(
+            slug="org-legacy-1",
+            name="Legacy Aliases",
+            owner="agt_steward",
+            member_agent_ids={"agt_steward"},
+        )
+        mock_subnet_service.get_subnet = AsyncMock(
+            side_effect=[SubnetNotFoundException("x"), subnet]
+        )
+        mock_subnet_service.create_subnet = AsyncMock(return_value=subnet)
+        org = await org_service.create_org(
+            display_name="Legacy Aliases",
+            caller_type="agent",
+            caller_sub="agt_steward",
+            subnet_id="org-legacy-1",
+            plugins={"work": "minimal", "loop": "thin"},
+        )
+        assert org.plugins["work"] == "builtin_work"
+        assert org.plugins["loop"] == "heartbeat"
+
+    async def test_update_rejects_unavailable_plugin(
+        self, org_service, mock_org_repo
+    ):
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.update_org(
+                org.org_id,
+                plugins={"work": "paperclip"},
+                caller_type="agent",
+                caller_sub="agt_steward",
+            )
+        assert ei.value.reason == "plugin_unavailable"
+        mock_org_repo.save_org.assert_not_called()

--- a/tests/services/test_work_patterns.py
+++ b/tests/services/test_work_patterns.py
@@ -1,0 +1,59 @@
+"""Unit tests for Org work-pattern registry (Phase 2a)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from acn.services.org_service import OrgConflictError
+from acn.services.work_patterns import (
+    DEFAULT_ORG_PLUGINS,
+    normalize_org_plugins,
+    resolve_work_pattern,
+    validate_org_plugins,
+)
+from acn.services.work_patterns.builtin import BuiltinWorkPattern
+
+
+def test_default_plugins_are_canonical():
+    assert DEFAULT_ORG_PLUGINS == {
+        "work": "builtin_work",
+        "loop": "heartbeat",
+        "memory": "noop",
+    }
+
+
+def test_normalize_legacy_aliases():
+    assert normalize_org_plugins({"work": "minimal", "loop": "thin"}) == {
+        "work": "builtin_work",
+        "loop": "heartbeat",
+        "memory": "noop",
+    }
+
+
+def test_validate_unknown_plugin():
+    with pytest.raises(OrgConflictError) as ei:
+        validate_org_plugins({"work": "totally_unknown"})
+    assert ei.value.reason == "unknown_plugin"
+
+
+def test_validate_unavailable_plugins():
+    with pytest.raises(OrgConflictError) as ei:
+        validate_org_plugins({"work": "task_pool"})
+    assert ei.value.reason == "plugin_unavailable"
+    with pytest.raises(OrgConflictError) as ei:
+        validate_org_plugins({"work": "paperclip"})
+    assert ei.value.reason == "plugin_unavailable"
+
+
+def test_resolve_builtin_and_aliases():
+    repo = MagicMock()
+    assert isinstance(resolve_work_pattern("builtin_work", repo), BuiltinWorkPattern)
+    assert isinstance(resolve_work_pattern("minimal", repo), BuiltinWorkPattern)
+    with pytest.raises(OrgConflictError) as ei:
+        resolve_work_pattern("task_pool", repo)
+    assert ei.value.reason == "plugin_unavailable"
+    with pytest.raises(OrgConflictError) as ei:
+        resolve_work_pattern("nope", repo)
+    assert ei.value.reason == "unknown_plugin"

--- a/tests/services/test_work_patterns.py
+++ b/tests/services/test_work_patterns.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from acn.services.org_service import OrgConflictError
+from acn.core.exceptions import OrgConflictError
 from acn.services.work_patterns import (
     DEFAULT_ORG_PLUGINS,
     normalize_org_plugins,


### PR DESCRIPTION
## Summary
- Add `IWorkPattern` + `builtin_work` plugin wrapping existing Org work items
- Resolve/normalize `org.plugins` on create/update (legacy `minimal`/`thin` aliases; reject `task_pool`/`paperclip` until P2b+)
- Route create/list/update/tick through the Work Port; defaults and smoke path stay equivalent

## Test plan
- [x] `pytest tests/services/test_work_patterns.py tests/services/test_org_service.py`
- [x] `ruff check` on touched paths
- [ ] CI green
- [ ] Optional: `scripts/smoke_org_kernel.sh` against a local/CN instance