### PR TITLE
docs(org): close out wallet v0 — S0–S6 done, S6b deferred

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -49,9 +49,9 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 
 ## 下一步
 
-- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet **S0–S5** + Paperclip **0.3.3** poll 入站。  
-- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（本地可不填公网 URL；含 Org-paid 软验）。  
+- **已完成：** Phase 1 Kernel；Phase 2a（Work Port + `builtin_work`）；P2c（Paperclip Org work）；Org wallet **S0–S6**；Paperclip **`@acnlabs/paperclip-plugin-acn@0.3.5`**（Org-paid · 余额显示 · poll 入站 · 充值指引）。  
+- **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（本地可不填公网 URL；含 Org-paid 软验与 topup curl）。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
-- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md)（S0–S6 done；**S6b** optional in-plugin topup next）。  
-- **按需：** P2b；自动 receive；按 `org_id` 列表。  
-- **其后：** Phase 3 增强 Port / Plugin 宿主。
+- **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
+- **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks。  
+- **其后：** Phase 3 增强 Port / Plugin 宿主；或换产品主线（驯养师 / TaskBoard 等）。

--- a/docs/org-harness/org-task-bridge-v0.md
+++ b/docs/org-harness/org-task-bridge-v0.md
@@ -135,7 +135,7 @@ Smoke: [`scripts/smoke_org_publish_task.sh`](../../scripts/smoke_org_publish_tas
 ## Paperclip / Patterns
 
 - Inward Issue ↔ Org work: [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)
-- Plugin ≥ **0.3.3** issue **ACN** tab: **Import ACN task** / **Publish to ACN
+- Plugin ≥ **0.3.5** issue **ACN** tab: **Import ACN task** / **Publish to ACN
   network** (explicit actions; default Issue sync stays Org work only), plus
   **Pay from Org wallet** (+ reward) for Org-paid publish.
   Local Paperclip + hosted ACN: inbound uses **periodic poll** by default
@@ -155,7 +155,8 @@ acn org publish-task --org org_… -t "…" -d "…" --tags review \
 - Forces `creator_type=org`, `credits`, and escrow when reward > 0
 - Requires Org treasury governance (owner / created_by)
 - Default `--pay-from agent` stays attribution-only (unchanged money path)
-- Paperclip ≥ **0.3.3**: Issue ACN tab checkbox **Pay from Org wallet**
+- Paperclip ≥ **0.3.5**: Issue ACN tab checkbox **Pay from Org wallet**
+  (shows Org Credits; fund via Backend topup — see quickstart)
   (fund via Backend `/api/org-wallets/*`; plugin does not topup);
   inbound poll when no public webhook URL
 

--- a/docs/org-harness/org-wallet-v0.md
+++ b/docs/org-harness/org-wallet-v0.md
@@ -214,11 +214,11 @@ Emit via existing outbox / webhook style used for agent wallet where possible.
 | **S4b** | Paperclip inbound without public URL (poll fallback) | S4 | done — `@acnlabs/paperclip-plugin-acn@0.3.3` |
 | **S5** | Ownership sync (`owner_id` on claim/transfer/release) + dissolve freeze | S1 | done — CN soft-val 2026-07-24 |
 | **S6** | `GET /orgs/{id}/wallet` proxy + Paperclip balance display | S5 | done — `@acnlabs/paperclip-plugin-acn@0.3.4` |
-| **S6b** | Paperclip / ACN topup UX (optional; external fund still OK) | S6 | next |
+| **S6b** | Paperclip / ACN topup UX | S6 | **deferred** — fund via Backend; plugin ≥ **0.3.5** shows path |
 
 Soft-validate on a Paperclip instance:
 [quickstart-org-paperclip.md § Org-paid](./quickstart-org-paperclip.md#org-paid-soft-validate)
-(plugin ≥ **0.3.3**; local inbound via poll).
+(plugin ≥ **0.3.5**; local inbound via poll).
 Live API smoke (no UI):
 [`scripts/smoke_org_wallet.sh`](../../scripts/smoke_org_wallet.sh) (Org-paid publish/refund);
 [`scripts/smoke_org_wallet_s5.sh`](../../scripts/smoke_org_wallet_s5.sh) (claim/transfer/release/dissolve → Backend wallet).

--- a/docs/org-harness/quickstart-org-paperclip.md
+++ b/docs/org-harness/quickstart-org-paperclip.md
@@ -39,7 +39,7 @@
 |----|------|
 | ACN | Hosted：`https://api.acnlabs.dev`（CN：`https://acn.acnlabs.cn`）或本地 `:9000` |
 | Paperclip | 自托管，**plugin worker 已开** |
-| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.4**（Org-paid + 余额显示 + 本地 poll 入站） |
+| 插件 | `@acnlabs/paperclip-plugin-acn` **≥ 0.3.5**（Org-paid + 余额 + 充值指引 + poll 入站） |
 | 凭证 | 一把有写权限的 agent API key（`acn_…`）——它将成为 Org 的 **`created_by`（治理方）** |
 | HMAC | `openssl rand -hex 32`，两边配置同一 secret |
 
@@ -191,7 +191,7 @@ Paperclip **可以换成**其他 Pattern：只要会调 `/orgs/*/work*` 并收 s
 
 ## Org-paid soft-validate
 
-前置：插件 **≥ 0.3.4**；Org 已绑定；Backend 可访问
+前置：插件 **≥ 0.3.5**；Org 已绑定；Backend 可访问
 （CN：`https://api.acnlabs.cn` · 全球：你的 Backend 基址）。
 
 **插件内不做 topup**（有意）：先充钱，再在 Issue ACN 页签勾选


### PR DESCRIPTION
## Summary
- README「已完成」对齐到 Org wallet **S0–S6** + plugin **0.3.5**.
- S6b in-plugin topup marked **deferred**; quickstart/bridge require ≥ 0.3.5.

## Test plan
- [ ] Docs tables/links render


Made with [Cursor](https://cursor.com)