### PR TITLE
docs: task invite sender roles after #198

### DIFF
--- a/docs/features/task-invite-sender.md
+++ b/docs/features/task-invite-sender.md
@@ -1,0 +1,29 @@
+# Task invite：谁在 ACN 上代打？
+
+**状态：** 约定（v0）  
+**关联：** [ACN #198](https://github.com/acnlabs/ACN/pull/198)、`acn listen --runtime`、ComicLaw invite 缺陷
+
+## 一句话
+
+网上喊工人的，必须是 **ACN agent**。人类没有 agent 工牌时，平台可过渡用 `system:task-invite`；正途是 **垂类自己的 agent** 或 **官方 task-broker**。
+
+## 分工
+
+| 场景 | A2A 发件人（`from_agent`） | 说明 |
+|------|---------------------------|------|
+| AgentPlanet 人类直接发任务 | **task-broker**（待建） | 验人后以官方任务智能体发；过渡期可用 `system:task-invite` |
+| ComicLaw 等垂类发到 ACN | **客户 cell**（或 Studio/Org 任务 agent） | 工人看到垂类身份；可加白名单 |
+| 人类经自己的 agent 发 | 该 **用户 agent** | 无需代打 |
+
+**不要**默认「垂类 cell → task-broker → 再代打」——除非 broker 只做后台校验，发出去仍挂垂类身份。
+
+## 过渡（#198 已合）
+
+`TaskService.invite_agent` 在 inviter **不在 agent 名册**时，用 `system:task-invite` 路由 A2A，`metadata.from_agent` 仍写真实邀请人。  
+`system:` 会走策略豁免；长期应用上表「正途」替换。
+
+## 验收（部署后）
+
+1. Mode B 工人 `acn listen --runtime …` 在线  
+2. Creator invite  
+3. 数秒内 wake（无需 reconcile）  

--- a/docs/issues/task-invite-a2a-push.md
+++ b/docs/issues/task-invite-a2a-push.md
@@ -1,30 +1,20 @@
-# Draft GitHub issue: Task invite → A2A push
+# Task invite → A2A push
 
-> Create with `gh issue create` when GitHub auth is available.
-> Title: **Task invite should push A2A task_request to invitee**
+**状态：** 已合并 — [ACN #198](https://github.com/acnlabs/ACN/pull/198) (`07e643a`)  
+**后续：** 部署后 ComicLaw 端到端验收；身份正途见 [task-invite-sender.md](../features/task-invite-sender.md)
 
 ## Summary
 
-`TaskService.invite_agent` previously only wrote `invited_agent_ids` + activity — **no A2A / notify / inbox push**. Mode A and Mode B workers therefore never woke on invite (including `acn listen --runtime`).
+`TaskService.invite_agent` 曾只写 `invited_agent_ids`，不推 A2A。#198 后 best-effort 推送 `task_request`（含人类 inviter → `system:task-invite`），并 emit `task.invited`。
 
-This is a **send-side** gap, not a transport bug. Documented by ComicLaw: `docs/acn-invite-no-a2a-defect.md` (comiclaw-studio).
-
-## Fix
-
-Branch: `feat/task-invite-a2a-push`
-
-- After invite whitelist save: best-effort `MessageService.send_message` with A2A `task_request` (`metadata.task_id` / `acn_task_id` for `--runtime` dedupe).
-- New webhook `task.invited` (`WebhookEventType.TASK_INVITED`) with `invitee_id`.
-- Push / webhook failure must **not** roll back the invite.
-
-## Acceptance
+## Acceptance（部署后）
 
 1. Mode B worker online with `acn listen --runtime …`
 2. Creator invites that worker
 3. Listen receives A2A / wake within seconds (no reconcile needed)
-4. Offline invitee → inbox (existing MessageRouter); whitelist still written
+4. Offline invitee → inbox; whitelist still written
 
 ## Related
 
-- CLI runtime receiver: #191 / `@acnlabs/acn-cli@0.14.0`
-- ComicLaw: after this lands, mark defect doc **ACN 已修 / 待验收** and verify end-to-end
+- CLI runtime: #191 / `@acnlabs/acn-cli@0.14.0`
+- ComicLaw: `docs/acn-invite-no-a2a-defect.md` → **ACN 已修 / 待验收**


### PR DESCRIPTION
## Summary
- Add `docs/features/task-invite-sender.md`: vertical cell vs task-broker vs transitional `system:task-invite`.
- Mark `docs/issues/task-invite-a2a-push.md` as merged (#198) with deploy acceptance checklist.

## Test plan
- [ ] Docs-only; skim links to #198