### PR TITLE
docs(org): rename to Org 待办执行器（外部）

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -27,7 +27,7 @@
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` 为 legacy） |
 | **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · P2a/P2c 完成 · P2b 按需）** |
 | **[plugin-catalog-v0.md](./plugin-catalog-v0.md)** | **官方 Port 推荐短名单（冷启动：默认 + ≤2 候选 / 状态）** |
-| **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)** | **Agent-native Loop：通用 spawn 侧车 POC（Accepted；C1 poll）** |
+| **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)** | **Org 待办执行器（外部）— agent 自动跑命令 POC（C1–C2）** |
 | [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
 
 理论草稿（隐喻 / 协议史）：
@@ -57,5 +57,5 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 - **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Memory 等 adapter-planned）。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配。  
-- **实验（C1–C2）：** [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（poll + spawn 侧车；C3 webhook 按需）。  
+- **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主；或换产品主线（驯养师 / TaskBoard 等）。

--- a/docs/org-harness/clawteam-loop-adapter-poc-v0.md
+++ b/docs/org-harness/clawteam-loop-adapter-poc-v0.md
@@ -1,7 +1,7 @@
-# Moved: Org Loop spawn sidecar POC
+# Moved: Org 待办执行器（外部）POC
 
-本文已重写为更贴可插拔模型的通用侧车选型：
+本文已重写并更名：
 
-→ **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)**
+→ **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)**（产品名：**Org 待办执行器（外部）**）
 
-ClawTeam 仍是推荐的 `spawnCommand` 配方之一，不再作为模块名称。
+ClawTeam 仍是推荐的 `spawnCommand` 配方之一。

--- a/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
+++ b/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
@@ -1,13 +1,35 @@
-# Org Loop spawn sidecar — 选型 + POC v0
+# Org 待办执行器（外部）— 选型 + POC v0
 
 **Status:** Accepted · **C1 + C2 shipped**（C3 webhook 按需）  
 **Date:** 2026-07-27  
 **Audience:** Org Harness 维护者 / Pattern 作者  
 **Depends on:** [design-v0.md](./design-v0.md) §5–§6 · [plugin-catalog-v0.md](./plugin-catalog-v0.md) · [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)  
-**Code:** [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)
+**Code:** [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（目录 slug 保留，指同一组件）
 
-> **模块是什么：** 外部「执行侧车」——看见 Org 待办 → 跑你配置的命令 →（可选）回写 work。  
-> **ClawTeam 是什么：** 推荐配方之一（`spawnCommand` 示例），**不是**侧车本体，也不是 ACN Kernel 插件名。
+> **它是什么：** **Org 待办执行器（外部）** — 跑在 ACN **外面**的小程序：看见 Org 待办 → 在本机跑你配置的命令 → 成功则回写 work。  
+> **不是什么：** **不是** Org Harness 新 Kernel 模块；**不是** `plugins.loop=*`；**不是** Paperclip。  
+> **ClawTeam：** 只是 `spawnCommand` 的**示例配方**，不是执行器本体。
+
+---
+
+## 在 Org Harness 里的位置
+
+```text
+Org Harness（ACN 内，已有）
+  Kernel · Work Port（builtin_work）· Loop（heartbeat）
+
+        ↓  可选，你自己部署
+
+Org 待办执行器（外部 Pattern，与 Paperclip 同级）
+        ↓  spawnCommand（可换）
+本机 worker（ClawTeam / 脚本 / agent CLI…）
+```
+
+| 对比 | Paperclip | Org 待办执行器（外部） |
+|---|---|---|
+| 给谁 | 人看板 | agent / 本机自动跑 |
+| 在哪 | Paperclip 服务 | 你的机器 |
+| 进 Kernel？ | 否 | 否 |
 
 ---
 
@@ -16,7 +38,7 @@
 ACN 已经能建组织、派扁平行任务、打 tick。  
 缺的是：tick 之后，**本机自动拉起某个 worker 去干活**。
 
-Paperclip 补的是「给人看的看板」；这条 POC 补的是「给 agent 用的执行器钩子」。
+Paperclip 补「给人看的看板」；待办执行器补「给 agent 用的自动干活钩子」。
 
 ---
 
@@ -24,22 +46,11 @@ Paperclip 补的是「给人看的看板」；这条 POC 补的是「给 agent �
 
 | 题 | 决定 |
 |---|---|
-| 做什么 | **通用 spawn 侧车**（外部进程），契约稳定、实现可换 |
+| 做什么 | **Org 待办执行器（外部）** — 契约稳定，命令可换 |
 | 不做什么 | 不设 `plugins.loop=clawteam`；不进进程内 registry |
 | Work / Loop | 仍用 `builtin_work` + `heartbeat` |
 | ClawTeam / 其它 | 仅作 `spawnCommand` **示例配方** |
-| LangGraph 等 | 延后（那是 Work Graph，不是本 POC） |
-
-```text
-ACN Org
-  work = builtin_work · loop = heartbeat
-            │ poll open work  (或以后 webhook)
-            ▼
-   org-loop-spawn-sidecar   ← 可插拔模块（本 POC）
-            │ spawnCommand（可换）
-            ▼
-   ClawTeam / 脚本 / 任意 L1 worker
-```
+| LangGraph 等 | 延后（Work Graph，不是本 POC） |
 
 ---
 
@@ -48,23 +59,21 @@ ACN Org
 | # | 题 | 决定 |
 |---|---|---|
 | 1 | 仓库 | ACN 仓 [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)；成了再拆独立仓 |
-| 2 | 身份 | **列表/poll**：治理或有权读者 API key。**关单 `PATCH work`：** 今日仅 **governance**（owner / created_by）→ 侧车持治理 key 在 worker 成功退出后关单；成员 key 留给 worker 自己的 L1/A2A，不冒充关单 |
-| 3 | 上游 | **任意 `spawnCommand`**；README 给 ClawTeam（或 echo 狗粮）示例，不钉死上游版本 |
-
-> 纠正：此前「成员 key PATCH done」与 v0 API 不符（`update_work` 走 `_require_governance`）。POC 按上表。
+| 2 | 身份 | **poll 列表**：治理或有权读者 key。**关单 PATCH：** 仅 **governance** → 执行器持治理 key，worker 成功退出后标 `done` |
+| 3 | 上游 | **任意 `spawnCommand`**；README 给 echo / ClawTeam 示例 |
 
 ---
 
 ## 4. POC 场景
 
-**最小可验：** 有 open work → 侧车 poll 到 →（C2）跑 `spawnCommand` → 退出 0 → 治理 key 把 work 标 `done`。
+**最小可验：** open work → 执行器 poll 到 → 跑 `spawnCommand` → exit 0 → 治理 key 标 `done`。
 
 | 切片 | 产出 | 状态 |
 |---|---|---|
-| **C0** | 本文 Accepted + catalog 指向 | **done** |
-| **C1** | poll open work + 日志（不 spawn） | **done** |
-| **C2** | `spawnCommand` + 成功后 PATCH done | **done** — `run_sidecar.py` + `smoke_org_loop_spawn_sidecar.sh` |
-| **C3** | webhook / 重试幂等（可选） | 按需 |
+| **C0** | 本文 Accepted + catalog | **done** |
+| **C1** | poll + 日志 | **done** — `poll_open_work.py` |
+| **C2** | spawn + PATCH done | **done** — `run_sidecar.py` + `smoke_org_loop_spawn_sidecar.sh` |
+| **C3** | webhook / 重试幂等 | 按需 |
 
 ---
 
@@ -72,8 +81,7 @@ ACN Org
 
 - 人类看板、审批、Org Memory、Task Pool 镜像  
 - 短命 worker ≠ `OrgMembership`  
-- 完整对等任何上游（ClawTeam / LangGraph…）  
-- 把 Project / Workspace 塞进 Kernel  
+- Project / Workspace 进 Kernel  
 
 ---
 
@@ -82,11 +90,11 @@ ACN Org
 ```yaml
 acnBaseUrl: https://acn.acnlabs.cn
 acnOrgId: org_…
-acnApiKey: acn_…              # governance（C2 关单需要）
+acnApiKey: acn_…              # governance（关单需要）
 mode: poll
 pollIntervalSec: 30
 spawnCommand: "echo work={{work_id}}"   # 可换成 ClawTeam / 自写脚本
 ```
 
-入站 POC：**poll** `GET /orgs/{id}/work?open_only=true`。  
-出站（C2）：`PATCH /orgs/{id}/work/{work_id}` status（governance）。
+入站：**poll** `GET /orgs/{id}/work?open_only=true`。  
+出站：**PATCH** `/orgs/{id}/work/{work_id}` → `done`（governance）。

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -86,7 +86,7 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 |---|---|---|
 | **`heartbeat`** | **shipped** | 默认薄 tick（`POST …/loop/tick`）。别名 `thin` → `heartbeat`。 |
 | Paperclip / harness 唤醒 | **shipped**（外部） | Pattern 或 subnet harness 收 `org.*` 后驱动成员 L1；不必换 loop id。 |
-| **Org Loop spawn sidecar**（任意 `spawnCommand`；ClawTeam 等为配方） | **adapter-planned**（C1 shipped in examples） | 外部侧车，非 `plugins.loop=*`；见 [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)。 |
+| **Org 待办执行器（外部）**（任意 `spawnCommand`；ClawTeam 等为配方） | **adapter-planned**（C1–C2 in examples） | 外部 Pattern，非 `plugins.loop=*`；见 [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)。 |
 
 ### 3. Memory — `IOrgMemory`（`plugins.memory`）
 

--- a/examples/org-loop-spawn-sidecar/README.md
+++ b/examples/org-loop-spawn-sidecar/README.md
@@ -1,10 +1,12 @@
-# Org Loop spawn sidecar（POC）
+# Org 待办执行器（外部）— POC 示例代码
 
-外部执行侧车：poll Org open work → 跑可配置命令 → 治理 key 关单。
+跑在 ACN **外面**：poll Org 待办 → 跑可配置命令 → 治理 key 关单。
 
 设计：[org-loop-spawn-sidecar-poc-v0.md](../../docs/org-harness/org-loop-spawn-sidecar-poc-v0.md)
 
-## C1 — poll + 日志
+> 目录名 `org-loop-spawn-sidecar` 是历史 slug；产品名：**Org 待办执行器（外部）**。
+
+## C1 — 只看待办
 
 ```bash
 export ACN_BASE_URL=https://acn.acnlabs.cn
@@ -13,22 +15,16 @@ export ACN_API_KEY=acn_…
 python3 poll_open_work.py --once
 ```
 
-## C2 — spawn + 关单
+## C2 — 跑命令 + 关单
 
-需要 **governance** API key（owner / created_by）。worker 命令成功（exit 0）后 PATCH `done`。
+需要 **governance** API key。命令成功（exit 0）后标 `done`。
 
 ```bash
-export ACN_BASE_URL=https://acn.acnlabs.cn
-export ACN_ORG_ID=org_…
-export ACN_API_KEY=acn_…                     # governance
 export SPAWN_COMMAND='echo work={{work_id}} title={{title}}'
 python3 run_sidecar.py --once
 ```
 
-`SPAWN_COMMAND` 模板变量：`{{work_id}}` `{{title}}` `{{org_id}}` `{{status}}`
-
-默认会先 `todo` → `in_progress`，spawn 成功后再 → `done`。  
-加 `--dry-run` 只打印命令；`--no-mark-in-progress` 跳过中间状态。
+模板变量：`{{work_id}}` `{{title}}` `{{org_id}}` `{{status}}`
 
 ## 狗粮
 
@@ -36,4 +32,4 @@ python3 run_sidecar.py --once
 ACN_BASE_URL=… ACN_API_KEY=acn_… ./scripts/smoke_org_loop_spawn_sidecar.sh
 ```
 
-ClawTeam 等：把 `SPAWN_COMMAND` 换成你的本地入口即可，侧车本体不变。
+ClawTeam 等：只改 `SPAWN_COMMAND`，执行器本体不变。


### PR DESCRIPTION
## Summary
- User-facing name: **Org 待办执行器（外部）** (not a new Kernel module; external Pattern like Paperclip)
- Rewrite POC doc with positioning table vs Paperclip
- Update README, plugin-catalog, examples README; clawteam redirect note

## Test plan
- [ ] Skim org-loop-spawn-sidecar-poc-v0.md § positioning
- [ ] CI green → merge