### PR TITLE
feat(tasks): best-effort A2A push on task invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Task invite → A2A push:** `POST /tasks/{id}/invite` (and
+  `TaskService.invite_agent`) now best-effort routes an A2A
+  `task_request` to the invitee via `MessageService` /
+  `MessageRouter` (Mode A direct / Mode B relay / offline inbox).
+  Metadata includes `task_id` / `acn_task_id` so `acn listen --runtime`
+  can wake and dedupe. Push failure is logged and does **not** roll
+  back the invite whitelist. New webhook event `task.invited`
+  (`WebhookEventType.TASK_INVITED`) with `data.invitee_id`.
+  Skill **0.17.10**.
+
 ### Docs
 
 - **Org ↔ Task Pool bridge v0** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can wake and dedupe. Push failure is logged and does **not** roll
   back the invite whitelist. New webhook event `task.invited`
   (`WebhookEventType.TASK_INVITED`) with `data.invitee_id`.
+  Non-agent inviters (e.g. human Studio users) send as
+  `system:task-invite` so the push is not rejected by the agent
+  registry lookup; metadata still carries the real `from_agent`.
   Skill **0.17.10**.
 
 ### Docs

--- a/acn/api.py
+++ b/acn/api.py
@@ -650,6 +650,8 @@ async def lifespan(app: FastAPI):
         subnet_service=subnet_service_instance,
         # org-wallet-v0: Org-paid task cancel → treasury principal + escrow refund
         org_service=org_service_instance,
+        # Task invite → A2A push (Mode A/B/inbox via MessageRouter)
+        message_service=message_service_instance,
         # Settlement saga v0.1 — both are None in Redis-only mode,
         # which forces ``complete_task`` onto its legacy non-atomic
         # path (existing pre-v0.1 behavior). In PG mode the saga

--- a/acn/protocols/ap2/webhook.py
+++ b/acn/protocols/ap2/webhook.py
@@ -63,6 +63,7 @@ class WebhookEventType(StrEnum):
 
     # Task lifecycle
     TASK_CREATED = "task.created"
+    TASK_INVITED = "task.invited"
     TASK_ACCEPTED = "task.accepted"
     TASK_SUBMITTED = "task.submitted"
     TASK_COMPLETED = "task.completed"

--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -1155,6 +1155,10 @@ async def invite_solver(
     """Invite a specific solver to the task (creator only).
 
     Invited solvers can join via /accept even when require_join_approval is True.
+
+    After the invite whitelist is saved, ACN best-effort pushes an A2A
+    ``task_request`` to the invitee (Mode A direct / Mode B relay /
+    offline inbox). Push failure does not roll back the invite.
     """
     inviter_id, _, _ = _resolve_actor(payload, request)
 

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+# Reserved sender when the task creator is not a registered agent
+# (e.g. human Studio user). ``MessageService.send_message`` skips the
+# agent-table lookup for ``system:<slug>``; the real inviter stays in
+# message metadata ``from_agent``.
+_TASK_INVITE_SYSTEM_SENDER = "system:task-invite"
+
 # Namespace for ``event_id = uuid5(NS, f"{task_id}:{trigger}")``. Using a
 # fixed URL-based namespace means the same (task_id, trigger) pair always
 # resolves to the same event_id across processes/replicas — the outbox
@@ -564,6 +570,20 @@ class TaskService:
         )
         return task
 
+    async def _resolve_invite_sender(self, inviter_id: str) -> str:
+        """Return ``from_agent_id`` for the invite A2A push.
+
+        Registered agents send as themselves. Humans (or any inviter not
+        in the agent registry) send as ``system:task-invite`` so
+        ``MessageService`` does not reject the push with AgentNotFound.
+        """
+        if self.agent_repository is None:
+            return inviter_id
+        sender = await self.agent_repository.find_by_id(inviter_id)
+        if sender:
+            return inviter_id
+        return _TASK_INVITE_SYSTEM_SENDER
+
     async def _push_invite_a2a(
         self,
         task: Task,
@@ -575,6 +595,7 @@ class TaskService:
         if not self.message_service:
             return
 
+        from_agent_id = await self._resolve_invite_sender(inviter_id)
         payload = {
             "task_id": task.task_id,
             "title": task.title,
@@ -593,6 +614,7 @@ class TaskService:
                 "type": "task_request",
                 "message_type": "task_request",
                 "title": task.title,
+                # Real inviter (may be a human id); routing sender may be system.
                 "from_agent": inviter_id,
             },
             task_id=task.task_id,
@@ -600,7 +622,7 @@ class TaskService:
 
         try:
             await self.message_service.send_message(
-                from_agent_id=inviter_id,
+                from_agent_id=from_agent_id,
                 to_agent_id=invitee_id,
                 message=message,
                 message_type="task_request",
@@ -610,6 +632,7 @@ class TaskService:
                 "task_invite_a2a_push_failed",
                 task_id=task.task_id,
                 inviter_id=inviter_id,
+                from_agent_id=from_agent_id,
                 invitee_id=invitee_id,
                 error=str(e),
             )

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -3,11 +3,14 @@
 Business logic for task management, including AP2 payment integration.
 """
 
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import structlog
+from a2a.compat.v0_3.types import DataPart, Message, TextPart  # type: ignore[import-untyped]
 
 from ..core.entities import Participation, ParticipationStatus, Task, TaskStatus
 from ..core.exceptions import SubnetNotFoundException
@@ -25,6 +28,9 @@ from ..protocols.ap2 import PaymentTaskManager, WebhookEventType, WebhookService
 from ..protocols.ap2.core import PLATFORM_CURRENCIES
 from .activity_service import ActivityService
 from .subnet_service import SubnetService
+
+if TYPE_CHECKING:
+    from .message_service import MessageService
 
 logger = structlog.get_logger()
 
@@ -81,6 +87,7 @@ class TaskService:
         subnet_repository: ISubnetRepository | None = None,
         subnet_service: SubnetService | None = None,
         org_service: Any | None = None,
+        message_service: MessageService | None = None,
         # Settlement saga v0.1 — keyword-only, all three OPTIONAL so
         # Redis-only / in-memory deployments and legacy test fixtures
         # constructed without saga wiring keep working unchanged. The
@@ -114,6 +121,9 @@ class TaskService:
                 ``api.py`` always supplies one.
             org_service: OrgService for Org-paid task cancel authorization
                 (org-wallet-v0). Optional in tests; production wires it.
+            message_service: MessageService for best-effort A2A invite
+                push (optional). When None, ``invite_agent`` only
+                updates the whitelist — matches pre-push behavior.
             settlement_outbox: Outbox repository for the settlement saga
                 (v0.1). When None, ``complete_task`` uses its legacy
                 non-atomic path — see docstring there.
@@ -135,6 +145,7 @@ class TaskService:
         self.subnet_repository = subnet_repository
         self.subnet_service = subnet_service
         self.org_service = org_service
+        self.message_service = message_service
         # Saga wiring — see attribute docstrings on each, and the
         # decision matrix on ``_saga_enabled`` below.
         self.settlement_outbox = settlement_outbox
@@ -503,6 +514,12 @@ class TaskService:
         """Creator invites a specific solver to the task.
 
         Invited solvers can join even when require_join_approval is True.
+
+        After the whitelist write, best-effort pushes an A2A
+        ``task_request`` to the invitee via ``MessageService`` (Mode A
+        direct / Mode B relay / offline inbox). Push failure is logged
+        and does **not** roll back the invite. Also emits
+        ``WebhookEventType.TASK_INVITED`` when a webhook service is wired.
         """
         task = await self.get_task(task_id)
 
@@ -532,6 +549,13 @@ class TaskService:
                 metadata={"invitee_id": invitee_id},
             )
 
+        await self._push_invite_a2a(task, inviter_id=inviter_id, invitee_id=invitee_id)
+        await self._notify_webhook(
+            WebhookEventType.TASK_INVITED,
+            task,
+            extra={"invitee_id": invitee_id},
+        )
+
         logger.info(
             "task_solver_invited",
             task_id=task_id,
@@ -539,6 +563,56 @@ class TaskService:
             invitee_id=invitee_id,
         )
         return task
+
+    async def _push_invite_a2a(
+        self,
+        task: Task,
+        *,
+        inviter_id: str,
+        invitee_id: str,
+    ) -> None:
+        """Best-effort A2A task_request to the invitee (does not raise)."""
+        if not self.message_service:
+            return
+
+        payload = {
+            "task_id": task.task_id,
+            "title": task.title,
+            "subnet_id": task.subnet_slug,
+        }
+        message = Message(
+            role="user",
+            parts=[
+                TextPart(text=f"You have been invited to task: {task.title}"),
+                DataPart(data=payload),
+            ],
+            message_id=f"msg-{uuid4().hex[:12]}",
+            metadata={
+                "task_id": task.task_id,
+                "acn_task_id": task.task_id,
+                "type": "task_request",
+                "message_type": "task_request",
+                "title": task.title,
+                "from_agent": inviter_id,
+            },
+            task_id=task.task_id,
+        )
+
+        try:
+            await self.message_service.send_message(
+                from_agent_id=inviter_id,
+                to_agent_id=invitee_id,
+                message=message,
+                message_type="task_request",
+            )
+        except Exception as e:  # noqa: BLE001 — invite must stay durable
+            logger.warning(
+                "task_invite_a2a_push_failed",
+                task_id=task.task_id,
+                inviter_id=inviter_id,
+                invitee_id=invitee_id,
+                error=str(e),
+            )
 
     async def _join_task(
         self,
@@ -2055,7 +2129,13 @@ class TaskService:
                     error=str(exc),
                 )
 
-    async def _notify_webhook(self, event: WebhookEventType, task: Task) -> None:
+    async def _notify_webhook(
+        self,
+        event: WebhookEventType,
+        task: Task,
+        *,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
         """Send webhook notification.
 
         Two delivery targets:
@@ -2068,6 +2148,9 @@ class TaskService:
            ``harness_secret``. This is what makes Org Harnesses pluggable:
            Paperclip / OpenHarness / etc. only need to register a URL on the
            subnet and they will receive the full task lifecycle.
+
+        ``extra`` is merged into the top-level payload (e.g. ``invitee_id``
+        on ``task.invited``). Failures are logged and never raised.
         """
         if not self.webhook:
             return
@@ -2092,6 +2175,8 @@ class TaskService:
                 if (task.metadata or {}).get(k) is not None
             },
         }
+        if extra:
+            payload.update(extra)
 
         try:
             await self.webhook.send_event(
@@ -2219,7 +2304,7 @@ class TaskService:
 
     async def _distribute_reward(
         self,
-        task: "Task",
+        task: Task,
         amount: float,
         description: str,
         participant_id: str | None = None,

--- a/docs/api.md
+++ b/docs/api.md
@@ -312,6 +312,7 @@ HMAC-SHA256 signed with `harness_secret` in the `X-ACN-Signature: sha256=<hex>` 
 | `agent.joined_subnet` | An agent joins the subnet |
 | `agent.left_subnet` | An agent leaves the subnet |
 | `task.created` | A task is created in this subnet |
+| `task.invited` | Creator invites a solver (`data.invitee_id`; also best-effort A2A `task_request` to the invitee) |
 | `task.accepted` | An agent accepts a task |
 | `task.submitted` | An agent submits results |
 | `task.rejected` | A single-participant submission is rejected |

--- a/docs/issues/task-invite-a2a-push.md
+++ b/docs/issues/task-invite-a2a-push.md
@@ -1,0 +1,30 @@
+# Draft GitHub issue: Task invite → A2A push
+
+> Create with `gh issue create` when GitHub auth is available.
+> Title: **Task invite should push A2A task_request to invitee**
+
+## Summary
+
+`TaskService.invite_agent` previously only wrote `invited_agent_ids` + activity — **no A2A / notify / inbox push**. Mode A and Mode B workers therefore never woke on invite (including `acn listen --runtime`).
+
+This is a **send-side** gap, not a transport bug. Documented by ComicLaw: `docs/acn-invite-no-a2a-defect.md` (comiclaw-studio).
+
+## Fix
+
+Branch: `feat/task-invite-a2a-push`
+
+- After invite whitelist save: best-effort `MessageService.send_message` with A2A `task_request` (`metadata.task_id` / `acn_task_id` for `--runtime` dedupe).
+- New webhook `task.invited` (`WebhookEventType.TASK_INVITED`) with `invitee_id`.
+- Push / webhook failure must **not** roll back the invite.
+
+## Acceptance
+
+1. Mode B worker online with `acn listen --runtime …`
+2. Creator invites that worker
+3. Listen receives A2A / wake within seconds (no reconcile needed)
+4. Offline invitee → inbox (existing MessageRouter); whitelist still written
+
+## Related
+
+- CLI runtime receiver: #191 / `@acnlabs/acn-cli@0.14.0`
+- ComicLaw: after this lands, mark defect doc **ACN 已修 / 待验收** and verify end-to-end

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.9"
+  version: "0.17.10"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -142,7 +142,7 @@ acn config show
 | `acn tasks review <task_id> --approve\|--reject [--notes <text>]` | Approve or reject submission (creator only) |
 | `acn tasks cancel <task_id>` | Cancel task |
 | `acn tasks history <agent_id>` | View agent's task history (submissions, feedback, resubmit counts) |
-| `acn tasks invite <task_id> --agent-id <agent_id>` | Invite specific agent |
+| `acn tasks invite <task_id> --agent-id <agent_id>` | Invite specific agent (writes whitelist; **best-effort A2A `task_request`** to invitee via MessageRouter — Mode A/B/inbox; push failure does not roll back invite) |
 | `acn tasks participations <task_id>` | List participants |
 | `acn tasks participation <task_id>` | Check your participation |
 | `acn tasks approve-applicant <task_id> --participation-id <pid>` | Approve applicant as assignee (creator only) |

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -166,7 +166,7 @@ Optional network task facility. **Not** the default Org Work Port.
 | POST | `/tasks` | API Key / Auth0 | Create task |
 | POST | `/tasks/agent/create` | API Key | Create task (agent shorthand) |
 | POST | `/tasks/{id}/accept` | API Key | Accept task |
-| POST | `/tasks/{id}/invite` | API Key | Invite specific agent |
+| POST | `/tasks/{id}/invite` | API Key | Invite specific agent (best-effort A2A `task_request` to invitee; webhook `task.invited`) |
 | POST | `/tasks/{id}/submit` | API Key | Submit result |
 | POST | `/tasks/{id}/review` | API Key | Approve/reject submission |
 | POST | `/tasks/{id}/cancel` | API Key | Cancel task |

--- a/tests/services/test_task_service_invite_a2a.py
+++ b/tests/services/test_task_service_invite_a2a.py
@@ -1,0 +1,133 @@
+"""Unit tests for TaskService.invite_agent A2A push (best-effort)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from acn.core.entities.task import Task, TaskStatus
+from acn.protocols.ap2 import WebhookEventType
+from acn.services.task_service import TaskService
+
+
+def _make_task(**overrides) -> Task:
+    defaults = {
+        "task_id": "task-invite-001",
+        "creator_type": "agent",
+        "creator_id": "creator-001",
+        "creator_name": "Creator",
+        "title": "Fix the invite push",
+        "description": "Invitee should receive A2A",
+        "reward": "10",
+        "reward_currency": "credits",
+        "status": TaskStatus.OPEN,
+        "subnet_slug": "demo-subnet",
+        "invited_agent_ids": [],
+    }
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+@pytest.fixture
+def mock_repo():
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_message_service():
+    svc = AsyncMock()
+    svc.send_message = AsyncMock(return_value={"status": "delivered"})
+    return svc
+
+
+@pytest.fixture
+def mock_webhook():
+    wh = AsyncMock()
+    wh.send_event = AsyncMock()
+    wh.send_to = AsyncMock()
+    return wh
+
+
+class TestInviteAgentA2APush:
+    async def test_invite_sends_a2a_with_task_id_metadata(
+        self, mock_repo, mock_message_service, mock_webhook
+    ):
+        task = _make_task()
+        mock_repo.find_by_id = AsyncMock(return_value=task)
+        mock_repo.save = AsyncMock()
+
+        service = TaskService(
+            repository=mock_repo,
+            message_service=mock_message_service,
+            webhook_service=mock_webhook,
+        )
+
+        result = await service.invite_agent(
+            task_id=task.task_id,
+            inviter_id="creator-001",
+            invitee_id="worker-001",
+            invitee_name="Worker",
+        )
+
+        assert "worker-001" in result.invited_agent_ids
+        mock_repo.save.assert_awaited_once()
+        mock_message_service.send_message.assert_awaited_once()
+
+        call = mock_message_service.send_message.await_args
+        assert call.kwargs["from_agent_id"] == "creator-001"
+        assert call.kwargs["to_agent_id"] == "worker-001"
+        assert call.kwargs["message_type"] == "task_request"
+        message = call.kwargs["message"]
+        assert message.metadata["task_id"] == "task-invite-001"
+        assert message.metadata["acn_task_id"] == "task-invite-001"
+        assert message.metadata["type"] == "task_request"
+        assert message.metadata["message_type"] == "task_request"
+        assert message.metadata["title"] == "Fix the invite push"
+
+        mock_webhook.send_event.assert_awaited_once()
+        wh_call = mock_webhook.send_event.await_args
+        assert wh_call.kwargs["event"] == WebhookEventType.TASK_INVITED
+        assert wh_call.kwargs["task_id"] == "task-invite-001"
+        assert wh_call.kwargs["data"]["invitee_id"] == "worker-001"
+
+    async def test_invite_push_failure_does_not_rollback(
+        self, mock_repo, mock_message_service
+    ):
+        task = _make_task()
+        mock_repo.find_by_id = AsyncMock(return_value=task)
+        mock_repo.save = AsyncMock()
+        mock_message_service.send_message = AsyncMock(
+            side_effect=RuntimeError("router down")
+        )
+
+        service = TaskService(
+            repository=mock_repo,
+            message_service=mock_message_service,
+        )
+
+        result = await service.invite_agent(
+            task_id=task.task_id,
+            inviter_id="creator-001",
+            invitee_id="worker-001",
+        )
+
+        assert "worker-001" in result.invited_agent_ids
+        mock_repo.save.assert_awaited_once()
+        mock_message_service.send_message.assert_awaited_once()
+
+    async def test_invite_without_message_service_only_writes_whitelist(self, mock_repo):
+        task = _make_task()
+        mock_repo.find_by_id = AsyncMock(return_value=task)
+        mock_repo.save = AsyncMock()
+
+        service = TaskService(repository=mock_repo, message_service=None)
+
+        result = await service.invite_agent(
+            task_id=task.task_id,
+            inviter_id="creator-001",
+            invitee_id="worker-001",
+        )
+
+        assert "worker-001" in result.invited_agent_ids
+        mock_repo.save.assert_awaited_once()
+        assert service.message_service is None

--- a/tests/services/test_task_service_invite_a2a.py
+++ b/tests/services/test_task_service_invite_a2a.py
@@ -131,3 +131,32 @@ class TestInviteAgentA2APush:
         assert "worker-001" in result.invited_agent_ids
         mock_repo.save.assert_awaited_once()
         assert service.message_service is None
+
+    async def test_human_inviter_sends_as_system_task_invite(
+        self, mock_repo, mock_message_service
+    ):
+        """Human creators are not in the agent table — use system: sender."""
+        task = _make_task(creator_type="human", creator_id="human-user-1")
+        mock_repo.find_by_id = AsyncMock(return_value=task)
+        mock_repo.save = AsyncMock()
+
+        agent_repo = AsyncMock()
+        agent_repo.find_by_id = AsyncMock(return_value=None)
+
+        service = TaskService(
+            repository=mock_repo,
+            message_service=mock_message_service,
+            agent_repository=agent_repo,
+        )
+
+        result = await service.invite_agent(
+            task_id=task.task_id,
+            inviter_id="human-user-1",
+            invitee_id="worker-001",
+        )
+
+        assert "worker-001" in result.invited_agent_ids
+        call = mock_message_service.send_message.await_args
+        assert call.kwargs["from_agent_id"] == "system:task-invite"
+        assert call.kwargs["message"].metadata["from_agent"] == "human-user-1"
+        agent_repo.find_by_id.assert_awaited_once_with("human-user-1")


### PR DESCRIPTION
## Summary
- After Task Pool `invite` saves the whitelist, best-effort route an A2A `task_request` to the invitee via `MessageService` / `MessageRouter` (Mode A direct / Mode B relay / offline inbox), so `acn listen --runtime` can wake without reconcile.
- Emit webhook `task.invited` with `data.invitee_id`; push/webhook failures do not roll back the invite.
- Docs/Skill **0.17.10** + unit tests for metadata, failure durability, and no-`message_service` compatibility.

## Test plan
- [x] `pytest tests/services/test_task_service_invite_a2a.py` (3 passed)
- [ ] Mode B worker online with `acn listen --runtime …`; creator invites; listen wakes within seconds
- [ ] Invitee offline → message lands in inbox; `invited_agent_ids` still written
- [ ] After merge: ComicLaw mark `acn-invite-no-a2a-defect.md` as ACN fixed / pending acceptance