### PR TITLE
feat(org): platform webhooks for wallet S5

### DIFF
--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -173,7 +173,7 @@ class OrgService:
                 "org_webhook_skip_no_subnet",
                 org_id=org.org_id,
                 subnet_id=org.subnet_id,
-                event=event.value,
+                webhook_event=event.value,
             )
             return
         if not subnet.harness_url:
@@ -191,8 +191,46 @@ class OrgService:
             logger.warning(
                 "org_webhook_delivery_failed",
                 org_id=org.org_id,
-                event=event.value,
+                webhook_event=event.value,
                 exc_info=True,
+            )
+
+    async def _emit_platform(
+        self,
+        org: Org,
+        event: WebhookEventType,
+        data: dict[str, Any],
+    ) -> None:
+        """Notify AgentPlanet Backend (org-wallet-v0 S5).
+
+        Best-effort via durable outbox — never rolls back Org mutations.
+        Harness delivery stays on ``_emit`` (subnet URL); this targets the
+        configured platform ``WEBHOOK_URL``.
+        """
+        if not self.webhook_service:
+            return
+        kind, subject = self.treasury_subject(org)
+        payload = {
+            "org_id": org.org_id,
+            "owner": org.owner.to_dict(),
+            "created_by": org.created_by.to_dict(),
+            "treasury_subject": {"kind": kind, "subject": subject},
+            "owner_changed_at": org.updated_at.isoformat() if org.updated_at else None,
+            **data,
+        }
+        try:
+            await self.webhook_service.send_event(
+                event=event,
+                task_id=org.org_id,
+                data=payload,
+                outbox=True,
+            )
+        except Exception as e:  # noqa: BLE001 — must not break Org ops
+            logger.warning(
+                "org_platform_webhook_failed",
+                org_id=org.org_id,
+                event=event.value,
+                error=str(e),
             )
 
     # ------------------------------------------------------------------
@@ -884,6 +922,11 @@ class OrgService:
             WebhookEventType.ORG_OWNER_CHANGED,
             {"owner": org.owner.to_dict(), "action": "claim"},
         )
+        await self._emit_platform(
+            org,
+            WebhookEventType.ORG_OWNER_CHANGED,
+            {"action": "claim"},
+        )
         return org
 
     async def transfer(
@@ -939,6 +982,11 @@ class OrgService:
             WebhookEventType.ORG_OWNER_CHANGED,
             {"owner": org.owner.to_dict(), "action": "transfer"},
         )
+        await self._emit_platform(
+            org,
+            WebhookEventType.ORG_OWNER_CHANGED,
+            {"action": "transfer"},
+        )
         return org
 
     async def release(
@@ -961,6 +1009,11 @@ class OrgService:
             org,
             WebhookEventType.ORG_OWNER_CHANGED,
             {"owner": {"kind": "none"}, "action": "release"},
+        )
+        await self._emit_platform(
+            org,
+            WebhookEventType.ORG_OWNER_CHANGED,
+            {"action": "release"},
         )
         return org
 
@@ -986,6 +1039,7 @@ class OrgService:
         org.updated_at = datetime.now(UTC)
         await self.repository.save_org(org)
         await self._emit(org, WebhookEventType.ORG_DISSOLVED, {})
+        await self._emit_platform(org, WebhookEventType.ORG_DISSOLVED, {})
         return org
 
     # ------------------------------------------------------------------

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -229,7 +229,7 @@ class OrgService:
             logger.warning(
                 "org_platform_webhook_failed",
                 org_id=org.org_id,
-                event=event.value,
+                webhook_event=event.value,
                 error=str(e),
             )
 

--- a/tests/services/test_org_service.py
+++ b/tests/services/test_org_service.py
@@ -317,6 +317,46 @@ class TestOwnership:
         assert result.owner.subject == "agt_new"
         mock_subnet_service.transfer_owner.assert_awaited_once()
 
+    async def test_claim_emits_platform_owner_changed(
+        self, org_service, mock_org_repo, mock_subnet_service, mock_webhook
+    ):
+        """Backend wallet sync (S5) listens on send_event, not harness send_to."""
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        mock_subnet_service.get_subnet = AsyncMock(
+            return_value=Subnet(
+                slug=org.subnet_id,
+                name="T",
+                owner="agt_steward",
+                harness_url="https://harness.example/hook",
+            )
+        )
+        await org_service.claim(
+            org.org_id,
+            caller_type="agent",
+            caller_sub="agt_steward",
+        )
+        mock_webhook.send_event.assert_awaited()
+        kwargs = mock_webhook.send_event.await_args.kwargs
+        assert kwargs["event"] == WebhookEventType.ORG_OWNER_CHANGED
+        assert kwargs["outbox"] is True
+        assert kwargs["data"]["action"] == "claim"
+        assert kwargs["data"]["treasury_subject"]["subject"] == "agt_steward"
+        assert kwargs["data"]["org_id"] == org.org_id
+
+    async def test_dissolve_emits_platform_dissolved(
+        self, org_service, mock_org_repo, mock_webhook
+    ):
+        org = _stored_org()
+        mock_org_repo.find_org.return_value = org
+        await org_service.dissolve(
+            org.org_id,
+            caller_type="agent",
+            caller_sub="agt_steward",
+        )
+        events = [c.kwargs["event"] for c in mock_webhook.send_event.await_args_list]
+        assert WebhookEventType.ORG_DISSOLVED in events
+
     async def test_claim_cannot_designate_unowned_agent(
         self, org_service, mock_org_repo
     ):


### PR DESCRIPTION
## Summary
- `OrgService._emit_platform` → `send_event(..., outbox=True)` on claim/transfer/release/dissolve
- Payload includes `treasury_subject` + `owner_changed_at` for Backend wallet sync
- Keeps existing harness `_emit` (Pattern inbound unchanged)
- Fix structlog `event=` clash in harness skip log

Pairs with Backend org-wallet S5 PR.

## Test plan
- [x] `test_claim_emits_platform_owner_changed` / `test_dissolve_emits_platform_dissolved`
- [ ] Deploy with Backend S5; claim Org with funded wallet → `owner_id` updates