### PR TITLE
feat(sdk): TypeScript Org Harness Work Port APIs (0.15.0)

### DIFF
--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-23
+
+### Added — Org Harness Work Port (builtin_work)
+
+- `getOrg` / `createOrg`
+- `createWork` / `updateWork` / `listWork`
+- `tickOrgLoop`
+- Types: `Org`, `OrgWorkItem`, `OrgWorkStatus`, …
+- Helper: `orgSubnetId(org)`
+- `ACNError.body` / `.reason` / `.boundOrgIdHint` for Org conflict recovery
+  (e.g. subnet already bound → reuse `org_…`)
+
 ## [0.14.2] - 2026-07-23
 
 ### Added — Delivery transport (ADR-0012 Mode A ↔ Mode B)

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -68,6 +68,13 @@ import type {
   SubnetJoinRequestListResponse,
   SubnetJoinRequestRow,
   SystemHealth,
+  Org,
+  OrgCreateRequest,
+  OrgLoopTickResponse,
+  OrgWorkCreateRequest,
+  OrgWorkItem,
+  OrgWorkListResponse,
+  OrgWorkUpdateRequest,
 } from './types';
 import { normalizeBaseUrl, resolveHostedBaseUrl } from './regions';
 
@@ -190,7 +197,11 @@ export class ACNClient {
             ? body.request_id
             : (response.headers.get('X-Request-ID') ?? undefined);
 
-        throw new ACNError(response.status, message, { errorCode, requestId });
+        throw new ACNError(response.status, message, {
+          errorCode,
+          requestId,
+          body,
+        });
       }
 
       if (response.status === 204) {
@@ -1591,6 +1602,69 @@ export class ACNClient {
       },
     });
   }
+
+  // ============================================
+  // Org Harness (Work Port / builtin_work)
+  // ============================================
+
+  /** GET /api/v1/orgs/{orgId} */
+  async getOrg(orgId: string): Promise<Org> {
+    return this.get(`/api/v1/orgs/${encodeURIComponent(orgId)}`);
+  }
+
+  /** POST /api/v1/orgs */
+  async createOrg(request: OrgCreateRequest): Promise<Org> {
+    return this.post('/api/v1/orgs', request);
+  }
+
+  /** POST /api/v1/orgs/{orgId}/work */
+  async createWork(
+    orgId: string,
+    request: OrgWorkCreateRequest,
+  ): Promise<OrgWorkItem> {
+    const body: Record<string, unknown> = { title: request.title };
+    if (request.assignee_agent_id != null && request.assignee_agent_id !== '') {
+      body.assignee_agent_id = request.assignee_agent_id;
+    }
+    return this.post(
+      `/api/v1/orgs/${encodeURIComponent(orgId)}/work`,
+      body,
+    );
+  }
+
+  /** PATCH /api/v1/orgs/{orgId}/work/{workId} */
+  async updateWork(
+    orgId: string,
+    workId: string,
+    request: OrgWorkUpdateRequest,
+  ): Promise<OrgWorkItem> {
+    const body: Record<string, unknown> = { status: request.status };
+    if (request.assignee_agent_id != null && request.assignee_agent_id !== '') {
+      body.assignee_agent_id = request.assignee_agent_id;
+    }
+    return this.patch(
+      `/api/v1/orgs/${encodeURIComponent(orgId)}/work/${encodeURIComponent(workId)}`,
+      body,
+    );
+  }
+
+  /** GET /api/v1/orgs/{orgId}/work */
+  async listWork(
+    orgId: string,
+    options?: { openOnly?: boolean },
+  ): Promise<OrgWorkListResponse> {
+    return this.get(`/api/v1/orgs/${encodeURIComponent(orgId)}/work`, {
+      open_only: options?.openOnly,
+    });
+  }
+
+  /** POST /api/v1/orgs/{orgId}/loop/tick */
+  async tickOrgLoop(orgId: string): Promise<OrgLoopTickResponse> {
+    return this.post(
+      `/api/v1/orgs/${encodeURIComponent(orgId)}/loop/tick`,
+      {},
+    );
+  }
 }
 
 /**
@@ -1610,16 +1684,51 @@ export class ACNError extends Error {
   errorCode?: string;
   /** Request ID minted by ACN for 5xx responses (useful for support) */
   requestId?: string;
+  /** Parsed JSON body when the server returned an object. */
+  body?: Record<string, unknown>;
 
   constructor(
     public status: number,
     message: string,
-    options?: { errorCode?: string; requestId?: string }
+    options?: {
+      errorCode?: string;
+      requestId?: string;
+      body?: Record<string, unknown>;
+    }
   ) {
     super(message);
     this.name = 'ACNError';
     this.errorCode = options?.errorCode;
     this.requestId = options?.requestId;
+    this.body = options?.body;
+  }
+
+  /** `details.reason` from flat ACN error bodies (e.g. OrgConflictError). */
+  get reason(): string | undefined {
+    const details = this.body?.details;
+    if (details && typeof details === 'object' && !Array.isArray(details)) {
+      const r = (details as Record<string, unknown>).reason;
+      return typeof r === 'string' ? r : undefined;
+    }
+    return undefined;
+  }
+
+  /**
+   * Best-effort extract `org_…` from conflict bodies/messages
+   * (subnet already bound to an Org).
+   */
+  get boundOrgIdHint(): string | undefined {
+    const details = this.body?.details;
+    if (details && typeof details === 'object' && !Array.isArray(details)) {
+      const id = (details as Record<string, unknown>).bound_org_id;
+      if (typeof id === 'string' && id.startsWith('org_')) return id;
+    }
+    const msg =
+      (typeof this.body?.message === 'string' ? this.body.message : '') +
+      ' ' +
+      this.message;
+    const m = msg.match(/\borg_[0-9a-fA-F]+\b/);
+    return m?.[0];
   }
 }
 

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -143,10 +143,25 @@ export type {
   AllowlistActionResponse,
   AllowlistEntry,
   AllowlistListResponse,
+
+  // Org Harness Types
+  Org,
+  OrgCreateRequest,
+  OrgFencing,
+  OrgLoopTickResponse,
+  OrgWorkCreateRequest,
+  OrgWorkItem,
+  OrgWorkListResponse,
+  OrgWorkStatus,
+  OrgWorkUpdateRequest,
 } from './types';
 
 // Value exports (constants)
-export { KNOWN_PAYMENT_TASK_STATUSES, KNOWN_INBOX_MESSAGE_STATUSES } from './types';
+export {
+  KNOWN_PAYMENT_TASK_STATUSES,
+  KNOWN_INBOX_MESSAGE_STATUSES,
+  orgSubnetId,
+} from './types';
 
 // Task pool types
 export type {

--- a/clients/typescript/src/org.test.ts
+++ b/clients/typescript/src/org.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Org Harness Work Port — TypeScript SDK surface tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ACNClient, ACNError } from './client';
+import { orgSubnetId } from './types';
+
+interface CapturedRequest {
+  url: URL;
+  init: RequestInit;
+}
+
+function setupFetchStub(
+  handler: (url: URL, init: RequestInit) => { status: number; body: unknown },
+): { client: ACNClient; calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  const fetchStub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(input instanceof URL ? input.toString() : String(input));
+    const reqInit = init ?? {};
+    calls.push({ url, init: reqInit });
+    const { status, body } = handler(url, reqInit);
+    return new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchStub);
+  const client = new ACNClient({
+    baseUrl: 'http://acn.test',
+    apiKey: 'acn_test',
+  });
+  return { client, calls };
+}
+
+describe('Org Harness SDK', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('createOrg / getOrg hit the right paths', async () => {
+    const org = {
+      org_id: 'org_abc',
+      display_name: 'Acme',
+      subnet_id: 'sub-1',
+      fencing: { subnet_id: 'sub-1' },
+    };
+    const { client, calls } = setupFetchStub(() => ({ status: 200, body: org }));
+
+    const created = await client.createOrg({
+      display_name: 'Acme',
+      subnet_id: 'sub-1',
+      join_policy: 'open',
+    });
+    expect(created.org_id).toBe('org_abc');
+    expect(calls[0]!.url.pathname).toBe('/api/v1/orgs');
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(JSON.parse(String(calls[0]!.init.body))).toMatchObject({
+      display_name: 'Acme',
+      subnet_id: 'sub-1',
+      join_policy: 'open',
+    });
+
+    await client.getOrg('org_abc');
+    expect(calls[1]!.url.pathname).toBe('/api/v1/orgs/org_abc');
+    expect(calls[1]!.init.method).toBe('GET');
+  });
+
+  it('createWork / updateWork / listWork / tickOrgLoop', async () => {
+    const work = {
+      work_id: 'work_1',
+      org_id: 'org_abc',
+      title: 'Ship SDK',
+      status: 'todo',
+    };
+    const { client, calls } = setupFetchStub((url) => {
+      if (url.pathname.endsWith('/loop/tick')) {
+        return { status: 200, body: { open_count: 1 } };
+      }
+      if (url.pathname.endsWith('/work') && (!url.search || url.search.includes('open_only'))) {
+        // GET list vs POST create distinguished by method below — body differs
+      }
+      if (url.pathname.endsWith('/work') || url.pathname.includes('/work/')) {
+        if (url.searchParams.has('open_only')) {
+          return { status: 200, body: { work: [work] } };
+        }
+        return { status: 200, body: work };
+      }
+      return { status: 500, body: { message: 'unexpected' } };
+    });
+
+    await client.createWork('org_abc', { title: 'Ship SDK' });
+    expect(calls[0]!.url.pathname).toBe('/api/v1/orgs/org_abc/work');
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(JSON.parse(String(calls[0]!.init.body))).toEqual({ title: 'Ship SDK' });
+
+    await client.updateWork('org_abc', 'work_1', { status: 'done' });
+    expect(calls[1]!.url.pathname).toBe('/api/v1/orgs/org_abc/work/work_1');
+    expect(calls[1]!.init.method).toBe('PATCH');
+
+    const listed = await client.listWork('org_abc', { openOnly: true });
+    expect(listed.work).toHaveLength(1);
+    expect(calls[2]!.url.searchParams.get('open_only')).toBe('true');
+
+    const tick = await client.tickOrgLoop('org_abc');
+    expect(tick.open_count).toBe(1);
+    expect(calls[3]!.url.pathname).toBe('/api/v1/orgs/org_abc/loop/tick');
+    expect(calls[3]!.init.method).toBe('POST');
+  });
+
+  it('orgSubnetId prefers fencing', () => {
+    expect(
+      orgSubnetId({
+        org_id: 'org_x',
+        display_name: 'X',
+        subnet_id: 'top',
+        fencing: { subnet_id: 'fence' },
+      }),
+    ).toBe('fence');
+    expect(
+      orgSubnetId({ org_id: 'org_x', display_name: 'X', subnet_id: 'top' }),
+    ).toBe('top');
+  });
+
+  it('ACNError exposes reason and boundOrgIdHint', async () => {
+    const { client } = setupFetchStub(() => ({
+      status: 409,
+      body: {
+        error_code: 'conflict',
+        message: 'subnet already bound to org_deadbeef01234567',
+        details: {
+          reason: 'subnet_bound',
+          bound_org_id: 'org_deadbeef01234567',
+        },
+      },
+    }));
+
+    await expect(client.createOrg({ display_name: 'Dup' })).rejects.toMatchObject({
+      status: 409,
+      reason: 'subnet_bound',
+      boundOrgIdHint: 'org_deadbeef01234567',
+    });
+
+    const err = new ACNError(409, 'conflict prose mentions org_aabbccddeeff0011', {
+      body: { message: 'x' },
+    });
+    expect(err.boundOrgIdHint).toBe('org_aabbccddeeff0011');
+  });
+});

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1110,6 +1110,82 @@ export const KNOWN_INBOX_MESSAGE_STATUSES = [
 ] as const;
 export type InboxMessageStatus = string; // wide for forward-compat
 
+// ============================================
+// Org Harness (builtin_work Work Port)
+// ============================================
+
+/** Work item status for Org builtin_work (not Task Pool). */
+export type OrgWorkStatus = 'todo' | 'in_progress' | 'done' | 'cancelled';
+
+export interface OrgFencing {
+  subnet_id?: string;
+}
+
+/** Org record from GET/POST /api/v1/orgs. */
+export interface Org {
+  org_id: string;
+  display_name: string;
+  /** Canonical fence id (also mirrored under fencing.subnet_id). */
+  subnet_id?: string;
+  fencing?: OrgFencing;
+  plugins?: Record<string, string>;
+  roles?: string[];
+  status?: string;
+  steward_agent_id?: string;
+  charter?: Record<string, unknown>;
+  owner?: Record<string, unknown>;
+  created_by?: Record<string, unknown>;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface OrgCreateRequest {
+  display_name: string;
+  subnet_id?: string;
+  join_policy?: 'open' | 'approval';
+  is_private?: boolean;
+  steward_agent_id?: string;
+  charter?: Record<string, unknown>;
+  plugins?: Record<string, string>;
+  harness_url?: string;
+  harness_secret?: string;
+}
+
+export interface OrgWorkItem {
+  work_id: string;
+  org_id: string;
+  title: string;
+  status: OrgWorkStatus | string;
+  assignee_agent_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface OrgWorkCreateRequest {
+  title: string;
+  assignee_agent_id?: string | null;
+}
+
+export interface OrgWorkUpdateRequest {
+  status: OrgWorkStatus;
+  assignee_agent_id?: string | null;
+}
+
+export interface OrgWorkListResponse {
+  work: OrgWorkItem[];
+}
+
+export interface OrgLoopTickResponse {
+  open_count?: number;
+  work_ids?: string[];
+  [key: string]: unknown;
+}
+
+/** Prefer fencing.subnet_id, fall back to top-level subnet_id. */
+export function orgSubnetId(org: Org): string | undefined {
+  return org.fencing?.subnet_id || org.subnet_id || undefined;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- Add Org Work Port methods to `acn-client` (TS) **0.15.0**: `getOrg`, `createOrg`, `createWork`, `updateWork`, `listWork`, `tickOrgLoop`.
- Types + `orgSubnetId()` helper.
- `ACNError` gains `body` / `reason` / `boundOrgIdHint` for subnet-already-bound recovery (Paperclip adapter pattern).
- Vitest coverage in `org.test.ts`.

Unblocks deleting hand-rolled `org-api.ts` in `@acnlabs/paperclip-plugin-acn`.

## Test plan
- [x] `cd clients/typescript && npm test -- --run src/org.test.ts`
- [x] `npm run typecheck`
- [ ] After merge: publish `acn-client@0.15.0` to npm, then bump paperclip plugin


Made with [Cursor](https://cursor.com)