### PR TITLE
docs(org): Paperclip 0.3.3 poll inbound + S5 next

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -49,9 +49,9 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 ## 下一步
 
-- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet S1–S4（Backend + `pay_from_org` + CLI + Paperclip **0.3.2**）。  
-- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（含 Org-paid 软验）。  
+- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet S1–S4 + Paperclip **0.3.3** poll 入站。  
+- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（本地可不填公网 URL；含 Org-paid 软验）。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
-- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（decisions + S0–S4 landed）。  
-- **按需：** P2b；自动 receive；按 `org_id` 列表；claim/transfer 同步钱包 `owner_id`；解散冻结。  
+- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（S0–S4b done；**S5** ownership sync / dissolve freeze next）。  
+- **按需：** P2b；自动 receive；按 `org_id` 列表；钱包余额代理 UX。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -135,9 +135,11 @@ Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_tas
 ## Paperclip / Patterns
 
 - Inward Issue ↔ Org work: [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)
-- Plugin ≥ **0.3.2** issue **ACN** tab: **Import ACN task** / **Publish to ACN
+- Plugin ≥ **0.3.3** issue **ACN** tab: **Import ACN task** / **Publish to ACN
   network** (explicit actions; default Issue sync stays Org work only), plus
   **Pay from Org wallet** (+ reward) for Org-paid publish.
+  Local Paperclip + hosted ACN: inbound uses **periodic poll** by default
+  (public URL optional for realtime push).
   Repo: [`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin).
 
 ---
@@ -153,8 +155,9 @@ acn org publish-task --org org_… -t "…" -d "…" --tags review \
 - Forces `creator_type=org`, `credits`, and escrow when reward > 0
 - Requires Org treasury governance (owner / created_by)
 - Default `--pay-from agent` stays attribution-only (unchanged money path)
-- Paperclip ≥ **0.3.2**: Issue ACN tab checkbox **Pay from Org wallet**
-  (fund via Backend `/api/org-wallets/*`; plugin does not topup)
+- Paperclip ≥ **0.3.3**: Issue ACN tab checkbox **Pay from Org wallet**
+  (fund via Backend `/api/org-wallets/*`; plugin does not topup);
+  inbound poll when no public webhook URL
 
 See [org-wallet-v0.md](./org-wallet-v0.md). Soft-validate checklist:
 [quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate).

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -208,13 +208,16 @@ Emit via existing outbox / webhook style used for agent wallet where possible.
 | **S2** | `POST /orgs/{id}/publish-task` (`pay_from_org`) + escrow org lazy-create (**A/B/C**) | S1 | done |
 | **S3** | CLI `--pay-from org` | S2 | done |
 | **S4** | Paperclip Issue ACN tab **Pay from Org wallet** (thin; fund via Backend) | S3 | done — `@acnlabs/paperclip-plugin-acn@0.3.2` |
+| **S4b** | Paperclip inbound without public URL (poll fallback) | S4 | done — `@acnlabs/paperclip-plugin-acn@0.3.3` |
+| **S5** | Ownership sync (`owner_id` on claim/transfer/release) + dissolve freeze | S1 | next |
 
 Soft-validate on a Paperclip instance:
-[quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate).
+[quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate)
+(plugin ≥ **0.3.3**; local inbound via poll).
 Live API smoke (no UI): [`scripts/smoke_org_wallet.sh`](../../scripts/smoke_org_wallet.sh).
 
 **v0 non-goals (later):** on-chain Org address, member payroll splits, budget
-policies soft-warn/hard-stop (Pasture draft), multi-currency.
+policies soft-warn/hard-stop (Pasture draft), multi-currency; one-click tunnel.
 
 ---
 

--- a/docs/org-harness/quickstart-org-paperclip.md
+++ b/docs/org-harness/quickstart-org-paperclip.md
@@ -181,10 +181,9 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 | 现象 | 检查 |
 |------|------|
 | 无 `registered harness` | 本地预期如此（用 poll）；要实时 push 再填公网 `paperclipBaseUrl` / `PAPERCLIP_PUBLIC_URL` |
-| work 不建 Issue | 等 ≤2 min 或 Issue ACN 页 **Sync now**；`enableOrgWorkPoll`；`autoCreateIssues` |
+| work 不建 Issue | 等 ≤2 min 或 **Sync now**；`enableOrgWorkPoll`；有公网时再查 harness/HMAC |
 | `signed: false` | 未配 harness secret（生产务必配） |
 | Issue 不建 work | 是否人类创建（非插件 echo）；`acnOrgId` 是否已解析；看 worker 日志 |
-| work 不建 Issue | harness 是否指向本实例；HMAC 是否一致；`autoCreateIssues` |
 | 403 建 work | 是否在用非 `created_by` / 非 owner 的 key |
 | done 不回写 | `autoApproveOnDone`；Issue 是否在 `issue-work-map` |
 

--- a/docs/org-harness/quickstart-org-paperclip.md
+++ b/docs/org-harness/quickstart-org-paperclip.md
@@ -26,9 +26,9 @@
 
 | 步骤 | 期望 |
 |------|------|
-| 插件 setup | 日志出现 `registered harness` + `org_id` |
+| 插件 setup | 日志 `setup complete` + `org_id`；`inbound.mode` 为 `poll` 或 `push` |
 | Paperclip 新建 Issue（人类） | ACN 出现对应 `work_…`（`issue-work-map`） |
-| 或：治理 key `POST /orgs/{id}/work` | Paperclip 出现对应 Issue |
+| 或：治理 key `POST /orgs/{id}/work` | Paperclip 出现对应 Issue（**≤2 min** poll，或 push 即时） |
 | Issue → `done`（建议开 `autoApproveOnDone`） | work 状态 → `done` |
 
 ---
@@ -39,7 +39,7 @@
 |----|------|
 | ACN | Hosted：`https://api.acnlabs.dev`（CN：`https://acn.acnlabs.cn`）或本地 `:9000` |
 | Paperclip | 自托管，**plugin worker 已开** |
-| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.2**（Org-paid publish） |
+| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.3**（Org-paid + 本地 poll 入站） |
 | 凭证 | 一把有写权限的 agent API key（`acn_…`）——它将成为 Org 的 **`created_by`（治理方）** |
 | HMAC | `openssl rand -hex 32`，两边配置同一 secret |
 
@@ -86,9 +86,10 @@ paperclipai secrets set acn_harness_secret "$HARNESS_SECRET"
 | `acnHarnessSecretRef` | 指向 `$HARNESS_SECRET` |
 | `acnSubnetId` | `$SUBNET_ID`（若尚无 Org） |
 | `acnOrgId` | 已有则填 `org_…`；空则 setup 时创建 |
-| `paperclipBaseUrl` | **ACN 能访问到的** Paperclip 公网 URL |
+| `paperclipBaseUrl` | **可选**——公网 URL 仅用于实时 push；本地可空（或设 `PAPERCLIP_PUBLIC_URL`） |
 | `acnBaseUrl` | 默认全球；CN 填 `https://acn.acnlabs.cn` |
 | `autoCreateIssues` | `true`（默认） |
+| `enableOrgWorkPoll` | `true`（默认）——本地 + hosted ACN 靠周期同步入站 |
 | `autoApproveOnDone` | 试用建议 `true` |
 | `enableLegacyTaskMirror` | **保持 `false`** |
 
@@ -96,9 +97,11 @@ paperclipai secrets set acn_harness_secret "$HARNESS_SECRET"
 
 ```text
 acn-plugin: created ACN Org for company { org_id: "org_…", … }
-# 或 reusing / configured org
-acn-plugin: registered harness { subnet_id: "…", org_id: "…", signed: true }
-acn-plugin: setup complete { … }
+# 本地 Paperclip + hosted ACN（无公网 URL）— 正常：
+acn-plugin: realtime push not configured — periodic sync will cover inbound
+acn-plugin: setup complete { …, inbound: { mode: "poll", … } }
+# 若有公网 URL：
+# acn-plugin: registered harness (realtime push) { …, signed: true }
 ```
 
 把日志里的 `org_id` 写回 `acnOrgId`，避免反复建 Org。
@@ -177,7 +180,8 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 
 | 现象 | 检查 |
 |------|------|
-| 无 `registered harness` | `paperclipBaseUrl` 是否公网可达；`acnSubnetId` / Org 是否解析成功 |
+| 无 `registered harness` | 本地预期如此（用 poll）；要实时 push 再填公网 `paperclipBaseUrl` / `PAPERCLIP_PUBLIC_URL` |
+| work 不建 Issue | 等 ≤2 min 或 Issue ACN 页 **Sync now**；`enableOrgWorkPoll`；`autoCreateIssues` |
 | `signed: false` | 未配 harness secret（生产务必配） |
 | Issue 不建 work | 是否人类创建（非插件 echo）；`acnOrgId` 是否已解析；看 worker 日志 |
 | work 不建 Issue | harness 是否指向本实例；HMAC 是否一致；`autoCreateIssues` |
@@ -188,7 +192,7 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 
 ## Org-paid soft-validate
 
-前置：插件 **≥ 0.3.2**；Org 已绑定；Backend 可访问（CN：`api.acnlabs.cn` 等）。
+前置：插件 **≥ 0.3.3**；Org 已绑定；Backend 可访问（CN：`api.acnlabs.cn` 等）。
 
 1. **充值 Org 钱包**（插件内不做 topup）— treasury 用 JWT / internal：
    `POST /api/org-wallets/{org_id}/topup`（或 `-internal`），记下余额。


### PR DESCRIPTION
## Summary
- Quickstart / bridge / wallet docs: plugin ≥ **0.3.3**, local inbound via **poll**, public URL optional for realtime push
- Mark org-wallet **S4b** done; **S5** (ownership sync + dissolve freeze) as next

## Test plan
- [ ] Skim quickstart success criteria + troubleshooting rows
- [ ] Confirm S5 listed in org-wallet-v0 rollout table