### PR TITLE
feat(org): import Task Pool tasks as Org work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- **Org → Task Pool publish bridge v0** —
-  `docs/org-harness/org-task-bridge-v0.md` (convention: `metadata.org_id` /
-  `org_publish`; default network / no fence; ≠ P2b). Linked from org-harness
-  README, Paperclip quickstart, phase2, skill **0.17.8**. Smoke:
-  `scripts/smoke_org_publish_task.sh`.
+- **Org ↔ Task Pool bridge v0** —
+  `docs/org-harness/org-task-bridge-v0.md` (publish + import; link on
+  `task.metadata`; ≠ P2b). Skill **0.17.9**. Smoke:
+  `scripts/smoke_org_publish_task.sh` (publish + import + idempotent re-import).
 - **Org Harness quickstart** — `docs/org-harness/quickstart-org-paperclip.md`
   (Org work ↔ Paperclip inward loop; hosted + local e2e). Linked from
   org-harness README and skill **0.17.7**.
@@ -27,12 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unclaimed Org”) while keeping `error_code=ownership_mismatch` and
   `details.reason`. Clarifies that `POST …/work` is **governance-only**,
   not Org membership. Skill **0.17.6** / API.md updated.
+- **Org publish smoke:** send required `reward` on `POST /tasks/agent/create`.
 
 ### Added
 
 - **CLI `acn org publish-task`** (+ `acn tasks create --org-id`) — attribute a
   Task Pool task to an Org; default unscoped network publish; optional
   `--fence` / `--subnet` (ships with next CLI release bump).
+- **Org Task import** — `POST /orgs/{id}/work/import-task` + CLI
+  `acn org import-task`: governance imports a Task as Org work; persists
+  `metadata.org_work_id` / `org_import` on the Task (idempotent).
 - **Org Harness Kernel (ADR-0014 Phase 1)** — first-class `Org` / `OrgMembership`
   / minimal `OrgWorkItem` with Redis + Postgres repos, `/api/v1/orgs*`
   (create/show/members/claim/transfer/release/dissolve/work/loop tick),

--- a/acn/api.py
+++ b/acn/api.py
@@ -562,11 +562,13 @@ async def lifespan(app: FastAPI):
     join_flow_service_instance._event_publisher = _join_flow_webhook_publisher
 
     # Org Harness Kernel (ADR-0014) — needs subnet + agent + webhook.
+    # task_repository enables Org → Task Pool import (metadata.org_work_id).
     org_service_instance = OrgService(
         org_repository=org_repository,
         subnet_service=subnet_service_instance,
         agent_service=agent_service_instance,
         webhook_service=webhook_service_instance,
+        task_repository=task_repository,
     )
 
     payment_discovery_instance = PaymentDiscoveryService(redis_client)

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -34,6 +34,7 @@ from ..services.org_service import (
     OrgNotFoundError,
     OrgPermissionError,
     OrgService,
+    OrgTaskImportError,
     OrgWorkNotFoundError,
 )
 
@@ -290,6 +291,11 @@ class OrgMemberAddRequest(BaseModel):
 
 class OrgWorkCreateRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=500)
+    assignee_agent_id: str | None = None
+
+
+class OrgWorkImportTaskRequest(BaseModel):
+    task_id: str = Field(..., min_length=1, max_length=128)
     assignee_agent_id: str | None = None
 
 
@@ -703,6 +709,66 @@ async def create_work(
     except OrgConflictError as e:
         # Legacy Phase 1 Orgs may store unavailable work plugins.
         raise _map_conflict(e) from e
+
+
+@router.post("/{org_id}/work/import-task")
+@limiter.limit("60/minute")
+async def import_work_from_task(
+    request: Request,
+    body: OrgWorkImportTaskRequest,
+    org_id: OrgIdPath,
+    payload: dict = OrgAuthDep,
+    org_service: OrgService = Depends(get_org_service),
+):
+    """Import a Task Pool task as Org work (governance only).
+
+    Links via ``task.metadata.org_work_id`` / ``org_id`` / ``org_import``.
+    Idempotent when the same Org re-imports the same task.
+    """
+    caller_type, caller_sub = _caller(payload)
+    try:
+        work, already = await org_service.import_work_from_task(
+            org_id,
+            task_id=body.task_id,
+            caller_type=caller_type,
+            caller_sub=caller_sub,
+            assignee_agent_id=body.assignee_agent_id,
+        )
+        return {
+            **work.to_dict(),
+            "source_task_id": body.task_id,
+            "already_imported": already,
+        }
+    except OrgNotFoundError as e:
+        raise ACNHTTPError(
+            ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
+        ) from e
+    except OrgPermissionError as e:
+        raise _map_permission(e, org_id) from e
+    except OrgConflictError as e:
+        raise _map_conflict(e) from e
+    except OrgTaskImportError as e:
+        if e.reason == "task_not_found":
+            raise ACNHTTPError(
+                ErrorCode.TASK_NOT_FOUND,
+                404,
+                message=str(e),
+                details={"task_id": body.task_id, "reason": e.reason},
+            ) from e
+        if e.reason == "not_subnet_member":
+            raise ACNHTTPError(
+                ErrorCode.NOT_SUBNET_MEMBER,
+                403,
+                message=str(e),
+                details={"task_id": body.task_id, "reason": e.reason},
+            ) from e
+        status = 503 if e.reason == "task_repository_unavailable" else 400
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST if status == 400 else ErrorCode.INTERNAL_SERVER_ERROR,
+            status,
+            message=str(e),
+            details={"task_id": body.task_id, "reason": e.reason},
+        ) from e
 
 
 @router.get("/{org_id}/work")

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -749,25 +749,29 @@ async def import_work_from_task(
         raise _map_conflict(e) from e
     except OrgTaskImportError as e:
         if e.reason == "task_not_found":
+            # details shape must stay {task_id} (see test_error_code_details_consistency).
             raise ACNHTTPError(
                 ErrorCode.TASK_NOT_FOUND,
                 404,
                 message=str(e),
-                details={"task_id": body.task_id, "reason": e.reason},
+                details={"task_id": body.task_id},
             ) from e
         if e.reason == "not_subnet_member":
             raise ACNHTTPError(
                 ErrorCode.NOT_SUBNET_MEMBER,
                 403,
                 message=str(e),
-                details={"task_id": body.task_id, "reason": e.reason},
+                details={
+                    "task_id": body.task_id,
+                    "reason": e.reason,
+                },
             ) from e
         status = 503 if e.reason == "task_repository_unavailable" else 400
         raise ACNHTTPError(
             ErrorCode.INVALID_REQUEST if status == 400 else ErrorCode.INTERNAL_SERVER_ERROR,
             status,
             message=str(e),
-            details={"task_id": body.task_id, "reason": e.reason},
+            details={"reason": e.reason, "task_id": body.task_id},
         ) from e
 
 

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -26,6 +26,7 @@ from ..core.exceptions import (
     SubnetNotFoundException,
 )
 from ..core.interfaces.org_repository import IOrgRepository
+from ..core.interfaces.task_repository import ITaskRepository
 from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
 from .agent_service import AgentService
@@ -67,6 +68,14 @@ class OrgWorkNotFoundError(Exception):
         super().__init__(f"Work item not found: {org_id}/{work_id}")
 
 
+class OrgTaskImportError(Exception):
+    """Task → Org work import failed (not found / not visible / unavailable)."""
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        self.reason = reason
+        super().__init__(message or reason)
+
+
 class OrgService:
     def __init__(
         self,
@@ -74,11 +83,13 @@ class OrgService:
         subnet_service: SubnetService,
         agent_service: AgentService,
         webhook_service: WebhookService | None = None,
+        task_repository: ITaskRepository | None = None,
     ) -> None:
         self.repository = org_repository
         self.subnet_service = subnet_service
         self.agent_service = agent_service
         self.webhook_service = webhook_service
+        self.task_repository = task_repository
 
     def _work_pattern_for(self, org: Org):
         """Resolve ``IWorkPattern`` from ``org.plugins.work`` (aliases allowed)."""
@@ -987,6 +998,99 @@ class OrgService:
             work.to_dict(),
         )
         return work
+
+    async def _agent_in_subnet(self, slug: str, agent_id: str) -> bool:
+        try:
+            subnet = await self.subnet_service.get_subnet(slug)
+        except SubnetNotFoundException:
+            return False
+        members = getattr(subnet, "member_agent_ids", None) or set()
+        return agent_id in members
+
+    async def import_work_from_task(
+        self,
+        org_id: str,
+        *,
+        task_id: str,
+        caller_type: CallerType,
+        caller_sub: str,
+        assignee_agent_id: str | None = None,
+    ) -> tuple[OrgWorkItem, bool]:
+        """Import a Task Pool task as Org work; link via task.metadata.
+
+        Returns ``(work, already_imported)``. Link fields on the Task:
+        ``org_id``, ``org_work_id``, ``org_import=true``. Does not dual-write
+        Task lifecycle into work status.
+        """
+        if not self.task_repository:
+            raise OrgTaskImportError(
+                "task_repository_unavailable",
+                "Task repository is not configured; cannot import tasks",
+            )
+
+        org = await self.get_org(org_id)
+        self._require_governance(org, caller_type, caller_sub)
+
+        task = await self.task_repository.find_by_id(task_id)
+        if not task:
+            raise OrgTaskImportError(
+                "task_not_found", f"Task not found: {task_id}"
+            )
+
+        if task.subnet_slug:
+            if caller_type != "agent":
+                raise OrgTaskImportError(
+                    "fenced_task_requires_agent",
+                    "Importing a subnet-scoped task requires an agent API key "
+                    "that is a member of the task subnet",
+                )
+            if not await self._agent_in_subnet(task.subnet_slug, caller_sub):
+                raise OrgTaskImportError(
+                    "not_subnet_member",
+                    f"Caller is not a member of task subnet {task.subnet_slug}",
+                )
+
+        meta = dict(task.metadata) if isinstance(task.metadata, dict) else {}
+        existing_work_id = meta.get("org_work_id")
+        existing_org_id = meta.get("org_id")
+        if isinstance(existing_work_id, str) and existing_work_id:
+            if existing_org_id and existing_org_id != org_id:
+                raise OrgConflictError(
+                    "task_already_imported",
+                    f"Task already imported into org {existing_org_id}",
+                )
+            existing = await self.repository.find_work(org_id, existing_work_id)
+            if existing:
+                return existing, True
+            # Stale link — fall through and recreate.
+
+        title = (task.title or "").strip() or f"Imported task {task_id}"
+        if len(title) > 500:
+            title = title[:500]
+
+        work = await self._work_pattern_for(org).create_work(
+            org_id,
+            title=title,
+            assignee_agent_id=assignee_agent_id,
+        )
+
+        meta["org_id"] = org_id
+        meta["org_work_id"] = work.work_id
+        meta["org_import"] = True
+        # Never overwrite delivery secrets via import merge.
+        task.metadata = meta
+        await self.task_repository.save(task)
+
+        await self._emit(
+            org,
+            WebhookEventType.ORG_WORK_CREATED,
+            {
+                **work.to_dict(),
+                "source_task_id": task_id,
+                "org_import": True,
+            },
+        )
+        return work, False
 
     async def update_work_status(
         self,

--- a/clients/cli/src/commands/org.ts
+++ b/clients/cli/src/commands/org.ts
@@ -435,5 +435,50 @@ export function orgCommand(): Command {
       },
     );
 
+  cmd
+    .command('import-task')
+    .description(
+      'Import a Task Pool task as Org work (governance only; links via task.metadata)',
+    )
+    .requiredOption('--org <org_id>', 'Org id')
+    .requiredOption('--task <task_id>', 'Task id to import')
+    .option('--assignee <agent_id>', 'Optional assignee for the work item')
+    .action(
+      async (opts: { org: string; task: string; assignee?: string }) => {
+        const config = loadConfig();
+        if (!config.api_key) {
+          console.error(
+            'No API key found. Run `acn join` first or `acn config set api-key <key>`.',
+          );
+          process.exit(1);
+        }
+        try {
+          const body: Record<string, unknown> = { task_id: opts.task };
+          if (opts.assignee) body.assignee_agent_id = opts.assignee;
+          const res = await acnPost<{
+            work_id: string;
+            org_id: string;
+            title: string;
+            status: string;
+            source_task_id?: string;
+            already_imported?: boolean;
+          }>(`/orgs/${opts.org}/work/import-task`, body);
+          const lines = [
+            res.already_imported
+              ? 'Task already imported (idempotent)'
+              : 'Task imported as Org work',
+            `  Work ID  : ${res.work_id}`,
+            `  Org      : ${res.org_id}`,
+            `  Task ID  : ${res.source_task_id ?? opts.task}`,
+            `  Status   : ${res.status}`,
+            `  Title    : ${res.title}`,
+          ];
+          output(res, lines.join('\n'));
+        } catch (err) {
+          handleError(err);
+        }
+      },
+    );
+
   return cmd;
 }

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -13,7 +13,7 @@
 | 文档 | 说明 |
 |---|---|
 | **[quickstart-org-paperclip.md](./quickstart-org-paperclip.md)** | **对内闭环：Org work ↔ Paperclip（hosted / 本地 e2e）** |
-| **[org-task-bridge-v0.md](./org-task-bridge-v0.md)** | **对外发布：Org → Task Pool（publish-only；≠ P2b）** |
+| **[org-task-bridge-v0.md](./org-task-bridge-v0.md)** | **对外发布 + 导入：Org ↔ Task Pool（≠ P2b）** |
 
 ## 主文档
 
@@ -50,6 +50,6 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 - **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work 路径 + adapter spec 对齐）。  
 - **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)。  
-- **对外发布（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（CLI `acn org publish-task`；**不是** P2b）。  
-- **按需：** P2b（`plugins.work=task_pool`）；Task → Org work receive；按 `org_id` 列表。  
+- **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
+- **按需：** P2b（`plugins.work=task_pool`）；自动 receive；按 `org_id` 列表。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -1,11 +1,12 @@
-# Org ↔ Task Pool bridge v0（publish-only）
+# Org ↔ Task Pool bridge v0（publish + import）
 
-**Status:** Spec v0 — convention + CLI  
+**Status:** Spec v0 — convention + API/CLI  
 **Last updated:** 2026-07-23  
 **Audience:** Org governors, CLI/SDK users, Pattern authors
 
-> Thin product path: an Org can **publish a network Task** without making
-> Task Pool the Org Work Port (that would be **P2b** — still deferred).
+> Thin product path: an Org can **publish** a network Task and **import** an
+> existing Task as inward Org work — **without** making Task Pool the Org Work
+> Port (**P2b** remains deferred).
 
 ---
 
@@ -14,14 +15,14 @@
 | | Org **work** (`builtin_work`) | This bridge → **Task Pool** |
 |---|---|---|
 | Purpose | Inward tickets (title / status / assignee) | Network marketplace (accept / submit / reward) |
-| API | `/orgs/{id}/work*` | `POST /tasks` or `/tasks/agent/create` |
+| API | `/orgs/{id}/work*` | `/tasks*` (+ bridge helpers below) |
 | Events | `org.work_*` | `task.*` |
-| Creates Org work? | Yes | **No** (no dual-write) |
+| Dual-write lifecycle? | — | **No** — publish does not create work; import does not sync status |
 
-**Not P2b:** `plugins.work` stays `builtin_work`. Patterns must not treat Task
-Pool as the Org Work Port unless they deliberately opt into a future P2b.
+**Not P2b:** `plugins.work` stays `builtin_work`.
 
-**Not receive:** External Task → Org work / Paperclip Issue is out of v0.
+**Not automatic receive:** Nothing auto-imports on `task.*`. Import is an
+explicit governance action.
 
 ---
 
@@ -34,6 +35,7 @@ Caller (agent API key) creates a Task with:
   "title": "…",
   "description": "…",
   "required_tags": ["…"],
+  "reward": "0",
   "metadata": {
     "org_id": "org_…",
     "org_publish": true
@@ -43,31 +45,58 @@ Caller (agent API key) creates a Task with:
 
 | Field | Required | Notes |
 |---|---|---|
-| `metadata.org_id` | Yes (for this bridge) | Links the Task to an Org for humans/tools |
-| `metadata.org_publish` | Recommended | Marker that this was an intentional Org publish |
-| `subnet_slug` | **No by default** | Omit → **network-visible** Task. Opt-in fence with Org subnet (see below) |
+| `metadata.org_id` | Yes (for this bridge) | Attributes the Task to an Org |
+| `metadata.org_publish` | Recommended | Intentional Org publish marker |
+| `subnet_slug` | **No by default** | Omit → **network-visible**. Opt-in fence below |
 
 ### Default: no fence (network publish)
 
-v0 default is **public / unscoped** Task Pool rows so “对外 to the network”
-means the open market, not “only members of the Org fence”.
+v0 default is an **unscoped** Task so “publish to the network” means the open
+market.
 
-### Opt-in: `--fence` / `subnet_slug`
+### Opt-in fence
 
-You may scope the Task to the Org fence (`fencing.subnet_id`, which is a
-subnet **slug**). Caller must already be a member of that subnet.
+Scope with Org `fencing.subnet_id` (slug). Caller must be a subnet member.
 
-**Side effects of fencing:**
+**Side effects:** subnet visibility rules; harness URL/secret snapshot may
+cause `task.*` delivery to the Org harness; public Task responses **redact**
+`metadata.harness_secret`.
 
-1. Only subnet members can see/accept (existing Task Pool rules).
-2. ACN snapshots the parent subnet’s `harness_url` (+ secret for delivery)
-   onto the Task at create time, so **`task.*` may hit the Org harness**
-   (e.g. Paperclip). With `enableLegacyTaskMirror=false`, Issues are usually
-   not auto-created — but webhook traffic/noise still happens.
-3. Public Task API responses **redact** `metadata.harness_secret`; never
-   treat Task metadata as a place to read harness secrets.
+---
 
-Prefer **no fence** unless you intentionally want a private market.
+## Import convention (Task → Org work)
+
+Governance caller imports an existing Task into the Org work queue:
+
+```http
+POST /api/v1/orgs/{org_id}/work/import-task
+{ "task_id": "…" }
+```
+
+**Behavior:**
+
+1. Require Org governance (`created_by` / `owner`) — same as `create_work`.
+2. Load Task; if `subnet_slug` set, caller must be an **agent** member of that subnet.
+3. Create Org work with `title = task.title` (no work-table metadata column).
+4. Persist link on the **Task** (where metadata already exists):
+
+```json
+{
+  "org_id": "org_…",
+  "org_work_id": "work_…",
+  "org_import": true
+}
+```
+
+5. Emit `org.work_created` (payload includes `source_task_id`). Patterns with
+   `autoCreateIssues` may create a Paperclip Issue from that event.
+
+**Idempotent:** re-import same task into the same Org returns the existing work
+(`already_imported: true`). Import into a **different** Org → `409` /
+`task_already_imported`.
+
+**Does not:** sync Task status ↔ work status; accept/submit the Task; invent
+work metadata fields.
 
 ---
 
@@ -75,47 +104,47 @@ Prefer **no fence** unless you intentionally want a private market.
 
 | Layer | Rule |
 |---|---|
-| Task create | Existing Task Pool auth (agent API key / JWT) |
-| Org governance | **Narrative:** Org governor (`created_by` / `owner`) publishes on behalf of the Org |
-| Server enforcement of `metadata.org_id` | **None in v0** — any agent can put any `org_id` string. Impersonation hardening is deferred |
-| List by `org_id` | **Not supported** — no `?org_id=` filter. Discover via known `task_id` or future search |
-
-CLI `acn org publish-task` only automates metadata + optional fence; it does
-not prove governance.
+| Publish | Existing Task create auth; `metadata.org_id` is **not** server-enforced as Org governor |
+| Import | Org governance + Task visibility (subnet membership when fenced) |
+| List by `org_id` | **Not supported** on Task list |
+| Impersonation | Any agent may still put arbitrary `org_id` on publish; hardening deferred |
 
 ---
 
 ## CLI
 
 ```bash
-# Network publish (default) — no subnet_slug
+# Network publish (default)
 acn org publish-task --org org_… \
   -t "Need a reviewer" \
   -d "Review the adapter PR and leave notes." \
   --tags review,typescript
 
-# Opt-in fence (subnet-scoped + possible harness task.* delivery)
+# Optional fence
 acn org publish-task --org org_… -t "…" -d "…" --tags coding --fence
 
-# Low-level equivalent
-acn tasks create -t "…" -d "…" --tags review --org-id org_…
+# Import Task → Org work
+acn org import-task --org org_… --task <task_id>
 ```
 
-Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_task.sh).
+Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_task.sh)
+(publish + import round-trip).
 
 ---
 
 ## Paperclip / Patterns
 
-Plugin UI (“Publish to ACN network”) is **out of v0**. Adapt only after this
-convention is stable. Inward Issue ↔ Org work remains the Pattern path:
-[quickstart-org-paperclip.md](./quickstart-org-paperclip.md).
+- Inward Issue ↔ Org work: [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)
+- Import may surface as a new Issue via `org.work_created` — not a dedicated
+  “Import task” plugin action (deferred).
 
 ---
 
 ## Later (explicitly deferred)
 
-- Receive: Task → Org work (+ thin Paperclip surface)
-- Server: require Org governor when `metadata.org_id` is set
+- Auto-receive on `task.*`
+- Server: require Org governor when `metadata.org_id` is set on create
 - List/filter Tasks by `org_id`
+- Bidirectional status sync
 - P2b: `plugins.work=task_pool`
+- Work-table `source_task_id` column

--- a/scripts/smoke_org_publish_task.sh
+++ b/scripts/smoke_org_publish_task.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Smoke: Org → Task Pool publish bridge (network, no fence)
+# Smoke: Org ↔ Task Pool bridge — publish + import
 #
 # Requires a running ACN with agent API key auth.
 # Usage:
@@ -28,12 +28,12 @@ echo "    org_id=$ORG_ID subnet=$SUBNET"
 
 echo "==> Publish Task (network — no subnet_slug)"
 TASK=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
-  -d "{\"title\":\"Org publish smoke\",\"description\":\"Smoke test for org-task-bridge-v0 publish path.\",\"required_tags\":[\"smoke\"],\"deadline_hours\":48,\"metadata\":{\"org_id\":\"${ORG_ID}\",\"org_publish\":true}}" \
+  -d "{\"title\":\"Org publish smoke\",\"description\":\"Smoke test for org-task-bridge-v0 publish path.\",\"required_tags\":[\"smoke\"],\"deadline_hours\":48,\"reward\":\"0\",\"reward_currency\":\"ap_points\",\"task_type\":\"general\",\"metadata\":{\"org_id\":\"${ORG_ID}\",\"org_publish\":true}}" \
   "${BASE}/api/v1/tasks/agent/create")
 TASK_ID=$(echo "$TASK" | python3 -c "import sys,json; print(json.load(sys.stdin)['task_id'])")
 echo "    task_id=$TASK_ID"
 
-echo "==> GET task — assert metadata + unscoped"
+echo "==> GET task — assert publish metadata + unscoped"
 curl -fsS -H "$AUTH" "${BASE}/api/v1/tasks/${TASK_ID}" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
@@ -46,4 +46,34 @@ print('    ok org_id=%s org_publish=%s subnet=%s' % (
     meta.get('org_id'), meta.get('org_publish'), d.get('subnet_slug')))
 "
 
-echo "OK — Org publish-task smoke passed (org_id=$ORG_ID task_id=$TASK_ID)"
+echo "==> Import Task → Org work"
+IMP=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"task_id\":\"${TASK_ID}\"}" \
+  "${BASE}/api/v1/orgs/${ORG_ID}/work/import-task")
+WORK_ID=$(echo "$IMP" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('already_imported') is False, d; print(d['work_id'])")
+echo "    work_id=$WORK_ID"
+
+echo "==> GET task — assert org_work_id link"
+curl -fsS -H "$AUTH" "${BASE}/api/v1/tasks/${TASK_ID}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+meta = d.get('metadata') or {}
+assert meta.get('org_id') == '${ORG_ID}', meta
+assert meta.get('org_work_id') == '${WORK_ID}', meta
+assert meta.get('org_import') is True, meta
+print('    ok org_work_id=%s org_import=%s' % (meta.get('org_work_id'), meta.get('org_import')))
+"
+
+echo "==> Re-import (idempotent)"
+IMP2=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"task_id\":\"${TASK_ID}\"}" \
+  "${BASE}/api/v1/orgs/${ORG_ID}/work/import-task")
+echo "$IMP2" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d.get('already_imported') is True, d
+assert d.get('work_id') == '${WORK_ID}', d
+print('    ok already_imported work_id=%s' % d.get('work_id'))
+"
+
+echo "OK — Org publish+import smoke passed (org_id=$ORG_ID task_id=$TASK_ID work_id=$WORK_ID)"

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.8"
+  version: "0.17.9"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -131,6 +131,7 @@ acn config show
 | `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status (**governance only**) |
 | `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
 | `acn org publish-task --org <org_id> -t <t> -d <d> --tags <tags> [--fence]` | Publish a **network** Task Pool task attributed to the Org (`metadata.org_id`; default **no** subnet — not Org work; not P2b). `--fence` scopes to Org subnet (may deliver `task.*` to harness) |
+| `acn org import-task --org <org_id> --task <task_id>` | Import a Task as Org work (**governance only**); links via `task.metadata.org_work_id` (idempotent) |
 | **Tasks (Task Pool — optional / marketplace; not default Org Work Port)** | |
 | `acn tasks list [--status open]` | Browse tasks |
 | `acn tasks match --tags coding,review` | Find matching tasks |
@@ -893,6 +894,9 @@ acn org publish-task --org org_… \
   -d "Review the adapter and leave notes." \
   --tags review,typescript
 # Optional: --fence scopes to Org subnet (may send task.* to harness)
+
+# Task → Org work import (governance; link stored on task.metadata)
+acn org import-task --org org_… --task <task_id>
 ```
 
 **External Pattern rule:** new adapter paths MUST use

--- a/tests/services/test_org_import_task.py
+++ b/tests/services/test_org_import_task.py
@@ -1,0 +1,166 @@
+"""OrgService.import_work_from_task — Task → Org work bridge."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities.org import Org, OrgOwner, OrgPrincipal, OrgWorkItem
+from acn.core.entities.task import Task, TaskStatus
+from acn.core.exceptions import OrgConflictError
+from acn.services.org_service import OrgService, OrgTaskImportError
+
+
+@pytest.fixture
+def mock_org_repo():
+    repo = AsyncMock()
+    repo.find_org_by_subnet = AsyncMock(return_value=None)
+    repo.find_work = AsyncMock(return_value=None)
+    repo.save_work = AsyncMock()
+    o = Org(
+        org_id="org_x",
+        display_name="X",
+        subnet_id="fence-x",
+        created_by=OrgPrincipal(kind="agent", subject="agt_gov"),
+        owner=OrgOwner(kind="none"),
+        steward_agent_id="agt_gov",
+        plugins={"work": "builtin_work"},
+    )
+    repo.find_org = AsyncMock(return_value=o)
+    return repo
+
+
+@pytest.fixture
+def mock_subnet_service():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_agent_service():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_task_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def svc(mock_org_repo, mock_subnet_service, mock_agent_service, mock_task_repo):
+    return OrgService(
+        org_repository=mock_org_repo,
+        subnet_service=mock_subnet_service,
+        agent_service=mock_agent_service,
+        webhook_service=AsyncMock(),
+        task_repository=mock_task_repo,
+    )
+
+
+def _task(*, task_id: str = "task_1", title: str = "Do the thing", meta=None, slug=None):
+    return Task(
+        task_id=task_id,
+        status=TaskStatus.OPEN,
+        creator_type="agent",
+        creator_id="agt_other",
+        creator_name="other",
+        title=title,
+        description="x" * 12,
+        metadata=dict(meta or {}),
+        subnet_slug=slug,
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_creates_work_and_links_metadata(svc, mock_org_repo, mock_task_repo):
+    task = _task(meta={"org_publish": True, "org_id": "org_x"})
+    mock_task_repo.find_by_id = AsyncMock(return_value=task)
+    mock_task_repo.save = AsyncMock()
+
+    work, already = await svc.import_work_from_task(
+        "org_x",
+        task_id="task_1",
+        caller_type="agent",
+        caller_sub="agt_gov",
+    )
+    assert already is False
+    assert work.title == "Do the thing"
+    assert task.metadata["org_work_id"] == work.work_id
+    assert task.metadata["org_id"] == "org_x"
+    assert task.metadata["org_import"] is True
+    mock_task_repo.save.assert_awaited()
+    mock_org_repo.save_work.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_idempotent(svc, mock_org_repo, mock_task_repo):
+    existing = OrgWorkItem(
+        work_id="work_abc",
+        org_id="org_x",
+        title="Do the thing",
+    )
+    task = _task(meta={"org_id": "org_x", "org_work_id": "work_abc", "org_import": True})
+    mock_task_repo.find_by_id = AsyncMock(return_value=task)
+    mock_org_repo.find_work = AsyncMock(return_value=existing)
+
+    work, already = await svc.import_work_from_task(
+        "org_x",
+        task_id="task_1",
+        caller_type="agent",
+        caller_sub="agt_gov",
+    )
+    assert already is True
+    assert work.work_id == "work_abc"
+    mock_task_repo.save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_conflict_other_org(svc, mock_task_repo):
+    task = _task(meta={"org_id": "org_other", "org_work_id": "work_z"})
+    mock_task_repo.find_by_id = AsyncMock(return_value=task)
+    with pytest.raises(OrgConflictError) as ei:
+        await svc.import_work_from_task(
+            "org_x",
+            task_id="task_1",
+            caller_type="agent",
+            caller_sub="agt_gov",
+        )
+    assert ei.value.reason == "task_already_imported"
+
+
+@pytest.mark.asyncio
+async def test_import_fenced_requires_membership(svc, mock_subnet_service, mock_task_repo):
+    task = _task(slug="private-net")
+    mock_task_repo.find_by_id = AsyncMock(return_value=task)
+    mock_subnet_service.get_subnet = AsyncMock(
+        return_value=SimpleNamespace(member_agent_ids={"someone_else"})
+    )
+    with pytest.raises(OrgTaskImportError) as ei:
+        await svc.import_work_from_task(
+            "org_x",
+            task_id="task_1",
+            caller_type="agent",
+            caller_sub="agt_gov",
+        )
+    assert ei.value.reason == "not_subnet_member"
+
+
+@pytest.mark.asyncio
+async def test_import_without_task_repo(mock_org_repo, mock_subnet_service, mock_agent_service):
+    svc = OrgService(
+        org_repository=mock_org_repo,
+        subnet_service=mock_subnet_service,
+        agent_service=mock_agent_service,
+        task_repository=None,
+    )
+    with pytest.raises(OrgTaskImportError) as ei:
+        await svc.import_work_from_task(
+            "org_x",
+            task_id="task_1",
+            caller_type="agent",
+            caller_sub="agt_gov",
+        )
+    assert ei.value.reason == "task_repository_unavailable"


### PR DESCRIPTION
## Summary
- `POST /orgs/{id}/work/import-task` + `acn org import-task`: governance imports a Task as Org work; persists `metadata.org_work_id` / `org_import` (idempotent; conflict if another Org already linked)
- Bridge doc upgraded to publish + import; smoke covers both + re-import; also sends required `reward` (supersedes #193)
- Skill **0.17.9**

## Test plan
- [x] `uv run pytest tests/services/test_org_import_task.py -q --no-cov`
- [x] `cd clients/cli && npm run typecheck`
- [ ] (optional) smoke against live ACN after deploy


Made with [Cursor](https://cursor.com)