### PR TITLE
fix(org): clearer 403 for non-governance create_work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Org permission 403 prose:** `_map_permission` now surfaces
+  `OrgPermissionError` message text (e.g. “Only created_by may govern an
+  unclaimed Org”) while keeping `error_code=ownership_mismatch` and
+  `details.reason`. Clarifies that `POST …/work` is **governance-only**,
+  not Org membership. Skill **0.17.6** / API.md updated.
+
 ### Added
 
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -303,6 +303,12 @@ def _org_response(org) -> dict[str, Any]:
 
 
 def _map_permission(exc: OrgPermissionError, org_id: str) -> ACNHTTPError:
+    """Map OrgPermissionError → 403/400.
+
+    Keep ``error_code`` / ``details.reason`` stable for clients; surface the
+    service prose in ``message`` so adapters can tell *membership* failures
+    apart from *governance* (created_by / owner) without reading ADR text.
+    """
     ownership_reasons = {
         "ownership_mismatch",
         "created_by_only",
@@ -319,9 +325,11 @@ def _map_permission(exc: OrgPermissionError, org_id: str) -> ACNHTTPError:
         if exc.reason in ownership_reasons
         else ErrorCode.INVALID_REQUEST
     )
+    prose = str(exc).strip()
     return ACNHTTPError(
         code,
         403 if code == ErrorCode.OWNERSHIP_MISMATCH else 400,
+        message=prose if prose and prose != exc.reason else None,
         details={"org_id": org_id, "reason": exc.reason},
     )
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.5"
+  version: "0.17.6"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -126,8 +126,8 @@ acn config show
 | `acn org release <org_id>` | Release ownership → none |
 | `acn org dissolve <org_id>` | Dissolve Org |
 | `acn org work list <org_id> [--open]` | List Org work items (Work Port) |
-| `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work item (`POST /orgs/{id}/work`) |
-| `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status |
+| `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work (`POST /orgs/{id}/work`) — **governance only** (unclaimed: `created_by`; claimed: `owner`). Membership alone is not enough |
+| `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status (**governance only**) |
 | `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
 | **Tasks (Task Pool — optional / legacy for Org Patterns)** | |
 | `acn tasks list [--status open]` | Browse tasks |
@@ -859,6 +859,7 @@ acn org create --name "Squad" --subnet my-subnet --join-policy open
 # → org_id: org_…
 
 # Work Port (preferred dispatch for Org Patterns — NOT Task Pool)
+# create/update require governance: unclaimed → created_by; claimed → owner
 acn org work create org_… --title "Ship the adapter"
 acn org work list org_… --open
 acn org work update org_… work_… --status done

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -136,12 +136,18 @@ Task Pool mode. See [`docs/org-harness/`](../../../docs/org-harness/README.md).
 | POST | `/orgs/{id}/release` | API Key / JWT | Release ownership → none |
 | POST | `/orgs/{id}/dissolve` | API Key / JWT | Dissolve Org |
 | GET | `/orgs/{id}/members` | API Key (entitled) | List members |
-| POST | `/orgs/{id}/members` | API Key / JWT | Add member |
-| DELETE | `/orgs/{id}/members/{agent_id}` | API Key / JWT | Remove member |
+| POST | `/orgs/{id}/members` | API Key / JWT | Add member (**governance** only) |
+| DELETE | `/orgs/{id}/members/{agent_id}` | API Key / JWT | Remove member (**governance** only) |
 | GET | `/orgs/{id}/work` | None / API Key | List work items (`?open_only=`) |
-| POST | `/orgs/{id}/work` | API Key / JWT | Create work item |
-| PATCH | `/orgs/{id}/work/{work_id}` | API Key / JWT | Update work status / assignee |
+| POST | `/orgs/{id}/work` | API Key / JWT | Create work (**governance** only — not “any member”) |
+| PATCH | `/orgs/{id}/work/{work_id}` | API Key / JWT | Update work (**governance** only) |
 | POST | `/orgs/{id}/loop/tick` | API Key / JWT | Thin Loop tick → `org.loop_tick` webhook |
+
+**Governance** = unclaimed Org (`owner.kind=none`) → only `created_by`; claimed
+Org → only `owner`. Org **membership** (worker/manager) does **not** grant
+create/update work. Non-governance callers get **403**
+`error_code=ownership_mismatch` with `details.reason` of `created_by_only` or
+`ownership_mismatch` (and a prose `message`).
 
 Harness webhook registration remains `PATCH /subnets/{id}/harness` (event sink).
 On `org.*` deliveries, envelope field `task_id` carries **`org_id`**.

--- a/tests/routes/test_orgs_auth.py
+++ b/tests/routes/test_orgs_auth.py
@@ -9,7 +9,24 @@ from fastapi import BackgroundTasks, Request
 from starlette.datastructures import Headers
 
 from acn.core.errors import ACNHTTPError, ErrorCode
-from acn.routes.orgs import require_org_auth, resolve_org_reader
+from acn.routes.orgs import _map_permission, require_org_auth, resolve_org_reader
+from acn.services.org_service import OrgPermissionError
+
+
+def test_map_permission_surfaces_governance_prose():
+    """403 keeps ownership_mismatch + reason, but message is actionable."""
+    err = _map_permission(
+        OrgPermissionError(
+            "created_by_only",
+            "Only created_by may govern an unclaimed Org",
+        ),
+        org_id="org_abc",
+    )
+    assert err.status_code == 403
+    assert err.code == ErrorCode.OWNERSHIP_MISMATCH
+    assert err.details == {"org_id": "org_abc", "reason": "created_by_only"}
+    assert "created_by" in err.message
+    assert err.message != "The authenticated caller does not own the requested resource."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Root cause of “external agent can’t create Org work” is **governance**, not membership: unclaimed → `created_by`, claimed → `owner`.
- `_map_permission` now puts that prose in `message` (keeps `error_code` / `details.reason`).
- Skill **0.17.6** + API.md spell out the rule.

## Test plan
- [x] `uv run pytest tests/routes/test_orgs_auth.py tests/services/test_org_service.py`
- [ ] Companion plugin e2e comment/fix in paperclip-acn-plugin


Made with [Cursor](https://cursor.com)