### PR TITLE
docs(skill): 0.17.12 Org Harness wallet closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent skill 0.17.12** — Org Harness closeout: wallet `GET /orgs/{id}/wallet`,
+  Org-paid fund path, plugin-catalog + hard rule (custom = external
+  Pattern/sidecar; `plugins.*` allowlist only). API.md org table synced.
+
 ## [0.15.7] - 2026-07-24
 
 Server patch: invite A2A is **agent-only** (#204). SDK / CLI versions unchanged.

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.11"
+  version: "0.17.12"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -130,6 +130,7 @@ acn config show
 | `acn org work create <org_id> --title <t> [--assignee <agent_id>]` | Create work (`POST /orgs/{id}/work`) — **governance only** (unclaimed: `created_by`; claimed: `owner`). Membership alone is not enough |
 | `acn org work update <org_id> <work_id> --status todo\|in_progress\|done\|cancelled` | Update work status (**governance only**) |
 | `acn org tick <org_id>` | Thin Loop tick (emits `org.loop_tick`) |
+| `GET /api/v1/orgs/{id}/wallet` | Org wallet summary (treasury/governance; Backend proxy; lazy `exists=false`) |
 | `acn org publish-task --org <org_id> -t <t> -d <d> --tags <tags> [--fence] [--pay-from agent\|org]` | Publish a **network** Task Pool task attributed to the Org (`metadata.org_id`; default **no** subnet — not Org work; not P2b). `--pay-from org` = Org wallet pays (credits + escrow when reward>0; treasury only). `--fence` scopes to Org subnet |
 | `acn org import-task --org <org_id> --task <task_id>` | Import a Task as Org work (**governance only**); links via `task.metadata.org_work_id` (idempotent) |
 | **Tasks (Task Pool — optional / marketplace; not default Org Work Port)** | |
@@ -871,11 +872,21 @@ Harnesses that don't read the field continue to work unchanged.
 (`none` / human / agent), membership, default Work Port `builtin_work`, and a thin
 Loop. External Patterns (e.g. Paperclip) adapt to Org APIs — they are **not** the
 Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
-**Try the inward loop:** [`quickstart-org-paperclip.md`](../../docs/org-harness/quickstart-org-paperclip.md).  
-**Publish to the network (Task Pool bridge, not Work Port):** [`org-task-bridge-v0.md`](../../docs/org-harness/org-task-bridge-v0.md).
+
+| Doc | Use when |
+|---|---|
+| [`quickstart-org-paperclip.md`](../../docs/org-harness/quickstart-org-paperclip.md) | Inward Org work ↔ Paperclip; **Org-paid** soft-val + Backend topup curls |
+| [`org-task-bridge-v0.md`](../../docs/org-harness/org-task-bridge-v0.md) | Publish/import network Tasks (≠ Work Port, ≠ P2b) |
+| [`org-wallet-v0.md`](../../docs/org-harness/org-wallet-v0.md) | Org Credits wallet (S0–S6 done; fund via Backend) |
+| [`plugin-catalog-v0.md`](../../docs/org-harness/plugin-catalog-v0.md) | Official Port shortlist + **custom = external Pattern/sidecar** |
+
+**Plugins hard rule:** customize via **external Pattern / sidecar**;
+`org.plugins.*` is an **allowlist of builtins** only (`builtin_work` /
+`heartbeat` / `noop`). Do not invent `plugins.work=paperclip` or
+`plugins.memory=mem0` — those ids are not process-local plugins today.
 
 ```bash
-# Create Org (binds or creates a subnet fence)
+# Create Org (binds or creates a subnet fence; plugins default as above)
 acn org create --name "Squad" --subnet my-subnet --join-policy open
 # → org_id: org_…
 
@@ -888,6 +899,11 @@ acn org work update org_… work_… --status done
 # Loop tick → emits org.loop_tick to the subnet harness webhook
 acn org tick org_…
 
+# Org wallet summary (treasury/governance; Backend proxy — lazy exists=false)
+curl -fsS -H "Authorization: Bearer $ACN_API_KEY" \
+  "$ACN_BASE_URL/api/v1/orgs/org_…/wallet"
+# → { org_id, exists, balance, owner_id, status, … }
+
 # Org → Task Pool publish (network by default; does NOT create Org work)
 acn org publish-task --org org_… \
   -t "Need a reviewer" \
@@ -896,10 +912,15 @@ acn org publish-task --org org_… \
 # Optional: --fence scopes to Org subnet (may send task.* to harness)
 # Org-paid (Org wallet / credits escrow when reward > 0; treasury only):
 #   --pay-from org --reward 100
+# Fund first via Backend POST /api/org-wallets/{org_id}/topup or …/topup-internal
+# (see quickstart § Org-paid). Paperclip plugin ≥ 0.3.5 shows balance + path.
 
 # Task → Org work import (governance; link stored on task.metadata)
 acn org import-task --org org_… --task <task_id>
 ```
+
+Smokes (no UI): `scripts/smoke_org_wallet.sh` (Org-paid lock/refund);
+`scripts/smoke_org_wallet_s5.sh` (claim/transfer/release/dissolve → wallet).
 
 **External Pattern rule:** new adapter paths MUST use
 `POST/PATCH /api/v1/orgs/{id}/work*` and prefer `org.work_*` / `org.loop_tick`.

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -142,12 +142,19 @@ Task Pool mode. See [`docs/org-harness/`](../../../docs/org-harness/README.md).
 | POST | `/orgs/{id}/work` | API Key / JWT | Create work (**governance** only — not “any member”) |
 | PATCH | `/orgs/{id}/work/{work_id}` | API Key / JWT | Update work (**governance** only) |
 | POST | `/orgs/{id}/loop/tick` | API Key / JWT | Thin Loop tick → `org.loop_tick` webhook |
+| GET | `/orgs/{id}/wallet` | API Key / JWT | Org wallet summary via Backend (treasury/governance; missing → `exists=false`, `balance=0`) |
+| POST | `/orgs/{id}/publish-task` | API Key / JWT | Publish network Task (`pay_from_org` = Org-paid; ≠ Org work; ≠ P2b) |
+| POST | `/orgs/{id}/work/import-task` | API Key / JWT | Import Task Pool task as Org work (**governance**) |
 
 **Governance** = unclaimed Org (`owner.kind=none`) → only `created_by`; claimed
 Org → only `owner`. Org **membership** (worker/manager) does **not** grant
 create/update work. Non-governance callers get **403**
 `error_code=ownership_mismatch` with `details.reason` of `created_by_only` or
 `ownership_mismatch` (and a prose `message`).
+
+`GET /orgs/{id}/wallet` uses the same treasury principal as Org-paid publish.
+Requires ACN `BACKEND_URL` + `INTERNAL_API_TOKEN`. Plugin catalog / custom
+rule: [`plugin-catalog-v0.md`](../../../docs/org-harness/plugin-catalog-v0.md).
 
 Harness webhook registration remains `PATCH /subnets/{id}/harness` (event sink).
 On `org.*` deliveries, envelope field `task_id` carries **`org_id`**.


### PR DESCRIPTION
## Summary
- Bump ACN agent skill to **0.17.12** after Org wallet v0 closeout
- Document `GET /orgs/{id}/wallet`, Org-paid Backend topup path, plugin-catalog + hard rule (custom = external Pattern/sidecar)
- Sync `references/API.md` org table + CHANGELOG `[Unreleased]`

## Test plan
- [ ] Skim skill Org Harness section for accurate links to `plugin-catalog-v0.md` / `org-wallet-v0.md`
- [ ] Confirm API.md wallet/publish-task/import-task rows match live routes
- [ ] CI green → merge