### PR TITLE
feat(sdk): getDelivery/setDelivery for Mode A↔B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SDK delivery helpers** — Python `acn-client` **0.12.2**
+  (`get_delivery` / `set_delivery`) and TypeScript `acn-client` **0.14.2**
+  (`getDelivery` / `setDelivery`) wrap `GET/PATCH /agents/{id}/delivery`.
+  Skill **0.17.4** documents the methods in `references/SDK.md`.
+
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-07-23
+
+### Added — Delivery transport (ADR-0012 Mode A ↔ Mode B)
+
+- `get_delivery(agent_id)` — derived transport (`direct` / `relay` / `none`).
+- `set_delivery(agent_id, delivery, *, endpoint=None)` — switch Mode A↔B
+  without re-registering (`GET/PATCH /agents/{id}/delivery`).
+
 ## [0.12.1] - 2026-07-19
 
 ### Added — Dual-region helpers (ADR-0013)

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -95,6 +95,8 @@ ACNClient(
 | `rotate_api_key(agent_id)` | Rotate API key — old key invalidated immediately, new key returned once |
 | `get_policy(agent_id)` | Get own inbound communication policy |
 | `update_policy(agent_id, mode, *, reject_reason?)` | Update inbound policy (`open`/`manifest`/`allowlist`/`closed`) |
+| `get_delivery(agent_id)` | Get derived delivery transport (`direct` / `relay` / `none`) |
+| `set_delivery(agent_id, delivery, *, endpoint?)` | Switch Mode A↔B without re-registering |
 
 #### Subnet Methods
 

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -2072,6 +2072,71 @@ class ACNClient:
         )
 
     # ============================================
+    # Delivery transport (ADR-0012 Mode A / Mode B)
+    # ============================================
+
+    async def get_delivery(self, agent_id: str) -> dict[str, Any]:
+        """Get the derived inbound delivery transport for this agent.
+
+        Orthogonal to :meth:`get_policy` (reception). Values:
+
+        - ``direct`` — Mode A: ACN dials the public A2A endpoint over HTTP
+        - ``relay`` — Mode B: hold an outbound WebSocket (``acn listen``)
+        - ``none`` — pull/reject only (policy is ``manifest`` / ``closed``)
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+
+        Returns:
+            ``{ agent_id, delivery, endpoint?, communication_mode }``
+        """
+        return await self._request("GET", f"/api/v1/agents/{agent_id}/delivery")
+
+    async def set_delivery(
+        self,
+        agent_id: str,
+        delivery: str,
+        *,
+        endpoint: str | None = None,
+    ) -> dict[str, Any]:
+        """Switch Mode A (direct) ↔ Mode B (relay) without re-registering.
+
+        Requires a push reception policy (``open`` / ``allowlist``). Use
+        :meth:`update_policy` first when still on ``manifest``.
+
+        Args:
+            agent_id: Must match the authenticated agent's ID.
+            delivery: ``'relay'`` or ``'direct'``.
+            endpoint: Required for ``direct`` — full public A2A JSON-RPC
+                URL. Must be omitted for ``relay``.
+
+        Returns:
+            ``{ agent_id, delivery, endpoint?, communication_mode,
+            a2a_handshake_ok?, next_step_hint? }``
+        """
+        normalized = (delivery or "").strip().lower()
+        if normalized not in ("direct", "relay"):
+            raise ValueError("delivery must be 'direct' or 'relay'")
+        if normalized == "relay" and endpoint:
+            raise ValueError(
+                "delivery='relay' is mutually exclusive with endpoint; "
+                "omit endpoint and run acn listen / hold a WebSocket"
+            )
+        if normalized == "direct" and not endpoint:
+            raise ValueError(
+                "delivery='direct' requires endpoint "
+                "(full A2A URL, e.g. https://host/a2a)"
+            )
+        body: dict[str, Any] = {"delivery": normalized}
+        if endpoint is not None:
+            body["endpoint"] = endpoint
+        return await self._request(
+            "PATCH",
+            f"/api/v1/agents/{agent_id}/delivery",
+            json=body,
+        )
+
+    # ============================================
     # Allowlist
     # ============================================
 

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -2115,21 +2115,26 @@ class ACNClient:
             a2a_handshake_ok?, next_step_hint? }``
         """
         normalized = (delivery or "").strip().lower()
+        # Blank / whitespace-only URLs are treated as omitted (matches server
+        # ``_validate_agent_endpoint_url`` and CLI preflight).
+        endpoint_clean = endpoint.strip() if isinstance(endpoint, str) else endpoint
+        if endpoint_clean == "":
+            endpoint_clean = None
         if normalized not in ("direct", "relay"):
             raise ValueError("delivery must be 'direct' or 'relay'")
-        if normalized == "relay" and endpoint:
+        if normalized == "relay" and endpoint_clean:
             raise ValueError(
                 "delivery='relay' is mutually exclusive with endpoint; "
                 "omit endpoint and run acn listen / hold a WebSocket"
             )
-        if normalized == "direct" and not endpoint:
+        if normalized == "direct" and not endpoint_clean:
             raise ValueError(
                 "delivery='direct' requires endpoint "
                 "(full A2A URL, e.g. https://host/a2a)"
             )
         body: dict[str, Any] = {"delivery": normalized}
-        if endpoint is not None:
-            body["endpoint"] = endpoint
+        if endpoint_clean is not None:
+            body["endpoint"] = endpoint_clean
         return await self._request(
             "PATCH",
             f"/api/v1/agents/{agent_id}/delivery",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.12.1"
+version = "0.12.2"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/python/tests/test_delivery.py
+++ b/clients/python/tests/test_delivery.py
@@ -1,0 +1,107 @@
+"""Python SDK tests for ``get_delivery`` / ``set_delivery`` (ADR-0012)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn_client.client import ACNClient
+
+
+def _make_client_with_stub(request_mock: AsyncMock) -> ACNClient:
+    client = ACNClient(base_url="http://acn.test")
+    client._request = request_mock  # type: ignore[method-assign]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_get_delivery_returns_server_payload():
+    server_payload: dict[str, Any] = {
+        "agent_id": "agent-1",
+        "delivery": "direct",
+        "endpoint": "https://agent.example.com/a2a",
+        "communication_mode": "open",
+    }
+    request_mock = AsyncMock(return_value=server_payload)
+    client = _make_client_with_stub(request_mock)
+
+    result = await client.get_delivery("agent-1")
+
+    assert result is server_payload
+    request_mock.assert_awaited_once_with(
+        "GET", "/api/v1/agents/agent-1/delivery"
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_delivery_relay():
+    server_payload: dict[str, Any] = {
+        "agent_id": "agent-1",
+        "delivery": "relay",
+        "endpoint": None,
+        "communication_mode": "open",
+        "next_step_hint": "run acn listen",
+    }
+    request_mock = AsyncMock(return_value=server_payload)
+    client = _make_client_with_stub(request_mock)
+
+    result = await client.set_delivery("agent-1", "relay")
+
+    assert result["delivery"] == "relay"
+    request_mock.assert_awaited_once_with(
+        "PATCH",
+        "/api/v1/agents/agent-1/delivery",
+        json={"delivery": "relay"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_delivery_direct_with_endpoint():
+    server_payload: dict[str, Any] = {
+        "agent_id": "agent-1",
+        "delivery": "direct",
+        "endpoint": "https://agent.example.com/a2a",
+        "communication_mode": "open",
+        "a2a_handshake_ok": True,
+    }
+    request_mock = AsyncMock(return_value=server_payload)
+    client = _make_client_with_stub(request_mock)
+
+    result = await client.set_delivery(
+        "agent-1", "direct", endpoint="https://agent.example.com/a2a"
+    )
+
+    assert result["delivery"] == "direct"
+    request_mock.assert_awaited_once_with(
+        "PATCH",
+        "/api/v1/agents/agent-1/delivery",
+        json={
+            "delivery": "direct",
+            "endpoint": "https://agent.example.com/a2a",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_delivery_direct_requires_endpoint():
+    client = _make_client_with_stub(AsyncMock())
+    with pytest.raises(ValueError, match="requires endpoint"):
+        await client.set_delivery("agent-1", "direct")
+
+
+@pytest.mark.asyncio
+async def test_set_delivery_relay_rejects_endpoint():
+    client = _make_client_with_stub(AsyncMock())
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await client.set_delivery(
+            "agent-1", "relay", endpoint="https://agent.example.com/a2a"
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_delivery_rejects_unknown_transport():
+    client = _make_client_with_stub(AsyncMock())
+    with pytest.raises(ValueError, match="direct' or 'relay"):
+        await client.set_delivery("agent-1", "none")

--- a/clients/python/tests/test_delivery.py
+++ b/clients/python/tests/test_delivery.py
@@ -92,6 +92,13 @@ async def test_set_delivery_direct_requires_endpoint():
 
 
 @pytest.mark.asyncio
+async def test_set_delivery_direct_rejects_whitespace_endpoint():
+    client = _make_client_with_stub(AsyncMock())
+    with pytest.raises(ValueError, match="requires endpoint"):
+        await client.set_delivery("agent-1", "direct", endpoint="   ")
+
+
+@pytest.mark.asyncio
 async def test_set_delivery_relay_rejects_endpoint():
     client = _make_client_with_stub(AsyncMock())
     with pytest.raises(ValueError, match="mutually exclusive"):

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-23
+
+### Added — Delivery transport (ADR-0012 Mode A ↔ Mode B)
+
+- `getDelivery(agentId)` — derived transport (`direct` / `relay` / `none`).
+- `setDelivery(agentId, delivery, endpoint?)` — switch Mode A↔B without
+  re-registering (`GET/PATCH /agents/{id}/delivery`).
+- Types: `DeliveryTransport`, `DeliveryTransportSet`, `DeliveryResponse`.
+
 ## [0.14.1] - 2026-07-19
 
 ### Added — Dual-region helpers (ADR-0013)

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -107,6 +107,8 @@ Options:
 | `rotateApiKey(agentId)` | Rotate API key — old key invalidated immediately, new key returned once |
 | `getPolicy(agentId)` | Get own inbound communication policy |
 | `updatePolicy(agentId, mode, options?)` | Update inbound policy (`open`/`manifest`/`allowlist`/`closed`) |
+| `getDelivery(agentId)` | Get derived delivery transport (`direct` / `relay` / `none`) |
+| `setDelivery(agentId, delivery, endpoint?)` | Switch Mode A↔B without re-registering |
 
 #### Subnet Methods
 

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "0.14.0",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "0.14.0",
+      "version": "0.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -32,6 +32,8 @@ import type {
   CommunicationPolicyMode,
   CommunicationPolicyResponse,
   CommunicationProfile,
+  DeliveryResponse,
+  DeliveryTransportSet,
   DashboardData,
   FollowActionResponse,
   FollowCheckResponse,
@@ -1402,6 +1404,46 @@ export class ACNClient {
     return this.request('PATCH', `/api/v1/agents/${agentId}/policy`, {
       body: { communication_policy: policy },
     });
+  }
+
+  // ============================================
+  // Delivery transport (ADR-0012 Mode A / Mode B)
+  // ============================================
+
+  /**
+   * Get the derived inbound delivery transport (`direct` | `relay` | `none`).
+   * Orthogonal to {@link getPolicy} (reception).
+   */
+  async getDelivery(agentId: string): Promise<DeliveryResponse> {
+    return this.get(`/api/v1/agents/${agentId}/delivery`);
+  }
+
+  /**
+   * Switch Mode A (direct) ↔ Mode B (relay) without re-registering.
+   * Requires a push reception policy (`open` / `allowlist`).
+   *
+   * @param agentId   Must match the authenticated agent.
+   * @param delivery  `relay` or `direct`.
+   * @param endpoint  Required for `direct` — full public A2A JSON-RPC URL.
+   */
+  async setDelivery(
+    agentId: string,
+    delivery: DeliveryTransportSet,
+    endpoint?: string
+  ): Promise<DeliveryResponse> {
+    if (delivery === 'relay' && endpoint) {
+      throw new Error(
+        "delivery='relay' is mutually exclusive with endpoint; omit endpoint and run acn listen"
+      );
+    }
+    if (delivery === 'direct' && !endpoint) {
+      throw new Error(
+        "delivery='direct' requires endpoint (full A2A URL, e.g. https://host/a2a)"
+      );
+    }
+    const body: Record<string, unknown> = { delivery };
+    if (endpoint !== undefined) body.endpoint = endpoint;
+    return this.request('PATCH', `/api/v1/agents/${agentId}/delivery`, { body });
   }
 
   // ============================================

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -1431,18 +1431,21 @@ export class ACNClient {
     delivery: DeliveryTransportSet,
     endpoint?: string
   ): Promise<DeliveryResponse> {
-    if (delivery === 'relay' && endpoint) {
+    // Blank / whitespace-only URLs count as omitted (matches server + CLI).
+    const endpointClean =
+      typeof endpoint === 'string' ? endpoint.trim() || undefined : endpoint;
+    if (delivery === 'relay' && endpointClean) {
       throw new Error(
         "delivery='relay' is mutually exclusive with endpoint; omit endpoint and run acn listen"
       );
     }
-    if (delivery === 'direct' && !endpoint) {
+    if (delivery === 'direct' && !endpointClean) {
       throw new Error(
         "delivery='direct' requires endpoint (full A2A URL, e.g. https://host/a2a)"
       );
     }
     const body: Record<string, unknown> = { delivery };
-    if (endpoint !== undefined) body.endpoint = endpoint;
+    if (endpointClean !== undefined) body.endpoint = endpointClean;
     return this.request('PATCH', `/api/v1/agents/${agentId}/delivery`, { body });
   }
 

--- a/clients/typescript/src/delivery.test.ts
+++ b/clients/typescript/src/delivery.test.ts
@@ -1,0 +1,113 @@
+/**
+ * TypeScript SDK tests for getDelivery / setDelivery (ADR-0012 Mode A/B).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ACNClient } from './client';
+
+interface CapturedRequest {
+  url: URL;
+  init: RequestInit;
+  body: unknown;
+}
+
+function setupFetchStub(
+  status: number,
+  body: unknown,
+): { client: ACNClient; calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  const fetchStub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const urlStr = input instanceof URL ? input.toString() : String(input);
+    let parsed: unknown = undefined;
+    if (init?.body && typeof init.body === 'string') {
+      parsed = JSON.parse(init.body);
+    }
+    calls.push({ url: new URL(urlStr), init: init ?? {}, body: parsed });
+    return new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: status === 204 ? {} : { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchStub);
+  const client = new ACNClient({ baseUrl: 'http://acn.test', apiKey: 'k' });
+  return { client, calls };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getDelivery', () => {
+  it('returns derived transport from the server', async () => {
+    const { client, calls } = setupFetchStub(200, {
+      agent_id: 'agent-1',
+      delivery: 'direct',
+      endpoint: 'https://agent.example.com/a2a',
+      communication_mode: 'open',
+    });
+
+    const result = await client.getDelivery('agent-1');
+
+    expect(result.delivery).toBe('direct');
+    expect(result.endpoint).toBe('https://agent.example.com/a2a');
+    expect(calls[0].init.method).toBe('GET');
+    expect(calls[0].url.pathname).toBe('/api/v1/agents/agent-1/delivery');
+  });
+});
+
+describe('setDelivery', () => {
+  it('PATCHes relay without endpoint', async () => {
+    const { client, calls } = setupFetchStub(200, {
+      agent_id: 'agent-1',
+      delivery: 'relay',
+      endpoint: null,
+      communication_mode: 'open',
+      next_step_hint: 'run acn listen',
+    });
+
+    const result = await client.setDelivery('agent-1', 'relay');
+
+    expect(result.delivery).toBe('relay');
+    expect(calls[0].init.method).toBe('PATCH');
+    expect(calls[0].url.pathname).toBe('/api/v1/agents/agent-1/delivery');
+    expect(calls[0].body).toEqual({ delivery: 'relay' });
+  });
+
+  it('PATCHes direct with endpoint', async () => {
+    const { client, calls } = setupFetchStub(200, {
+      agent_id: 'agent-1',
+      delivery: 'direct',
+      endpoint: 'https://agent.example.com/a2a',
+      communication_mode: 'open',
+      a2a_handshake_ok: true,
+    });
+
+    const result = await client.setDelivery(
+      'agent-1',
+      'direct',
+      'https://agent.example.com/a2a',
+    );
+
+    expect(result.delivery).toBe('direct');
+    expect(calls[0].body).toEqual({
+      delivery: 'direct',
+      endpoint: 'https://agent.example.com/a2a',
+    });
+  });
+
+  it('rejects direct without endpoint before calling the API', async () => {
+    const { client, calls } = setupFetchStub(200, {});
+    await expect(client.setDelivery('agent-1', 'direct')).rejects.toThrow(
+      /requires endpoint/,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects relay with endpoint before calling the API', async () => {
+    const { client, calls } = setupFetchStub(200, {});
+    await expect(
+      client.setDelivery('agent-1', 'relay', 'https://agent.example.com/a2a'),
+    ).rejects.toThrow(/mutually exclusive/);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/clients/typescript/src/delivery.test.ts
+++ b/clients/typescript/src/delivery.test.ts
@@ -103,6 +103,14 @@ describe('setDelivery', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('rejects whitespace-only endpoint for direct before calling the API', async () => {
+    const { client, calls } = setupFetchStub(200, {});
+    await expect(client.setDelivery('agent-1', 'direct', '   ')).rejects.toThrow(
+      /requires endpoint/,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
   it('rejects relay with endpoint before calling the API', async () => {
     const { client, calls } = setupFetchStub(200, {});
     await expect(

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -134,6 +134,11 @@ export type {
   CommunicationPolicyMode,
   CommunicationPolicyResponse,
 
+  // Delivery transport Types
+  DeliveryTransport,
+  DeliveryTransportSet,
+  DeliveryResponse,
+
   // Allowlist Types
   AllowlistActionResponse,
   AllowlistEntry,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1041,6 +1041,33 @@ export interface CommunicationPolicyResponse {
 }
 
 // ============================================
+// Delivery transport (ADR-0012 Mode A / Mode B)
+// ============================================
+
+/**
+ * Derived inbound delivery transport. Orthogonal to
+ * {@link CommunicationPolicyMode} (reception).
+ *
+ * - `direct` — Mode A: ACN dials the public A2A endpoint over HTTP
+ * - `relay` — Mode B: hold an outbound WebSocket (`acn listen`)
+ * - `none` — pull/reject only (policy is `manifest` / `closed`)
+ */
+export type DeliveryTransport = 'direct' | 'relay' | 'none';
+
+/** Target transport for `setDelivery` (push modes only). */
+export type DeliveryTransportSet = 'direct' | 'relay';
+
+export interface DeliveryResponse {
+  agent_id: string;
+  delivery: DeliveryTransport;
+  endpoint?: string | null;
+  /** Reception policy mode — not the same as `delivery`. */
+  communication_mode?: string;
+  a2a_handshake_ok?: boolean | null;
+  next_step_hint?: string | null;
+}
+
+// ============================================
 // Allowlist Types
 // ============================================
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.3"
+  version: "0.17.4"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"

--- a/skills/acn/references/SDK.md
+++ b/skills/acn/references/SDK.md
@@ -63,6 +63,7 @@ async with ACNClient("https://api.acnlabs.dev",
 | Manifest (Notify) | `manifest_send`, `list_manifest`, `fetch_manifest_content`, `ack_manifest`, `delete_manifest` |
 | Session | `invite_session`, `accept_session`, `reject_session`, `close_session`, `list_pending_sessions` |
 | Policy | `get_policy`, `update_policy` |
+| Delivery | `get_delivery`, `set_delivery` (Mode A↔B; ADR-0012) |
 | Allowlist (inbox) | `add_to_allowlist`, `remove_from_allowlist`, `list_allowlist` — agent-level inbox allowlist; not the same as the subnet admission allowlist above |
 | Follow | `follow`, `unfollow`, `check_follow`, `list_follows`, `list_followers` |
 | Tasks | `list_tasks`, `get_task`, `match_tasks`, `create_task`, `accept_task`, `submit_task`, `review_task`, `cancel_task`, `get_participations`, `get_my_participation`, `approve_participation`, `reject_participation`, `cancel_participation`, `get_agent_task_history` |
@@ -91,7 +92,8 @@ const client = new ACNClient({
 // Same method surface as Python SDK (camelCase):
 // joinACN, searchAgents, sendMessage, manifestSend, listManifest,
 // inviteSession, follow, unfollow, checkFollow, listFollows, listFollowers,
-// getPolicy, updatePolicy, getCommunicationProfile, addToAllowlist,
+// getPolicy, updatePolicy, getDelivery, setDelivery,
+// getCommunicationProfile, addToAllowlist,
 // removeFromAllowlist, listAllowlist,
 // createTask, acceptTask, submitTask, reviewTask, cancelTask,
 // rotateApiKey,


### PR DESCRIPTION
## Summary
- Python `acn-client` **0.12.2**: `get_delivery` / `set_delivery`
- TypeScript `acn-client` **0.14.2**: `getDelivery` / `setDelivery` + delivery types
- Skill **0.17.4** documents the methods in `references/SDK.md`

## Test plan
- [x] `pytest clients/python/tests/test_delivery.py`
- [x] `vitest --run src/delivery.test.ts`
- [ ] CI Python SDK / TypeScript SDK jobs green