### PR TITLE
fix(orgs): put OrgConflictError prose in HTTP message

### DIFF
--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -318,6 +318,21 @@ def _map_permission(exc: OrgPermissionError, org_id: str) -> ACNHTTPError:
     )
 
 
+def _map_conflict(exc: OrgConflictError) -> ACNHTTPError:
+    """Map OrgConflictError → 409; keep ``details={reason}`` shape stable.
+
+    ``message`` carries the service prose (e.g. bound ``org_…`` id) so
+    adapters can recover without widening the details schema.
+    """
+    prose = str(exc).strip()
+    return ACNHTTPError(
+        ErrorCode.RESOURCE_CONFLICT,
+        409,
+        message=prose if prose and prose != exc.reason else None,
+        details={"reason": exc.reason},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -359,11 +374,7 @@ async def create_org(
             details={"reason": str(e)},
         ) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e
 
 
 @router.get("/{org_id}")
@@ -430,11 +441,7 @@ async def update_org(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST, 400, details={"reason": str(e)}
@@ -467,9 +474,7 @@ async def claim_org(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT, 409, details={"reason": e.reason}
-        ) from e
+        raise _map_conflict(e) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST, 400, details={"reason": str(e)}
@@ -528,9 +533,7 @@ async def release_org(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT, 409, details={"reason": e.reason}
-        ) from e
+        raise _map_conflict(e) from e
 
 
 @router.post("/{org_id}/dissolve")
@@ -606,12 +609,16 @@ async def add_member(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        status = 503 if e.reason == "membership_sync_failed" else 409
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            status,
-            details={"reason": e.reason},
-        ) from e
+        if e.reason == "membership_sync_failed":
+            # 503 is outside ACNHTTPError's 4xx contract; keep prior shape.
+            raise ACNHTTPError(
+                ErrorCode.RESOURCE_CONFLICT,
+                409,
+                message=str(e) if str(e) else None,
+                details={"reason": e.reason},
+                headers={"Retry-After": "5"},
+            ) from e
+        raise _map_conflict(e) from e
     except ValueError as e:
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST, 400, details={"reason": str(e)}
@@ -677,11 +684,7 @@ async def create_work(
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
         # Legacy Phase 1 Orgs may store unavailable work plugins.
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e
 
 
 @router.get("/{org_id}/work")
@@ -713,11 +716,7 @@ async def list_work(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e
 
 
 @router.patch("/{org_id}/work/{work_id}")
@@ -754,11 +753,7 @@ async def update_work(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e
 
 
 @router.post("/{org_id}/loop/tick")
@@ -782,8 +777,4 @@ async def tick_loop(
     except OrgPermissionError as e:
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
-        raise ACNHTTPError(
-            ErrorCode.RESOURCE_CONFLICT,
-            409,
-            details={"reason": e.reason},
-        ) from e
+        raise _map_conflict(e) from e

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -6,7 +6,15 @@ import secrets
 from typing import Annotated, Any, Literal
 
 import structlog  # type: ignore[import-untyped]
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, Path, Request
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Header,
+    HTTPException,
+    Path,
+    Request,
+)
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 
@@ -610,12 +618,14 @@ async def add_member(
         raise _map_permission(e, org_id) from e
     except OrgConflictError as e:
         if e.reason == "membership_sync_failed":
-            # 503 is outside ACNHTTPError's 4xx contract; keep prior shape.
-            raise ACNHTTPError(
-                ErrorCode.RESOURCE_CONFLICT,
-                409,
-                message=str(e) if str(e) else None,
-                details={"reason": e.reason},
+            # ADR-0014 D4: compensate failed → 503 (retryable operator alert).
+            # ACNHTTPError forbids 5xx; use HTTPException like registry/deps.
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Org membership write failed and subnet leave compensation "
+                    "failed; retry later"
+                ),
                 headers={"Retry-After": "5"},
             ) from e
         raise _map_conflict(e) from e

--- a/tests/routes/test_orgs_membership_sync_503.py
+++ b/tests/routes/test_orgs_membership_sync_503.py
@@ -1,0 +1,71 @@
+"""Regression: membership_sync_failed → HTTP 503 (ADR-0014 D4), not 409/500.
+
+#176 originally set ``status=503`` on ``ACNHTTPError``, but that constructor
+rejects 5xx and raised ``ValueError`` → unhandled 500. #179 briefly mapped
+the reason to 409, which contradicts the ADR retry semantics. Pin 503 +
+``Retry-After`` via ``HTTPException``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from acn.routes.orgs import OrgMemberAddRequest, add_member
+from acn.services.org_service import OrgConflictError
+
+
+@pytest.mark.asyncio
+async def test_add_member_membership_sync_failed_returns_503():
+    org_service = AsyncMock()
+    org_service.add_member.side_effect = OrgConflictError(
+        "membership_sync_failed",
+        "subnet join succeeded but membership upsert failed",
+    )
+    request = MagicMock()
+    body = OrgMemberAddRequest(agent_id="agt_worker", role="worker")
+    payload = {"type": "agent", "sub": "agt_steward"}
+
+    with pytest.raises(HTTPException) as ei:
+        await add_member(
+            request=request,
+            body=body,
+            org_id="org_test",
+            payload=payload,
+            org_service=org_service,
+        )
+
+    assert ei.value.status_code == 503
+    assert ei.value.headers is not None
+    assert ei.value.headers.get("Retry-After") == "5"
+    assert "retry later" in str(ei.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_add_member_already_member_still_maps_to_acn_conflict():
+    """Non-sync conflicts stay on the 409 RESOURCE_CONFLICT path."""
+    from acn.core.errors import ACNHTTPError, ErrorCode
+
+    org_service = AsyncMock()
+    org_service.add_member.side_effect = OrgConflictError(
+        "already_member",
+        "agt_worker already in org",
+    )
+    request = MagicMock()
+    body = OrgMemberAddRequest(agent_id="agt_worker")
+    payload = {"type": "agent", "sub": "agt_steward"}
+
+    with pytest.raises(ACNHTTPError) as ei:
+        await add_member(
+            request=request,
+            body=body,
+            org_id="org_test",
+            payload=payload,
+            org_service=org_service,
+        )
+
+    assert ei.value.status_code == 409
+    assert ei.value.code == ErrorCode.RESOURCE_CONFLICT
+    assert ei.value.details == {"reason": "already_member"}


### PR DESCRIPTION
## Summary
- Centralize Org conflict → `RESOURCE_CONFLICT` via `_map_conflict`
- Keep `details` as `{reason}` (error-contract gate unchanged) while putting service prose (e.g. bound `org_id`) in `message` for adapters

## Test plan
- [x] `pytest tests/test_error_code_details_consistency.py`
- [ ] Create Org on an already-bound subnet → 409 body `message` includes `org_…` and `details.reason=subnet_already_bound`