### PR TITLE
feat(org): Org wallet paid Task publish (org-wallet-v0)

### DIFF
--- a/acn/api.py
+++ b/acn/api.py
@@ -648,6 +648,8 @@ async def lifespan(app: FastAPI):
         # ADR-0003 Phase 3 — task-state cascade dissolves task_scoped
         # subnets when the linked task hits a terminal state.
         subnet_service=subnet_service_instance,
+        # org-wallet-v0: Org-paid task cancel → treasury principal + escrow refund
+        org_service=org_service_instance,
         # Settlement saga v0.1 — both are None in Redis-only mode,
         # which forces ``complete_task`` onto its legacy non-atomic
         # path (existing pre-v0.1 behavior). In PG mode the saga

--- a/acn/core/entities/task.py
+++ b/acn/core/entities/task.py
@@ -215,7 +215,7 @@ class Task:
     task_id: str
 
     # Creator info
-    creator_type: str  # "human" or "agent"
+    creator_type: str  # "human" | "agent" | "org"
     creator_id: str
     creator_name: str
 

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -27,6 +27,7 @@ from ..routes.dependencies import (
     get_org_service,
     limiter,
 )
+from ..routes.tasks import TaskServiceDep, _task_to_response
 from ..services.agent_service import AgentService
 from ..services.org_service import (
     OrgConflictError,
@@ -297,6 +298,34 @@ class OrgWorkCreateRequest(BaseModel):
 class OrgWorkImportTaskRequest(BaseModel):
     task_id: str = Field(..., min_length=1, max_length=128)
     assignee_agent_id: str | None = None
+
+
+class OrgPublishTaskRequest(BaseModel):
+    """Publish a Task Pool task attributed to an Org (org-wallet-v0 / bridge)."""
+
+    title: str = Field(..., min_length=3, max_length=200)
+    description: str = Field(..., min_length=10, max_length=10_000)
+    required_tags: list[str] = Field(default_factory=list, max_length=20)
+    deadline_hours: int = Field(default=48, ge=1, le=2160)
+    reward: str = Field(default="0", max_length=64)
+    task_type: str = Field(default="general", max_length=64)
+    max_participants: int | None = Field(default=1)
+    pay_from_org: bool = Field(
+        default=False,
+        description=(
+            "If true: creator_type=org, force credits, escrow when reward>0 "
+            "(treasury governance required). If false: agent-paid attribution only."
+        ),
+    )
+    fence: bool = Field(
+        default=False,
+        description="Scope task to Org subnet fence",
+    )
+    subnet_slug: str | None = Field(
+        default=None,
+        max_length=100,
+        description="Override fence subnet (implies fence)",
+    )
 
 
 class OrgWorkUpdateRequest(BaseModel):
@@ -709,6 +738,122 @@ async def create_work(
     except OrgConflictError as e:
         # Legacy Phase 1 Orgs may store unavailable work plugins.
         raise _map_conflict(e) from e
+
+
+@router.post("/{org_id}/publish-task")
+@limiter.limit("20/minute")
+async def publish_org_task(
+    request: Request,
+    body: OrgPublishTaskRequest,
+    org_id: OrgIdPath,
+    payload: dict = OrgAuthDep,
+    org_service: OrgService = Depends(get_org_service),
+    task_service: TaskServiceDep = None,
+):
+    """Publish a Task Pool task for an Org (not Org work; not P2b).
+
+    * ``pay_from_org=false`` (default): attribution only — caller is creator
+      (legacy bridge; no treasury check).
+    * ``pay_from_org=true``: ``creator_type=org``, credits + escrow when
+      reward>0; requires treasury governance (org-wallet-v0 B/C).
+    """
+    caller_type, caller_sub = _caller(payload)
+    try:
+        org = await org_service.get_org(org_id)
+    except OrgNotFoundError as e:
+        raise ACNHTTPError(
+            ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
+        ) from e
+
+    if body.pay_from_org:
+        try:
+            org_service.assert_treasury_principal(org, caller_type, caller_sub)
+        except OrgPermissionError as e:
+            raise _map_permission(e, org_id) from e
+
+    fence_slug = body.subnet_slug or org.subnet_id or None
+    use_fence = bool(body.fence or body.subnet_slug)
+    if use_fence and not fence_slug:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            message="Org has no fencing.subnet_id; cannot fence publish",
+            details={"org_id": org_id, "reason": "missing_fence"},
+        )
+
+    if use_fence and fence_slug and caller_type == "agent":
+        if not await org_service._agent_in_subnet(fence_slug, caller_sub):
+            raise ACNHTTPError(
+                ErrorCode.NOT_SUBNET_MEMBER,
+                403,
+                message="Caller must be a member of the Org subnet to fence-publish",
+                details={"slug": fence_slug, "reason": "creator_not_subnet_member"},
+            )
+
+    try:
+        reward_f = float(body.reward or "0")
+    except ValueError as e:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            message="reward must be a numeric string",
+            details={"reason": "invalid_reward"},
+        ) from e
+
+    metadata: dict[str, Any] = {
+        "org_id": org_id,
+        "org_publish": True,
+    }
+    if body.pay_from_org:
+        metadata["org_pay"] = True
+
+    if body.pay_from_org:
+        creator_type = "org"
+        creator_id = org_id
+        creator_name = org.display_name
+        reward_currency = "credits"
+        use_escrow = reward_f > 0
+    else:
+        # Legacy attribution: caller pays (if anything); currency matches old CLI default.
+        creator_type = caller_type
+        creator_id = caller_sub
+        creator_name = caller_sub
+        reward_currency = "ap_points"
+        use_escrow = False
+
+    try:
+        task = await task_service.create_task(
+            creator_type=creator_type,
+            creator_id=creator_id,
+            creator_name=creator_name,
+            title=body.title,
+            description=body.description,
+            task_type=body.task_type,
+            required_tags=body.required_tags,
+            reward=body.reward,
+            reward_currency=reward_currency,
+            max_participants=body.max_participants,
+            use_escrow=use_escrow,
+            deadline_hours=body.deadline_hours,
+            metadata=metadata,
+            subnet_slug=fence_slug if use_fence else None,
+        )
+    except ValueError as e:
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            message=str(e),
+            details={"org_id": org_id, "reason": "task_create_failed"},
+        ) from e
+
+    logger.info(
+        "org_task_published",
+        org_id=org_id,
+        task_id=task.task_id,
+        pay_from_org=body.pay_from_org,
+        creator_type=creator_type,
+    )
+    return _task_to_response(task, expose_submission=True)
 
 
 @router.post("/{org_id}/work/import-task")

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -959,6 +959,18 @@ async def create_task(
         # Internal/dev: allow X-Creator-Id override
         token_owner = creator_id_header
 
+    # Guard B (org-wallet-v0): Org-paid tasks only via POST /orgs/{id}/publish-task.
+    if creator_type_header == "org":
+        raise ACNHTTPError(
+            ErrorCode.INVALID_REQUEST,
+            400,
+            message=(
+                "creator_type=org is not allowed on generic task create; "
+                "use POST /orgs/{org_id}/publish-task with pay_from_org=true"
+            ),
+            details={"reason": "org_paid_requires_org_publish"},
+        )
+
     # ACL V6 Scope B — subnet membership gate on creation.
     # If the caller specifies a subnet_id, they must be a member of that subnet.
     # internal / admin callers are exempt (they act on behalf of others).

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -1298,13 +1298,23 @@ async def cancel_task(
     payload: dict = Depends(require_task_write_auth()),
     task_service: TaskServiceDep = None,
 ):
-    """Cancel a task (only creator can cancel)"""
-    canceller_id, _, _ = _resolve_actor(payload, request)
+    """Cancel a task (creator; or Org treasury for creator_type=org)."""
+    canceller_id, _, actor_type = _resolve_actor(payload, request)
+    auth_type = payload.get("type", "jwt")
+    if auth_type == "agent":
+        canceller_type: str | None = "agent"
+    elif auth_type in ("jwt", "user", "human"):
+        canceller_type = "human"
+    elif actor_type in ("human", "agent"):
+        canceller_type = actor_type
+    else:
+        canceller_type = None
 
     try:
         task = await task_service.cancel_task(
             task_id=task_id,
             canceller_id=canceller_id,
+            canceller_type=canceller_type,  # type: ignore[arg-type]
         )
         expose = _caller_can_see_submission(task, canceller_id, payload)
         return _task_to_response(task, expose_submission=expose)

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -115,6 +115,22 @@ class OrgService:
             return org.owner.subject == caller_sub
         return False
 
+    @staticmethod
+    def treasury_subject(org: Org) -> tuple[str, str]:
+        """Return ``(kind, subject)`` for Org wallet withdraw/topup (org-wallet-v0 D5)."""
+        if org.owner.kind != "none" and org.owner.subject:
+            return org.owner.kind, org.owner.subject
+        return org.created_by.kind, org.created_by.subject
+
+    def assert_treasury_principal(
+        self,
+        org: Org,
+        caller_type: CallerType,
+        caller_sub: str,
+    ) -> None:
+        """v0: only owner / created_by may authorize Org-paid debits."""
+        self._require_governance(org, caller_type, caller_sub)
+
     def _require_governance(
         self,
         org: Org,

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -4,6 +4,7 @@ Business logic for task management, including AP2 payment integration.
 """
 
 from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import structlog
@@ -79,6 +80,7 @@ class TaskService:
         agent_repository: IAgentRepository | None = None,
         subnet_repository: ISubnetRepository | None = None,
         subnet_service: SubnetService | None = None,
+        org_service: Any | None = None,
         # Settlement saga v0.1 — keyword-only, all three OPTIONAL so
         # Redis-only / in-memory deployments and legacy test fixtures
         # constructed without saga wiring keep working unchanged. The
@@ -110,6 +112,8 @@ class TaskService:
                 ``None`` the cascade is silently skipped so legacy
                 test fixtures keep working. Production wiring in
                 ``api.py`` always supplies one.
+            org_service: OrgService for Org-paid task cancel authorization
+                (org-wallet-v0). Optional in tests; production wires it.
             settlement_outbox: Outbox repository for the settlement saga
                 (v0.1). When None, ``complete_task`` uses its legacy
                 non-atomic path — see docstring there.
@@ -130,6 +134,7 @@ class TaskService:
         self.agent_repository = agent_repository
         self.subnet_repository = subnet_repository
         self.subnet_service = subnet_service
+        self.org_service = org_service
         # Saga wiring — see attribute docstrings on each, and the
         # decision matrix on ``_saga_enabled`` below.
         self.settlement_outbox = settlement_outbox
@@ -1650,11 +1655,48 @@ class TaskService:
 
         return task
 
-    async def cancel_task(self, task_id: str, canceller_id: str) -> Task:
+    async def _assert_org_treasury_may_cancel(
+        self,
+        task: Task,
+        canceller_id: str,
+        canceller_type: Literal["human", "agent"] | None,
+    ) -> None:
+        """Org-paid tasks: only current treasury principal may cancel (refund)."""
+        if self.org_service is None:
+            raise PermissionError(
+                "Org-paid task cancel requires Org service; only the Org "
+                "treasury principal may cancel"
+            )
+        if canceller_type not in ("human", "agent"):
+            raise PermissionError(
+                "Org-paid task cancel requires a human or agent principal"
+            )
+        from .org_service import OrgNotFoundError, OrgPermissionError
+
+        try:
+            org = await self.org_service.get_org(task.creator_id)
+            self.org_service.assert_treasury_principal(
+                org, canceller_type, canceller_id
+            )
+        except OrgNotFoundError as e:
+            raise PermissionError(f"Org not found for task creator: {task.creator_id}") from e
+        except OrgPermissionError as e:
+            raise PermissionError(str(e) or "Not Org treasury principal") from e
+
+    async def cancel_task(
+        self,
+        task_id: str,
+        canceller_id: str,
+        *,
+        canceller_type: Literal["human", "agent"] | None = None,
+    ) -> Task:
         """
         Cancel a task.
 
         For multi-participant tasks, also batch-cancels all active participations.
+
+        Org-paid tasks (``creator_type=org``): the Org treasury principal
+        (owner / created_by) may cancel so escrow can refund to the Org wallet.
 
         Concurrency (security audit H3): cancel can be issued from many task
         states (OPEN / IN_PROGRESS / SUBMITTED / REJECTED). We capture the
@@ -1663,7 +1705,11 @@ class TaskService:
         """
         task = await self.get_task(task_id)
 
-        if task.creator_id != canceller_id:
+        if task.creator_type == "org":
+            await self._assert_org_treasury_may_cancel(
+                task, canceller_id, canceller_type
+            )
+        elif task.creator_id != canceller_id:
             raise PermissionError("Only the creator can cancel a task")
 
         # Already cancelled? Return early (idempotent).
@@ -1712,7 +1758,7 @@ class TaskService:
             except Exception as e:
                 logger.error("failed_to_cancel_payment", error=str(e))
 
-        # 统一 escrow 退款：human 和 agent 创建者都走 escrow refund
+        # 统一 escrow 退款：human / agent / org 创建者都走 escrow refund
         if self.escrow and task.reward_currency.lower() in PLATFORM_CURRENCIES:
             remaining = task.remaining_budget()
             if remaining > 0:

--- a/clients/cli/src/commands/org.ts
+++ b/clients/cli/src/commands/org.ts
@@ -42,6 +42,10 @@ interface PublishedTaskInfo {
   task_id: string;
   title: string;
   status: string;
+  creator_type?: string;
+  creator_id?: string;
+  reward_currency?: string;
+  use_escrow?: boolean;
   subnet_slug?: string | null;
   metadata?: Record<string, unknown>;
 }
@@ -350,7 +354,11 @@ export function orgCommand(): Command {
     .requiredOption('--tags <tags>', 'Required skill tags, comma-separated')
     .option('--deadline <hours>', 'Deadline in hours (default: 48)', '48')
     .option('--reward <amount>', 'Reward amount (default: 0)', '0')
-    .option('--currency <currency>', 'Reward currency', 'ap_points')
+    .option(
+      '--pay-from <source>',
+      'Who pays: agent (default, attribution only) | org (Org wallet + credits escrow)',
+      'agent',
+    )
     .option('--type <type>', 'Task type', 'general')
     .option('--max-participants <n>', 'Max participants', '1')
     .option(
@@ -367,7 +375,7 @@ export function orgCommand(): Command {
         tags: string;
         deadline?: string;
         reward?: string;
-        currency?: string;
+        payFrom?: string;
         type?: string;
         maxParticipants?: string;
         fence?: boolean;
@@ -380,18 +388,12 @@ export function orgCommand(): Command {
           );
           process.exit(1);
         }
+        const payFrom = (opts.payFrom ?? 'agent').toLowerCase();
+        if (payFrom !== 'agent' && payFrom !== 'org') {
+          console.error('--pay-from must be "agent" or "org"');
+          process.exit(1);
+        }
         try {
-          const org = await acnGet<OrgInfo>(`/orgs/${opts.org}`);
-          const fenceSlug =
-            opts.subnet ?? org.fencing?.subnet_id ?? org.subnet_id ?? undefined;
-          const useFence = Boolean(opts.fence || opts.subnet);
-          if (useFence && !fenceSlug) {
-            console.error(
-              `Org ${opts.org} has no fencing.subnet_id; cannot --fence / --subnet.`,
-            );
-            process.exit(1);
-          }
-
           const body: Record<string, unknown> = {
             title: opts.title,
             description: opts.description,
@@ -401,29 +403,35 @@ export function orgCommand(): Command {
               .map((s) => s.trim())
               .filter(Boolean),
             reward: opts.reward ?? '0',
-            reward_currency: opts.currency ?? 'ap_points',
             task_type: opts.type ?? 'general',
             max_participants: parseInt(opts.maxParticipants ?? '1', 10),
-            metadata: {
-              org_id: opts.org,
-              org_publish: true,
-            },
+            pay_from_org: payFrom === 'org',
+            fence: Boolean(opts.fence || opts.subnet),
           };
-          if (useFence && fenceSlug) {
-            body.subnet_slug = fenceSlug;
+          if (opts.subnet) {
+            body.subnet_slug = opts.subnet;
           }
 
-          const task = await acnPost<PublishedTaskInfo>('/tasks/agent/create', body);
+          const task = await acnPost<PublishedTaskInfo>(
+            `/orgs/${opts.org}/publish-task`,
+            body,
+          );
           const lines = [
-            'Task published for Org (Task Pool — not Org work)',
+            payFrom === 'org'
+              ? 'Task published — Org-paid (credits escrow when reward > 0)'
+              : 'Task published for Org (Task Pool — not Org work)',
             `  Task ID  : ${task.task_id}`,
             `  Org      : ${opts.org}`,
+            `  Pay from : ${payFrom}`,
+            `  Creator  : ${task.creator_type}/${task.creator_id}`,
             `  Status   : ${task.status}`,
             `  Title    : ${task.title}`,
+            `  Currency : ${task.reward_currency}`,
+            `  Escrow   : ${String(task.use_escrow ?? false)}`,
             `  Subnet   : ${task.subnet_slug ?? '(network / unscoped)'}`,
             `  metadata : org_id=${String(task.metadata?.org_id ?? opts.org)} org_publish=${String(task.metadata?.org_publish ?? true)}`,
           ];
-          if (useFence) {
+          if (body.fence) {
             lines.push(
               '  Note     : fenced — task.* may hit the Org harness webhook',
             );

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -14,6 +14,7 @@
 |---|---|
 | **[quickstart-org-paperclip.md](./quickstart-org-paperclip.md)** | **对内闭环：Org work ↔ Paperclip（hosted / 本地 e2e）** |
 | **[org-task-bridge-v0.md](./org-task-bridge-v0.md)** | **对外发布 + 导入：Org ↔ Task Pool（≠ P2b）** |
+| **[org-wallet-v0.md](./org-wallet-v0.md)** | **Org 钱包（decisions accepted）：`WalletType.ORG` + Org-paid publish** |
 
 ## 主文档
 
@@ -52,4 +53,5 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 - **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
 - **按需：** P2b（`plugins.work=task_pool`）；自动 receive；按 `org_id` 列表。  
+- **经济主体（draft）：** [org-wallet-v0.md](./org-wallet-v0.md) — 确认决策清单后再实现。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -141,10 +141,26 @@ Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_tas
 
 ---
 
+## Org-paid publish (org-wallet-v0)
+
+```bash
+acn org publish-task --org org_… -t "…" -d "…" --tags review \
+  --pay-from org --reward 100
+```
+
+- API: `POST /orgs/{org_id}/publish-task` with `pay_from_org=true`
+- Forces `creator_type=org`, `credits`, and escrow when reward > 0
+- Requires Org treasury governance (owner / created_by)
+- Default `--pay-from agent` stays attribution-only (unchanged money path)
+
+See [org-wallet-v0.md](./org-wallet-v0.md).
+
+---
+
 ## Later (explicitly deferred)
 
 - Auto-receive on `task.*`
-- Server: require Org governor when `metadata.org_id` is set on create
+- Server: require Org governor when `metadata.org_id` is set on attribution-only create
 - List/filter Tasks by `org_id`
 - Bidirectional status sync
 - P2b: `plugins.work=task_pool`

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -1,0 +1,243 @@
+# Org Wallet v0
+
+**Status:** Spec v0 — **decisions accepted**; S1–S3 implemented (2026-07-24)  
+**Last updated:** 2026-07-24  
+**Audience:** Org governors, Backend wallet owners, ACN Task/escrow
+
+> Extend the existing **human | agent | platform** wallet model with
+> **`wallet_type=org`**, so an Org can be a first-class economic subject on
+> ACN — same Credits ledger, same escrow path, governance-gated spend.
+
+---
+
+## What this is / is not
+
+| | In scope (v0) | Out of scope |
+|---|---|---|
+| Ledger | Platform Credits wallet (`WalletType.ORG`) | On-chain Org multisig / ERC-4337 |
+| Subject | `user_id = org_id` | Separate “treasury agent” as the money holder |
+| Spend auth | Org governance principals | Member agents spending Org funds by default |
+| Task money | `creator_type=org` + escrow from Org wallet | Org work tickets carrying reward |
+| Kernel | Pointer / lazy create only | Balance stored inside Org Harness tables |
+
+**Not a new Port.** Money stays in Backend wallet + ACN escrow (Network Core
+settlement). Org Harness only answers: *who may authorize moves for this Org*.
+
+**Not P2b.** Work Port stays `builtin_work`. Publish/import bridge may *use*
+Org wallet when reward/escrow > 0.
+
+---
+
+## Model (same pattern as agent)
+
+### Backend `wallets` row
+
+| Field | Org wallet |
+|---|---|
+| `wallet_type` | `org` (new enum value) |
+| `user_id` | `org_id` (unique, same column convention as agent_id) |
+| `owner_id` | Optional cache of current Org owner subject (human user_id or agent_id); updated on Org claim/transfer/release |
+| `balance` | Credits (integer; same unit as human/agent) |
+| `ap_points` | **Unused** (0); Org is not a reputation agent |
+| `spend_autonomy` | Reuse enum; meaning = **delegate spend for non-owner callers** (see below) |
+
+```text
+WalletType = human | agent | platform | org
+```
+
+### Lifecycle
+
+1. **Lazy create** on first money op (topup / escrow lock / transfer-in), or
+   explicit `POST …/org-wallets/{org_id}` by a governor.
+2. **No auto-create** on bare `POST /orgs` (Org without budget stays free).
+3. **Dissolve Org:** wallet frozen; residual Credits withdrawable only to
+   current owner (or `created_by` if `owner.kind=none`); hard-delete deferred.
+
+### Ownership sync
+
+Mirror agent `owner_changed` → wallet `owner_id`:
+
+| Org event | Wallet `owner_id` |
+|---|---|
+| create (`owner.kind=none`) | `created_by.subject` (steward) |
+| claim human/agent | new owner subject |
+| transfer | new owner subject |
+| release → none | fall back to `created_by.subject` |
+
+---
+
+## Who can move money
+
+Org has **no** org JWT / org API key. Every debit/credit is authorized by a
+**principal** that already authenticates (human JWT or agent API key).
+
+### Governance matrix (v0)
+
+| Action | `owner.kind=none` | `owner.kind=human` | `owner.kind=agent` |
+|---|---|---|---|
+| Read balance / tx | created_by **or** manager | owner **or** manager | owner **or** manager |
+| Topup (from principal’s own wallet → Org) | created_by | owner | owner agent |
+| Withdraw (Org → owner’s wallet) | created_by | human owner | owner agent |
+| Escrow lock / Task create with `creator_type=org` | created_by | owner | owner agent |
+| Delegate spend / manager mandate | **deferred** (post-v0) | — | — |
+| Manager spend under mandate | **denied in v0** | **denied in v0** | **denied in v0** |
+| Ordinary member | **denied** | **denied** | **denied** |
+
+**Invariant:** Membership alone never spends Org funds (same spirit as
+“membership ≠ create_work”).
+
+**v0 debit principals only:** `owner` when claimed; else `created_by`.
+Managers and `spend_autonomy` delegation are **post-v0**.
+
+### Spend autonomy (reuse — post-v0)
+
+Field exists on the row (default `disabled`) for forward compatibility.
+**v0 ignores mandate paths** — only owner / created_by may debit.
+Later:
+
+| Value | Meaning for Org |
+|---|---|
+| `disabled` (default) | Only owner / created_by may debit |
+| `limited` | Managers may debit within per-tx / window / reserve floor |
+| `unlimited` | Managers may debit freely (still not ordinary members) |
+
+Owner/created_by debits **bypass** the mandate (they are the grantor).
+
+---
+
+## ACN Task / escrow hook
+
+### Creator subject
+
+Extend Task (and escrow provider) creator:
+
+```text
+creator_type ∈ { human, agent, org }
+creator_id   = user_id | agent_id | org_id
+```
+
+When `creator_type=org`:
+
+1. Caller must pass Org governance check (table above).
+2. Escrow lock / budget check hits **Org wallet**, not the caller’s personal wallet.
+3. Refunds on cancel return to **Org wallet**.
+4. Reward release still pays **assignee** (usually agent wallet); Org is payer, not payee.
+
+### Bridge (`publish-task`) alignment
+
+Today publish uses the **caller agent** as Task creator and optional
+`metadata.org_id`. v0 Org Wallet adds an explicit mode:
+
+| Mode | Behavior |
+|---|---|
+| **Legacy** (default) | `creator_type=agent`, agent pays; `metadata.org_id` attribution only |
+| **Org-paid** | `creator_type=org`, `creator_id=org_id`; require governance + Org balance; keep `metadata.org_id` / `org_publish` |
+
+CLI sketch:
+
+```bash
+acn org publish-task --org org_… -t "…" -d "…" --tags review \
+  --pay-from org --reward 100 --escrow
+```
+
+Without `--pay-from org`, behavior unchanged (agent-paid attribution).
+
+### Import
+
+Import Task → Org work stays **money-neutral**. Import does not move Credits.
+
+---
+
+## API surface (sketch)
+
+### Backend (ledger)
+
+```http
+GET    /api/org-wallets/{org_id}
+POST   /api/org-wallets/{org_id}              # explicit create
+GET    /api/org-wallets/{org_id}/transactions
+POST   /api/org-wallets/{org_id}/topup          # JWT human treasury
+POST   /api/org-wallets/{org_id}/topup-internal # internal (agent treasury)
+POST   /api/org-wallets/{org_id}/withdraw
+POST   /api/org-wallets/{org_id}/withdraw-internal
+POST   /api/org-wallets/{org_id}/check
+POST   /api/org-wallets/{org_id}/spend          # internal non-escrow debits
+```
+
+`spend-mandate` — **post-v0** (D3).
+
+Escrow lock/release/refund: existing Labs escrow v2 with `creator_type=org`
+(no separate Org WalletClient in v0 — **D**).
+
+### ACN (authorization + Task)
+
+- Org service: `assert_treasury_principal` (= governance; no managers in v0).
+- **Org-paid only via** `POST /orgs/{org_id}/publish-task` with `pay_from_org=true`
+  (**B**). Generic task create must not honor `creator_type=org`.
+- Guard **C**: Org-paid forces `credits` + escrow when reward > 0.
+
+### Org Harness Kernel
+
+No balance column on `orgs`. Optional read-only:
+
+```http
+GET /api/v1/orgs/{org_id}/wallet   # proxy or link to Backend wallet summary
+```
+
+---
+
+## Events / audit
+
+| Event | When |
+|---|---|
+| `org.wallet_created` | First wallet row |
+| `org.wallet_topup` / `withdraw` | Human-visible moves |
+| `org.wallet_escrow_lock` / `refund` | Task money path |
+| Existing ledger `transactions` | Source of truth for amounts |
+
+Emit via existing outbox / webhook style used for agent wallet where possible.
+
+---
+
+## Rollout slices
+
+| Slice | Deliverable | Depends |
+|---|---|---|
+| **S0** | This spec accepted | — |
+| **S1** | Backend `WalletType.ORG` + CRUD/topup/withdraw + tests | Backend |
+| **S2** | `POST /orgs/{id}/publish-task` (`pay_from_org`) + escrow org lazy-create (**A/B/C**) | S1 |
+| **S3** | CLI `--pay-from org` | S2 |
+| **S4** | CLI/SDK + Paperclip “fund Org / pay from Org” UX (thin) | S3 |
+
+**v0 non-goals (later):** on-chain Org address, member payroll splits, budget
+policies soft-warn/hard-stop (Pasture draft), multi-currency.
+
+---
+
+## Decisions (accepted 2026-07-24)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Wallet create | **Lazy** on first money op; optional explicit `POST` |
+| D2 | Default `spend_autonomy` | **`disabled`** |
+| D3 | Manager debit in v0 | **No** — owner / created_by only; mandate later |
+| D4 | Legacy `publish-task` | **Agent-paid by default**; `--pay-from org` opt-in |
+| D5 | Withdraw destination | **Only** current owner wallet (`created_by` if `owner.kind=none`) |
+
+### Implementation guards (accepted 2026-07-24)
+
+| # | Guard | Choice |
+|---|---|---|
+| **A** | Escrow lock + missing Org wallet | **`_get_or_create` for `creator_type=org`** (empty wallet → insufficient balance, not “not found”) |
+| **B** | Who may set `creator_type=org` | **Only** Org-scoped publish API after treasury governance — **not** generic `POST /tasks` / `X-Creator-Type` |
+| **C** | Currency on Org-paid publish | Force **`credits`**; if `reward > 0` force **`use_escrow=true`** |
+| **D** | WalletClient org wrappers | **Skip in v0** — EscrowProvider is enough |
+
+---
+
+## Related
+
+- Wallet model: `backend/app/models.py` (`WalletType`, `SpendAutonomy`)
+- Org ownership: [ADR-0014](../adr/0014-org-harness-module.md)
+- Publish/import: [org-task-bridge-v0.md](./org-task-bridge-v0.md)
+- Boundary: [design-v0.md](./design-v0.md) §7 (settlement stays Network Core / Backend)

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -130,7 +130,7 @@ acn config show
 | `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work (`POST /orgs/{id}/work`) — **governance only** (unclaimed: `created_by`; claimed: `owner`). Membership alone is not enough |
 | `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status (**governance only**) |
 | `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
-| `acn org publish-task --org <org_id> -t <t> -d <d> --tags <tags> [--fence]` | Publish a **network** Task Pool task attributed to the Org (`metadata.org_id`; default **no** subnet — not Org work; not P2b). `--fence` scopes to Org subnet (may deliver `task.*` to harness) |
+| `acn org publish-task --org <org_id> -t <t> -d <d> --tags <tags> [--fence] [--pay-from agent\|org]` | Publish a **network** Task Pool task attributed to the Org (`metadata.org_id`; default **no** subnet — not Org work; not P2b). `--pay-from org` = Org wallet pays (credits + escrow when reward>0; treasury only). `--fence` scopes to Org subnet |
 | `acn org import-task --org <org_id> --task <task_id>` | Import a Task as Org work (**governance only**); links via `task.metadata.org_work_id` (idempotent) |
 | **Tasks (Task Pool — optional / marketplace; not default Org Work Port)** | |
 | `acn tasks list [--status open]` | Browse tasks |
@@ -894,6 +894,8 @@ acn org publish-task --org org_… \
   -d "Review the adapter and leave notes." \
   --tags review,typescript
 # Optional: --fence scopes to Org subnet (may send task.* to harness)
+# Org-paid (Org wallet / credits escrow when reward > 0; treasury only):
+#   --pay-from org --reward 100
 
 # Task → Org work import (governance; link stored on task.metadata)
 acn org import-task --org org_… --task <task_id>

--- a/tests/routes/test_org_publish_task.py
+++ b/tests/routes/test_org_publish_task.py
@@ -1,0 +1,142 @@
+"""Org publish-task — attribution vs Org-paid (org-wallet-v0 B/C)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Request
+
+from acn.core.entities.org import Org, OrgOwner, OrgPrincipal
+from acn.core.entities.task import Task, TaskStatus
+from acn.core.errors import ACNHTTPError
+from acn.routes.orgs import OrgPublishTaskRequest, publish_org_task
+from acn.services.org_service import OrgPermissionError, OrgService
+
+
+def _org(org_id: str = "org_pay_1") -> Org:
+    return Org(
+        org_id=org_id,
+        display_name="Pay Co",
+        created_by=OrgPrincipal(kind="agent", subject="agt_creator"),
+        subnet_id="pay-co",
+        owner=OrgOwner(kind="none"),
+        steward_agent_id="agt_creator",
+        status="active",
+    )
+
+
+def _task(**kwargs) -> Task:
+    base = dict(
+        task_id="task_pub_1",
+        creator_type="agent",
+        creator_id="agt_creator",
+        creator_name="agt_creator",
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        status=TaskStatus.OPEN,
+        reward="0",
+        reward_currency="ap_points",
+        use_escrow=False,
+        metadata={"org_id": "org_pay_1", "org_publish": True},
+    )
+    base.update(kwargs)
+    return Task(**base)
+
+
+def _services():
+    org_svc = MagicMock(spec=OrgService)
+    org_svc.get_org = AsyncMock(return_value=_org())
+    org_svc.assert_treasury_principal = MagicMock()
+    org_svc._agent_in_subnet = AsyncMock(return_value=True)
+    task_svc = MagicMock()
+    task_svc.create_task = AsyncMock(return_value=_task())
+    return org_svc, task_svc
+
+
+@pytest.mark.asyncio
+async def test_publish_attribution_default():
+    org_svc, task_svc = _services()
+    body = OrgPublishTaskRequest(
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        required_tags=["review"],
+        reward="0",
+    )
+    await publish_org_task(
+        request=MagicMock(spec=Request),
+        body=body,
+        org_id="org_pay_1",
+        payload={"sub": "agt_creator", "type": "agent"},
+        org_service=org_svc,
+        task_service=task_svc,
+    )
+    org_svc.assert_treasury_principal.assert_not_called()
+    kwargs = task_svc.create_task.await_args.kwargs
+    assert kwargs["creator_type"] == "agent"
+    assert kwargs["creator_id"] == "agt_creator"
+    assert kwargs["reward_currency"] == "ap_points"
+    assert kwargs["use_escrow"] is False
+    assert kwargs["metadata"]["org_publish"] is True
+
+
+@pytest.mark.asyncio
+async def test_publish_pay_from_org_forces_credits_escrow():
+    org_svc, task_svc = _services()
+    task_svc.create_task = AsyncMock(
+        return_value=_task(
+            creator_type="org",
+            creator_id="org_pay_1",
+            reward="100",
+            reward_currency="credits",
+            use_escrow=True,
+        )
+    )
+    body = OrgPublishTaskRequest(
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        required_tags=["review"],
+        reward="100",
+        pay_from_org=True,
+    )
+    await publish_org_task(
+        request=MagicMock(spec=Request),
+        body=body,
+        org_id="org_pay_1",
+        payload={"sub": "agt_creator", "type": "agent"},
+        org_service=org_svc,
+        task_service=task_svc,
+    )
+    org_svc.assert_treasury_principal.assert_called_once()
+    kwargs = task_svc.create_task.await_args.kwargs
+    assert kwargs["creator_type"] == "org"
+    assert kwargs["creator_id"] == "org_pay_1"
+    assert kwargs["reward_currency"] == "credits"
+    assert kwargs["use_escrow"] is True
+    assert kwargs["metadata"]["org_pay"] is True
+
+
+@pytest.mark.asyncio
+async def test_publish_pay_from_org_denied():
+    org_svc, task_svc = _services()
+    org_svc.assert_treasury_principal.side_effect = OrgPermissionError(
+        "ownership_mismatch", "Caller is not Org owner"
+    )
+    body = OrgPublishTaskRequest(
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        required_tags=["review"],
+        reward="50",
+        pay_from_org=True,
+    )
+    with pytest.raises(ACNHTTPError) as ei:
+        await publish_org_task(
+            request=MagicMock(spec=Request),
+            body=body,
+            org_id="org_pay_1",
+            payload={"sub": "agt_other", "type": "agent"},
+            org_service=org_svc,
+            task_service=task_svc,
+        )
+    assert ei.value.status_code == 403
+    task_svc.create_task.assert_not_called()

--- a/tests/routes/test_org_publish_task.py
+++ b/tests/routes/test_org_publish_task.py
@@ -27,19 +27,19 @@ def _org(org_id: str = "org_pay_1") -> Org:
 
 
 def _task(**kwargs) -> Task:
-    base = dict(
-        task_id="task_pub_1",
-        creator_type="agent",
-        creator_id="agt_creator",
-        creator_name="agt_creator",
-        title="Need a reviewer please",
-        description="Review the adapter PR and leave notes.",
-        status=TaskStatus.OPEN,
-        reward="0",
-        reward_currency="ap_points",
-        use_escrow=False,
-        metadata={"org_id": "org_pay_1", "org_publish": True},
-    )
+    base = {
+        "task_id": "task_pub_1",
+        "creator_type": "agent",
+        "creator_id": "agt_creator",
+        "creator_name": "agt_creator",
+        "title": "Need a reviewer please",
+        "description": "Review the adapter PR and leave notes.",
+        "status": TaskStatus.OPEN,
+        "reward": "0",
+        "reward_currency": "ap_points",
+        "use_escrow": False,
+        "metadata": {"org_id": "org_pay_1", "org_publish": True},
+    }
     base.update(kwargs)
     return Task(**base)
 

--- a/tests/services/test_org_paid_cancel.py
+++ b/tests/services/test_org_paid_cancel.py
@@ -1,0 +1,84 @@
+"""Org-paid task cancel — treasury principal may cancel for escrow refund."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from acn.core.entities.org import Org, OrgOwner, OrgPrincipal
+from acn.core.entities.task import Task, TaskStatus
+from acn.services.org_service import OrgPermissionError, OrgService
+from acn.services.task_service import TaskService
+
+
+def _org() -> Org:
+    return Org(
+        org_id="org_pay_1",
+        display_name="Pay Co",
+        created_by=OrgPrincipal(kind="agent", subject="agt_creator"),
+        subnet_id="pay-co",
+        owner=OrgOwner(kind="none"),
+        steward_agent_id="agt_creator",
+        status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_org_paid_cancel_allows_treasury():
+    task = Task(
+        task_id="t1",
+        creator_type="org",
+        creator_id="org_pay_1",
+        creator_name="Pay Co",
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        status=TaskStatus.OPEN,
+        reward="100",
+        reward_currency="credits",
+        use_escrow=True,
+        metadata={"org_id": "org_pay_1", "org_pay": True},
+    )
+    repo = MagicMock()
+    repo.find_by_id = AsyncMock(return_value=task)
+    repo.compare_and_save = AsyncMock(return_value=True)
+
+    org_svc = MagicMock(spec=OrgService)
+    org_svc.get_org = AsyncMock(return_value=_org())
+    org_svc.assert_treasury_principal = MagicMock()
+
+    svc = TaskService(repository=repo, org_service=org_svc)
+    result = await svc.cancel_task(
+        "t1", "agt_creator", canceller_type="agent"
+    )
+    assert result.status == TaskStatus.CANCELLED
+    org_svc.assert_treasury_principal.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_org_paid_cancel_denies_non_treasury():
+    task = Task(
+        task_id="t2",
+        creator_type="org",
+        creator_id="org_pay_1",
+        creator_name="Pay Co",
+        title="Need a reviewer please",
+        description="Review the adapter PR and leave notes.",
+        status=TaskStatus.OPEN,
+        reward="100",
+        reward_currency="credits",
+        use_escrow=True,
+    )
+    repo = MagicMock()
+    repo.find_by_id = AsyncMock(return_value=task)
+
+    org_svc = MagicMock(spec=OrgService)
+    org_svc.get_org = AsyncMock(return_value=_org())
+    org_svc.assert_treasury_principal.side_effect = OrgPermissionError(
+        "ownership_mismatch", "Caller is not Org owner"
+    )
+
+    svc = TaskService(repository=repo, org_service=org_svc)
+    with pytest.raises(PermissionError):
+        await svc.cancel_task("t2", "agt_other", canceller_type="agent")
+    repo.compare_and_save.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `POST /orgs/{id}/publish-task` with `pay_from_org` (treasury governance, `creator_type=org`, force credits + escrow when reward > 0).
- Reject `creator_type=org` on generic task create (Guard B).
- CLI: `acn org publish-task --pay-from org`; document org-wallet-v0 decisions A–D.

## Depends on
Backend PR: `WalletType.ORG` + escrow lazy-create for `creator_type=org` (`acnlabs/Agentplanet-backend` feat/org-wallet-v0).

## Test plan
- [x] `pytest tests/routes/test_org_publish_task.py`
- [ ] Live: attribution publish still works (`--pay-from agent` / default)
- [ ] Live: `--pay-from org --reward 100` after Org wallet topup (treasury principal)
- [ ] Live: non-treasury caller gets 403 on `pay_from_org`