### PR TITLE
chore(release): 0.15.4 — Python Org SDK 0.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,15 +196,32 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    # PyPI may fail independently (e.g. unverified publisher email) without
+    # blocking the GitHub Release / npm / Docker artifacts.
     needs: [publish-python, publish-npm, publish-cli, docker]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.publish-npm.result == 'success'
+      && needs.publish-cli.result == 'success'
+      && needs.docker.result == 'success'
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          body: |
+            ## Publish status
+            - PyPI (`acn-client`): ${{ needs.publish-python.result }}
+            - npm (`acn-client`): ${{ needs.publish-npm.result }}
+            - CLI: ${{ needs.publish-cli.result }}
+            - Docker: ${{ needs.docker.result }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,8 +220,10 @@ jobs:
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           body: |
             ## Publish status
-            - PyPI (`acn-client`): ${{ needs.publish-python.result }}
-            - npm (`acn-client`): ${{ needs.publish-npm.result }}
-            - CLI: ${{ needs.publish-cli.result }}
-            - Docker: ${{ needs.docker.result }}
+            - PyPI (`acn-client`): `${{ needs.publish-python.result }}`
+            - npm (`acn-client`): `${{ needs.publish-npm.result }}`
+            - CLI: `${{ needs.publish-cli.result }}`
+            - Docker: `${{ needs.docker.result }}`
+
+            ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Python `acn-client` 0.13.0** — Org Harness Work Port client parity with
-  TypeScript 0.15 (`get_org` / `create_org` / `create_work` / `update_work` /
-  `list_work` / `tick_org_loop`, `org_subnet_id()`, `ACNError.bound_org_id_hint`).
-
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),
@@ -54,6 +50,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent skill 0.17.2** — documents Org Harness (`acn org …`, Work Port),
   preferred `org.*` harness events, and Task Pool as optional/legacy for
   Pattern adapters; `references/API.md` gains `/orgs*` table.
+
+## [0.15.4] - 2026-07-23
+
+SDK publish cycle: server **0.15.4** (version bump for release workflow),
+Python `acn-client` **0.13.0** (Org Work Port parity with TypeScript 0.15),
+skill **0.17.5**. TypeScript `acn-client` **0.15.0** and CLI **0.13.3**
+already on npm (skipped).
+
+### Added — Python Org Harness Work Port
+
+- Python `acn-client` **0.13.0** — `get_org` / `create_org` / `create_work` /
+  `update_work` / `list_work` / `tick_org_loop`, `org_subnet_id()`,
+  `ACNError.reason` / `bound_org_id_hint`.
+
+### Fixed — Release workflow
+
+- GitHub Release no longer blocked when PyPI publish fails (e.g. unverified
+  publisher email). Publish status is summarized in the release body.
+
+### Docs
+
+- Agent skill **0.17.5** — `references/SDK.md` documents Org Harness methods
+  for Python and TypeScript.
 
 ## [0.15.3] - 2026-07-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.15.3"
+version = "0.15.4"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.4"
+  version: "0.17.5"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"

--- a/skills/acn/references/SDK.md
+++ b/skills/acn/references/SDK.md
@@ -64,6 +64,7 @@ async with ACNClient("https://api.acnlabs.dev",
 | Session | `invite_session`, `accept_session`, `reject_session`, `close_session`, `list_pending_sessions` |
 | Policy | `get_policy`, `update_policy` |
 | Delivery | `get_delivery`, `set_delivery` (Mode A↔B; ADR-0012) |
+| Org Harness (builtin_work) | `get_org`, `create_org`, `create_work`, `update_work`, `list_work`, `tick_org_loop`; helper `org_subnet_id(org)`; `ACNError.reason` / `bound_org_id_hint` for subnet-bound conflicts (≥ **0.13.0**) |
 | Allowlist (inbox) | `add_to_allowlist`, `remove_from_allowlist`, `list_allowlist` — agent-level inbox allowlist; not the same as the subnet admission allowlist above |
 | Follow | `follow`, `unfollow`, `check_follow`, `list_follows`, `list_followers` |
 | Tasks | `list_tasks`, `get_task`, `match_tasks`, `create_task`, `accept_task`, `submit_task`, `review_task`, `cancel_task`, `get_participations`, `get_my_participation`, `approve_participation`, `reject_participation`, `cancel_participation`, `get_agent_task_history` |
@@ -93,6 +94,8 @@ const client = new ACNClient({
 // joinACN, searchAgents, sendMessage, manifestSend, listManifest,
 // inviteSession, follow, unfollow, checkFollow, listFollows, listFollowers,
 // getPolicy, updatePolicy, getDelivery, setDelivery,
+// getOrg, createOrg, createWork, updateWork, listWork, tickOrgLoop,
+// orgSubnetId(org), ACNError.reason / boundOrgIdHint,
 // getCommunicationProfile, addToAllowlist,
 // removeFromAllowlist, listAllowlist,
 // createTask, acceptTask, submitTask, reviewTask, cancelTask,

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.15.3"
+version = "0.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Server **0.15.4** release cut to publish Python `acn-client@0.13.0` (Org Work Port).
- Skill **0.17.5** documents Org methods in `references/SDK.md`.
- Release workflow: GitHub Release still creates if PyPI fails (publisher email issue).

## Test plan
- [ ] CI green
- [ ] After merge: tag `v0.15.4`
- [ ] Confirm PyPI `acn-client==0.13.0` **or** note still blocked at https://pypi.org/manage/account/


Made with [Cursor](https://cursor.com)