### PR TITLE
docs(org): mark wallet S6 done (plugin 0.3.4)

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -52,6 +52,6 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 - **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet **S0–S5** + Paperclip **0.3.3** poll 入站。  
 - **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（本地可不填公网 URL；含 Org-paid 软验）。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
-- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（S0–S5 done；**S6** balance/topup UX + wallet proxy next）。  
+- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（S0–S6 done；**S6b** optional in-plugin topup next）。  
 - **按需：** P2b；自动 receive；按 `org_id` 列表。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主。

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -1,6 +1,6 @@
 # Org Wallet v0
 
-**Status:** Spec v0 — **decisions accepted**; S0–S5 done (2026-07-24)  
+**Status:** Spec v0 — **decisions accepted**; S0–S6 done (2026-07-25)  
 **Last updated:** 2026-07-24  
 **Audience:** Org governors, Backend wallet owners, ACN Task/escrow
 
@@ -213,7 +213,7 @@ Emit via existing outbox / webhook style used for agent wallet where possible.
 | **S4** | Paperclip Issue ACN tab **Pay from Org wallet** (thin; fund via Backend) | S3 | done — `@acnlabs/paperclip-plugin-acn@0.3.2` |
 | **S4b** | Paperclip inbound without public URL (poll fallback) | S4 | done — `@acnlabs/paperclip-plugin-acn@0.3.3` |
 | **S5** | Ownership sync (`owner_id` on claim/transfer/release) + dissolve freeze | S1 | done — CN soft-val 2026-07-24 |
-| **S6** | `GET /orgs/{id}/wallet` proxy + Paperclip balance display | S5 | in progress |
+| **S6** | `GET /orgs/{id}/wallet` proxy + Paperclip balance display | S5 | done — `@acnlabs/paperclip-plugin-acn@0.3.4` |
 | **S6b** | Paperclip / ACN topup UX (optional; external fund still OK) | S6 | next |
 
 Soft-validate on a Paperclip instance:


### PR DESCRIPTION
## Summary
- Mark Org wallet **S6** done after CN deploy + `@acnlabs/paperclip-plugin-acn@0.3.4` publish.
- Next optional slice: **S6b** in-plugin topup.

## Test plan
- [ ] Docs table renders


Made with [Cursor](https://cursor.com)