### PR TITLE
feat(python-sdk): Org Work Port client parity (0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Python `acn-client` 0.13.0** — Org Harness Work Port client parity with
+  TypeScript 0.15 (`get_org` / `create_org` / `create_work` / `update_work` /
+  `list_work` / `tick_org_loop`, `org_subnet_id()`, `ACNError.bound_org_id_hint`).
+
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-23
+
+### Added — Org Harness Work Port (parity with TypeScript 0.15)
+
+- `get_org` / `create_org` / `create_work` / `update_work` / `list_work` /
+  `tick_org_loop` on `ACNClient` (`/api/v1/orgs*` · default Work Port
+  `builtin_work`).
+- Models: `Org`, `OrgCreateRequest`, `OrgWorkItem`, `OrgWorkCreateRequest`,
+  `OrgWorkUpdateRequest`, `OrgWorkListResponse`, `OrgLoopTickResponse`,
+  `OrgFencing`, `KNOWN_ORG_WORK_STATUSES`, helper `org_subnet_id()`.
+- `ACNError.body`, `.reason`, `.bound_org_id_hint` for Org conflict recovery
+  (e.g. subnet already bound).
+
 ## [0.12.2] - 2026-07-23
 
 ### Added — Delivery transport (ADR-0012 Mode A ↔ Mode B)

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -112,6 +112,18 @@ ACNClient(
 | `list_children(parent_subnet_id)` | List immediate child subnets |
 | `promote_subnet(subnet_id)` | Promote `task_scoped` child to `persistent` (idempotent) |
 
+#### Org Harness Methods (builtin_work)
+
+| Method | Description |
+|--------|-------------|
+| `get_org(org_id)` | Get Org by id |
+| `create_org(request)` | Create Org (default Work Port `builtin_work`) |
+| `create_work(org_id, request)` | Create Org work item |
+| `update_work(org_id, work_id, request)` | Patch work status / assignee |
+| `list_work(org_id, *, open_only?)` | List Org work |
+| `tick_org_loop(org_id)` | Thin Loop tick → emits `org.loop_tick` |
+| `org_subnet_id(org)` | Helper: prefer `fencing.subnet_id` |
+
 #### Subnet Admission Methods
 
 Only active on `join_policy=approval` subnets.

--- a/clients/python/acn_client/__init__.py
+++ b/clients/python/acn_client/__init__.py
@@ -12,6 +12,7 @@ Example:
 from .client import ACNClient, ACNError
 from .models import (
     KNOWN_INBOX_MESSAGE_STATUSES,
+    KNOWN_ORG_WORK_STATUSES,
     KNOWN_PAYMENT_TASK_STATUSES,
     AgentInfo,
     AgentJoinRequest,
@@ -27,6 +28,14 @@ from .models import (
     ManifestEntry,
     ManifestSendRequest,
     MessageType,
+    Org,
+    OrgCreateRequest,
+    OrgFencing,
+    OrgLoopTickResponse,
+    OrgWorkCreateRequest,
+    OrgWorkItem,
+    OrgWorkListResponse,
+    OrgWorkUpdateRequest,
     ParticipationInfo,
     PaymentCapability,
     PaymentMethod,
@@ -42,6 +51,7 @@ from .models import (
     TaskInfo,
     TaskReviewRequest,
     TaskSubmitRequest,
+    org_subnet_id,
 )
 from .realtime import ACNRealtime, ACNRealtimeOptions, AuthMode, WSState
 from .regions import (
@@ -118,4 +128,15 @@ __all__ = [
     "TaskSubmitRequest",
     "TaskReviewRequest",
     "ParticipationInfo",
+    # Org Harness (builtin_work)
+    "KNOWN_ORG_WORK_STATUSES",
+    "Org",
+    "OrgCreateRequest",
+    "OrgFencing",
+    "OrgLoopTickResponse",
+    "OrgWorkCreateRequest",
+    "OrgWorkItem",
+    "OrgWorkListResponse",
+    "OrgWorkUpdateRequest",
+    "org_subnet_id",
 ]

--- a/clients/python/acn_client/client.py
+++ b/clients/python/acn_client/client.py
@@ -5,6 +5,7 @@ Official Python client for ACN REST API.
 """
 
 import os
+import re
 from typing import Any
 
 import httpx
@@ -20,6 +21,13 @@ from .models import (
     ManifestContentResponse,
     ManifestEntry,
     ManifestSendRequest,
+    Org,
+    OrgCreateRequest,
+    OrgLoopTickResponse,
+    OrgWorkCreateRequest,
+    OrgWorkItem,
+    OrgWorkListResponse,
+    OrgWorkUpdateRequest,
     ParticipationInfo,
     PaymentCapability,
     PaymentStats,
@@ -48,10 +56,12 @@ class ACNError(Exception):
       header so operators can grep it out of structured logs. The exception
       ``str()`` includes it so it shows up in stack traces and chat error
       messages without callers needing to remember to print it themselves.
+    * Inspect ``body`` / ``reason`` / ``bound_org_id_hint`` for Org Harness
+      conflicts (e.g. subnet already bound → recover the existing ``org_…``).
 
     Backward compatibility: the ``ACNError(status_code, message)`` two-arg
-    form continues to work; ``error_code`` and ``request_id`` are kw-only
-    and default to ``None`` so older call sites never break.
+    form continues to work; keyword fields default to ``None`` so older
+    call sites never break.
     """
 
     def __init__(
@@ -61,17 +71,41 @@ class ACNError(Exception):
         *,
         error_code: str | None = None,
         request_id: str | None = None,
+        body: dict[str, Any] | None = None,
     ):
         self.status_code = status_code
         self.message = message
         self.error_code = error_code
         self.request_id = request_id
+        self.body = body
         # Bake request_id into the str so it travels through any layer that
         # only logs the exception message (and not the attributes). The
         # whole point of H4's request_id contract is to give the user a
         # short token they can paste into a support ticket.
         suffix = f" [request_id={request_id}]" if request_id else ""
         super().__init__(f"ACN Error {status_code}: {message}{suffix}")
+
+    @property
+    def reason(self) -> str | None:
+        """``details.reason`` from flat ACN error bodies (e.g. OrgConflictError)."""
+        details = (self.body or {}).get("details")
+        if isinstance(details, dict):
+            r = details.get("reason")
+            return r if isinstance(r, str) else None
+        return None
+
+    @property
+    def bound_org_id_hint(self) -> str | None:
+        """Best-effort extract ``org_…`` from conflict bodies/messages."""
+        details = (self.body or {}).get("details")
+        if isinstance(details, dict):
+            oid = details.get("bound_org_id")
+            if isinstance(oid, str) and oid.startswith("org_"):
+                return oid
+        body_msg = (self.body or {}).get("message")
+        msg = f"{body_msg if isinstance(body_msg, str) else ''} {self.message}"
+        m = re.search(r"\borg_[0-9a-fA-F]+\b", msg)
+        return m.group(0) if m else None
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +240,7 @@ def _build_acn_error(response: httpx.Response) -> ACNError:
         message,
         error_code=error_code,
         request_id=request_id,
+        body=body or None,
     )
 
 
@@ -560,6 +595,83 @@ class ACNClient:
             f"/api/v1/subnets/{slug}/harness",
             json={"harness_url": harness_url, "harness_secret": harness_secret},
         )
+
+    # ============================================
+    # Org Harness (Work Port / builtin_work)
+    # ============================================
+
+    async def get_org(self, org_id: str) -> Org:
+        """GET /api/v1/orgs/{org_id}."""
+        data = await self._request("GET", f"/api/v1/orgs/{org_id}")
+        return Org.model_validate(data)
+
+    async def create_org(self, request: OrgCreateRequest) -> Org:
+        """POST /api/v1/orgs — create an Org (default Work Port: builtin_work)."""
+        data = await self._request(
+            "POST",
+            "/api/v1/orgs",
+            json=request.model_dump(exclude_none=True),
+        )
+        return Org.model_validate(data)
+
+    async def create_work(
+        self,
+        org_id: str,
+        request: OrgWorkCreateRequest,
+    ) -> OrgWorkItem:
+        """POST /api/v1/orgs/{org_id}/work."""
+        body: dict[str, Any] = {"title": request.title}
+        if request.assignee_agent_id:
+            body["assignee_agent_id"] = request.assignee_agent_id
+        data = await self._request(
+            "POST",
+            f"/api/v1/orgs/{org_id}/work",
+            json=body,
+        )
+        return OrgWorkItem.model_validate(data)
+
+    async def update_work(
+        self,
+        org_id: str,
+        work_id: str,
+        request: OrgWorkUpdateRequest,
+    ) -> OrgWorkItem:
+        """PATCH /api/v1/orgs/{org_id}/work/{work_id}."""
+        body: dict[str, Any] = {"status": request.status}
+        if request.assignee_agent_id:
+            body["assignee_agent_id"] = request.assignee_agent_id
+        data = await self._request(
+            "PATCH",
+            f"/api/v1/orgs/{org_id}/work/{work_id}",
+            json=body,
+        )
+        return OrgWorkItem.model_validate(data)
+
+    async def list_work(
+        self,
+        org_id: str,
+        *,
+        open_only: bool | None = None,
+    ) -> OrgWorkListResponse:
+        """GET /api/v1/orgs/{org_id}/work."""
+        params: dict[str, Any] = {}
+        if open_only is not None:
+            params["open_only"] = open_only
+        data = await self._request(
+            "GET",
+            f"/api/v1/orgs/{org_id}/work",
+            params=params or None,
+        )
+        return OrgWorkListResponse.model_validate(data)
+
+    async def tick_org_loop(self, org_id: str) -> OrgLoopTickResponse:
+        """POST /api/v1/orgs/{org_id}/loop/tick — thin Loop tick."""
+        data = await self._request(
+            "POST",
+            f"/api/v1/orgs/{org_id}/loop/tick",
+            json={},
+        )
+        return OrgLoopTickResponse.model_validate(data)
 
     async def get_agent_subnets(self, agent_id: str) -> list[str]:
         """Get agent's subnets"""

--- a/clients/python/acn_client/models.py
+++ b/clients/python/acn_client/models.py
@@ -766,6 +766,120 @@ class ParticipationInfo(BaseModel):
 
 
 # ============================================
+# Org Harness (builtin_work Work Port)
+# ============================================
+
+KNOWN_ORG_WORK_STATUSES: tuple[str, ...] = (
+    "todo",
+    "in_progress",
+    "done",
+    "cancelled",
+)
+
+
+class OrgFencing(BaseModel):
+    """Org fence — typically the bound subnet id."""
+
+    model_config = ConfigDict(extra="allow")
+
+    subnet_id: str | None = None
+
+
+class Org(BaseModel):
+    """Org record from GET/POST /api/v1/orgs."""
+
+    model_config = ConfigDict(extra="allow")
+
+    org_id: str
+    display_name: str
+    subnet_id: str | None = None
+    fencing: OrgFencing | None = None
+    plugins: dict[str, str] | None = None
+    roles: list[str] | None = None
+    status: str | None = None
+    steward_agent_id: str | None = None
+    charter: dict[str, Any] | None = None
+    owner: dict[str, Any] | None = None
+    created_by: dict[str, Any] | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class OrgCreateRequest(BaseModel):
+    """POST /api/v1/orgs body."""
+
+    display_name: str
+    subnet_id: str | None = None
+    join_policy: str | None = None
+    is_private: bool | None = None
+    steward_agent_id: str | None = None
+    charter: dict[str, Any] | None = None
+    plugins: dict[str, str] | None = None
+    harness_url: str | None = None
+    harness_secret: str | None = None
+
+
+class OrgWorkItem(BaseModel):
+    """Org builtin_work item (not Task Pool)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    work_id: str
+    org_id: str
+    title: str
+    status: str
+    assignee_agent_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class OrgWorkCreateRequest(BaseModel):
+    """POST /api/v1/orgs/{org_id}/work body."""
+
+    title: str
+    assignee_agent_id: str | None = None
+
+
+class OrgWorkUpdateRequest(BaseModel):
+    """PATCH /api/v1/orgs/{org_id}/work/{work_id} body."""
+
+    status: str
+    assignee_agent_id: str | None = None
+
+
+class OrgWorkListResponse(BaseModel):
+    """GET /api/v1/orgs/{org_id}/work response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    work: list[OrgWorkItem] = Field(default_factory=list)
+
+
+class OrgLoopTickResponse(BaseModel):
+    """POST /api/v1/orgs/{org_id}/loop/tick response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    open_count: int | None = None
+    work_ids: list[str] | None = None
+
+
+def org_subnet_id(org: Org | dict[str, Any]) -> str | None:
+    """Prefer ``fencing.subnet_id``, fall back to top-level ``subnet_id``."""
+    if isinstance(org, Org):
+        if org.fencing and org.fencing.subnet_id:
+            return org.fencing.subnet_id
+        return org.subnet_id
+    fencing = org.get("fencing")
+    if isinstance(fencing, dict):
+        fence = fencing.get("subnet_id")
+        if isinstance(fence, str) and fence:
+            return fence
+    top = org.get("subnet_id")
+    return top if isinstance(top, str) and top else None
+
+
+# ============================================
 # Monitoring Models
 # ============================================
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.12.2"
+version = "0.13.0"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/python/tests/test_org.py
+++ b/clients/python/tests/test_org.py
@@ -1,0 +1,146 @@
+"""Org Harness Work Port — Python SDK surface (parity with TS 0.15)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from acn_client.client import ACNClient, ACNError, _build_acn_error
+from acn_client.models import (
+    Org,
+    OrgCreateRequest,
+    OrgWorkCreateRequest,
+    OrgWorkUpdateRequest,
+    org_subnet_id,
+)
+
+
+def _make_client_with_stub(request_mock: AsyncMock) -> ACNClient:
+    client = ACNClient(base_url="http://acn.test")
+    client._request = request_mock  # type: ignore[method-assign]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_org_and_get_org_paths():
+    org_payload: dict[str, Any] = {
+        "org_id": "org_abc",
+        "display_name": "Acme",
+        "subnet_id": "sub-1",
+        "fencing": {"subnet_id": "sub-1"},
+    }
+    request_mock = AsyncMock(return_value=org_payload)
+    client = _make_client_with_stub(request_mock)
+
+    created = await client.create_org(
+        OrgCreateRequest(
+            display_name="Acme",
+            subnet_id="sub-1",
+            join_policy="open",
+        )
+    )
+    assert created.org_id == "org_abc"
+    request_mock.assert_awaited_with(
+        "POST",
+        "/api/v1/orgs",
+        json={
+            "display_name": "Acme",
+            "subnet_id": "sub-1",
+            "join_policy": "open",
+        },
+    )
+
+    await client.get_org("org_abc")
+    request_mock.assert_awaited_with("GET", "/api/v1/orgs/org_abc")
+
+
+@pytest.mark.asyncio
+async def test_create_update_list_work_and_tick():
+    work_payload = {
+        "work_id": "work_1",
+        "org_id": "org_abc",
+        "title": "Ship SDK",
+        "status": "todo",
+    }
+    request_mock = AsyncMock(
+        side_effect=[
+            work_payload,
+            {**work_payload, "status": "done"},
+            {"work": [work_payload]},
+            {"open_count": 1, "work_ids": ["work_1"]},
+        ]
+    )
+    client = _make_client_with_stub(request_mock)
+
+    await client.create_work("org_abc", OrgWorkCreateRequest(title="Ship SDK"))
+    assert request_mock.await_args_list[0].args == (
+        "POST",
+        "/api/v1/orgs/org_abc/work",
+    )
+    assert request_mock.await_args_list[0].kwargs["json"] == {"title": "Ship SDK"}
+
+    await client.update_work(
+        "org_abc", "work_1", OrgWorkUpdateRequest(status="done")
+    )
+    assert request_mock.await_args_list[1].args == (
+        "PATCH",
+        "/api/v1/orgs/org_abc/work/work_1",
+    )
+    assert request_mock.await_args_list[1].kwargs["json"] == {"status": "done"}
+
+    listed = await client.list_work("org_abc", open_only=True)
+    assert len(listed.work) == 1
+    assert request_mock.await_args_list[2].kwargs["params"] == {"open_only": True}
+
+    tick = await client.tick_org_loop("org_abc")
+    assert tick.open_count == 1
+    assert request_mock.await_args_list[3].args == (
+        "POST",
+        "/api/v1/orgs/org_abc/loop/tick",
+    )
+
+
+def test_org_subnet_id_prefers_fencing():
+    assert (
+        org_subnet_id(
+            Org(
+                org_id="org_x",
+                display_name="X",
+                subnet_id="top",
+                fencing={"subnet_id": "fence"},
+            )
+        )
+        == "fence"
+    )
+    assert (
+        org_subnet_id(Org(org_id="org_x", display_name="X", subnet_id="top"))
+        == "top"
+    )
+
+
+def test_acn_error_reason_and_bound_org_id_hint():
+    response = httpx.Response(
+        409,
+        content=(
+            b'{"error_code":"conflict","message":"subnet already bound to '
+            b'org_deadbeef01234567","details":{"reason":"subnet_bound",'
+            b'"bound_org_id":"org_deadbeef01234567"}}'
+        ),
+        headers={"content-type": "application/json"},
+    )
+    err = _build_acn_error(response)
+    assert err.status_code == 409
+    assert err.reason == "subnet_bound"
+    assert err.bound_org_id_hint == "org_deadbeef01234567"
+    assert err.body is not None
+    assert err.body["details"]["bound_org_id"] == "org_deadbeef01234567"
+
+    prose = ACNError(
+        409,
+        "conflict prose mentions org_aabbccddeeff0011",
+        body={"message": "x"},
+    )
+    assert prose.bound_org_id_hint == "org_aabbccddeeff0011"


### PR DESCRIPTION
## Summary
- Python `acn-client` **0.13.0**: Org Harness Work Port APIs matching TypeScript 0.15 (`get_org` / `create_org` / `create_work` / `update_work` / `list_work` / `tick_org_loop`, `org_subnet_id()`).
- `ACNError.body` / `.reason` / `.bound_org_id_hint` for Org conflict recovery.
- Models + `KNOWN_ORG_WORK_STATUSES`; README table; root CHANGELOG note.
- No P2b (`task_pool`).

## Test plan
- [x] `uv run pytest tests/test_org.py tests/test_error_parsing.py` (20 passed)
- [ ] After merge: tag/publish PyPI when publisher account allows (see 0.15.3 note)


Made with [Cursor](https://cursor.com)