### PR TITLE
fix(smoke): include required reward on org publish-task

### DIFF
--- a/scripts/smoke_org_publish_task.sh
+++ b/scripts/smoke_org_publish_task.sh
@@ -28,7 +28,7 @@ echo "    org_id=$ORG_ID subnet=$SUBNET"
 
 echo "==> Publish Task (network — no subnet_slug)"
 TASK=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
-  -d "{\"title\":\"Org publish smoke\",\"description\":\"Smoke test for org-task-bridge-v0 publish path.\",\"required_tags\":[\"smoke\"],\"deadline_hours\":48,\"metadata\":{\"org_id\":\"${ORG_ID}\",\"org_publish\":true}}" \
+  -d "{\"title\":\"Org publish smoke\",\"description\":\"Smoke test for org-task-bridge-v0 publish path.\",\"required_tags\":[\"smoke\"],\"deadline_hours\":48,\"reward\":\"0\",\"reward_currency\":\"ap_points\",\"task_type\":\"general\",\"metadata\":{\"org_id\":\"${ORG_ID}\",\"org_publish\":true}}" \
   "${BASE}/api/v1/tasks/agent/create")
 TASK_ID=$(echo "$TASK" | python3 -c "import sys,json; print(json.load(sys.stdin)['task_id'])")
 echo "    task_id=$TASK_ID"


### PR DESCRIPTION
## Summary
- `scripts/smoke_org_publish_task.sh` now sends `reward` / `reward_currency` / `task_type` so `POST /tasks/agent/create` passes validation.

## Test plan
- [x] Ran smoke against `https://api.acnlabs.dev` — OK after fix


Made with [Cursor](https://cursor.com)