### PR TITLE
docs(skill): 0.17.13 clarify Org wallet topup auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Agent skill 0.17.13** — Clarify Org-paid Backend topup auth (human JWT vs
+  `topup-internal` + `X-Internal-Token`); note `INTERNAL_API_TOKEN` is
+  ACN server-side for `GET /orgs/{id}/wallet`, not caller credentials.
 - **Agent skill 0.17.12** — Org Harness closeout: wallet `GET /orgs/{id}/wallet`,
   Org-paid fund path, plugin-catalog + hard rule (custom = external
   Pattern/sidecar; `plugins.*` allowlist only). API.md org table synced.

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.12"
+  version: "0.17.13"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -912,8 +912,10 @@ acn org publish-task --org org_… \
 # Optional: --fence scopes to Org subnet (may send task.* to harness)
 # Org-paid (Org wallet / credits escrow when reward > 0; treasury only):
 #   --pay-from org --reward 100
-# Fund first via Backend POST /api/org-wallets/{org_id}/topup or …/topup-internal
-# (see quickstart § Org-paid). Paperclip plugin ≥ 0.3.5 shows balance + path.
+# Fund first on Backend (ACN_API_KEY alone cannot topup):
+#   human treasury → POST /api/org-wallets/{org_id}/topup  (Authorization: Bearer JWT)
+#   agent/smoke   → POST …/topup-internal  (X-Internal-Token + from_subject_id=treasury agent)
+# See quickstart § Org-paid. Paperclip plugin ≥ 0.3.5 shows balance + path.
 
 # Task → Org work import (governance; link stored on task.metadata)
 acn org import-task --org org_… --task <task_id>

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -152,9 +152,10 @@ create/update work. Non-governance callers get **403**
 `error_code=ownership_mismatch` with `details.reason` of `created_by_only` or
 `ownership_mismatch` (and a prose `message`).
 
-`GET /orgs/{id}/wallet` uses the same treasury principal as Org-paid publish.
-Requires ACN `BACKEND_URL` + `INTERNAL_API_TOKEN`. Plugin catalog / custom
-rule: [`plugin-catalog-v0.md`](../../../docs/org-harness/plugin-catalog-v0.md).
+`GET /orgs/{id}/wallet` uses the same **caller** treasury principal as Org-paid
+publish (API Key / JWT). ACN server-side proxy to Backend also needs
+`BACKEND_URL` + `INTERNAL_API_TOKEN` (not client credentials). Plugin catalog /
+custom rule: [`plugin-catalog-v0.md`](../../../docs/org-harness/plugin-catalog-v0.md).
 
 Harness webhook registration remains `PATCH /subnets/{id}/harness` (event sink).
 On `org.*` deliveries, envelope field `task_id` carries **`org_id`**.


### PR DESCRIPTION
## Summary
- Address Bugbot findings on skill 0.17.12
- Spell out Org-paid Backend topup auth (human JWT vs `topup-internal` + `X-Internal-Token` / `from_subject_id`)
- Clarify `INTERNAL_API_TOKEN` is ACN server-side for wallet proxy, not caller credentials

## Test plan
- [ ] Skill Org-paid comments match quickstart § Org-paid curls
- [ ] API.md wallet note does not imply clients send `INTERNAL_API_TOKEN`
- [ ] CI green → merge