### PR TITLE
docs(org-harness): sync status + agent skill 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is `POST /orgs` + Org work APIs; Link 3 acceptance forbids Task Pool on the
   new path; `task.*` marked legacy. Index/design/BACKLOG updated for P2a/P2c
   done and P2b optional.
+- **Agent skill 0.17.2** — documents Org Harness (`acn org …`, Work Port),
+  preferred `org.*` harness events, and Task Pool as optional/legacy for
+  Pattern adapters; `references/API.md` gains `/orgs*` table.
 
 ## [0.15.1] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   order, subnet steward agent, Phase 1 = Kernel + minimal work + thin Loop.
   Supporting: API tiers, org model, adapter spec,
   `scripts/smoke_org_harness_four_links.sh`.
-- **Adapter Spec + Phase 2 status** — `org-pattern-adapter-spec-v0.md` bootstrap
-  is `POST /orgs` + Org work APIs; Link 3 acceptance forbids Task Pool on the
-  new path; `task.*` marked legacy. Index/design/BACKLOG updated for P2a/P2c
-  done and P2b optional.
+- **Phase 2 status sync (after #180)** — index / design / BACKLOG mark P2a/P2c
+  done and P2b optional; clarify default Work Port is `builtin_work` (Task Pool
+  optional). Adapter-spec body landed in #180.
 - **Agent skill 0.17.2** — documents Org Harness (`acn org …`, Work Port),
   preferred `org.*` harness events, and Task Pool as optional/legacy for
   Pattern adapters; `references/API.md` gains `/orgs*` table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `OrgSubnetBindingConflictError` → 409 `subnet_already_bound`. New
   repository-layer tests (fakeredis + mock-session).
 
+- **Org Harness Phase 2a Work Port** — `IWorkPattern` resolve with default
+  `builtin_work` wrapping minimal Org work; `org.plugins.work` selectable;
+  Loop tick lists open work via the Port. See
+  `docs/org-harness/phase2-work-port-v0.md`.
+
 ### Docs
 
 - **Org Harness design v0 + ADR-0014** — `docs/org-harness/design-v0.md`: ACN
   module (optional Owner none/human/agent, agent members), Kernel + Ports,
   Loop-first. **ADR-0014 Accepted**: none-owner steward rules, Membership↔subnet
   order, subnet steward agent, Phase 1 = Kernel + minimal work + thin Loop.
-  Supporting: API tiers, org model, adapter spec (Task-mirror transitional),
+  Supporting: API tiers, org model, adapter spec,
   `scripts/smoke_org_harness_four_links.sh`.
+- **Adapter Spec + Phase 2 status** — `org-pattern-adapter-spec-v0.md` bootstrap
+  is `POST /orgs` + Org work APIs; Link 3 acceptance forbids Task Pool on the
+  new path; `task.*` marked legacy. Index/design/BACKLOG updated for P2a/P2c
+  done and P2b optional.
 
 ## [0.15.1] - 2026-07-19
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -887,14 +887,20 @@ H-erc8004 把 `chain` 改成 client-optional + 服务端派生 + 收到值必须
 **Phase 1 Kernel shipped** (ADR-0014): `/api/v1/orgs*`, CLI `acn org …`,
 minimal work + thin Loop. Design: [`docs/org-harness/`](org-harness/README.md).
 
-Still deferred (Phase 2+):
+**Phase 2a / P2c shipped:** Work Port + default `builtin_work`; Paperclip
+adapter on Org work + `org.*` (see
+[`org-pattern-adapter-spec-v0.md`](org-harness/org-pattern-adapter-spec-v0.md)).
 
-- **DEF-WORK-PLUGIN** — Phase 2 Work Port：见 [`org-harness/phase2-work-port-v0.md`](org-harness/phase2-work-port-v0.md)（P2a 默认 `builtin_work`；Task Pool 为可选 Builtin）
+Still deferred (Phase 2b / 3+):
+
+- **DEF-WORK-PLUGIN** — ~~P2a `builtin_work`~~ / ~~P2c Paperclip Org path~~ done；
+  remaining **P2b** `plugins.work=task_pool` in-process（按需）— 见
+  [`org-harness/phase2-work-port-v0.md`](org-harness/phase2-work-port-v0.md)
 - **DEF-MEM** — Org Memory / SOPs (Pattern-local; Mem0/Zep/PG+vector)
 - **DEF-ORGREP** — Cross-org reputation (beyond per-agent ERC-8004 reads)
 - **DEF-DISPUTE** — Dispute / jury after escrow window (ADR-0010 Future)
 - **DEF-FED** — Federation across ACN instances ([federation.md](federation.md))
-- **DEF-ORGC** — Portable `/orgs/*` Core API (only if multi-Pattern discovery needs it)
+- **DEF-ORGC** — Further multi-Pattern Org discovery（`/api/v1/orgs*` Kernel API 已存在）
 - **DEF-SAGA** — Settlement saga v1 (Gated v0 atomicity)
 - **DEF-RAILS** — Agentic payment rails (ADR-0009 P2)
 - **DEF-ORG-ACL** — Org read ACL v1 ships a **redacted view** for private-fence

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -1,7 +1,7 @@
 # Org Harness
 
-**Status:** Design v0 + [ADR-0014](../adr/0014-org-harness-module.md) Accepted；**Phase 1 Kernel 已落地**（`/api/v1/orgs*` · `acn org …`）  
-**Last updated:** 2026-07-21
+**Status:** Design v0 + [ADR-0014](../adr/0014-org-harness-module.md) Accepted；**Phase 1 Kernel + Phase 2a/P2c 已落地**（`/api/v1/orgs*` · Work Port `builtin_work` · Paperclip Org path）  
+**Last updated:** 2026-07-22
 
 > **Org Harness** 是 ACN 的**新模块**：给「一群 agent 组成的 Org」提供组织层挽具。  
 > **ACN** 仍叫 ACN（智能体协作网络），不是 Pasture。  
@@ -16,8 +16,8 @@
 | **[../adr/0014-org-harness-module.md](../adr/0014-org-harness-module.md)** | **P0/P1 机制 ADR（已 Accepted）** |
 | [org-model-v0.md](./org-model-v0.md) | Org / Membership 数据模型 |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core 消费契约（外部 Pattern 用） |
-| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（过渡期 Task 镜像）；服从 design-v0 + ADR |
-| **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · 切片 P2a/b/c）** |
+| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` 为 legacy） |
+| **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · P2a/P2c 完成 · P2b 按需）** |
 
 理论草稿（隐喻 / 协议史）：
 
@@ -32,7 +32,7 @@ Org = N × Agent + Org Harness   (± optional Owner: none | human | agent)
 Org Harness Module = Kernel（固定） + Ports（可插拔）
   Org Graph（Kernel）: Org · 可选 Owner · agent 成员 · subnet 绑定
   Control Loop（Port）: 组织心跳 — 观察队列 → 分派/唤醒 → 回收
-  Work Graph（Port 策略）: TaskPool / Paperclip / Swarm / LangGraph / DAG…
+  Work Graph（Port 策略）: **builtin_work（默认）** / TaskPool（可选）/ Paperclip / Swarm / …
   其它 Ports: Memory · Capability · Policy · Events
 
 L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Kernel
@@ -40,4 +40,6 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 ## 下一步
 
-Phase 1 Kernel + 加固已落地。Phase 2 见 **[phase2-work-port-v0.md](./phase2-work-port-v0.md)**（先 P2a 插座 + 默认小工单）。
+- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work 路径 + adapter spec 对齐）。  
+- **按需：** P2b（`plugins.work=task_pool` 进程内适配）— 见 **[phase2-work-port-v0.md](./phase2-work-port-v0.md)**。  
+- **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -205,7 +205,7 @@ Org C → Work=paperclip     Loop=paperclip_wake Memory=vector
 | OpenAI Swarm → Agents SDK | Handoff 协调 | 可作为 **`IWorkPattern` 策略插件** |
 | CrewAI / LangGraph / MAF | 角色队 / 图编排 | 同上，挂 Port |
 | Paperclip | 公司式控制面 + UI | **外部 Pattern**；[`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin) 是适配器，**不是** Org Harness 本体 |
-| ACN Task Pool | Builtin 轻量 WorkPattern | Org Harness 的默认插件之一，可被替换 |
+| ACN Task Pool | Builtin 轻量 WorkPattern | **可选**插件（`plugins.work=task_pool`）；**默认**是 `builtin_work`，不是 Task Pool |
 
 ```text
 Org Harness
@@ -286,7 +286,7 @@ Org Harness **消费** Core，不重新实现：
 |---|---|
 | subnet + admission | Org 的硬围栏（Kernel 绑定） |
 | `PATCH …/harness` webhook | `IEventSink` 默认出口；外挂 Pattern 接收端 |
-| Task Pool | Builtin `IWorkPattern` 默认实现之一 |
+| Task Pool | Builtin `IWorkPattern` **可选**实现（默认是 `builtin_work`） |
 | `paperclip-acn-plugin` | Paperclip ↔ ACN 适配器；演进目标对齐本设计的 Port，而非替代模块 |
 | Mode B `acn listen` | L1 成员入网/接活方式之一 |
 
@@ -316,9 +316,9 @@ Org Harness **消费** Core，不重新实现：
 
 > **短方案（实施准绳）：** [phase2-work-port-v0.md](./phase2-work-port-v0.md)
 
-1. **P2a（必做）** 最小 Port 插座 + 默认 `builtin_work`（现有 `OrgWorkItem`）；`smoke_org_kernel.sh` 行为不变  
+1. ~~**P2a（必做）** 最小 Port 插座 + 默认 `builtin_work`（现有 `OrgWorkItem`）；`smoke_org_kernel.sh` 行为不变~~  
 2. **P2b（按需）** `plugins.work=task_pool` 进程内可选适配（非默认；外部 Pattern 仍禁绑 `/tasks/*`）  
-3. **P2c（可并行）** `paperclip-acn-plugin`：Issues ↔ Org work + `org.*`，弱化 Task 镜像  
+3. ~~**P2c（可并行）** `paperclip-acn-plugin`：Issues ↔ Org work + `org.*`，弱化 Task 镜像~~（C0–C3 + adapter spec）  
 
 ### Phase 3 — 增强 Port
 
@@ -357,7 +357,7 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 | [../adr/0014-org-harness-module.md](../adr/0014-org-harness-module.md) | **P0/P1 决策 ADR（Accepted）** |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core / Pattern 消费契约 |
 | [org-model-v0.md](./org-model-v0.md) | 数据模型（随本文修订 ownership） |
-| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（过渡期 Task 镜像）；以本文 + ADR-0014 为准 |
+| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` legacy）；以本文 + ADR-0014 为准 |
 | [`../_drafts/pasture-engineering.md`](../_drafts/pasture-engineering.md) | 学科隐喻与升维理论（Draft） |
 | [`../_drafts/pasture-protocol.md`](../_drafts/pasture-protocol.md) | 协议理论 Draft；命名以本文为准 |
 

--- a/docs/org-harness/phase2-work-port-v0.md
+++ b/docs/org-harness/phase2-work-port-v0.md
@@ -1,6 +1,7 @@
 # Phase 2 — Work Port（短方案）
 
-**Status:** Agreed for implementation sequencing（2026-07-21）  
+**Status:** P2a + P2c done；P2b optional（2026-07-22）  
+
 **Depends on:** [design-v0.md](./design-v0.md) §5 / §10, [ADR-0014](../adr/0014-org-harness-module.md) D5–D7  
 **Audience:** 实施与审阅；先定边界，再写代码
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -119,7 +119,7 @@ acn config show
 | `acn org members add <org_id> <agent_id> [--role worker]` | Add member |
 | `acn org members remove <org_id> <agent_id>` | Remove member |
 | `acn org claim <org_id>` | Claim unclaimed Org |
-| `acn org transfer <org_id> --to <owner>` | Transfer ownership |
+| `acn org transfer <org_id> --kind human\|agent --subject <id>` | Transfer ownership |
 | `acn org release <org_id>` | Release ownership → none |
 | `acn org dissolve <org_id>` | Dissolve Org |
 | `acn org work list <org_id> [--open]` | List Org work items (Work Port) |

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -114,11 +114,14 @@ acn config show
 | **Org Harness** | |
 | `acn org create --name <name> [--subnet <slug>] [--join-policy open\|approval]` | Create Org (binds/creates subnet fence); default work plugin `builtin_work` |
 | `acn org show <org_id>` | Show Org details |
-| `acn org update <org_id> [--name ...] [--plugins work=builtin_work]` | Update charter / plugins / display name |
+| `acn org update <org_id> [--name ...] [--charter '<json>'] [--plugins '<json>']` | Update charter / plugins / display name (`--plugins '{"work":"builtin_work"}'`) |
 | `acn org members list <org_id>` | List active members |
-| `acn org members add <org_id> <agent_id>` | Add member |
+| `acn org members add <org_id> <agent_id> [--role worker]` | Add member |
 | `acn org members remove <org_id> <agent_id>` | Remove member |
-| `acn org claim\|transfer\|release\|dissolve <org_id>` | Ownership lifecycle |
+| `acn org claim <org_id>` | Claim unclaimed Org |
+| `acn org transfer <org_id> --to <owner>` | Transfer ownership |
+| `acn org release <org_id>` | Release ownership → none |
+| `acn org dissolve <org_id>` | Dissolve Org |
 | `acn org work list <org_id> [--open]` | List Org work items (Work Port) |
 | `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work item (`POST /orgs/{id}/work`) |
 | `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status |
@@ -848,8 +851,8 @@ acn subnet harness clear <subnet_id>
 ```
 
 **Preferred events:** `org.work_created`, `org.work_updated`, `org.loop_tick`,
-`org.created` / `org.member_*` / `org.dissolved`, plus `agent.joined_subnet` /
-`agent.left_subnet`.
+`org.created`, `org.member_added`, `org.member_removed`, `org.owner_changed`,
+`org.dissolved`, plus `agent.joined_subnet` / `agent.left_subnet`.
 
 **Legacy / optional:** `task.*`, `participation.rejected` (Task Pool).
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: acn
-description: Agent Collaboration Network — Register your agent, discover other agents by skill, route messages, manage subnets, and work on tasks. Use when joining ACN, finding collaborators, sending or broadcasting messages, or accepting and completing task assignments.
+description: Agent Collaboration Network — Register your agent, discover other agents by skill, route messages, manage subnets/orgs, and work on Org work items or Task Pool tasks. Use when joining ACN, finding collaborators, sending or broadcasting messages, Org Harness (acn org), or accepting and completing assignments.
 license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.1"
+  version: "0.17.2"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -111,11 +111,23 @@ acn config show
 | `acn agents social-card <agent_id> --url <url>` | Set social card URL (SOCIAL.md pointer) |
 | `acn agents social-card <agent_id> --clear` | Clear social card URL |
 | `PATCH /api/v1/agents/{id}/profile` `{"name"?,"description"?,"tags"?}` | Edit your own name/description/tags (partial update; agent API key) |
-| **Tasks** | |
+| **Org Harness** | |
+| `acn org create --name <name> [--subnet <slug>] [--join-policy open\|approval]` | Create Org (binds/creates subnet fence); default work plugin `builtin_work` |
+| `acn org show <org_id>` | Show Org details |
+| `acn org update <org_id> [--name ...] [--plugins work=builtin_work]` | Update charter / plugins / display name |
+| `acn org members list <org_id>` | List active members |
+| `acn org members add <org_id> <agent_id>` | Add member |
+| `acn org members remove <org_id> <agent_id>` | Remove member |
+| `acn org claim\|transfer\|release\|dissolve <org_id>` | Ownership lifecycle |
+| `acn org work list <org_id> [--open]` | List Org work items (Work Port) |
+| `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work item (`POST /orgs/{id}/work`) |
+| `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status |
+| `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
+| **Tasks (Task Pool — optional / legacy for Org Patterns)** | |
 | `acn tasks list [--status open]` | Browse tasks |
 | `acn tasks match --tags coding,review` | Find matching tasks |
 | `acn tasks get <task_id>` | Get task details |
-| `acn tasks create --title <t> --description <d> --tags <tags> [--subnet <slug>]` | Create a task; `--subnet` scopes it to subnet members only |
+| `acn tasks create --title <t> --description <d> --tags <tags> [--subnet <slug>]` | Create a Task Pool task; `--subnet` scopes it to subnet members only |
 | `acn tasks accept <task_id>` | Accept a task (blocked on cultivator-human TaskBoard work — humans only) |
 | `acn tasks submit <task_id> --result "..."` | Submit result |
 | `acn tasks review <task_id> --approve\|--reject [--notes <text>]` | Approve or reject submission (creator only) |
@@ -166,8 +178,8 @@ acn config show
 | `acn subnet create --name <name> [--id <id>] [--description ...] [--private]` | Create a subnet (you become the owner) |
 | `acn subnet delete <subnet_id>` | Delete a subnet you own |
 | `acn subnet transfer <subnet_id> --to <new_owner_agent_id>` | Transfer subnet ownership to another registered agent (ADR-0005) |
-| `acn subnet harness set <subnet_id> --url <url> [--secret <secret>]` | Register an Org Harness webhook endpoint on a subnet you own |
-| `acn subnet harness clear <subnet_id>` | Unregister the Org Harness from a subnet you own |
+| `acn subnet harness set <subnet_id> --url <url> [--secret <secret>]` | Register harness webhook URL on a subnet you own (event sink for Org / Task lifecycle) |
+| `acn subnet harness clear <subnet_id>` | Clear harness webhook from a subnet you own |
 | **Wallet** | |
 | `acn wallet` / `acn wallet info` | View wallet, payment methods, pricing, ERC-8004 |
 | `acn wallet set-capability --methods <csv> --networks <csv> [--wallets <json>] [--no-accepts]` | Declare accepted methods/networks/wallets |
@@ -792,29 +804,60 @@ include a `parent_subnet_id` field in the payload `data` block —
 `null` for top-level subnets, the parent ID for children.
 Harnesses that don't read the field continue to work unchanged.
 
-### Connect an Org Harness (pluggable orchestration)
+### Org Harness (organisations + Work Port)
 
-An **Org Harness** is an external orchestration system (e.g. a custom webhook receiver) that
-receives lifecycle events for a subnet and can coordinate the agents inside it.
-The subnet owner registers a webhook URL; ACN delivers signed events to it:
+**Org Harness** is an **ACN module** (ADR-0014): persistent Orgs with optional Owner
+(`none` / human / agent), membership, default Work Port `builtin_work`, and a thin
+Loop. External Patterns (e.g. Paperclip) adapt to Org APIs — they are **not** the
+Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
 
 ```bash
-# Register a harness on a subnet you own
+# Create Org (binds or creates a subnet fence)
+acn org create --name "Squad" --subnet my-subnet --join-policy open
+# → org_id: org_…
+
+# Work Port (preferred dispatch for Org Patterns — NOT Task Pool)
+acn org work create org_… --title "Ship the adapter"
+acn org work list org_… --open
+acn org work update org_… work_… --status done
+
+# Loop tick → emits org.loop_tick to the subnet harness webhook
+acn org tick org_…
+```
+
+**External Pattern rule:** new adapter paths MUST use
+`POST/PATCH /api/v1/orgs/{id}/work*` and prefer `org.work_*` / `org.loop_tick`.
+Do **not** bind ordinary Pattern issues to `/api/v1/tasks/*` unless you
+deliberately select Task Pool mode. Spec:
+[`org-pattern-adapter-spec-v0.md`](../../docs/org-harness/org-pattern-adapter-spec-v0.md).
+
+### Harness webhook (event sink on a subnet)
+
+The subnet owner registers a webhook URL; ACN delivers signed lifecycle events
+(Org + Task + membership). This is the **event sink**, not the Org module:
+
+```bash
 acn subnet harness set <subnet_id> \
-  --url https://your-harness.example.com/acn/webhook \
+  --url https://your-pattern.example.com/hooks/acn \
   --secret your-hmac-secret
 
-# Check the current harness (visible to all members)
 acn subnet get <subnet_id>
 # → "harness_url": "https://...", "harness_registered": true
 
-# Remove the harness
 acn subnet harness clear <subnet_id>
 ```
 
-Events: `agent.joined_subnet`, `agent.left_subnet`, `task.*` lifecycle events,
-`participation.rejected`. All payloads signed `X-ACN-Signature: sha256=<hmac>`.
-Failures are best-effort — never surfaced as errors to agents.
+**Preferred events:** `org.work_created`, `org.work_updated`, `org.loop_tick`,
+`org.created` / `org.member_*` / `org.dissolved`, plus `agent.joined_subnet` /
+`agent.left_subnet`.
+
+**Legacy / optional:** `task.*`, `participation.rejected` (Task Pool).
+
+All payloads signed `X-ACN-Signature: sha256=<hmac>`. Failures are best-effort.
+
+> On `org.*` events the webhook envelope reuses field name `task_id` but the
+> value is the **`org_id`**. Always route by `event` and read work fields from
+> `data` (`work_id`, `status`, …).
 
 ### Grader Loop (Outcomes)
 

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -116,7 +116,37 @@ applicant / invitee).
 
 ---
 
-## Tasks
+## Org Harness
+
+Org module (ADR-0014). Default Work Port is `builtin_work`. External Patterns
+should dispatch via `/orgs/{id}/work*` — not Task Pool — unless they opt into
+Task Pool mode. See [`docs/org-harness/`](../../docs/org-harness/README.md).
+
+| Method | Endpoint | Auth | Description |
+|---|---|---|---|
+| POST | `/orgs` | API Key / JWT (`acn:write`) | Create Org (optional `subnet_id`, `join_policy`, `harness_url`) |
+| GET | `/orgs/{id}` | None / API Key | Show Org (private-fence redaction for unentitled readers) |
+| PATCH | `/orgs/{id}` | API Key / JWT | Update display_name / charter / plugins |
+| POST | `/orgs/{id}/claim` | API Key / JWT | Claim unclaimed Org |
+| POST | `/orgs/{id}/transfer` | API Key / JWT | Transfer ownership |
+| POST | `/orgs/{id}/release` | API Key / JWT | Release ownership → none |
+| POST | `/orgs/{id}/dissolve` | API Key / JWT | Dissolve Org |
+| GET | `/orgs/{id}/members` | API Key (entitled) | List members |
+| POST | `/orgs/{id}/members` | API Key / JWT | Add member |
+| DELETE | `/orgs/{id}/members/{agent_id}` | API Key / JWT | Remove member |
+| GET | `/orgs/{id}/work` | None / API Key | List work items (`?open_only=`) |
+| POST | `/orgs/{id}/work` | API Key / JWT | Create work item |
+| PATCH | `/orgs/{id}/work/{work_id}` | API Key / JWT | Update work status / assignee |
+| POST | `/orgs/{id}/loop/tick` | API Key / JWT | Thin Loop tick → `org.loop_tick` webhook |
+
+Harness webhook registration remains `PATCH /subnets/{id}/harness` (event sink).
+On `org.*` deliveries, envelope field `task_id` carries **`org_id`**.
+
+---
+
+## Tasks (Task Pool)
+
+Optional network task facility. **Not** the default Org Work Port.
 
 | Method | Endpoint | Auth | Description |
 |---|---|---|---|

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -120,7 +120,7 @@ applicant / invitee).
 
 Org module (ADR-0014). Default Work Port is `builtin_work`. External Patterns
 should dispatch via `/orgs/{id}/work*` — not Task Pool — unless they opt into
-Task Pool mode. See [`docs/org-harness/`](../../docs/org-harness/README.md).
+Task Pool mode. See [`docs/org-harness/`](../../../docs/org-harness/README.md).
 
 | Method | Endpoint | Auth | Description |
 |---|---|---|---|


### PR DESCRIPTION
## Summary
Follow-up to #180:
- README / design-v0 / BACKLOG / CHANGELOG: P2a/P2c done; `builtin_work` default
- Agent skill **0.17.2**: `acn org …` Work Port, preferred `org.*` events, Task Pool optional for Patterns; `references/API.md` `/orgs*` table

## Test plan
- [x] Docs/skill review
- [ ] Skim skill Org section against `acn org --help`