### PR TITLE
feat(org): Org Loop spawn sidecar C2

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -57,5 +57,5 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 - **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Memory 等 adapter-planned）。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配。  
-- **实验（Accepted）：** [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C1 poll；C2 spawn 下一刀）。  
+- **实验（C1–C2）：** [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（poll + spawn 侧车；C3 webhook 按需）。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主；或换产品主线（驯养师 / TaskBoard 等）。

--- a/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
+++ b/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
@@ -1,6 +1,6 @@
 # Org Loop spawn sidecar — 选型 + POC v0
 
-**Status:** Accepted（C0）· C1 in progress  
+**Status:** Accepted · **C1 + C2 shipped**（C3 webhook 按需）  
 **Date:** 2026-07-27  
 **Audience:** Org Harness 维护者 / Pattern 作者  
 **Depends on:** [design-v0.md](./design-v0.md) §5–§6 · [plugin-catalog-v0.md](./plugin-catalog-v0.md) · [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)  
@@ -62,8 +62,8 @@ ACN Org
 | 切片 | 产出 | 状态 |
 |---|---|---|
 | **C0** | 本文 Accepted + catalog 指向 | **done** |
-| **C1** | poll open work + 日志（不 spawn） | **本 PR** |
-| **C2** | `spawnCommand` + 成功后 PATCH done | 下一刀 |
+| **C1** | poll open work + 日志（不 spawn） | **done** |
+| **C2** | `spawnCommand` + 成功后 PATCH done | **done** — `run_sidecar.py` + `smoke_org_loop_spawn_sidecar.sh` |
 | **C3** | webhook / 重试幂等（可选） | 按需 |
 
 ---

--- a/examples/org-loop-spawn-sidecar/README.md
+++ b/examples/org-loop-spawn-sidecar/README.md
@@ -1,31 +1,39 @@
 # Org Loop spawn sidecar（POC）
 
-外部执行侧车：poll Org open work →（C2）跑可配置命令 → 治理 key 关单。
+外部执行侧车：poll Org open work → 跑可配置命令 → 治理 key 关单。
 
 设计：[org-loop-spawn-sidecar-poc-v0.md](../../docs/org-harness/org-loop-spawn-sidecar-poc-v0.md)
 
 ## C1 — poll + 日志
 
-不 spawn、不改状态；只证明能看见待办。
-
 ```bash
-export ACN_BASE_URL=https://acn.acnlabs.cn   # 或你的 ACN
+export ACN_BASE_URL=https://acn.acnlabs.cn
 export ACN_ORG_ID=org_…
-export ACN_API_KEY=acn_…                     # 有权读该 Org work 的 key
-python3 poll_open_work.py
-# 或单次：
+export ACN_API_KEY=acn_…
 python3 poll_open_work.py --once
 ```
 
-环境变量：
+## C2 — spawn + 关单
 
-| 变量 | 说明 |
-|---|---|
-| `ACN_BASE_URL` | 含或不含 `/api/v1` 均可 |
-| `ACN_ORG_ID` | Org id |
-| `ACN_API_KEY` | Bearer |
-| `POLL_INTERVAL_SEC` | 默认 `30`（`--once` 时忽略） |
+需要 **governance** API key（owner / created_by）。worker 命令成功（exit 0）后 PATCH `done`。
 
-## C2（未做）
+```bash
+export ACN_BASE_URL=https://acn.acnlabs.cn
+export ACN_ORG_ID=org_…
+export ACN_API_KEY=acn_…                     # governance
+export SPAWN_COMMAND='echo work={{work_id}} title={{title}}'
+python3 run_sidecar.py --once
+```
 
-`spawnCommand` + worker 成功后 `PATCH …/work/{id}` → `done`（governance key）。
+`SPAWN_COMMAND` 模板变量：`{{work_id}}` `{{title}}` `{{org_id}}` `{{status}}`
+
+默认会先 `todo` → `in_progress`，spawn 成功后再 → `done`。  
+加 `--dry-run` 只打印命令；`--no-mark-in-progress` 跳过中间状态。
+
+## 狗粮
+
+```bash
+ACN_BASE_URL=… ACN_API_KEY=acn_… ./scripts/smoke_org_loop_spawn_sidecar.sh
+```
+
+ClawTeam 等：把 `SPAWN_COMMAND` 换成你的本地入口即可，侧车本体不变。

--- a/examples/org-loop-spawn-sidecar/acn_org.py
+++ b/examples/org-loop-spawn-sidecar/acn_org.py
@@ -1,0 +1,58 @@
+"""Minimal ACN Org work HTTP helpers (stdlib only)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def normalize_base(url: str) -> str:
+    base = url.rstrip("/")
+    if not base.endswith("/api/v1"):
+        base = f"{base}/api/v1"
+    return base
+
+
+def _request(
+    method: str,
+    url: str,
+    api_key: str,
+    body: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    data = None
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode()
+        if not raw:
+            return {}
+        return json.loads(raw)
+
+
+def fetch_open_work(base: str, org_id: str, api_key: str) -> dict[str, Any]:
+    url = f"{base}/orgs/{org_id}/work?open_only=true"
+    return _request("GET", url, api_key)
+
+
+def patch_work_status(
+    base: str,
+    org_id: str,
+    work_id: str,
+    api_key: str,
+    status: str,
+) -> dict[str, Any]:
+    url = f"{base}/orgs/{org_id}/work/{work_id}"
+    return _request("PATCH", url, api_key, {"status": status})
+
+
+def work_id(item: dict[str, Any]) -> str:
+    return str(item.get("work_id") or item.get("id") or "")

--- a/examples/org-loop-spawn-sidecar/poll_open_work.py
+++ b/examples/org-loop-spawn-sidecar/poll_open_work.py
@@ -4,43 +4,21 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 import time
 import urllib.error
-import urllib.request
-from typing import Any
+
+from acn_org import fetch_open_work, normalize_base, work_id
 
 
-def _normalize_base(url: str) -> str:
-    base = url.rstrip("/")
-    if not base.endswith("/api/v1"):
-        base = f"{base}/api/v1"
-    return base
-
-
-def fetch_open_work(base: str, org_id: str, api_key: str) -> dict[str, Any]:
-    url = f"{base}/orgs/{org_id}/work?open_only=true"
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Accept": "application/json",
-        },
-        method="GET",
-    )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode())
-
-
-def log_batch(payload: dict[str, Any]) -> None:
+def log_batch(payload: dict) -> None:
     org_id = payload.get("org_id", "?")
     items = payload.get("work") or []
     count = payload.get("count", len(items))
     print(f"[org-loop-spawn] org={org_id} open_count={count}", flush=True)
     for w in items:
-        wid = w.get("work_id") or w.get("id") or "?"
+        wid = work_id(w) or "?"
         title = w.get("title") or ""
         status = w.get("status") or "?"
         print(f"  - {wid}  status={status}  {title}", flush=True)
@@ -61,13 +39,10 @@ def main() -> int:
     interval = int(os.environ.get("POLL_INTERVAL_SEC", "30"))
 
     if not base_url or not org_id or not api_key:
-        print(
-            "Need ACN_BASE_URL, ACN_ORG_ID, ACN_API_KEY",
-            file=sys.stderr,
-        )
+        print("Need ACN_BASE_URL, ACN_ORG_ID, ACN_API_KEY", file=sys.stderr)
         return 2
 
-    base = _normalize_base(base_url)
+    base = normalize_base(base_url)
     while True:
         try:
             payload = fetch_open_work(base, org_id, api_key)

--- a/examples/org-loop-spawn-sidecar/run_sidecar.py
+++ b/examples/org-loop-spawn-sidecar/run_sidecar.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""C2: poll open Org work, run spawnCommand, governance PATCH → done on success."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+
+from acn_org import fetch_open_work, normalize_base, patch_work_status, work_id
+
+
+def expand_command(template: str, org_id: str, item: dict) -> str:
+    wid = work_id(item)
+    replacements = {
+        "{{work_id}}": wid,
+        "{{title}}": str(item.get("title") or ""),
+        "{{org_id}}": org_id,
+        "{{status}}": str(item.get("status") or ""),
+    }
+    cmd = template
+    for needle, value in replacements.items():
+        cmd = cmd.replace(needle, value)
+    return cmd
+
+
+def process_item(
+    *,
+    base: str,
+    org_id: str,
+    api_key: str,
+    item: dict,
+    spawn_command: str,
+    dry_run: bool,
+    mark_in_progress: bool,
+) -> bool:
+    wid = work_id(item)
+    if not wid:
+        print("[org-loop-spawn] skip item without work_id", file=sys.stderr)
+        return False
+
+    cmd = expand_command(spawn_command, org_id, item)
+    title = item.get("title") or ""
+    print(f"[org-loop-spawn] work={wid} title={title!r}", flush=True)
+
+    if dry_run:
+        print(f"  dry-run command: {cmd}", flush=True)
+        return True
+
+    if mark_in_progress and item.get("status") == "todo":
+        try:
+            patch_work_status(base, org_id, wid, api_key, "in_progress")
+            print("  status → in_progress", flush=True)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            print(f"  PATCH in_progress failed HTTP {e.code}: {body}", file=sys.stderr)
+            return False
+
+    print(f"  spawn: {cmd}", flush=True)
+    proc = subprocess.run(cmd, shell=True)
+    if proc.returncode != 0:
+        print(f"  spawn exit {proc.returncode}; work left open", file=sys.stderr)
+        return False
+
+    try:
+        patch_work_status(base, org_id, wid, api_key, "done")
+        print("  status → done", flush=True)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        print(f"  PATCH done failed HTTP {e.code}: {body}", file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Single poll cycle then exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print spawn commands only; no subprocess or PATCH",
+    )
+    parser.add_argument(
+        "--no-mark-in-progress",
+        action="store_true",
+        help="Skip PATCH in_progress before spawn",
+    )
+    args = parser.parse_args()
+
+    base_url = os.environ.get("ACN_BASE_URL", "").strip()
+    org_id = os.environ.get("ACN_ORG_ID", "").strip()
+    api_key = os.environ.get("ACN_API_KEY", "").strip()
+    spawn_command = os.environ.get("SPAWN_COMMAND", "").strip()
+    interval = int(os.environ.get("POLL_INTERVAL_SEC", "30"))
+
+    if not base_url or not org_id or not api_key:
+        print("Need ACN_BASE_URL, ACN_ORG_ID, ACN_API_KEY", file=sys.stderr)
+        return 2
+    if not spawn_command and not args.dry_run:
+        print("Need SPAWN_COMMAND (governance key required for PATCH)", file=sys.stderr)
+        return 2
+
+    base = normalize_base(base_url)
+    mark_in_progress = not args.no_mark_in_progress
+    in_flight: set[str] = set()
+
+    while True:
+        try:
+            payload = fetch_open_work(base, org_id, api_key)
+            items = payload.get("work") or []
+            print(
+                f"[org-loop-spawn] org={org_id} open_count={payload.get('count', len(items))}",
+                flush=True,
+            )
+            for item in items:
+                wid = work_id(item)
+                if not wid or wid in in_flight:
+                    continue
+                in_flight.add(wid)
+                process_item(
+                    base=base,
+                    org_id=org_id,
+                    api_key=api_key,
+                    item=item,
+                    spawn_command=spawn_command or "echo work={{work_id}}",
+                    dry_run=args.dry_run,
+                    mark_in_progress=mark_in_progress,
+                )
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            print(f"[org-loop-spawn] HTTP {e.code}: {body}", file=sys.stderr)
+            if args.once:
+                return 1
+        except Exception as e:
+            print(f"[org-loop-spawn] error: {e}", file=sys.stderr)
+            if args.once:
+                return 1
+
+        if args.once:
+            return 0
+        time.sleep(max(1, interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_org_loop_spawn_sidecar.sh
+++ b/scripts/smoke_org_loop_spawn_sidecar.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Smoke: Org Loop spawn sidecar (C2) — create work → sidecar → done
+#
+# Usage:
+#   ACN_BASE_URL=https://api.acnlabs.dev \
+#   ACN_API_KEY=acn_xxx \
+#   ./scripts/smoke_org_loop_spawn_sidecar.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE="${ACN_BASE_URL:-http://127.0.0.1:8000}"
+KEY="${ACN_API_KEY:?ACN_API_KEY required}"
+AUTH="Authorization: Bearer ${KEY}"
+SIDECAR="${ROOT}/examples/org-loop-spawn-sidecar"
+
+echo "==> Resolve caller agent"
+ME=$(curl -fsS -H "$AUTH" "${BASE}/api/v1/agents/me")
+AGENT_ID=$(echo "$ME" | python3 -c "import sys,json; print(json.load(sys.stdin)['agent_id'])")
+
+NAME="smoke-sidecar-$(date +%s)"
+echo "==> Create Org: $NAME"
+ORG=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"display_name\":\"${NAME}\"}" \
+  "${BASE}/api/v1/orgs")
+ORG_ID=$(echo "$ORG" | python3 -c "import sys,json; print(json.load(sys.stdin)['org_id'])")
+
+echo "==> Create open work"
+WORK=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"title\":\"sidecar smoke\",\"assignee_agent_id\":\"${AGENT_ID}\"}" \
+  "${BASE}/api/v1/orgs/${ORG_ID}/work")
+WORK_ID=$(echo "$WORK" | python3 -c "import sys,json; print(json.load(sys.stdin)['work_id'])")
+echo "    org_id=$ORG_ID work_id=$WORK_ID"
+
+echo "==> Run sidecar once (SPAWN_COMMAND=true)"
+export ACN_BASE_URL="$BASE"
+export ACN_ORG_ID="$ORG_ID"
+export ACN_API_KEY="$KEY"
+export SPAWN_COMMAND="true"
+python3 "${SIDECAR}/run_sidecar.py" --once
+
+echo "==> Verify work done"
+STATUS=$(curl -fsS -H "$AUTH" "${BASE}/api/v1/orgs/${ORG_ID}/work?open_only=false" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); w=[x for x in d['work'] if x['work_id']=='${WORK_ID}'][0]; print(w['status'])")
+if [[ "$STATUS" != "done" ]]; then
+  echo "expected status=done got $STATUS" >&2
+  exit 1
+fi
+
+echo "OK — Org Loop spawn sidecar smoke passed (org_id=$ORG_ID work_id=$WORK_ID)"


### PR DESCRIPTION
## Summary
- C2: `run_sidecar.py` — poll open work, expand `SPAWN_COMMAND` (`{{work_id}}` etc.), spawn, governance PATCH → `done`
- Shared `acn_org.py`; refactor C1 poll script
- Smoke: `scripts/smoke_org_loop_spawn_sidecar.sh` (create org/work → sidecar → assert done)

## Test plan
- [ ] `python3 -m py_compile examples/org-loop-spawn-sidecar/*.py`
- [ ] Optional: `ACN_BASE_URL=… ACN_API_KEY=… ./scripts/smoke_org_loop_spawn_sidecar.sh`
- [ ] CI green → merge