### PR TITLE
feat(org): GET /orgs/{id}/wallet Backend proxy (S6)

### DIFF
--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -856,6 +856,50 @@ async def publish_org_task(
     return _task_to_response(task, expose_submission=True)
 
 
+@router.get("/{org_id}/wallet")
+@limiter.limit("60/minute")
+async def get_org_wallet(
+    request: Request,
+    org_id: OrgIdPath,
+    payload: dict = OrgAuthDep,
+    org_service: OrgService = Depends(get_org_service),
+):
+    """Read Org wallet summary via Backend (org-wallet-v0 S6).
+
+    Treasury / governance only (same principal as Org-paid publish).
+    Lazy wallets that do not exist yet return ``exists=false`` and
+    ``balance=0`` (not 404). Requires ``BACKEND_URL`` + ``INTERNAL_API_TOKEN``.
+    """
+    caller_type, caller_sub = _caller(payload)
+    try:
+        org = await org_service.get_org(org_id)
+        org_service.assert_treasury_principal(org, caller_type, caller_sub)
+    except OrgNotFoundError as e:
+        raise ACNHTTPError(
+            ErrorCode.ORG_NOT_FOUND, 404, details={"org_id": org_id}
+        ) from e
+    except OrgPermissionError as e:
+        raise _map_permission(e, org_id) from e
+
+    settings = get_settings()
+    if not settings.backend_url:
+        raise ACNHTTPError(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            503,
+            message="BACKEND_URL is not configured",
+            details={"org_id": org_id, "reason": "backend_unconfigured"},
+        )
+
+    from ..services.wallet_client import WalletClient
+
+    client = WalletClient(
+        backend_url=settings.backend_url,
+        internal_token=settings.internal_api_token,
+    )
+    summary = await client.get_org_wallet(org_id)
+    return summary.model_dump()
+
+
 @router.post("/{org_id}/work/import-task")
 @limiter.limit("60/minute")
 async def import_work_from_task(

--- a/acn/services/__init__.py
+++ b/acn/services/__init__.py
@@ -30,7 +30,7 @@ from .reputation_service import ReputationService
 from .session_service import SessionEntry, SessionService
 from .subnet_service import SubnetService
 from .task_service import TaskNotFoundException, TaskService
-from .wallet_client import WalletClient
+from .wallet_client import OrgWalletSummary, WalletClient
 
 __all__ = [
     "AgentService",
@@ -59,5 +59,6 @@ __all__ = [
     "SubnetService",
     "TaskService",
     "TaskNotFoundException",
+    "OrgWalletSummary",
     "WalletClient",
 ]

--- a/acn/services/wallet_client.py
+++ b/acn/services/wallet_client.py
@@ -31,6 +31,18 @@ class EarningsResult(BaseModel):
     error: str | None = None
 
 
+class OrgWalletSummary(BaseModel):
+    """Backend Org wallet summary (org-wallet-v0 S6 proxy)."""
+
+    org_id: str
+    exists: bool
+    wallet_id: str | None = None
+    balance: int = 0
+    owner_id: str | None = None
+    spend_autonomy: str | None = None
+    status: str | None = None
+
+
 class WalletClient:
     """
     Client for Backend's Agent Wallet API
@@ -657,3 +669,56 @@ class WalletClient:
 
         except httpx.RequestError:
             return False, 0
+
+    async def get_org_wallet(self, org_id: str) -> OrgWalletSummary:
+        """Fetch Org wallet from Backend (lazy — 404 → exists=false).
+
+        Used by ``GET /api/v1/orgs/{org_id}/wallet``. Auth is caller's
+        responsibility (ACN treasury / governance); this client only
+        carries ``X-Internal-Token``.
+        """
+        if not self.backend_url:
+            return OrgWalletSummary(
+                org_id=org_id,
+                exists=False,
+                balance=0,
+                status="unavailable",
+            )
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout, trust_env=False) as client:
+                response = await client.get(
+                    f"{self.backend_url}/api/org-wallets/{org_id}",
+                    headers=self._get_headers(),
+                )
+            if response.status_code == 404:
+                return OrgWalletSummary(org_id=org_id, exists=False, balance=0)
+            if response.status_code != 200:
+                logger.warning(
+                    "org_wallet_get_failed",
+                    org_id=org_id,
+                    status=response.status_code,
+                )
+                return OrgWalletSummary(
+                    org_id=org_id,
+                    exists=False,
+                    balance=0,
+                    status="unavailable",
+                )
+            data = self._parse_json(response)
+            return OrgWalletSummary(
+                org_id=org_id,
+                exists=True,
+                wallet_id=data.get("wallet_id"),
+                balance=int(data.get("balance") or 0),
+                owner_id=data.get("owner_id"),
+                spend_autonomy=data.get("spend_autonomy"),
+                status=data.get("status") or "active",
+            )
+        except httpx.RequestError as e:
+            logger.error("org_wallet_get_error", org_id=org_id, error=str(e))
+            return OrgWalletSummary(
+                org_id=org_id,
+                exists=False,
+                balance=0,
+                status="unavailable",
+            )

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -178,11 +178,14 @@ Escrow lock/release/refund: existing Labs escrow v2 with `creator_type=org`
 
 ### Org Harness Kernel
 
-No balance column on `orgs`. Optional read-only:
+No balance column on `orgs`. Read-only proxy (**S6**):
 
 ```http
-GET /api/v1/orgs/{org_id}/wallet   # proxy or link to Backend wallet summary
+GET /api/v1/orgs/{org_id}/wallet   # treasury-gated; Backend summary (exists/balance/status)
 ```
+
+Requires ACN `BACKEND_URL` + `INTERNAL_API_TOKEN`. Missing wallet →
+`exists=false`, `balance=0` (not 404).
 
 ---
 
@@ -210,7 +213,8 @@ Emit via existing outbox / webhook style used for agent wallet where possible.
 | **S4** | Paperclip Issue ACN tab **Pay from Org wallet** (thin; fund via Backend) | S3 | done — `@acnlabs/paperclip-plugin-acn@0.3.2` |
 | **S4b** | Paperclip inbound without public URL (poll fallback) | S4 | done — `@acnlabs/paperclip-plugin-acn@0.3.3` |
 | **S5** | Ownership sync (`owner_id` on claim/transfer/release) + dissolve freeze | S1 | done — CN soft-val 2026-07-24 |
-| **S6** | Paperclip balance/topup UX + optional `GET /orgs/{id}/wallet` proxy | S5 | next |
+| **S6** | `GET /orgs/{id}/wallet` proxy + Paperclip balance display | S5 | in progress |
+| **S6b** | Paperclip / ACN topup UX (optional; external fund still OK) | S6 | next |
 
 Soft-validate on a Paperclip instance:
 [quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate)

--- a/tests/routes/test_org_wallet.py
+++ b/tests/routes/test_org_wallet.py
@@ -1,0 +1,78 @@
+"""GET /orgs/{id}/wallet — treasury-gated Backend proxy (org-wallet-v0 S6)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+
+from acn.core.entities.org import Org, OrgOwner, OrgPrincipal
+from acn.core.errors import ACNHTTPError
+from acn.routes.orgs import get_org_wallet
+from acn.services.org_service import OrgPermissionError, OrgService
+from acn.services.wallet_client import OrgWalletSummary
+
+
+def _org(org_id: str = "org_w_1") -> Org:
+    return Org(
+        org_id=org_id,
+        display_name="Wallet Co",
+        created_by=OrgPrincipal(kind="agent", subject="agt_creator"),
+        subnet_id="wallet-co",
+        owner=OrgOwner(kind="none"),
+        steward_agent_id="agt_creator",
+        status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_org_wallet_ok():
+    org_svc = MagicMock(spec=OrgService)
+    org_svc.get_org = AsyncMock(return_value=_org())
+    org_svc.assert_treasury_principal = MagicMock()
+    summary = OrgWalletSummary(
+        org_id="org_w_1",
+        exists=True,
+        wallet_id="w1",
+        balance=42,
+        owner_id="agt_creator",
+        spend_autonomy="disabled",
+        status="active",
+    )
+    with (
+        patch("acn.routes.orgs.get_settings") as gs,
+        patch("acn.services.wallet_client.WalletClient") as WC,
+    ):
+        gs.return_value = MagicMock(
+            backend_url="http://backend:8000",
+            internal_api_token="t" * 32,
+        )
+        WC.return_value.get_org_wallet = AsyncMock(return_value=summary)
+        out = await get_org_wallet(
+            request=MagicMock(spec=Request),
+            org_id="org_w_1",
+            payload={"sub": "agt_creator", "type": "agent"},
+            org_service=org_svc,
+        )
+    org_svc.assert_treasury_principal.assert_called_once()
+    assert out["exists"] is True
+    assert out["balance"] == 42
+    assert out["org_id"] == "org_w_1"
+
+
+@pytest.mark.asyncio
+async def test_get_org_wallet_forbidden():
+    org_svc = MagicMock(spec=OrgService)
+    org_svc.get_org = AsyncMock(return_value=_org())
+    org_svc.assert_treasury_principal = MagicMock(
+        side_effect=OrgPermissionError("ownership_mismatch", "nope")
+    )
+    with pytest.raises(ACNHTTPError) as ei:
+        await get_org_wallet(
+            request=MagicMock(spec=Request),
+            org_id="org_w_1",
+            payload={"sub": "agt_other", "type": "agent"},
+            org_service=org_svc,
+        )
+    assert ei.value.status_code == 403


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/orgs/{org_id}/wallet` — treasury/governance gated, proxies Backend `GET /api/org-wallets/{id}` with internal token.
- Lazy missing wallet → `exists=false`, `balance=0` (not 404).
- Spec: mark S6 in progress; S6b = optional topup UX.

## Test plan
- [x] `pytest tests/routes/test_org_wallet.py`
- [ ] CN smoke: treasury key → `GET …/wallet` returns balance after topup
- [ ] Non-treasury agent → 403


Made with [Cursor](https://cursor.com)