### PR TITLE
fix(tasks): drop system:task-invite — invite A2A agent-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Invite A2A is agent-only:** removed transitional `system:task-invite`
+  spoof. Non-agent inviters still get the whitelist write, but A2A push
+  is skipped (`task_invite_a2a_skipped_non_agent_inviter`). Upper
+  platforms must use their own registered service agent as creator.
+  See `docs/features/task-invite-sender.md`. Skill **0.17.11**.
+
 ## [0.15.6] - 2026-07-24
 
 Server release: **Task invite → A2A push** (#198) plus docs for sender roles
@@ -23,15 +31,12 @@ artifacts).
   can wake and dedupe. Push failure is logged and does **not** roll
   back the invite whitelist. New webhook event `task.invited`
   (`WebhookEventType.TASK_INVITED`) with `data.invitee_id`.
-  Non-agent inviters (e.g. human Studio users) send as
-  `system:task-invite` so the push is not rejected by the agent
-  registry lookup; metadata still carries the real `from_agent`.
   Skill **0.17.10**.
 
 ### Docs
 
 - **Task invite sender roles** — `docs/features/task-invite-sender.md`
-  (vertical cell vs official `task-broker` vs transitional `system:`).
+  (upper platforms use their own service agents; ACN is agent-only).
 - **Org ↔ Task Pool bridge v0** —
   `docs/org-harness/org-task-bridge-v0.md` (publish + import; link on
   `task.metadata`; ≠ P2b). Skill **0.17.9**. Smoke:

--- a/acn/services/task_service.py
+++ b/acn/services/task_service.py
@@ -34,12 +34,6 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
-# Reserved sender when the task creator is not a registered agent
-# (e.g. human Studio user). ``MessageService.send_message`` skips the
-# agent-table lookup for ``system:<slug>``; the real inviter stays in
-# message metadata ``from_agent``.
-_TASK_INVITE_SYSTEM_SENDER = "system:task-invite"
-
 # Namespace for ``event_id = uuid5(NS, f"{task_id}:{trigger}")``. Using a
 # fixed URL-based namespace means the same (task_id, trigger) pair always
 # resolves to the same event_id across processes/replicas — the outbox
@@ -522,9 +516,10 @@ class TaskService:
         Invited solvers can join even when require_join_approval is True.
 
         After the whitelist write, best-effort pushes an A2A
-        ``task_request`` to the invitee via ``MessageService`` (Mode A
-        direct / Mode B relay / offline inbox). Push failure is logged
-        and does **not** roll back the invite. Also emits
+        ``task_request`` to the invitee via ``MessageService`` when the
+        inviter is a registered agent (Mode A / Mode B / offline inbox).
+        Non-agent inviters skip the push. Push failure is logged and
+        does **not** roll back the invite. Also emits
         ``WebhookEventType.TASK_INVITED`` when a webhook service is wired.
         """
         task = await self.get_task(task_id)
@@ -570,20 +565,6 @@ class TaskService:
         )
         return task
 
-    async def _resolve_invite_sender(self, inviter_id: str) -> str:
-        """Return ``from_agent_id`` for the invite A2A push.
-
-        Registered agents send as themselves. Humans (or any inviter not
-        in the agent registry) send as ``system:task-invite`` so
-        ``MessageService`` does not reject the push with AgentNotFound.
-        """
-        if self.agent_repository is None:
-            return inviter_id
-        sender = await self.agent_repository.find_by_id(inviter_id)
-        if sender:
-            return inviter_id
-        return _TASK_INVITE_SYSTEM_SENDER
-
     async def _push_invite_a2a(
         self,
         task: Task,
@@ -591,11 +572,32 @@ class TaskService:
         inviter_id: str,
         invitee_id: str,
     ) -> None:
-        """Best-effort A2A task_request to the invitee (does not raise)."""
+        """Best-effort A2A task_request to the invitee (does not raise).
+
+        ACN task messaging is agent-to-agent only. Upper platforms that
+        expose human UX (AgentPlanet, ComicLaw, …) must create/invite
+        using their own registered agent identity. Non-agent inviters
+        keep the whitelist write but skip the A2A push (no ``system:``
+        spoofing).
+        """
         if not self.message_service:
             return
 
-        from_agent_id = await self._resolve_invite_sender(inviter_id)
+        if self.agent_repository is not None:
+            sender = await self.agent_repository.find_by_id(inviter_id)
+            if not sender:
+                logger.warning(
+                    "task_invite_a2a_skipped_non_agent_inviter",
+                    task_id=task.task_id,
+                    inviter_id=inviter_id,
+                    invitee_id=invitee_id,
+                    hint=(
+                        "ACN does not push invite A2A for human/non-agent "
+                        "creators; use a platform service agent as creator"
+                    ),
+                )
+                return
+
         payload = {
             "task_id": task.task_id,
             "title": task.title,
@@ -614,7 +616,6 @@ class TaskService:
                 "type": "task_request",
                 "message_type": "task_request",
                 "title": task.title,
-                # Real inviter (may be a human id); routing sender may be system.
                 "from_agent": inviter_id,
             },
             task_id=task.task_id,
@@ -622,7 +623,7 @@ class TaskService:
 
         try:
             await self.message_service.send_message(
-                from_agent_id=from_agent_id,
+                from_agent_id=inviter_id,
                 to_agent_id=invitee_id,
                 message=message,
                 message_type="task_request",
@@ -632,7 +633,6 @@ class TaskService:
                 "task_invite_a2a_push_failed",
                 task_id=task.task_id,
                 inviter_id=inviter_id,
-                from_agent_id=from_agent_id,
                 invitee_id=invitee_id,
                 error=str(e),
             )

--- a/docs/features/task-invite-sender.md
+++ b/docs/features/task-invite-sender.md
@@ -1,29 +1,34 @@
-# Task invite：谁在 ACN 上代打？
+# Task invite：谁在 ACN 上发 A2A？
 
-**状态：** 约定（v0）  
-**关联：** [ACN #198](https://github.com/acnlabs/ACN/pull/198)、`acn listen --runtime`、ComicLaw invite 缺陷
+**状态：** 约定（v1）  
+**关联：** [ACN #198](https://github.com/acnlabs/ACN/pull/198)、`acn listen --runtime`
 
 ## 一句话
 
-网上喊工人的，必须是 **ACN agent**。人类没有 agent 工牌时，平台可过渡用 `system:task-invite`；正途是 **垂类自己的 agent** 或 **官方 task-broker**。
+**ACN 只做 agent↔agent。** 不支持「人类 ID 直接建单/邀请并推 A2A」。  
+上层（AgentPlanet、ComicLaw、…）若要给人用，**各自注册平台服务 agent**，用该 agent 的身份调 ACN。
 
 ## 分工
 
-| 场景 | A2A 发件人（`from_agent`） | 说明 |
-|------|---------------------------|------|
-| AgentPlanet 人类直接发任务 | **task-broker**（待建） | 验人后以官方任务智能体发；过渡期可用 `system:task-invite` |
-| ComicLaw 等垂类发到 ACN | **客户 cell**（或 Studio/Org 任务 agent） | 工人看到垂类身份；可加白名单 |
-| 人类经自己的 agent 发 | 该 **用户 agent** | 无需代打 |
+| 层 | 规则 |
+|----|------|
+| **ACN** | Task create / invite / A2A 推送的 `from_agent` 必须是已注册 agent |
+| **ComicLaw** | `comiclaw-studio` / 客户 cell 等自有 agent |
+| **AgentPlanet** | 人类网页发任务 → 后端用 **AgentPlanet 自己的服务 agent** 调 ACN |
+| **其他垂类** | 同一逻辑：自有 agent，不依赖 ACN 官方「任务柜台」 |
 
-**不要**默认「垂类 cell → task-broker → 再代打」——除非 broker 只做后台校验，发出去仍挂垂类身份。
+ACN **不**提供官方 task-broker / `system:task-invite` 代发。
 
-## 过渡（#198 已合）
+## Invite 推送行为
 
-`TaskService.invite_agent` 在 inviter **不在 agent 名册**时，用 `system:task-invite` 路由 A2A，`metadata.from_agent` 仍写真实邀请人。  
-`system:` 会走策略豁免；长期应用上表「正途」替换。
+1. 写 `invited_agent_ids`（始终）  
+2. Best-effort A2A `task_request`：**仅当 inviter 在 agent 名册中**  
+3. Inviter 不是 agent → **跳过 A2A**（打日志 `task_invite_a2a_skipped_non_agent_inviter`），白名单仍写入  
 
-## 验收（部署后）
+历史上短暂存在的 `system:task-invite` 代发已移除。
+
+## 验收
 
 1. Mode B 工人 `acn listen --runtime …` 在线  
-2. Creator invite  
+2. **Agent** creator invite  
 3. 数秒内 wake（无需 reconcile）  

--- a/docs/issues/task-invite-a2a-push.md
+++ b/docs/issues/task-invite-a2a-push.md
@@ -1,20 +1,9 @@
 # Task invite → A2A push
 
-**状态：** 已合并 — [ACN #198](https://github.com/acnlabs/ACN/pull/198) (`07e643a`)  
-**后续：** 部署后 ComicLaw 端到端验收；身份正途见 [task-invite-sender.md](../features/task-invite-sender.md)
+**状态：** 已合并并验收 — [ACN #198](https://github.com/acnlabs/ACN/pull/198) / `v0.15.6`；ComicLaw 生产验收通过（2026-07-24）
 
-## Summary
+## Follow-up
 
-`TaskService.invite_agent` 曾只写 `invited_agent_ids`，不推 A2A。#198 后 best-effort 推送 `task_request`（含人类 inviter → `system:task-invite`），并 emit `task.invited`。
-
-## Acceptance（部署后）
-
-1. Mode B worker online with `acn listen --runtime …`
-2. Creator invites that worker
-3. Listen receives A2A / wake within seconds (no reconcile needed)
-4. Offline invitee → inbox; whitelist still written
-
-## Related
-
-- CLI runtime: #191 / `@acnlabs/acn-cli@0.14.0`
-- ComicLaw: `docs/acn-invite-no-a2a-defect.md` → **ACN 已修 / 待验收**
+- Removed `system:task-invite` spoof — ACN invite A2A is **agent-only**.
+  Platforms that need human UX register their own service agent.
+  See [task-invite-sender.md](../features/task-invite-sender.md).

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.10"
+  version: "0.17.11"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -142,7 +142,7 @@ acn config show
 | `acn tasks review <task_id> --approve\|--reject [--notes <text>]` | Approve or reject submission (creator only) |
 | `acn tasks cancel <task_id>` | Cancel task |
 | `acn tasks history <agent_id>` | View agent's task history (submissions, feedback, resubmit counts) |
-| `acn tasks invite <task_id> --agent-id <agent_id>` | Invite specific agent (writes whitelist; **best-effort A2A `task_request`** to invitee via MessageRouter — Mode A/B/inbox; push failure does not roll back invite) |
+| `acn tasks invite <task_id> --agent-id <agent_id>` | Invite specific agent (writes whitelist; **best-effort A2A `task_request`** when inviter is a registered agent — Mode A/B/inbox; non-agent inviters skip push; push failure does not roll back invite) |
 | `acn tasks participations <task_id>` | List participants |
 | `acn tasks participation <task_id>` | Check your participation |
 | `acn tasks approve-applicant <task_id> --participation-id <pid>` | Approve applicant as assignee (creator only) |

--- a/tests/services/test_task_service_invite_a2a.py
+++ b/tests/services/test_task_service_invite_a2a.py
@@ -132,10 +132,10 @@ class TestInviteAgentA2APush:
         mock_repo.save.assert_awaited_once()
         assert service.message_service is None
 
-    async def test_human_inviter_sends_as_system_task_invite(
+    async def test_non_agent_inviter_skips_a2a_keeps_whitelist(
         self, mock_repo, mock_message_service
     ):
-        """Human creators are not in the agent table — use system: sender."""
+        """ACN is agent-only: non-agent inviters get whitelist, no A2A spoof."""
         task = _make_task(creator_type="human", creator_id="human-user-1")
         mock_repo.find_by_id = AsyncMock(return_value=task)
         mock_repo.save = AsyncMock()
@@ -156,7 +156,6 @@ class TestInviteAgentA2APush:
         )
 
         assert "worker-001" in result.invited_agent_ids
-        call = mock_message_service.send_message.await_args
-        assert call.kwargs["from_agent_id"] == "system:task-invite"
-        assert call.kwargs["message"].metadata["from_agent"] == "human-user-1"
+        mock_repo.save.assert_awaited_once()
+        mock_message_service.send_message.assert_not_awaited()
         agent_repo.find_by_id.assert_awaited_once_with("human-user-1")


### PR DESCRIPTION
## Summary
- Remove transitional `system:task-invite` spoof after ComicLaw acceptance.
- Non-agent inviters: whitelist still written; A2A push skipped with clear log.
- Docs/Skill **0.17.11**: ACN is agent-only; AgentPlanet/ComicLaw use their own service agents.

## Test plan
- [x] `pytest tests/services/test_task_service_invite_a2a.py` (4 passed)
- [ ] Deploy; agent creator invite still wakes Mode B listen
- [ ] Non-agent inviter: no A2A (log `task_invite_a2a_skipped_non_agent_inviter`)