### PR TITLE
feat(cli): Mode B local receiver with --runtime wake adapters

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-23
+
+### Added — Local receiver + runtime wake (Mode B production path)
+
+- **`acn listen --runtime http|command|log`** — built-in A2A JSON-RPC
+  receiver (no local port) plus host wake adapter. Answers
+  `message/send` / `message/stream` with a valid `kind: message` result
+  **before** waking the host (wake failure does not fail A2A).
+- **`--wake-url` / `--wake-header` / `--wake-exec` / `--wake-timeout`** —
+  wake knobs for `http` and `command` runtimes.
+- **In-process dedupe** (default on; `--no-dedupe`, `--dedupe-ttl`) by
+  `task_id ?? message_id`. Restart clears the window. Wake failure
+  releases the slot so at-least-once retries can wake again.
+- Design: [`docs/features/acn-local-receiver-mvp.md`](../../docs/features/acn-local-receiver-mvp.md).
+
+### Changed
+
+- **`--forward` / `--exec`** remain supported as compatibility tunnels;
+  production docs recommend `--runtime`. Legacy `--exec` still means
+  “stdout = full A2A response” — do not confuse with
+  `--runtime command --wake-exec`.
+
 ## [0.13.3] - 2026-07-22
 
 > Coordinated release with ACN server `0.15.2` and agent skill `0.17.3`.

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -67,6 +67,46 @@ acn heartbeat
 acn heartbeat --agent-id <id>   # override agent ID
 ```
 
+### `acn listen` (Mode B — no public endpoint)
+
+Hold an outbound WebSocket and receive relayed A2A requests in real time.
+
+**Production (recommended):** built-in A2A receiver + wake your host runtime.
+No local A2A port required.
+
+```bash
+# Register for relay delivery, then:
+acn listen --runtime http \
+  --wake-url http://127.0.0.1:10122/hooks/agent \
+  --wake-header 'Authorization: Bearer …'
+
+acn listen --runtime command --wake-exec '/path/to/wake.sh'
+acn listen --runtime log   # debug: print normalized events to stderr
+```
+
+Semantics: CLI answers `message/send` / `message/stream` with a valid A2A
+`accepted` message **immediately**, then POSTs/execs a normalized event to
+wake the host. Wake failure is logged (`wake_failed`) and does **not** fail
+the A2A reply. Dedupe is on by default (`--no-dedupe` to disable).
+
+**Coverage:** only traffic that arrives over the Mode B relay. Open Task Pool
+rows that were never pushed as A2A still need `acn tasks list` / reconcile.
+
+**Compat (advanced):** tunnel to your own A2A server, or let a subprocess
+print the full JSON-RPC response:
+
+```bash
+acn listen --forward http://127.0.0.1:8080
+acn listen --exec './handle-a2a.sh'   # stdout = full A2A JSON-RPC body
+```
+
+> Do not confuse legacy `--exec` with `--runtime command --wake-exec`.
+> The former must emit a protocol-valid A2A response; the latter only wakes
+> the host after the CLI has already answered A2A.
+
+Keep `acn listen` and `acn heartbeat` in the same lifecycle for idle agents
+(see [listen + heartbeat systemd example](../../docs/runbooks/acn-listen-heartbeat.md)).
+
 ### `acn agents`
 
 Discover agents on ACN.

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/cli/src/commands/delivery.ts
+++ b/clients/cli/src/commands/delivery.ts
@@ -128,8 +128,9 @@ export function deliveryCommand(): Command {
             res.delivery === 'relay'
               ? [
                   '',
-                  'Next: keep a local A2A handler up, then:',
-                  '  acn listen --forward http://localhost:PORT',
+                  'Next: run the Mode B listener (built-in A2A + wake host):',
+                  '  acn listen --runtime http --wake-url http://127.0.0.1:PORT/wake',
+                  'Compat: acn listen --forward http://localhost:PORT',
                 ]
               : [];
           output(res, [formatDelivery(res), ...followUp].join('\n'));

--- a/clients/cli/src/commands/listen.ts
+++ b/clients/cli/src/commands/listen.ts
@@ -3,6 +3,14 @@ import { spawn } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import WebSocket from 'ws';
 import { loadConfig } from '../config.js';
+import { DedupeStore } from './normalize-event.js';
+import { dispatchLocalReceiver } from './local-receiver.js';
+import {
+  DEFAULT_WAKE_TIMEOUT_MS,
+  parseWakeHeaders,
+  validateRuntimeOptions,
+  type RuntimeId,
+} from './runtime-adapter.js';
 
 /**
  * ADR-0012 Mode B — agent-side listener.
@@ -24,13 +32,10 @@ import { loadConfig } from '../config.js';
  *   agent -> ACN  : {type:"a2a_stream_end",   id, status?, error?}
  * Non-SSE responses keep using a single a2a_response — purely additive.
  *
- * Two handler modes:
- *   --forward <url>  tunnel each request to a local HTTP server (the agent's
- *                    existing A2A server, e.g. http://localhost:8080).
- *                    SSE responses are streamed (P2d).
- *   --exec <command> run a shell command per request; the request body is fed
- *                    on stdin and the command's stdout becomes the response.
- *                    Always buffered (exec streaming is deferred, see #171).
+ * Handler modes:
+ *   --runtime http|command|log  built-in A2A receiver + wake host (production default)
+ *   --forward <url>             tunnel to a local A2A server (compat; SSE streamed)
+ *   --exec <command>            stdout = full A2A JSON-RPC response (compat; buffered)
  */
 
 export interface A2aRequestFrame {
@@ -74,14 +79,28 @@ export type OutboundFrame = A2aResponseFrame | A2aStreamChunkFrame | A2aStreamEn
 /** Emit one reply frame to ACN over the control channel. */
 export type SendFrame = (frame: OutboundFrame) => void;
 
+export interface RuntimeHandlerOptions {
+  runtime: RuntimeId;
+  wakeUrl?: string;
+  wakeHeaders?: Record<string, string>;
+  wakeExec?: string;
+  wakeTimeoutMs?: number;
+  dedupe: boolean;
+  dedupeTtlSec: number;
+}
+
 export interface HandlerOptions {
   forward?: string;
   exec?: string;
+  runtime?: RuntimeHandlerOptions;
 }
 
 interface HandlerDeps {
   fetchFn?: typeof fetch;
   spawnFn?: typeof spawn;
+  logFn?: (line: string) => void;
+  /** Shared across requests when using --runtime (set by runListener). */
+  dedupeStore?: DedupeStore;
 }
 
 // Headers that must not be replayed to the downstream handler: they describe
@@ -126,6 +145,8 @@ function errorResponse(id: string, status: number, detail: string): A2aResponseF
  * live socket: a ``--forward`` SSE response is streamed as chunk frames, every
  * other case emits a single ``a2a_response``. Pure except for the injected
  * ``fetch`` / ``spawn`` deps, so it is unit testable without a live socket.
+ *
+ * For ``--runtime``, the A2A response is emitted before wake completes.
  */
 export async function dispatchA2aRequest(
   frame: A2aRequestFrame,
@@ -135,6 +156,23 @@ export async function dispatchA2aRequest(
 ): Promise<void> {
   const bodyBuf = decodeBody(frame);
   try {
+    if (opts.runtime) {
+      const store =
+        deps.dedupeStore ?? new DedupeStore(opts.runtime.dedupeTtlSec);
+      dispatchLocalReceiver(
+        frame.id,
+        bodyBuf.toString('utf-8'),
+        opts.runtime,
+        store,
+        send,
+        {
+          fetchFn: deps.fetchFn,
+          spawnFn: deps.spawnFn,
+          logFn: deps.logFn,
+        }
+      );
+      return;
+    }
     if (opts.forward) {
       await forwardToHttp(frame, bodyBuf, opts.forward, deps.fetchFn ?? fetch, send);
       return;
@@ -323,6 +361,9 @@ function runListener(cfg: ListenerConfig): void {
   const wsUrl = toWebsocketUrl(cfg.baseUrl, cfg.agentId);
   let backoff = INITIAL_BACKOFF_MS;
   let stopped = false;
+  const dedupeStore = cfg.runtime
+    ? new DedupeStore(cfg.runtime.dedupeTtlSec)
+    : undefined;
 
   const connect = (): void => {
     const ws = new WebSocket(wsUrl, {
@@ -332,7 +373,12 @@ function runListener(cfg: ListenerConfig): void {
 
     ws.on('open', () => {
       // Status to stderr so stdout stays clean for pipe consumers.
-      console.error(`[acn listen] connected as ${cfg.agentId} → ${wsUrl}`);
+      const mode = cfg.runtime
+        ? `runtime=${cfg.runtime.runtime}`
+        : cfg.forward
+          ? `forward=${cfg.forward}`
+          : `exec`;
+      console.error(`[acn listen] connected as ${cfg.agentId} → ${wsUrl} (${mode})`);
       backoff = INITIAL_BACKOFF_MS;
       keepalive = setInterval(() => {
         if (ws.readyState === WebSocket.OPEN) {
@@ -358,7 +404,7 @@ function runListener(cfg: ListenerConfig): void {
             ws.send(JSON.stringify(out));
           }
         };
-        void dispatchA2aRequest(f as A2aRequestFrame, cfg, send);
+        void dispatchA2aRequest(f as A2aRequestFrame, cfg, send, { dedupeStore });
       }
       // {type:"pong"} keepalive ack and the {type:"system"} welcome frame
       // need no action.
@@ -398,55 +444,159 @@ function runListener(cfg: ListenerConfig): void {
   connect();
 }
 
+function collectWakeHeader(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
+
+/** Validate mutually exclusive handler flags. Returns an error message or null. */
+export function validateListenHandlerFlags(opts: {
+  runtime?: string;
+  forward?: string;
+  exec?: string;
+  wakeUrl?: string;
+  wakeExec?: string;
+}): string | null {
+  const modes = [opts.runtime, opts.forward, opts.exec].filter(Boolean);
+  if (modes.length === 0) {
+    return (
+      'Provide a handler: --runtime http|command|log (recommended), ' +
+      'or legacy --forward <url> / --exec <command>.'
+    );
+  }
+  if (modes.length > 1) {
+    return 'Use only one handler: --runtime, --forward, or --exec — not combined.';
+  }
+  return validateRuntimeOptions({
+    runtime: opts.runtime,
+    wakeUrl: opts.wakeUrl,
+    wakeExec: opts.wakeExec,
+  });
+}
+
 export function listenCommand(): Command {
   const cmd = new Command('listen')
     .description(
       'Hold an outbound connection to ACN and answer relayed A2A requests in ' +
-        'real time (ADR-0012 Mode B). For agents with no public endpoint.'
+        'real time (ADR-0012 Mode B). Prefer --runtime for production; ' +
+        '--forward/--exec remain as compatibility tunnels.'
     )
     .option(
+      '--runtime <id>',
+      'Built-in A2A receiver + wake host: http | command | log (no local A2A port)'
+    )
+    .option('--wake-url <url>', 'POST target for --runtime http')
+    .option(
+      '--wake-header <k:v>',
+      'Extra header for --runtime http (repeatable)',
+      collectWakeHeader,
+      [] as string[]
+    )
+    .option(
+      '--wake-exec <cmd>',
+      'Shell command for --runtime command (event JSON on stdin). ' +
+        'Not the same as legacy --exec (which must print a full A2A response).'
+    )
+    .option(
+      '--wake-timeout <ms>',
+      'Wake timeout in ms (default 5000)',
+      String(DEFAULT_WAKE_TIMEOUT_MS)
+    )
+    .option('--no-dedupe', 'Disable in-process task/message id dedupe (default: on)')
+    .option('--dedupe-ttl <sec>', 'Dedupe window seconds (default 3600)', '3600')
+    .option(
       '--forward <url>',
-      'Tunnel each relayed request to a local HTTP server (e.g. http://localhost:8080)'
+      'Compat: tunnel each request to a local A2A HTTP server'
     )
     .option(
       '--exec <command>',
-      'Run a shell command per request: body on stdin, stdout becomes the response'
+      'Compat: shell per request; stdout must be a full A2A JSON-RPC response'
     )
     .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
-    .action((opts: { forward?: string; exec?: string; agentId?: string }) => {
-      const config = loadConfig();
-      const apiKey = config.api_key;
-      const agentId = opts.agentId ?? config.agent_id;
+    .action(
+      (opts: {
+        runtime?: string;
+        wakeUrl?: string;
+        wakeHeader?: string[];
+        wakeExec?: string;
+        wakeTimeout?: string;
+        dedupe?: boolean;
+        dedupeTtl?: string;
+        forward?: string;
+        exec?: string;
+        agentId?: string;
+      }) => {
+        const config = loadConfig();
+        const apiKey = config.api_key;
+        const agentId = opts.agentId ?? config.agent_id;
 
-      if (!apiKey) {
-        console.error(
-          'No API key found. Run `acn join` first or `acn config set api-key <key>`.'
-        );
-        process.exit(1);
-      }
-      if (!agentId) {
-        console.error(
-          'No agent ID found. Run `acn join` first or `acn config set agent-id <id>`.'
-        );
-        process.exit(1);
-      }
-      if (!opts.forward && !opts.exec) {
-        console.error('Provide a handler: --forward <url> or --exec <command>.');
-        process.exit(1);
-      }
-      if (opts.forward && opts.exec) {
-        console.error('Use only one handler: --forward or --exec, not both.');
-        process.exit(1);
-      }
+        if (!apiKey) {
+          console.error(
+            'No API key found. Run `acn join` first or `acn config set api-key <key>`.'
+          );
+          process.exit(1);
+        }
+        if (!agentId) {
+          console.error(
+            'No agent ID found. Run `acn join` first or `acn config set agent-id <id>`.'
+          );
+          process.exit(1);
+        }
 
-      runListener({
-        agentId,
-        apiKey: apiKey!,
-        baseUrl: config.base_url,
-        forward: opts.forward,
-        exec: opts.exec,
-      });
-    });
+        const flagErr = validateListenHandlerFlags({
+          runtime: opts.runtime,
+          forward: opts.forward,
+          exec: opts.exec,
+          wakeUrl: opts.wakeUrl,
+          wakeExec: opts.wakeExec,
+        });
+        if (flagErr) {
+          console.error(flagErr);
+          process.exit(1);
+        }
+
+        let wakeHeaders: Record<string, string> | undefined;
+        if (opts.runtime === 'http') {
+          try {
+            wakeHeaders = parseWakeHeaders(opts.wakeHeader);
+          } catch (err) {
+            console.error(err instanceof Error ? err.message : String(err));
+            process.exit(1);
+          }
+        }
+
+        const wakeTimeoutMs = Number.parseInt(opts.wakeTimeout ?? '', 10);
+        const dedupeTtlSec = Number.parseInt(opts.dedupeTtl ?? '', 10);
+        if (opts.runtime && (!Number.isFinite(wakeTimeoutMs) || wakeTimeoutMs <= 0)) {
+          console.error('--wake-timeout must be a positive integer (ms).');
+          process.exit(1);
+        }
+        if (opts.runtime && (!Number.isFinite(dedupeTtlSec) || dedupeTtlSec <= 0)) {
+          console.error('--dedupe-ttl must be a positive integer (seconds).');
+          process.exit(1);
+        }
+
+        runListener({
+          agentId,
+          apiKey: apiKey!,
+          baseUrl: config.base_url,
+          forward: opts.forward,
+          exec: opts.exec,
+          runtime: opts.runtime
+            ? {
+                runtime: opts.runtime as RuntimeId,
+                wakeUrl: opts.wakeUrl,
+                wakeHeaders,
+                wakeExec: opts.wakeExec,
+                wakeTimeoutMs,
+                // commander: --no-dedupe sets dedupe=false; default true
+                dedupe: opts.dedupe !== false,
+                dedupeTtlSec,
+              }
+            : undefined,
+        });
+      }
+    );
 
   return cmd;
 }

--- a/clients/cli/src/commands/local-receiver.ts
+++ b/clients/cli/src/commands/local-receiver.ts
@@ -1,0 +1,250 @@
+/**
+ * Built-in Mode B A2A receiver: answer JSON-RPC immediately, then wake runtime.
+ * Does not bind a local HTTP port — replies go out over the relay WS.
+ */
+
+import { randomUUID } from 'crypto';
+import {
+  DedupeStore,
+  dedupeKey,
+  normalizeEvent,
+  parseJsonRpcBody,
+  type NormalizedEvent,
+} from './normalize-event.js';
+import {
+  wakeRuntime,
+  type RuntimeWakeOptions,
+  type WakeDeps,
+} from './runtime-adapter.js';
+
+const HANDLED_METHODS = new Set(['message/send', 'message/stream']);
+
+/** Structurally matches listen.ts ``A2aResponseFrame`` (kept local to avoid cycles). */
+export interface ReceiverResponseFrame {
+  type: 'a2a_response';
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface LocalReceiverOptions extends RuntimeWakeOptions {
+  dedupe: boolean;
+  dedupeTtlSec: number;
+}
+
+export interface LocalReceiverDeps extends WakeDeps {
+  generateId?: () => string;
+  now?: () => Date;
+  logFn?: (line: string) => void;
+}
+
+export interface ProcessIncomingResult {
+  response: ReceiverResponseFrame;
+  event: NormalizedEvent | null;
+  shouldWake: boolean;
+  dedupeHit: boolean;
+}
+
+function jsonRpcResponse(
+  correlationId: string,
+  jsonrpcId: unknown,
+  payload: Record<string, unknown>
+): ReceiverResponseFrame {
+  return {
+    type: 'a2a_response',
+    id: correlationId,
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: jsonrpcId ?? null,
+      ...payload,
+    }),
+  };
+}
+
+function acceptedMessage(
+  correlationId: string,
+  jsonrpcId: unknown,
+  messageId: string
+): ReceiverResponseFrame {
+  return jsonRpcResponse(correlationId, jsonrpcId, {
+    result: {
+      kind: 'message',
+      messageId,
+      role: 'agent',
+      parts: [{ kind: 'text', text: 'accepted' }],
+    },
+  });
+}
+
+function jsonRpcError(
+  correlationId: string,
+  jsonrpcId: unknown,
+  code: number,
+  message: string
+): ReceiverResponseFrame {
+  return jsonRpcResponse(correlationId, jsonrpcId, {
+    error: { code, message },
+  });
+}
+
+/**
+ * Pure: parse body → A2A response + whether to wake.
+ * Dedupe store is mutated when a wake-eligible event is accepted.
+ */
+export function processIncomingRequest(
+  correlationId: string,
+  bodyText: string,
+  opts: Pick<LocalReceiverOptions, 'dedupe'>,
+  dedupeStore: DedupeStore,
+  deps: Pick<LocalReceiverDeps, 'generateId' | 'now'> = {}
+): ProcessIncomingResult {
+  const generateId = deps.generateId ?? (() => randomUUID());
+  const parsed = parseJsonRpcBody(bodyText);
+  if (!parsed.ok) {
+    return {
+      response: jsonRpcError(correlationId, null, parsed.code, parsed.message),
+      event: null,
+      shouldWake: false,
+      dedupeHit: false,
+    };
+  }
+
+  const { body } = parsed;
+  const jsonrpcId = body.id ?? null;
+  const method = body.method as string;
+
+  if (!HANDLED_METHODS.has(method)) {
+    return {
+      response: jsonRpcError(
+        correlationId,
+        jsonrpcId,
+        -32601,
+        `Method not found: ${method}`
+      ),
+      event: null,
+      shouldWake: false,
+      dedupeHit: false,
+    };
+  }
+
+  const event = normalizeEvent(body, {
+    generateId,
+    now: deps.now,
+  });
+  const replyMessageId = generateId();
+  const response = acceptedMessage(correlationId, jsonrpcId, replyMessageId);
+
+  if (opts.dedupe) {
+    const key = dedupeKey(event);
+    if (dedupeStore.isDuplicate(key)) {
+      return { response, event, shouldWake: false, dedupeHit: true };
+    }
+  }
+
+  return { response, event, shouldWake: true, dedupeHit: false };
+}
+
+function formatWakeFailed(event: NormalizedEvent, reason: string): string {
+  const task = event.task_id ?? '-';
+  return (
+    `[acn listen] wake_failed message_id=${event.message_id} ` +
+    `task_id=${task} reason=${reason}`
+  );
+}
+
+function formatDeduped(event: NormalizedEvent): string {
+  return `[acn listen] deduped key=${dedupeKey(event)}`;
+}
+
+/**
+ * Answer A2A first via ``send``, then fire-and-forget wake.
+ * Returns as soon as the A2A frame is emitted (wake is not awaited).
+ */
+export function dispatchLocalReceiver(
+  correlationId: string,
+  bodyText: string,
+  opts: LocalReceiverOptions,
+  dedupeStore: DedupeStore,
+  send: (frame: ReceiverResponseFrame) => void,
+  deps: LocalReceiverDeps = {}
+): void {
+  const logFn = deps.logFn ?? ((line: string) => console.error(line));
+  const result = processIncomingRequest(
+    correlationId,
+    bodyText,
+    opts,
+    dedupeStore,
+    deps
+  );
+
+  send(result.response);
+
+  if (result.dedupeHit && result.event) {
+    logFn(formatDeduped(result.event));
+    return;
+  }
+
+  if (!result.shouldWake || !result.event) return;
+
+  const event = result.event;
+  const key = opts.dedupe ? dedupeKey(event) : null;
+  void wakeRuntime(event, opts, deps)
+    .then((wake) => {
+      if (!wake.ok) {
+        // Release the slot so ACN at-least-once retries can wake again.
+        if (key) dedupeStore.forget(key);
+        logFn(formatWakeFailed(event, wake.reason));
+      }
+    })
+    .catch((err: unknown) => {
+      if (key) dedupeStore.forget(key);
+      const msg = err instanceof Error ? err.message : String(err);
+      logFn(formatWakeFailed(event, msg.slice(0, 200)));
+    });
+}
+
+/** Awaitable variant for tests that need to observe wake completion. */
+export async function dispatchLocalReceiverAndWaitWake(
+  correlationId: string,
+  bodyText: string,
+  opts: LocalReceiverOptions,
+  dedupeStore: DedupeStore,
+  send: (frame: ReceiverResponseFrame) => void,
+  deps: LocalReceiverDeps = {}
+): Promise<{ dedupeHit: boolean; woke: boolean }> {
+  const logFn = deps.logFn ?? ((line: string) => console.error(line));
+  const result = processIncomingRequest(
+    correlationId,
+    bodyText,
+    opts,
+    dedupeStore,
+    deps
+  );
+  send(result.response);
+
+  if (result.dedupeHit && result.event) {
+    logFn(formatDeduped(result.event));
+    return { dedupeHit: true, woke: false };
+  }
+  if (!result.shouldWake || !result.event) {
+    return { dedupeHit: false, woke: false };
+  }
+
+  const key = opts.dedupe ? dedupeKey(result.event) : null;
+  try {
+    const wake = await wakeRuntime(result.event, opts, deps);
+    if (!wake.ok) {
+      if (key) dedupeStore.forget(key);
+      logFn(formatWakeFailed(result.event, wake.reason));
+    }
+    return { dedupeHit: false, woke: wake.ok };
+  } catch (err) {
+    if (key) dedupeStore.forget(key);
+    const msg = err instanceof Error ? err.message : String(err);
+    logFn(formatWakeFailed(result.event, msg.slice(0, 200)));
+    return { dedupeHit: false, woke: false };
+  }
+}

--- a/clients/cli/src/commands/normalize-event.ts
+++ b/clients/cli/src/commands/normalize-event.ts
@@ -1,0 +1,157 @@
+/**
+ * Normalize a relayed A2A JSON-RPC body into a stable wake event, and
+ * provide an in-process TTL dedupe window (restart clears the window).
+ */
+
+export interface NormalizedEvent {
+  event_type: 'a2a_message';
+  task_id: string | null;
+  message_id: string;
+  context_id: string | null;
+  from_agent: string | null;
+  received_at: string;
+  raw: Record<string, unknown>;
+}
+
+export type JsonRpcParseResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; code: -32700 | -32600; message: string };
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+function asNonEmptyString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+/** Parse UTF-8 request body into a JSON-RPC object (or a typed parse error). */
+export function parseJsonRpcBody(bodyText: string): JsonRpcParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return { ok: false, code: -32700, message: 'Parse error' };
+  }
+  const body = asRecord(parsed);
+  if (!body) {
+    return { ok: false, code: -32600, message: 'Invalid Request' };
+  }
+  if (body.jsonrpc !== '2.0' || typeof body.method !== 'string') {
+    return { ok: false, code: -32600, message: 'Invalid Request' };
+  }
+  return { ok: true, body };
+}
+
+function extractTaskId(message: Record<string, unknown>): string | null {
+  const metadata = asRecord(message.metadata);
+  if (metadata) {
+    const fromMeta =
+      asNonEmptyString(metadata.task_id) ?? asNonEmptyString(metadata.acn_task_id);
+    if (fromMeta) return fromMeta;
+  }
+  const parts = message.parts;
+  if (!Array.isArray(parts)) return null;
+  for (const part of parts) {
+    const p = asRecord(part);
+    if (!p || p.kind !== 'data') continue;
+    const data = asRecord(p.data);
+    if (!data) continue;
+    const fromData =
+      asNonEmptyString(data.task_id) ?? asNonEmptyString(data.acn_task_id);
+    if (fromData) return fromData;
+  }
+  return null;
+}
+
+function extractMessageId(
+  message: Record<string, unknown>,
+  generateId: () => string
+): string {
+  return (
+    asNonEmptyString(message.messageId) ??
+    asNonEmptyString(message.message_id) ??
+    generateId()
+  );
+}
+
+function extractContextId(message: Record<string, unknown>): string | null {
+  return (
+    asNonEmptyString(message.contextId) ?? asNonEmptyString(message.context_id)
+  );
+}
+
+function extractFromAgent(message: Record<string, unknown>): string | null {
+  const metadata = asRecord(message.metadata);
+  if (!metadata) return null;
+  return (
+    asNonEmptyString(metadata.from_agent) ??
+    asNonEmptyString(metadata.fromAgent)
+  );
+}
+
+/**
+ * Build a normalized wake event from a valid JSON-RPC body.
+ * Call only after parseJsonRpcBody succeeds for message/send|stream.
+ */
+export function normalizeEvent(
+  body: Record<string, unknown>,
+  opts: { generateId?: () => string; now?: () => Date } = {}
+): NormalizedEvent {
+  const generateId = opts.generateId ?? (() => crypto.randomUUID());
+  const now = opts.now ?? (() => new Date());
+  const params = asRecord(body.params);
+  const message = asRecord(params?.message) ?? {};
+
+  return {
+    event_type: 'a2a_message',
+    task_id: extractTaskId(message),
+    message_id: extractMessageId(message, generateId),
+    context_id: extractContextId(message),
+    from_agent: extractFromAgent(message),
+    received_at: now().toISOString(),
+    raw: body,
+  };
+}
+
+export function dedupeKey(event: NormalizedEvent): string {
+  return event.task_id ?? event.message_id;
+}
+
+/** In-process TTL dedupe. Restart clears the window. */
+export class DedupeStore {
+  private readonly map = new Map<string, number>();
+
+  constructor(private readonly ttlSec: number) {}
+
+  /** Returns true if key was already seen within TTL; otherwise marks and returns false. */
+  isDuplicate(key: string, nowMs: number = Date.now()): boolean {
+    this.gc(nowMs);
+    const exp = this.map.get(key);
+    if (exp !== undefined && exp > nowMs) return true;
+    this.map.set(key, nowMs + this.ttlSec * 1000);
+    return false;
+  }
+
+  /**
+   * Drop a key so a later retry can wake again.
+   * Used when wake fails after we reserved the slot on accept.
+   */
+  forget(key: string): void {
+    this.map.delete(key);
+  }
+
+  /** Test helper — current window size after GC. */
+  size(nowMs: number = Date.now()): number {
+    this.gc(nowMs);
+    return this.map.size;
+  }
+
+  private gc(nowMs: number): void {
+    for (const [k, exp] of this.map) {
+      if (exp <= nowMs) this.map.delete(k);
+    }
+  }
+}

--- a/clients/cli/src/commands/runtime-adapter.ts
+++ b/clients/cli/src/commands/runtime-adapter.ts
@@ -1,0 +1,181 @@
+/**
+ * Runtime wake adapters for `acn listen --runtime`.
+ * CLI already answered A2A; these only notify the host agent.
+ */
+
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import type { NormalizedEvent } from './normalize-event.js';
+
+export type RuntimeId = 'http' | 'command' | 'log';
+
+export interface RuntimeWakeOptions {
+  runtime: RuntimeId;
+  wakeUrl?: string;
+  wakeHeaders?: Record<string, string>;
+  wakeExec?: string;
+  wakeTimeoutMs?: number;
+}
+
+export type WakeResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export interface WakeDeps {
+  fetchFn?: typeof fetch;
+  spawnFn?: typeof spawn;
+  logFn?: (line: string) => void;
+}
+
+const DEFAULT_WAKE_TIMEOUT_MS = 5000;
+
+/** Parse repeated `--wake-header 'Key: Value'` strings. */
+export function parseWakeHeaders(raw: string[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const item of raw ?? []) {
+    const idx = item.indexOf(':');
+    if (idx <= 0) {
+      throw new Error(
+        `Invalid --wake-header "${item}". Expected "Header-Name: value".`
+      );
+    }
+    const key = item.slice(0, idx).trim();
+    const value = item.slice(idx + 1).trim();
+    if (!key) {
+      throw new Error(
+        `Invalid --wake-header "${item}". Expected "Header-Name: value".`
+      );
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function validateRuntimeOptions(opts: {
+  runtime?: string;
+  wakeUrl?: string;
+  wakeExec?: string;
+}): string | null {
+  if (!opts.runtime) return null;
+  if (opts.runtime !== 'http' && opts.runtime !== 'command' && opts.runtime !== 'log') {
+    return `Unknown --runtime "${opts.runtime}". Use: http | command | log`;
+  }
+  if (opts.runtime === 'http' && !opts.wakeUrl) {
+    return '--runtime http requires --wake-url <url>';
+  }
+  if (opts.runtime === 'command' && !opts.wakeExec) {
+    return '--runtime command requires --wake-exec <cmd>';
+  }
+  return null;
+}
+
+async function wakeHttp(
+  event: NormalizedEvent,
+  opts: RuntimeWakeOptions,
+  deps: WakeDeps
+): Promise<WakeResult> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const timeoutMs = opts.wakeTimeoutMs ?? DEFAULT_WAKE_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(opts.wakeUrl!, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(opts.wakeHeaders ?? {}),
+      },
+      body: JSON.stringify(event),
+      signal: controller.signal,
+    });
+    // Drain the body so keep-alive sockets are not left half-open.
+    try {
+      await res.arrayBuffer();
+    } catch {
+      /* ignore drain errors */
+    }
+    if (res.status < 200 || res.status >= 300) {
+      return { ok: false, reason: `http_${res.status}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: msg.slice(0, 200) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function wakeCommand(
+  event: NormalizedEvent,
+  opts: RuntimeWakeOptions,
+  deps: WakeDeps
+): Promise<WakeResult> {
+  const spawnFn = deps.spawnFn ?? spawn;
+  const timeoutMs = opts.wakeTimeoutMs ?? DEFAULT_WAKE_TIMEOUT_MS;
+  const body = Buffer.from(JSON.stringify(event), 'utf-8');
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const child: ChildProcess = spawnFn(opts.wakeExec!, { shell: true });
+    const errOut: Buffer[] = [];
+
+    const finish = (result: WakeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish({ ok: false, reason: 'timeout' });
+    }, timeoutMs);
+
+    child.stderr?.on('data', (d: Buffer) => errOut.push(Buffer.from(d)));
+    child.on('error', (e: Error) =>
+      finish({ ok: false, reason: e.message.slice(0, 200) })
+    );
+    child.on('close', (code: number | null) => {
+      if (code === 0) finish({ ok: true });
+      else {
+        const detail = Buffer.concat(errOut).toString('utf-8').slice(0, 80);
+        finish({
+          ok: false,
+          reason: detail ? `exit_${code}:${detail}` : `exit_${code}`,
+        });
+      }
+    });
+
+    child.stdin?.end(body);
+  });
+}
+
+function wakeLog(event: NormalizedEvent, deps: WakeDeps): WakeResult {
+  const logFn = deps.logFn ?? ((line: string) => console.error(line));
+  logFn(JSON.stringify(event));
+  return { ok: true };
+}
+
+/** Wake the host runtime. Never throws. */
+export async function wakeRuntime(
+  event: NormalizedEvent,
+  opts: RuntimeWakeOptions,
+  deps: WakeDeps = {}
+): Promise<WakeResult> {
+  switch (opts.runtime) {
+    case 'http':
+      return wakeHttp(event, opts, deps);
+    case 'command':
+      return wakeCommand(event, opts, deps);
+    case 'log':
+      return wakeLog(event, deps);
+    default:
+      return { ok: false, reason: `unknown_runtime` };
+  }
+}
+
+export { DEFAULT_WAKE_TIMEOUT_MS };

--- a/clients/cli/tests/local-receiver.test.ts
+++ b/clients/cli/tests/local-receiver.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for built-in Mode B local receiver + runtime wake adapters.
+ */
+
+import { EventEmitter } from 'events';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  dispatchA2aRequest,
+  handleA2aRequest,
+  validateListenHandlerFlags,
+  type A2aRequestFrame,
+  type OutboundFrame,
+} from '../src/commands/listen.js';
+import {
+  dispatchLocalReceiverAndWaitWake,
+  processIncomingRequest,
+} from '../src/commands/local-receiver.js';
+import {
+  DedupeStore,
+  normalizeEvent,
+  parseJsonRpcBody,
+} from '../src/commands/normalize-event.js';
+import {
+  parseWakeHeaders,
+  validateRuntimeOptions,
+  wakeRuntime,
+} from '../src/commands/runtime-adapter.js';
+
+function messageSendBody(overrides: Record<string, unknown> = {}): string {
+  const message = {
+    role: 'user',
+    messageId: 'msg-1',
+    kind: 'message',
+    parts: [{ kind: 'text', text: 'hi' }],
+    ...overrides,
+  };
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 'rpc-1',
+    method: 'message/send',
+    params: { message },
+  });
+}
+
+function makeRequest(body: string, id = 'corr-1'): A2aRequestFrame {
+  return {
+    type: 'a2a_request',
+    id,
+    method: 'POST',
+    path: '/',
+    headers: { 'content-type': 'application/json' },
+    body,
+    body_encoding: 'utf-8',
+  };
+}
+
+describe('parseJsonRpcBody / normalizeEvent', () => {
+  it('extracts task_id from metadata then data parts', () => {
+    const withMeta = parseJsonRpcBody(
+      messageSendBody({ metadata: { task_id: 'task-meta' } })
+    );
+    expect(withMeta.ok).toBe(true);
+    if (!withMeta.ok) return;
+    expect(normalizeEvent(withMeta.body).task_id).toBe('task-meta');
+
+    const withData = parseJsonRpcBody(
+      messageSendBody({
+        parts: [{ kind: 'data', data: { acn_task_id: 'task-data' } }],
+      })
+    );
+    expect(withData.ok).toBe(true);
+    if (!withData.ok) return;
+    expect(normalizeEvent(withData.body).task_id).toBe('task-data');
+  });
+
+  it('generates message_id when absent', () => {
+    const parsed = parseJsonRpcBody(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: { message: { role: 'user', parts: [] } },
+      })
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const event = normalizeEvent(parsed.body, { generateId: () => 'gen-1' });
+    expect(event.message_id).toBe('gen-1');
+    expect(event.event_type).toBe('a2a_message');
+  });
+});
+
+describe('processIncomingRequest', () => {
+  it('returns accepted message with kind for message/send', () => {
+    const store = new DedupeStore(3600);
+    const result = processIncomingRequest(
+      'corr-1',
+      messageSendBody(),
+      { dedupe: true },
+      store,
+      { generateId: () => 'reply-1' }
+    );
+    expect(result.shouldWake).toBe(true);
+    const body = JSON.parse(result.response.body);
+    expect(body.result.kind).toBe('message');
+    expect(body.result.parts[0].text).toBe('accepted');
+    expect(body.id).toBe('rpc-1');
+  });
+
+  it('handles message/stream the same way (single-shot accepted)', () => {
+    const store = new DedupeStore(3600);
+    const body = messageSendBody();
+    const streamBody = body.replace('message/send', 'message/stream');
+    const result = processIncomingRequest('c', streamBody, { dedupe: false }, store);
+    expect(result.shouldWake).toBe(true);
+    expect(JSON.parse(result.response.body).result.kind).toBe('message');
+  });
+
+  it('returns -32601 for unknown methods without waking', () => {
+    const store = new DedupeStore(3600);
+    const result = processIncomingRequest(
+      'c',
+      JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tasks/get', params: {} }),
+      { dedupe: true },
+      store
+    );
+    expect(result.shouldWake).toBe(false);
+    expect(JSON.parse(result.response.body).error.code).toBe(-32601);
+  });
+
+  it('dedupes by task_id and skips second wake', () => {
+    const store = new DedupeStore(3600);
+    const body = messageSendBody({ metadata: { task_id: 't1' } });
+    const first = processIncomingRequest('c1', body, { dedupe: true }, store);
+    const second = processIncomingRequest('c2', body, { dedupe: true }, store);
+    expect(first.shouldWake).toBe(true);
+    expect(second.shouldWake).toBe(false);
+    expect(second.dedupeHit).toBe(true);
+    expect(JSON.parse(second.response.body).result.kind).toBe('message');
+  });
+});
+
+describe('validateListenHandlerFlags', () => {
+  it('requires exactly one handler mode', () => {
+    expect(validateListenHandlerFlags({})).toMatch(/Provide a handler/);
+    expect(
+      validateListenHandlerFlags({ runtime: 'http', forward: 'http://x' })
+    ).toMatch(/only one handler/);
+  });
+
+  it('requires wake-url / wake-exec for runtime modes', () => {
+    expect(validateRuntimeOptions({ runtime: 'http' })).toMatch(/wake-url/);
+    expect(validateRuntimeOptions({ runtime: 'command' })).toMatch(/wake-exec/);
+    expect(validateRuntimeOptions({ runtime: 'log' })).toBeNull();
+  });
+
+  it('parses wake headers', () => {
+    expect(parseWakeHeaders(['Authorization: Bearer tok'])).toEqual({
+      Authorization: 'Bearer tok',
+    });
+    expect(() => parseWakeHeaders(['bad'])).toThrow(/Invalid/);
+  });
+});
+
+describe('wakeRuntime + dispatch order', () => {
+  it('answers A2A before a slow http wake completes', async () => {
+    let resolveFetch!: (v: Response) => void;
+    const fetchFn = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    const frames: OutboundFrame[] = [];
+    const order: string[] = [];
+
+    const dispatchPromise = dispatchA2aRequest(
+      makeRequest(messageSendBody()),
+      {
+        runtime: {
+          runtime: 'http',
+          wakeUrl: 'http://127.0.0.1:9/wake',
+          dedupe: false,
+          dedupeTtlSec: 3600,
+          wakeTimeoutMs: 5000,
+        },
+      },
+      (f) => {
+        frames.push(f);
+        order.push('a2a');
+      },
+      {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        logFn: () => undefined,
+      }
+    );
+
+    // dispatch returns immediately after send (wake is fire-and-forget)
+    await dispatchPromise;
+    expect(order).toEqual(['a2a']);
+    expect(frames).toHaveLength(1);
+    expect(JSON.parse((frames[0] as { body: string }).body).result.kind).toBe(
+      'message'
+    );
+
+    // wake still in flight
+    expect(fetchFn).toHaveBeenCalled();
+    resolveFetch({
+      status: 200,
+      headers: { get: () => null },
+      text: async () => '',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response);
+  });
+
+  function mockFetch(status: number) {
+    return vi.fn().mockResolvedValue({
+      status,
+      headers: { get: () => null },
+      text: async () => '',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+  }
+
+  it('logs wake_failed when http wake returns non-2xx but still accepted A2A', async () => {
+    const logs: string[] = [];
+    const store = new DedupeStore(3600);
+    const frames: OutboundFrame[] = [];
+    const fetchFn = mockFetch(502);
+
+    await dispatchLocalReceiverAndWaitWake(
+      'corr-1',
+      messageSendBody({ messageId: 'm-fail' }),
+      {
+        runtime: 'http',
+        wakeUrl: 'http://127.0.0.1:9/wake',
+        dedupe: true,
+        dedupeTtlSec: 3600,
+        wakeTimeoutMs: 1000,
+      },
+      store,
+      (f) => frames.push(f),
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: (l) => logs.push(l) }
+    );
+
+    expect(JSON.parse((frames[0] as { body: string }).body).result.kind).toBe(
+      'message'
+    );
+    expect(logs.some((l) => l.includes('wake_failed') && l.includes('http_502'))).toBe(
+      true
+    );
+  });
+
+  it('releases dedupe on wake failure so a retry can wake again', async () => {
+    const logs: string[] = [];
+    const store = new DedupeStore(3600);
+    const opts = {
+      runtime: 'http' as const,
+      wakeUrl: 'http://127.0.0.1:9/wake',
+      dedupe: true,
+      dedupeTtlSec: 3600,
+      wakeTimeoutMs: 1000,
+    };
+    const body = messageSendBody({ metadata: { task_id: 'retry-1' } });
+
+    const failFetch = mockFetch(502);
+    await dispatchLocalReceiverAndWaitWake(
+      'c1',
+      body,
+      opts,
+      store,
+      () => undefined,
+      { fetchFn: failFetch as unknown as typeof fetch, logFn: (l) => logs.push(l) }
+    );
+    expect(failFetch).toHaveBeenCalledTimes(1);
+    expect(store.size()).toBe(0);
+
+    const okFetch = mockFetch(204);
+    const second = await dispatchLocalReceiverAndWaitWake(
+      'c2',
+      body,
+      opts,
+      store,
+      () => undefined,
+      { fetchFn: okFetch as unknown as typeof fetch, logFn: (l) => logs.push(l) }
+    );
+    expect(second.dedupeHit).toBe(false);
+    expect(second.woke).toBe(true);
+    expect(okFetch).toHaveBeenCalledTimes(1);
+    expect(logs.some((l) => l.includes('deduped'))).toBe(false);
+  });
+
+  it('logs deduped on second delivery after successful wake', async () => {
+    const logs: string[] = [];
+    const store = new DedupeStore(3600);
+    const fetchFn = mockFetch(204);
+    const opts = {
+      runtime: 'http' as const,
+      wakeUrl: 'http://127.0.0.1:9/wake',
+      dedupe: true,
+      dedupeTtlSec: 3600,
+      wakeTimeoutMs: 1000,
+    };
+    const body = messageSendBody({ metadata: { task_id: 'dup-1' } });
+
+    await dispatchLocalReceiverAndWaitWake(
+      'c1',
+      body,
+      opts,
+      store,
+      () => undefined,
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: (l) => logs.push(l) }
+    );
+    await dispatchLocalReceiverAndWaitWake(
+      'c2',
+      body,
+      opts,
+      store,
+      () => undefined,
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: (l) => logs.push(l) }
+    );
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(logs.some((l) => l.includes('deduped key=dup-1'))).toBe(true);
+  });
+
+  it('runtime command wakes with event JSON on stdin', async () => {
+    const spawnFn = vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        stdin: { end: (b: Buffer) => void };
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = {
+        end: (b: Buffer) => {
+          const event = JSON.parse(b.toString('utf-8'));
+          expect(event.event_type).toBe('a2a_message');
+          expect(event.message_id).toBe('msg-cmd');
+          queueMicrotask(() => child.emit('close', 0));
+        },
+      };
+      return child;
+    });
+
+    const result = await wakeRuntime(
+      {
+        event_type: 'a2a_message',
+        task_id: null,
+        message_id: 'msg-cmd',
+        context_id: null,
+        from_agent: null,
+        received_at: new Date().toISOString(),
+        raw: {},
+      },
+      { runtime: 'command', wakeExec: 'true', wakeTimeoutMs: 1000 },
+      { spawnFn: spawnFn as never }
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('handleA2aRequest --runtime vs legacy --exec', () => {
+  it('runtime path returns accepted even without a local server', async () => {
+    const resp = await handleA2aRequest(
+      makeRequest(messageSendBody()),
+      {
+        runtime: {
+          runtime: 'log',
+          dedupe: false,
+          dedupeTtlSec: 60,
+        },
+      },
+      { logFn: () => undefined }
+    );
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(resp.body).result.kind).toBe('message');
+  });
+
+  it('legacy --exec still uses stdout as the A2A body', async () => {
+    const spawnFn = vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        stdin: { end: (b: Buffer) => void };
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      queueMicrotask(() => {
+        child.stdout.emit('data', Buffer.from('{"jsonrpc":"2.0","result":{"custom":true}}'));
+        child.emit('close', 0);
+      });
+      return child;
+    });
+    const resp = await handleA2aRequest(
+      makeRequest(messageSendBody()),
+      { exec: 'cat' },
+      { spawnFn: spawnFn as never }
+    );
+    expect(JSON.parse(resp.body).result.custom).toBe(true);
+  });
+});

--- a/docs/features/acn-local-receiver-mvp.md
+++ b/docs/features/acn-local-receiver-mvp.md
@@ -1,0 +1,229 @@
+# ACN Local Receiver MVP — 实现清单
+
+**状态：** 已实现（CLI `0.14.0`）  
+**范围：** 仅 `@acnlabs/acn-cli`（`acn listen`）  
+**来源：** ComicLaw RFC `acn-local-receiver-rfc.md`；延续 ADR-0012 Mode B  
+**不动：** ACN server 协议、ComicLaw 业务、OpenClaw 深度集成、Python/TS SDK（P2）  
+**实现：** `clients/cli/src/commands/{listen,local-receiver,normalize-event,runtime-adapter}.ts`  
+**运维示例：** [`docs/runbooks/acn-listen-heartbeat.md`](../runbooks/acn-listen-heartbeat.md)
+
+---
+
+## 问题与目标
+
+Mode B 今天只有传输：
+
+```bash
+acn listen --forward http://127.0.0.1:PORT
+```
+
+CLI 不保证本机有合法 A2A 接收端，也不叫醒宿主 runtime。空端口时推送静默失败，任务仍 `open`，agent 看起来 online。
+
+**目标：** 一条命令完成本机接收 + 规范化事件投递；业务 accept/干活仍归宿主。
+
+```
+ACN relay (已有)
+  → listen WS
+  → [NEW] 内置 A2A receiver（合法 JSON-RPC 应答）
+  → [NEW] 规范化事件
+  → [NEW] runtime adapter（http | command | log）
+  → 宿主被叫醒
+```
+
+### 相对 RFC 的有意简化
+
+RFC 曾写「本机绑定 `127.0.0.1` 高位端口」。**MVP 不启本地 HTTP 端口**：receiver 嵌在 `listen` 进程内，经 Mode B WebSocket 直接应答。少一个空端口失败面，且对 relay 语义足够。
+
+旧路径保留：`--forward` / `--exec`（原语义不变）。
+
+---
+
+## Flags
+
+| Flag | 必填 | 说明 |
+|---|---|---|
+| `--runtime <id>` | 与旧 handler 三选一 | `http` \| `command` \| `log` |
+| `--wake-url <url>` | `runtime=http` 时必填 | `POST` 规范化事件 JSON |
+| `--wake-header <k:v>` | 否，可重复 | 附加到 wake 请求 |
+| `--wake-exec <cmd>` | `runtime=command` 时必填 | 事件 JSON 走 stdin |
+| `--wake-timeout <ms>` | 否，默认 `5000` | 单次 wake 超时 |
+| `--no-dedupe` | 否 | 关闭去重（**默认开启**） |
+| `--dedupe-ttl <sec>` | 否，默认 `3600` | 去重窗口（进程内；重启丢失） |
+| `--forward` / `--exec` | 兼容 | 与 `--runtime` **互斥** |
+| `-i, --agent-id` | 否 | 沿用现有 |
+
+**互斥：** 必须恰好一种：`--runtime` **或** `--forward` **或** `--exec`。
+
+**命名警示（易混）：**
+
+| Flag | 含义 |
+|---|---|
+| `--exec <cmd>`（旧） | 子进程 **stdout = 完整 A2A JSON-RPC 响应**；CLI 不代答 |
+| `--runtime command --wake-exec <cmd>`（新） | CLI **自己**回 A2A accepted；子进程只负责 **wake**（stdin = 规范化事件） |
+
+**推荐生产用法：**
+
+```bash
+acn listen --runtime http \
+  --wake-url http://127.0.0.1:10122/hooks/agent \
+  --wake-header 'Authorization: Bearer …'
+```
+
+---
+
+## 接口
+
+### 处理顺序（硬约束）
+
+对每个 relay 来的请求：
+
+1. 解析 JSON-RPC / 抽取事件字段  
+2. **立即**回合法 A2A 应答（不阻塞在 wake 上）  
+3. 若未 dedupe：在 `--wake-timeout` 内异步 wake  
+4. wake 失败 → stderr 记 `wake_failed`（含 `message_id` / `task_id`）；**不**改已发出的 A2A 应答  
+
+原因：ACN relay 有约 30s `deadline_ms`；wake 堵死会导致发送方 504，重新引入「看起来失败」的静默坑。
+
+**语义取舍：** `A2A accepted ≠ 宿主已处理`。缓解：异步 wake + 固定日志字段 + 文档强调仍要 inbox / Task list reconcile。MVP **不**在 wake 失败时返回 A2A error。
+
+### 内置 A2A 应答（receiver → ACN）
+
+对 `message/send` **与** `message/stream`，MVP 一律回**单发**合法 `message`（不转发 SSE）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<request-id>",
+  "result": {
+    "kind": "message",
+    "messageId": "<uuid>",
+    "role": "agent",
+    "parts": [{ "kind": "text", "text": "accepted" }]
+  }
+}
+```
+
+- 未知 method → JSON-RPC `-32601`
+- 解析失败 → `-32700` / `-32600`
+- **不**在 CLI 内 `tasks accept` / 跑业务
+
+### 规范化事件（adapter 输入）
+
+```json
+{
+  "event_type": "a2a_message",
+  "task_id": null,
+  "message_id": "…",
+  "context_id": null,
+  "from_agent": null,
+  "received_at": "2026-07-23T12:00:00Z",
+  "raw": {}
+}
+```
+
+| 字段 | 规则 |
+|---|---|
+| `event_type` | 固定 `a2a_message`（有 `task_id` 也不改成 `task_request`，避免假称已接 Task） |
+| `task_id` | 按下方抽取表；都没有则为 `null` |
+| `message_id` | 必填（无则 CLI 生成） |
+| `raw` | 原始 JSON-RPC body（object） |
+
+#### `task_id` 抽取（按优先级，命中即停）
+
+| 优先级 | 路径 |
+|---|---|
+| 1 | `params.message.metadata.task_id` |
+| 2 | `params.message.metadata.acn_task_id` |
+| 3 | `params.message` 的 data part：`data.task_id` / `data.acn_task_id` |
+| 4 | 无 → `null`（去重仅用 `message_id`） |
+
+`message_id`：`params.message.messageId` → `params.message.message_id` → CLI 生成 UUID。
+
+#### 覆盖边界（写进验收预期）
+
+`acn listen --runtime …` **只处理经 Mode B relay 到达的 A2A 请求**。  
+不订阅 Task Pool list；从未推到本 agent、仅出现在 `acn tasks list` 的 open 任务，**仍靠** reconcile / 轮询 / 人工 handle。本 MVP 不取代拉取兜底。
+
+### 去重
+
+- 默认开启；`--no-dedupe` 关闭  
+- key：`task_id ?? message_id`  
+- 存储：**进程内** Map + TTL；**重启丢失窗口**（不要求跨重启去重）  
+- 应答时先占位（挡住并发双推）；**wake 成功才保留**；wake 失败则 `forget` 该 key，便于 ACN at-least-once 重推再叫醒  
+- 命中（成功 wake 之后的重复推送）：仍回 A2A accepted，**不再 wake**；stderr 打 `deduped`（含 key）
+
+### Runtime 行为
+
+| id | 行为 | 失败 |
+|---|---|---|
+| `http` | `POST wake-url`，body = 事件 JSON；尊重 `--wake-header` | 非 2xx / 超时 → `wake_failed` |
+| `command` | 跑 `--wake-exec`，stdin = 事件 JSON | 非 0 / 超时 → `wake_failed` |
+| `log` | 只打 stderr JSON 一行（完整事件） | 无 |
+
+stderr 固定可检索字段（示例）：
+
+```text
+[acn listen] wake_failed message_id=… task_id=… reason=timeout|http_502|exit_1
+[acn listen] deduped key=…
+```
+
+---
+
+## 非目标
+
+- `openclaw-hooks` 一等公民（P1：用 `--runtime http` + OpenClaw hooks URL 作为文档示例即可）
+- listen 内嵌 `heartbeat`（P1；见下方生产组合）
+- SDK `ACNClient.listen({ runtime })`（P2）
+- 服务端改协议 / vanity subdomain
+- ComicLaw Studio / 扣款 / `production-worker.sh`
+- 跨进程/跨重启持久去重
+- 本地绑定 HTTP 端口（相对 RFC 有意不做）
+
+---
+
+## 验收
+
+仅需 CLI + 本机 wake 探针：
+
+| # | 步骤 | 期望 |
+|---|---|---|
+| 1 | `acn join --relay` + `acn listen --runtime http --wake-url http://127.0.0.1:<probe>/wake` | 进程常驻，WS connected；**无**本机 A2A 端口监听 |
+| 2 | 他方对该 agent `message send`（走 relay） | probe **数秒内**收到含 `message_id` 的 JSON；有 metadata 时含 `task_id` |
+| 3 | 重复推同一 `task_id`（或同 `message_id`），且首次 wake 已成功 | A2A 仍成功；第二次 **不**再 wake；stderr `deduped` |
+| 3b | 首次 wake 失败后再推同一 key | 释放 dedupe；第二次 **应再 wake** |
+| 4 | 故意不启 probe，只 listen | A2A 应答仍成功（不再「空端口」）；stderr `wake_failed` |
+| 5 | wake 探针 sleep > deadline 模拟慢宿主 | A2A **仍在 wake 完成前**返回 accepted（先应答后 wake） |
+| 6 | `message/stream` 经 relay | 回单发 accepted `message`，不要求 SSE |
+| 7 | `--forward http://127.0.0.1:9` 旧路径 | 行为与今日一致（兼容不回归） |
+| 8 | `--exec` 旧路径与 `--runtime command` | 语义不混淆；单测分别覆盖 |
+| 9 | 仅存在于 Task Pool、从未 A2A 推送的 open task | **不**期望 listen 自动 wake（拉取兜底仍必要） |
+| 10 | 单测 | receiver 形状、互斥 flag、dedupe、先应答后 wake、http/command/log adapter |
+
+### 文档交付（必须落地，非「一小段」）
+
+| 文件 | 内容 |
+|---|---|
+| `clients/cli/README.md` | 生产推荐 `--runtime`；旧 `--forward`/`--exec` 降为高级/兼容 |
+| `skills/acn/SKILL.md` | Mode B 小节推荐 `--runtime http\|command\|log`；注明覆盖边界 |
+| `clients/cli/CHANGELOG.md` | `0.14.0` 条目 |
+| 示例 unit（可放 README 或 `docs/runbooks/`） | `listen` 与 `acn heartbeat` **同生命周期**（两个 ExecStart 或 sidecar timer），避免「接得住消息但 discovery offline」 |
+
+---
+
+## 交付切面
+
+| 项 | 位置 |
+|---|---|
+| 实现 | `clients/cli/src/commands/listen.ts`（建议拆 `runtime-adapter.ts` / `normalize-event.ts`） |
+| 测试 | `clients/cli/tests/listen*.test.ts` |
+| 说明 | 上表文档交付 |
+| 版本 | CLI minor（`0.14.0`），**无需** server 发版 |
+
+---
+
+## 后续（非本 MVP）
+
+| 优先级 | 项 |
+|---|---|
+| P1 | `openclaw-hooks` 预设；正式 systemd 示例（listen + heartbeat） |
+| P2 | SDK 对等 API；metrics / 日志字段对齐；可选持久去重 |

--- a/docs/runbooks/acn-listen-heartbeat.md
+++ b/docs/runbooks/acn-listen-heartbeat.md
@@ -1,0 +1,71 @@
+# Runbook: `acn listen` + `acn heartbeat` (Mode B idle agents)
+
+Idle Mode B agents receive over `acn listen` but rarely make authenticated
+API calls. Without a periodic heartbeat they flip to `offline` in discovery
+even though the WebSocket is still up.
+
+Run **both** in the same lifecycle (same machine / unit family).
+
+## systemd (two units)
+
+`/etc/systemd/system/acn-listen.service`:
+
+```ini
+[Unit]
+Description=ACN Mode B listener (local receiver + runtime wake)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=acn
+WorkingDirectory=/home/acn
+Environment=HOME=/home/acn
+ExecStart=/usr/bin/npx @acnlabs/acn-cli listen --runtime http --wake-url http://127.0.0.1:10122/hooks/agent
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`/etc/systemd/system/acn-heartbeat.timer` + `.service`:
+
+```ini
+# acn-heartbeat.service
+[Unit]
+Description=ACN agent heartbeat
+
+[Service]
+Type=oneshot
+User=acn
+Environment=HOME=/home/acn
+ExecStart=/usr/bin/npx @acnlabs/acn-cli heartbeat
+```
+
+```ini
+# acn-heartbeat.timer
+[Unit]
+Description=ACN heartbeat every 15 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+Unit=acn-heartbeat.service
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+sudo systemctl enable --now acn-listen.service
+sudo systemctl enable --now acn-heartbeat.timer
+```
+
+## Notes
+
+- `A2A accepted ≠ host processed` — if wake fails, check journal for
+  `wake_failed` and fall back to inbox / task list reconcile.
+- Dedupe is in-process; restarting `acn-listen` clears the window.
+- Prefer `--runtime` over `--forward` so an empty local port cannot silently
+  drop relayed messages.

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -97,7 +97,8 @@ acn config show
 | `acn join --region cn\|global` | Join the regional ACN (persists `base-url` + `region`) |
 | `acn join --base-url <origin>` | Join a custom/self-hosted ACN origin |
 | `acn join --relay` | Register for Mode B (no public endpoint; then run `acn listen`) |
-| `acn listen [--forward <url>]` | Hold outbound WebSocket; receive pushes (Mode B) |
+| `acn listen --runtime http\|command\|log` | Mode B production path: built-in A2A receiver + wake host (no local port) |
+| `acn listen --forward <url>` / `--exec <cmd>` | Mode B compat tunnels (you supply A2A replies) |
 | `acn delivery get` | Show derived delivery transport (`direct` / `relay` / `none`) |
 | `acn delivery set relay` | Switch to Mode B without re-registering (then `acn listen`) |
 | `acn delivery set direct --endpoint <url>` | Switch to Mode A without re-registering |
@@ -304,20 +305,33 @@ acn join --name "MyAgent" --description "Coding specialist" \
 > inbound ports, firewalls/NAT, and TLS certificates entirely; ACN also
 > detects a dropped connection immediately.
 
-**Mode B (relay) — no public URL:**
+**Mode B (relay) — no public URL (production recommendation):**
 
 ```bash
 # 1. Register with delivery=relay (open/push policy, no --endpoint)
 acn join --name "MyAgent" --tags coding --relay
 
-# 2. Keep a local A2A handler running, then forward over the outbound WS
-acn listen --forward http://localhost:PORT
-# SSE message/stream replies are forwarded as chunk frames automatically.
+# 2. Built-in A2A receiver + wake your host runtime (no local A2A port)
+acn listen --runtime http \
+  --wake-url http://127.0.0.1:10122/hooks/agent \
+  --wake-header 'Authorization: Bearer …'
+# or: acn listen --runtime command --wake-exec '/path/to/wake.sh'
+# or: acn listen --runtime log   # debug
 ```
 
-Still implement a valid A2A `message/send` response on the local handler
-(see "Implement your receiving side" below) — `acn listen` only carries
-bytes; it does not invent a protocol-valid reply.
+The CLI answers `message/send` / `message/stream` with a valid A2A
+`accepted` message **immediately**, then wakes the host with a normalized
+event JSON. Wake failure is logged (`wake_failed`) and does **not** fail
+the A2A reply (and releases the dedupe slot so a retry can wake again).
+Dedupe is on by default (`task_id` / `message_id`).
+
+**Coverage boundary:** only A2A traffic that arrives over the Mode B relay.
+Open Task Pool rows never pushed as A2A still need list/reconcile.
+
+**Compat:** `acn listen --forward http://localhost:PORT` still tunnels to
+your own A2A server (you must return a valid `task`/`message` — see below).
+Legacy `--exec` means stdout = full A2A JSON-RPC response — not the same as
+`--runtime command --wake-exec` (wake-only).
 
 > **Fulfillment idempotency (sellers / task workers).** ACN delivery is
 > at-least-once and back-stopped by re-notification and queue polling, so you
@@ -377,7 +391,7 @@ acn inbox mode set open                                     # PATCH /agents/{id}
 ```bash
 # A → B (clear public URL; then hold the outbound WS)
 acn delivery set relay
-acn listen --forward http://localhost:PORT
+acn listen --runtime http --wake-url http://127.0.0.1:PORT/wake
 
 # B → A (public A2A URL must already answer probes)
 acn delivery set direct --endpoint https://my-agent.example.com/a2a
@@ -398,12 +412,16 @@ needed on the sender side.
 
 ### Implement your receiving side (what your server must RETURN)
 
-Registration and `acn listen` only get a message **to** you. They do **not**
-make your reply A2A-valid — that is your server's job, and getting it wrong is
-the single most common reason real-time delivery silently fails even though the
-endpoint is reachable.
+**If you use `acn listen --runtime …`**, the CLI already returns a valid A2A
+`message` (`accepted`). Your host only needs to handle the wake event and do
+business work — you do **not** need a local A2A port for Mode B.
 
-> **Transport ≠ protocol.** `--endpoint` / `acn listen` solve *how the bytes
+**If you use Mode A (`--endpoint`) or `acn listen --forward`**, you still own
+the A2A reply. Registration / forward only get bytes **to** you; getting the
+response shape wrong is the single most common reason real-time delivery
+silently fails even though the endpoint is reachable.
+
+> **Transport ≠ protocol.** `--endpoint` / `--forward` solve *how the bytes
 > reach you*. The A2A `message/send` contract still requires your handler to
 > reply with a JSON-RPC `result` containing **either a `task` or a `message`
 > object**. A bare `200`, an empty body, or `{"result":{}}` is rejected by the
@@ -444,10 +462,9 @@ trap above. (`acn listen`/`acn` is the **ACN** CLI — transport only; it relays
 your server's response verbatim and never makes it A2A-valid. The A2A SDK's only
 CLI, `a2a-db`, just runs task-store migrations — it is not a server.)
 
-So the receiving side has no "SDK vs CLI" choice: **use the SDK.** Then pick a
-transport — expose it publicly (push) **or** front it with
-`acn listen --forward http://localhost:PORT` (Mode B, no public endpoint). The
-SDK guarantees the response is valid in both.
+For Mode A or `--forward`, prefer the official A2A SDK so responses stay
+spec-valid. For Mode B without your own A2A server, prefer
+`acn listen --runtime …` (CLI answers A2A; host handles wake).
 
 > **"Isn't the SDK heavy?" — no, and it's recommended-not-required.** A2A is a
 > small protocol (JSON-RPC over HTTP), so you *may* implement it directly


### PR DESCRIPTION
## Summary
- Add `acn listen --runtime http|command|log`: built-in A2A receiver (no local port) + host wake, so Mode B agents are not stuck on empty `--forward` ports.
- Answer `message/send` / `message/stream` with a valid A2A `accepted` message **before** async wake; wake failure logs `wake_failed` and releases the dedupe slot for at-least-once retries.
- Keep `--forward` / `--exec` as compatibility tunnels; document production path + listen/heartbeat systemd example; bump CLI to `0.14.0`.

## Test plan
- [x] `cd clients/cli && npm test` (76) + `npm run typecheck`
- [ ] CI green on this PR
- [ ] Manual: `acn join --relay` + `acn listen --runtime http --wake-url http://127.0.0.1:<probe>/wake`, send a relayed message, confirm probe receives normalized event
- [ ] Confirm wake failure then retry wakes again; successful wake then duplicate is `deduped`
- [ ] Confirm legacy `--forward` / `--exec` still work