### PR TITLE
feat(org): Org → Task Pool publish bridge (CLI + docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CLI `acn org publish-task`** (+ `acn tasks create --org-id`) — attribute a
   Task Pool task to an Org; default unscoped network publish; optional
-  `--fence` / `--subnet`. CLI **0.14.1**.
+  `--fence` / `--subnet` (ships with next CLI release bump).
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- **Org → Task Pool publish bridge v0** —
+  `docs/org-harness/org-task-bridge-v0.md` (convention: `metadata.org_id` /
+  `org_publish`; default network / no fence; ≠ P2b). Linked from org-harness
+  README, Paperclip quickstart, phase2, skill **0.17.8**. Smoke:
+  `scripts/smoke_org_publish_task.sh`.
 - **Org Harness quickstart** — `docs/org-harness/quickstart-org-paperclip.md`
   (Org work ↔ Paperclip inward loop; hosted + local e2e). Linked from
   org-harness README and skill **0.17.7**.
 
 ### Fixed
 
+- **TaskResponse metadata redaction:** strip `harness_secret` from public
+  task responses (subnet harness snapshot remains on the entity for delivery).
 - **Org permission 403 prose:** `_map_permission` now surfaces
   `OrgPermissionError` message text (e.g. “Only created_by may govern an
   unclaimed Org”) while keeping `error_code=ownership_mismatch` and
@@ -23,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CLI `acn org publish-task`** (+ `acn tasks create --org-id`) — attribute a
+  Task Pool task to an Org; default unscoped network publish; optional
+  `--fence` / `--subnet`. CLI **0.14.1**.
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -523,6 +523,17 @@ class TaskReviewRequest(BaseModel):
     agent_id: str | None = Field(None, max_length=128, description="Agent ID (alternative to participation_id)")
 
 
+# Keys snapshotted onto task.metadata for delivery — never return to API clients.
+_TASK_METADATA_REDACT_KEYS = frozenset({"harness_secret"})
+
+
+def _public_task_metadata(metadata: dict | None) -> dict:
+    """Return task metadata safe for TaskResponse (strip delivery secrets)."""
+    if not metadata:
+        return {}
+    return {k: v for k, v in metadata.items() if k not in _TASK_METADATA_REDACT_KEYS}
+
+
 def _task_to_response(task, *, expose_submission: bool = False) -> TaskResponse:
     """Convert Task entity to response model.
 
@@ -532,7 +543,11 @@ def _task_to_response(task, *, expose_submission: bool = False) -> TaskResponse:
     the task assignee, a confirmed participant, ``acn:admin``, or an
     internal backend token. Anonymous and unrelated callers receive ``None``
     to avoid leaking sensitive deliverable content (ACL V6 Scope B).
+
+    ``metadata.harness_secret`` (subnet harness snapshot) is always redacted
+    from the public response; delivery still uses the stored entity metadata.
     """
+    meta = _public_task_metadata(task.metadata if isinstance(task.metadata, dict) else {})
     return TaskResponse(
         task_id=task.task_id,
         status=task.status.value,
@@ -563,8 +578,8 @@ def _task_to_response(task, *, expose_submission: bool = False) -> TaskResponse:
         created_at=task.created_at.isoformat(),
         deadline=task.deadline.isoformat() if task.deadline else None,
         group_id=task.group_id,
-        metadata=task.metadata or {},
-        ui_spec=(task.metadata or {}).get("ui_spec"),
+        metadata=meta,
+        ui_spec=meta.get("ui_spec"),
         submission=task.submission if expose_submission else None,
         submission_artifacts=task.submission_artifacts or [] if expose_submission else [],
         subnet_slug=task.subnet_slug,

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.13.3",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.13.3",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.14.1",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.1",
+  "version": "0.14.0",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/cli/src/commands/org.ts
+++ b/clients/cli/src/commands/org.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { acnDelete, acnGet, acnPatch, acnPost } from '../api.js';
+import { loadConfig } from '../config.js';
 import { handleError, output } from '../output.js';
 
 interface OrgInfo {
@@ -35,6 +36,14 @@ interface WorkInfo {
   title: string;
   status: string;
   assignee_agent_id?: string | null;
+}
+
+interface PublishedTaskInfo {
+  task_id: string;
+  title: string;
+  status: string;
+  subnet_slug?: string | null;
+  metadata?: Record<string, unknown>;
 }
 
 function formatOrg(o: OrgInfo): string {
@@ -329,6 +338,102 @@ export function orgCommand(): Command {
         handleError(err);
       }
     });
+
+  cmd
+    .command('publish-task')
+    .description(
+      'Publish a Task Pool task attributed to an Org (network by default; not Org work)',
+    )
+    .requiredOption('--org <org_id>', 'Org id (stored as metadata.org_id)')
+    .requiredOption('-t, --title <title>', 'Task title (min 3 chars)')
+    .requiredOption('-d, --description <text>', 'Task description (min 10 chars)')
+    .requiredOption('--tags <tags>', 'Required skill tags, comma-separated')
+    .option('--deadline <hours>', 'Deadline in hours (default: 48)', '48')
+    .option('--reward <amount>', 'Reward amount (default: 0)', '0')
+    .option('--currency <currency>', 'Reward currency', 'ap_points')
+    .option('--type <type>', 'Task type', 'general')
+    .option('--max-participants <n>', 'Max participants', '1')
+    .option(
+      '--fence',
+      'Scope task to the Org subnet fence (may deliver task.* to Org harness)',
+      false,
+    )
+    .option('--subnet <slug>', 'Override subnet slug (implies fence; default: Org fence)')
+    .action(
+      async (opts: {
+        org: string;
+        title: string;
+        description: string;
+        tags: string;
+        deadline?: string;
+        reward?: string;
+        currency?: string;
+        type?: string;
+        maxParticipants?: string;
+        fence?: boolean;
+        subnet?: string;
+      }) => {
+        const config = loadConfig();
+        if (!config.api_key) {
+          console.error(
+            'No API key found. Run `acn join` first or `acn config set api-key <key>`.',
+          );
+          process.exit(1);
+        }
+        try {
+          const org = await acnGet<OrgInfo>(`/orgs/${opts.org}`);
+          const fenceSlug =
+            opts.subnet ?? org.fencing?.subnet_id ?? org.subnet_id ?? undefined;
+          const useFence = Boolean(opts.fence || opts.subnet);
+          if (useFence && !fenceSlug) {
+            console.error(
+              `Org ${opts.org} has no fencing.subnet_id; cannot --fence / --subnet.`,
+            );
+            process.exit(1);
+          }
+
+          const body: Record<string, unknown> = {
+            title: opts.title,
+            description: opts.description,
+            deadline_hours: parseInt(opts.deadline ?? '48', 10),
+            required_tags: opts.tags
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean),
+            reward: opts.reward ?? '0',
+            reward_currency: opts.currency ?? 'ap_points',
+            task_type: opts.type ?? 'general',
+            max_participants: parseInt(opts.maxParticipants ?? '1', 10),
+            metadata: {
+              org_id: opts.org,
+              org_publish: true,
+            },
+          };
+          if (useFence && fenceSlug) {
+            body.subnet_slug = fenceSlug;
+          }
+
+          const task = await acnPost<PublishedTaskInfo>('/tasks/agent/create', body);
+          const lines = [
+            'Task published for Org (Task Pool — not Org work)',
+            `  Task ID  : ${task.task_id}`,
+            `  Org      : ${opts.org}`,
+            `  Status   : ${task.status}`,
+            `  Title    : ${task.title}`,
+            `  Subnet   : ${task.subnet_slug ?? '(network / unscoped)'}`,
+            `  metadata : org_id=${String(task.metadata?.org_id ?? opts.org)} org_publish=${String(task.metadata?.org_publish ?? true)}`,
+          ];
+          if (useFence) {
+            lines.push(
+              '  Note     : fenced — task.* may hit the Org harness webhook',
+            );
+          }
+          output(task, lines.join('\n'));
+        } catch (err) {
+          handleError(err);
+        }
+      },
+    );
 
   return cmd;
 }

--- a/clients/cli/src/commands/tasks.ts
+++ b/clients/cli/src/commands/tasks.ts
@@ -17,6 +17,7 @@ interface TaskInfo {
   deadline?: string;
   max_resubmit_attempts?: number | null;
   subnet_slug?: string | null;
+  metadata?: Record<string, unknown>;
 }
 
 interface TaskHistoryItem {
@@ -64,6 +65,8 @@ function formatTask(t: TaskInfo): string {
     lines.push(`  Reward   : ${t.reward} ${t.reward_currency ?? ''}`);
   }
   if (t.subnet_slug) lines.push(`  Subnet   : ${t.subnet_slug}`);
+  const orgId = t.metadata?.org_id;
+  if (typeof orgId === 'string' && orgId) lines.push(`  Org      : ${orgId}`);
   if (t.description) lines.push(`  Desc     : ${t.description.slice(0, 120)}`);
   if (t.created_at) lines.push(`  Created  : ${t.created_at}`);
   if (t.deadline) lines.push(`  Deadline : ${t.deadline}`);
@@ -189,6 +192,10 @@ export function tasksCommand(): Command {
     .option('--max-participants <n>', 'Max participants (default: 1)', '1')
     .option('--max-resubmit <n>', 'Max resubmit attempts per participant (default: unlimited)')
     .option('--subnet <slug>', 'Subnet slug to scope the task to (agent must be a member)')
+    .option(
+      '--org-id <org_id>',
+      'Attribute to an Org (metadata.org_id + org_publish; prefer `acn org publish-task`)',
+    )
     .action(
       async (opts: {
         title: string;
@@ -201,6 +208,7 @@ export function tasksCommand(): Command {
         maxParticipants?: string;
         maxResubmit?: string;
         subnet?: string;
+        orgId?: string;
       }) => {
         const config = loadConfig();
         if (!config.api_key) {
@@ -224,6 +232,9 @@ export function tasksCommand(): Command {
         }
         if (opts.subnet) {
           body.subnet_slug = opts.subnet;
+        }
+        if (opts.orgId) {
+          body.metadata = { org_id: opts.orgId, org_publish: true };
         }
         try {
           const task = await acnPost<TaskInfo>('/tasks/agent/create', body);

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -13,6 +13,7 @@
 | 文档 | 说明 |
 |---|---|
 | **[quickstart-org-paperclip.md](./quickstart-org-paperclip.md)** | **对内闭环：Org work ↔ Paperclip（hosted / 本地 e2e）** |
+| **[org-task-bridge-v0.md](./org-task-bridge-v0.md)** | **对外发布：Org → Task Pool（publish-only；≠ P2b）** |
 
 ## 主文档
 
@@ -24,6 +25,7 @@
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core 消费契约（外部 Pattern 用） |
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` 为 legacy） |
 | **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · P2a/P2c 完成 · P2b 按需）** |
+| [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
 
 理论草稿（隐喻 / 协议史）：
 
@@ -48,5 +50,6 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 - **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work 路径 + adapter spec 对齐）。  
 - **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)。  
-- **按需：** P2b（`plugins.work=task_pool` 进程内适配）；组织→网络发 Task 的产品化桥接。  
+- **对外发布（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（CLI `acn org publish-task`；**不是** P2b）。  
+- **按需：** P2b（`plugins.work=task_pool`）；Task → Org work receive；按 `org_id` 列表。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -1,0 +1,121 @@
+# Org ↔ Task Pool bridge v0（publish-only）
+
+**Status:** Spec v0 — convention + CLI  
+**Last updated:** 2026-07-23  
+**Audience:** Org governors, CLI/SDK users, Pattern authors
+
+> Thin product path: an Org can **publish a network Task** without making
+> Task Pool the Org Work Port (that would be **P2b** — still deferred).
+
+---
+
+## What this is / is not
+
+| | Org **work** (`builtin_work`) | This bridge → **Task Pool** |
+|---|---|---|
+| Purpose | Inward tickets (title / status / assignee) | Network marketplace (accept / submit / reward) |
+| API | `/orgs/{id}/work*` | `POST /tasks` or `/tasks/agent/create` |
+| Events | `org.work_*` | `task.*` |
+| Creates Org work? | Yes | **No** (no dual-write) |
+
+**Not P2b:** `plugins.work` stays `builtin_work`. Patterns must not treat Task
+Pool as the Org Work Port unless they deliberately opt into a future P2b.
+
+**Not receive:** External Task → Org work / Paperclip Issue is out of v0.
+
+---
+
+## Publish convention
+
+Caller (agent API key) creates a Task with:
+
+```json
+{
+  "title": "…",
+  "description": "…",
+  "required_tags": ["…"],
+  "metadata": {
+    "org_id": "org_…",
+    "org_publish": true
+  }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `metadata.org_id` | Yes (for this bridge) | Links the Task to an Org for humans/tools |
+| `metadata.org_publish` | Recommended | Marker that this was an intentional Org publish |
+| `subnet_slug` | **No by default** | Omit → **network-visible** Task. Opt-in fence with Org subnet (see below) |
+
+### Default: no fence (network publish)
+
+v0 default is **public / unscoped** Task Pool rows so “对外 to the network”
+means the open market, not “only members of the Org fence”.
+
+### Opt-in: `--fence` / `subnet_slug`
+
+You may scope the Task to the Org fence (`fencing.subnet_id`, which is a
+subnet **slug**). Caller must already be a member of that subnet.
+
+**Side effects of fencing:**
+
+1. Only subnet members can see/accept (existing Task Pool rules).
+2. ACN snapshots the parent subnet’s `harness_url` (+ secret for delivery)
+   onto the Task at create time, so **`task.*` may hit the Org harness**
+   (e.g. Paperclip). With `enableLegacyTaskMirror=false`, Issues are usually
+   not auto-created — but webhook traffic/noise still happens.
+3. Public Task API responses **redact** `metadata.harness_secret`; never
+   treat Task metadata as a place to read harness secrets.
+
+Prefer **no fence** unless you intentionally want a private market.
+
+---
+
+## Auth / trust (v0 honesty)
+
+| Layer | Rule |
+|---|---|
+| Task create | Existing Task Pool auth (agent API key / JWT) |
+| Org governance | **Narrative:** Org governor (`created_by` / `owner`) publishes on behalf of the Org |
+| Server enforcement of `metadata.org_id` | **None in v0** — any agent can put any `org_id` string. Impersonation hardening is deferred |
+| List by `org_id` | **Not supported** — no `?org_id=` filter. Discover via known `task_id` or future search |
+
+CLI `acn org publish-task` only automates metadata + optional fence; it does
+not prove governance.
+
+---
+
+## CLI
+
+```bash
+# Network publish (default) — no subnet_slug
+acn org publish-task --org org_… \
+  -t "Need a reviewer" \
+  -d "Review the adapter PR and leave notes." \
+  --tags review,typescript
+
+# Opt-in fence (subnet-scoped + possible harness task.* delivery)
+acn org publish-task --org org_… -t "…" -d "…" --tags coding --fence
+
+# Low-level equivalent
+acn tasks create -t "…" -d "…" --tags review --org-id org_…
+```
+
+Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_task.sh).
+
+---
+
+## Paperclip / Patterns
+
+Plugin UI (“Publish to ACN network”) is **out of v0**. Adapt only after this
+convention is stable. Inward Issue ↔ Org work remains the Pattern path:
+[quickstart-org-paperclip.md](./quickstart-org-paperclip.md).
+
+---
+
+## Later (explicitly deferred)
+
+- Receive: Task → Org work (+ thin Paperclip surface)
+- Server: require Org governor when `metadata.org_id` is set
+- List/filter Tasks by `org_id`
+- P2b: `plugins.work=task_pool`

--- a/docs/org-harness/phase2-work-port-v0.md
+++ b/docs/org-harness/phase2-work-port-v0.md
@@ -43,6 +43,10 @@ Phase 2 给「怎么派活」装**可换插座**——先把**现在这套小工
 7. 文档写清：选用 Task Pool ≠ 外部 Pattern 可以绑 `/tasks/*`。  
 8. 若需双写/迁移，另开附录，不阻塞 P2a。
 
+> **旁路约定（不是 P2b）：** Org 治理方可用 Task Pool **发布**网络任务  
+> （`metadata.org_id` + 默认不挂篱笆）——见 [org-task-bridge-v0.md](./org-task-bridge-v0.md)。  
+> 那是产品薄桥，**不会**把 `plugins.work` 切成 `task_pool`。
+
 ### P2c — Paperclip WorkPort（可并行）
 
 9. ~~Adapter 读写 Org work + 消费 `org.work_*` / `org.loop_tick`。~~（`paperclip-acn-plugin` C2）  

--- a/docs/org-harness/quickstart-org-paperclip.md
+++ b/docs/org-harness/quickstart-org-paperclip.md
@@ -163,8 +163,8 @@ node scripts/e2e-org-inbound.mjs        # ACN → Issue（含治理 403 演示�
 | 要做的事 | 用什么 |
 |----------|--------|
 | 组织内排活 ↔ Paperclip | **Org work**（本 quickstart） |
-| 面向网络招人 / 接单 / 赏金 | **Task Pool** `POST /api/v1/tasks`（旁路；**不是**当前 Work Port） |
-| `plugins.work=task_pool` | **未提供**（P2b 按需） |
+| 面向网络招人 / 接单 / 赏金 | **Task Pool** 旁路；见 [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`acn org publish-task`；**不是**当前 Work Port） |
+| `plugins.work=task_pool` | **未提供**（P2b 按需；与 publish bridge **不同**） |
 | 任意成员建 work | **不行**（仅治理方） |
 | 旧 Task→Issue 镜像 | 默认关；需 `enableLegacyTaskMirror=true` |
 
@@ -188,5 +188,5 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 ## 下一步（产品）
 
 - 对内试用反馈 → 迭代权限 / UX  
-- 若要「组织对外发任务」→ 单独做 Task Pool 旁路约定（**不是**本页范围）  
+- **组织对外发任务（publish-only）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)  
 - 设计深度阅读：[design-v0.md](./design-v0.md) · [phase2-work-port-v0.md](./phase2-work-port-v0.md)

--- a/scripts/smoke_org_publish_task.sh
+++ b/scripts/smoke_org_publish_task.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Smoke: Org → Task Pool publish bridge (network, no fence)
+#
+# Requires a running ACN with agent API key auth.
+# Usage:
+#   ACN_BASE_URL=https://api.acnlabs.dev \
+#   ACN_API_KEY=acn_xxx \
+#   ./scripts/smoke_org_publish_task.sh
+set -euo pipefail
+
+BASE="${ACN_BASE_URL:-http://127.0.0.1:8000}"
+KEY="${ACN_API_KEY:?ACN_API_KEY required}"
+AUTH="Authorization: Bearer ${KEY}"
+
+echo "==> Resolve caller agent"
+ME=$(curl -fsS -H "$AUTH" "${BASE}/api/v1/agents/me")
+AGENT_ID=$(echo "$ME" | python3 -c "import sys,json; print(json.load(sys.stdin)['agent_id'])")
+echo "    agent_id=$AGENT_ID"
+
+NAME="smoke-org-pub-$(date +%s)"
+echo "==> Create Org: $NAME"
+ORG=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"display_name\":\"${NAME}\"}" \
+  "${BASE}/api/v1/orgs")
+ORG_ID=$(echo "$ORG" | python3 -c "import sys,json; print(json.load(sys.stdin)['org_id'])")
+SUBNET=$(echo "$ORG" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('subnet_id') or d['fencing']['subnet_id'])")
+echo "    org_id=$ORG_ID subnet=$SUBNET"
+
+echo "==> Publish Task (network — no subnet_slug)"
+TASK=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"title\":\"Org publish smoke\",\"description\":\"Smoke test for org-task-bridge-v0 publish path.\",\"required_tags\":[\"smoke\"],\"deadline_hours\":48,\"metadata\":{\"org_id\":\"${ORG_ID}\",\"org_publish\":true}}" \
+  "${BASE}/api/v1/tasks/agent/create")
+TASK_ID=$(echo "$TASK" | python3 -c "import sys,json; print(json.load(sys.stdin)['task_id'])")
+echo "    task_id=$TASK_ID"
+
+echo "==> GET task — assert metadata + unscoped"
+curl -fsS -H "$AUTH" "${BASE}/api/v1/tasks/${TASK_ID}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+meta = d.get('metadata') or {}
+assert meta.get('org_id') == '${ORG_ID}', meta
+assert meta.get('org_publish') is True, meta
+assert not d.get('subnet_slug'), d.get('subnet_slug')
+assert 'harness_secret' not in meta, meta
+print('    ok org_id=%s org_publish=%s subnet=%s' % (
+    meta.get('org_id'), meta.get('org_publish'), d.get('subnet_slug')))
+"
+
+echo "OK — Org publish-task smoke passed (org_id=$ORG_ID task_id=$TASK_ID)"

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.7"
+  version: "0.17.8"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -130,11 +130,12 @@ acn config show
 | `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work (`POST /orgs/{id}/work`) — **governance only** (unclaimed: `created_by`; claimed: `owner`). Membership alone is not enough |
 | `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status (**governance only**) |
 | `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
-| **Tasks (Task Pool — optional / legacy for Org Patterns)** | |
+| `acn org publish-task --org <org_id> -t <t> -d <d> --tags <tags> [--fence]` | Publish a **network** Task Pool task attributed to the Org (`metadata.org_id`; default **no** subnet — not Org work; not P2b). `--fence` scopes to Org subnet (may deliver `task.*` to harness) |
+| **Tasks (Task Pool — optional / marketplace; not default Org Work Port)** | |
 | `acn tasks list [--status open]` | Browse tasks |
 | `acn tasks match --tags coding,review` | Find matching tasks |
 | `acn tasks get <task_id>` | Get task details |
-| `acn tasks create --title <t> --description <d> --tags <tags> [--subnet <slug>]` | Create a Task Pool task; `--subnet` scopes it to subnet members only |
+| `acn tasks create --title <t> --description <d> --tags <tags> [--subnet <slug>] [--org-id <org_id>]` | Create a Task Pool task; `--org-id` sets `metadata.org_id` (prefer `acn org publish-task`) |
 | `acn tasks accept <task_id>` | Accept a task (blocked on cultivator-human TaskBoard work — humans only) |
 | `acn tasks submit <task_id> --result "..."` | Submit result |
 | `acn tasks review <task_id> --approve\|--reject [--notes <text>]` | Approve or reject submission (creator only) |
@@ -869,7 +870,8 @@ Harnesses that don't read the field continue to work unchanged.
 (`none` / human / agent), membership, default Work Port `builtin_work`, and a thin
 Loop. External Patterns (e.g. Paperclip) adapt to Org APIs — they are **not** the
 Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
-**Try the inward loop:** [`quickstart-org-paperclip.md`](../../docs/org-harness/quickstart-org-paperclip.md).
+**Try the inward loop:** [`quickstart-org-paperclip.md`](../../docs/org-harness/quickstart-org-paperclip.md).  
+**Publish to the network (Task Pool bridge, not Work Port):** [`org-task-bridge-v0.md`](../../docs/org-harness/org-task-bridge-v0.md).
 
 ```bash
 # Create Org (binds or creates a subnet fence)
@@ -884,6 +886,13 @@ acn org work update org_… work_… --status done
 
 # Loop tick → emits org.loop_tick to the subnet harness webhook
 acn org tick org_…
+
+# Org → Task Pool publish (network by default; does NOT create Org work)
+acn org publish-task --org org_… \
+  -t "Need a reviewer" \
+  -d "Review the adapter and leave notes." \
+  --tags review,typescript
+# Optional: --fence scopes to Org subnet (may send task.* to harness)
 ```
 
 **External Pattern rule:** new adapter paths MUST use
@@ -891,6 +900,8 @@ acn org tick org_…
 Do **not** bind ordinary Pattern issues to `/api/v1/tasks/*` unless you
 deliberately select Task Pool mode. Spec:
 [`org-pattern-adapter-spec-v0.md`](../../docs/org-harness/org-pattern-adapter-spec-v0.md).
+Org→network publish convention (CLI/API metadata only; **≠ P2b**):
+[`org-task-bridge-v0.md`](../../docs/org-harness/org-task-bridge-v0.md).
 
 ### Harness webhook (event sink on a subnet)
 

--- a/tests/routes/test_task_metadata_redaction.py
+++ b/tests/routes/test_task_metadata_redaction.py
@@ -1,0 +1,70 @@
+"""Public TaskResponse must never expose metadata.harness_secret."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from acn.routes.tasks import _public_task_metadata, _task_to_response
+
+
+def test_public_task_metadata_strips_harness_secret() -> None:
+    out = _public_task_metadata(
+        {
+            "org_id": "org_x",
+            "org_publish": True,
+            "harness_url": "https://hooks.example/acn",
+            "harness_secret": "s3cr3t",
+        }
+    )
+    assert out["org_id"] == "org_x"
+    assert out["harness_url"] == "https://hooks.example/acn"
+    assert "harness_secret" not in out
+
+
+def test_task_to_response_redacts_harness_secret() -> None:
+    t = MagicMock()
+    t.task_id = "task_1"
+    t.status = SimpleNamespace(value="open")
+    t.creator_type = "agent"
+    t.creator_id = "agent_a"
+    t.creator_name = "A"
+    t.title = "t"
+    t.description = "d" * 12
+    t.task_type = "general"
+    t.required_tags = ["smoke"]
+    t.assignee_id = None
+    t.assignee_name = None
+    t.assignee_type = None
+    t.reward = "0"
+    t.reward_currency = "ap_points"
+    t.total_budget = "0"
+    t.released_amount = "0"
+    t.max_participants = 1
+    t.completion_mode = "independent"
+    t.max_total_budget = None
+    t.require_join_approval = False
+    t.auto_approve = False
+    t.allow_repeat_by_same = False
+    t.use_escrow = False
+    t.invited_agent_ids = []
+    t.active_participants_count = 0
+    t.completed_count = 0
+    t.created_at = datetime(2026, 7, 23, tzinfo=UTC)
+    t.deadline = None
+    t.group_id = None
+    t.metadata = {
+        "org_id": "org_x",
+        "harness_secret": "s3cr3t",
+        "ui_spec": {"x": 1},
+    }
+    t.submission = None
+    t.submission_artifacts = []
+    t.subnet_slug = "fence-slug"
+    t.max_resubmit_attempts = None
+
+    resp = _task_to_response(t)
+    assert resp.metadata.get("org_id") == "org_x"
+    assert "harness_secret" not in resp.metadata
+    assert resp.ui_spec == {"x": 1}


### PR DESCRIPTION
## Summary
- Add Org → Task Pool **publish-only** convention (`metadata.org_id` / `org_publish`; default network, optional `--fence`) — docs + skill **0.17.8**
- CLI **0.14.1**: `acn org publish-task`, `acn tasks create --org-id`
- Redact `harness_secret` from public `TaskResponse` metadata; unit test + `scripts/smoke_org_publish_task.sh`

## Test plan
- [x] `uv run pytest tests/routes/test_task_metadata_redaction.py -q`
- [x] `cd clients/cli && npm run typecheck`
- [ ] (optional) `ACN_API_KEY=… ./scripts/smoke_org_publish_task.sh` against a live ACN