### PR TITLE
chore(release): v0.15.7 — invite A2A agent-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.7] - 2026-07-24
+
+Server patch: invite A2A is **agent-only** (#204). SDK / CLI versions unchanged.
+
 ### Changed
 
 - **Invite A2A is agent-only:** removed transitional `system:task-invite`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.15.6"
+version = "0.15.7"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.15.6"
+version = "0.15.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Bump server to **0.15.7** so production `/health` matches the agent-only invite A2A deploy (#204).
- Dated CHANGELOG entry; Skill **0.17.11** already on main.

## Test plan
- [ ] Merge → tag `v0.15.7` → Railway redeploy → `/health` shows `0.15.7`