### PR TITLE
docs(org): Paperclip 0.3.2 Org-paid soft-validate

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -1,7 +1,7 @@
 # Org Harness
 
 **Status:** Design v0 + [ADR-0014](../adr/0014-org-harness-module.md) Accepted；**Phase 1 Kernel + Phase 2a/P2c 已落地**（`/api/v1/orgs*` · Work Port `builtin_work` · Paperclip Org path）  
-**Last updated:** 2026-07-23
+**Last updated:** 2026-07-24
 
 > **Org Harness** 是 ACN 的**新模块**：给「一群 agent 组成的 Org」提供组织层挽具。  
 > **ACN** 仍叫 ACN（智能体协作网络），不是 Pasture。  
@@ -49,9 +49,9 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 ## 下一步
 
-- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work 路径 + adapter spec 对齐）。  
-- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)。  
+- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet S1–S4（Backend + `pay_from_org` + CLI + Paperclip **0.3.2**）。  
+- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（含 Org-paid 软验）。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
-- **按需：** P2b（`plugins.work=task_pool`）；自动 receive；按 `org_id` 列表。  
-- **经济主体（draft）：** [org-wallet-v0.md](./org-wallet-v0.md) — 确认决策清单后再实现。  
+- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（decisions + S0–S4 landed）。  
+- **按需：** P2b；自动 receive；按 `org_id` 列表；claim/transfer 同步钱包 `owner_id`；解散冻结。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -135,8 +135,9 @@ Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_tas
 ## Paperclip / Patterns
 
 - Inward Issue ↔ Org work: [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)
-- Plugin ≥ **0.3.1** issue **ACN** tab: **Import ACN task** / **Publish to ACN
-  network** (explicit actions; default Issue sync stays Org work only).
+- Plugin ≥ **0.3.2** issue **ACN** tab: **Import ACN task** / **Publish to ACN
+  network** (explicit actions; default Issue sync stays Org work only), plus
+  **Pay from Org wallet** (+ reward) for Org-paid publish.
   Repo: [`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin).
 
 ---
@@ -152,8 +153,11 @@ acn org publish-task --org org_… -t "…" -d "…" --tags review \
 - Forces `creator_type=org`, `credits`, and escrow when reward > 0
 - Requires Org treasury governance (owner / created_by)
 - Default `--pay-from agent` stays attribution-only (unchanged money path)
+- Paperclip ≥ **0.3.2**: Issue ACN tab checkbox **Pay from Org wallet**
+  (fund via Backend `/api/org-wallets/*`; plugin does not topup)
 
-See [org-wallet-v0.md](./org-wallet-v0.md).
+See [org-wallet-v0.md](./org-wallet-v0.md). Soft-validate checklist:
+[quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate).
 
 ---
 

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -201,13 +201,17 @@ Emit via existing outbox / webhook style used for agent wallet where possible.
 
 ## Rollout slices
 
-| Slice | Deliverable | Depends |
-|---|---|---|
-| **S0** | This spec accepted | — |
-| **S1** | Backend `WalletType.ORG` + CRUD/topup/withdraw + tests | Backend |
-| **S2** | `POST /orgs/{id}/publish-task` (`pay_from_org`) + escrow org lazy-create (**A/B/C**) | S1 |
-| **S3** | CLI `--pay-from org` | S2 |
-| **S4** | CLI/SDK + Paperclip “fund Org / pay from Org” UX (thin) | S3 |
+| Slice | Deliverable | Depends | Status |
+|---|---|---|---|
+| **S0** | This spec accepted | — | done |
+| **S1** | Backend `WalletType.ORG` + CRUD/topup/withdraw + tests | Backend | done |
+| **S2** | `POST /orgs/{id}/publish-task` (`pay_from_org`) + escrow org lazy-create (**A/B/C**) | S1 | done |
+| **S3** | CLI `--pay-from org` | S2 | done |
+| **S4** | Paperclip Issue ACN tab **Pay from Org wallet** (thin; fund via Backend) | S3 | done — `@acnlabs/paperclip-plugin-acn@0.3.2` |
+
+Soft-validate on a Paperclip instance:
+[quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate).
+Live API smoke (no UI): [`scripts/smoke_org_wallet.sh`](../../scripts/smoke_org_wallet.sh).
 
 **v0 non-goals (later):** on-chain Org address, member payroll splits, budget
 policies soft-warn/hard-stop (Pasture draft), multi-currency.

--- a/docs/org-harness/quickstart-org-paperclip.md
+++ b/docs/org-harness/quickstart-org-paperclip.md
@@ -39,7 +39,7 @@
 |----|------|
 | ACN | Hosted：`https://api.acnlabs.dev`（CN：`https://acn.acnlabs.cn`）或本地 `:9000` |
 | Paperclip | 自托管，**plugin worker 已开** |
-| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.0** |
+| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.2**（Org-paid publish） |
 | 凭证 | 一把有写权限的 agent API key（`acn_…`）——它将成为 Org 的 **`created_by`（治理方）** |
 | HMAC | `openssl rand -hex 32`，两边配置同一 secret |
 
@@ -164,6 +164,7 @@ node scripts/e2e-org-inbound.mjs        # ACN → Issue（含治理 403 演示�
 |----------|--------|
 | 组织内排活 ↔ Paperclip | **Org work**（本 quickstart） |
 | 面向网络招人 / 接单 / 赏金 | **Task Pool** 旁路；见 [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`acn org publish-task`；**不是**当前 Work Port） |
+| Org 出钱发赏金 Task | **Org-paid**：CLI `--pay-from org` 或插件 **Pay from Org wallet**（见下方软验） |
 | `plugins.work=task_pool` | **未提供**（P2b 按需；与 publish bridge **不同**） |
 | 任意成员建 work | **不行**（仅治理方） |
 | 旧 Task→Issue 镜像 | 默认关；需 `enableLegacyTaskMirror=true` |
@@ -182,6 +183,24 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 | work 不建 Issue | harness 是否指向本实例；HMAC 是否一致；`autoCreateIssues` |
 | 403 建 work | 是否在用非 `created_by` / 非 owner 的 key |
 | done 不回写 | `autoApproveOnDone`；Issue 是否在 `issue-work-map` |
+
+---
+
+## Org-paid soft-validate
+
+前置：插件 **≥ 0.3.2**；Org 已绑定；Backend 可访问（CN：`api.acnlabs.cn` 等）。
+
+1. **充值 Org 钱包**（插件内不做 topup）— treasury 用 JWT / internal：
+   `POST /api/org-wallets/{org_id}/topup`（或 `-internal`），记下余额。
+2. Paperclip 打开任意 Issue → **ACN** 页签 → **Publish to ACN network**。
+3. 勾选 **Pay from Org wallet**，填 **reward**（> 0）→ 发布。
+4. 核对：Task `creator_type=org`；Org 余额减少（escrow lock）；
+   `metadata.org_id` / `org_publish` 存在。
+5. （可选）取消该 Task → escrow 退回 Org 钱包。
+
+CLI 等价路径与 API 细节：[org-task-bridge-v0.md](./org-task-bridge-v0.md) ·
+[org-wallet-v0.md](./org-wallet-v0.md)。  
+无 Paperclip 时可用 ACN：`scripts/smoke_org_wallet.sh`。
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `@acnlabs/paperclip-plugin-acn@0.3.2` **Pay from Org wallet** on the Issue ACN tab
- Mark org-wallet rollout S0–S4 as done
- Add soft-validate checklist to the Paperclip quickstart (fund via Backend `org-wallets`)

## Test plan
- [ ] Skim links from README → quickstart § Org-paid → org-wallet / org-task-bridge
- [ ] On a Paperclip instance ≥ 0.3.2: topup Org wallet → publish with checkbox → balance escrow → cancel refund