### PR TITLE
docs(org): Org Harness architecture guide + ClawTeam Loop selection

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -1,12 +1,13 @@
 # Org Harness
 
 **Status:** Design v0 + [ADR-0014](../adr/0014-org-harness-module.md) Accepted；**Phase 1 Kernel + Phase 2a/P2c 已落地**（`/api/v1/orgs*` · Work Port `builtin_work` · Paperclip Org path）  
-**Last updated:** 2026-07-24
+**Last updated:** 2026-07-27
 
 > **Org Harness** 是 ACN 的**新模块**：给「一群 agent 组成的 Org」提供组织层挽具。  
 > **ACN** 仍叫 ACN（智能体协作网络），不是 Pasture。  
 > **Pasture** 仅作白皮书隐喻。  
-> 协作主体是 **agent**。Org Owner **可选**（无人认领 / 人 / agent），与 ACN 上 agent 所有权同构——**人不是必须**。
+> 协作主体是 **agent**。Org Owner **可选**（无人认领 / 人 / agent），与 ACN 上 agent 所有权同构——**人不是必须**。  
+> **分层导读：** [design-v0.md §0](./design-v0.md#0-架构导读先读这个)（Kernel / Loop / Work / 外部 Pattern）。
 
 ## 先试用
 
@@ -20,7 +21,7 @@
 
 | 文档 | 说明 |
 |---|---|
-| **[design-v0.md](./design-v0.md)** | **方案设计与架构（综合定调，以此为准）** |
+| **[design-v0.md](./design-v0.md)** | **方案设计与架构（综合定调，以此为准；先读 §0）** |
 | **[../adr/0014-org-harness-module.md](../adr/0014-org-harness-module.md)** | **P0/P1 机制 ADR（已 Accepted）** |
 | [org-model-v0.md](./org-model-v0.md) | Org / Membership 数据模型 |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core 消费契约（外部 Pattern 用） |
@@ -28,6 +29,7 @@
 | **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · P2a/P2c 完成 · P2b 按需）** |
 | **[plugin-catalog-v0.md](./plugin-catalog-v0.md)** | **官方 Port 推荐短名单（冷启动：默认 + ≤2 候选 / 状态）** |
 | **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)** | **Org 待办执行器（外部）— agent 自动跑命令 POC（C1–C2）** |
+| [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（未实现；≠ 待办执行器） |
 | [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
 
 理论草稿（隐喻 / 协议史）：
@@ -42,11 +44,14 @@ Org = N × Agent + Org Harness   (± optional Owner: none | human | agent)
 
 Org Harness Module = Kernel（固定） + Ports（可插拔）
   Org Graph（Kernel）: Org · 可选 Owner · agent 成员 · subnet 绑定
-  Control Loop（Port）: 组织心跳 — 观察队列 → 分派/唤醒 → 回收
-  Work Graph（Port 策略）: **builtin_work（默认）** / TaskPool（可选）/ Paperclip / Swarm / …
+  Control Loop（Port）: 今日 heartbeat — 观察队列 → 分派/唤醒 → 回收
+  Work Graph（Port）: 今日 builtin_work（默认）；TaskPool deferred
   其它 Ports: Memory · Capability · Policy · Events
 
-L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Kernel
+自定义主路径 = 外部 Pattern（非 plugins.*）
+  Paperclip · Org 待办执行器 ·（将来）ClawTeam Loop 适配器等
+
+L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 ```
 
 ## 下一步
@@ -58,4 +63,5 @@ L1 harness（含会话级 fan-out）: 成员自带，不升维进 Org Harness Ke
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Memory 等 adapter-planned）。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配。  
 - **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
+- **选型（未实现）：** [ClawTeam ↔ Org Loop 适配器](./clawteam-org-loop-adapter-v0.md)（有真实多 worker 协调需求再开）。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主；或换产品主线（驯养师 / TaskBoard 等）。

--- a/docs/org-harness/clawteam-loop-adapter-poc-v0.md
+++ b/docs/org-harness/clawteam-loop-adapter-poc-v0.md
@@ -1,7 +1,10 @@
-# Moved: Org 待办执行器（外部）POC
+# 文件名已废弃（勿按此名理解）
 
-本文已重写并更名：
+**本路径文件名含 `clawteam-loop-adapter`，会误导。内容已拆到两处：**
 
-→ **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)**（产品名：**Org 待办执行器（外部）**）
+| 你要找的 | 去这里 |
+|---|---|
+| **Org 待办执行器（外部）** POC（poll → `spawnCommand` → 回写） | [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) |
+| **ClawTeam ↔ Org Loop 适配器** 选型（未实现；真·Loop 外部适配） | [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) |
 
-ClawTeam 仍是推荐的 `spawnCommand` 配方之一。
+架构分层见 [design-v0.md §0](./design-v0.md#0-架构导读先读这个)。

--- a/docs/org-harness/clawteam-org-loop-adapter-v0.md
+++ b/docs/org-harness/clawteam-org-loop-adapter-v0.md
@@ -1,0 +1,81 @@
+# ClawTeam ↔ Org Loop 适配器 — 选型 v0
+
+**Status:** Draft · **未实现**（adapter-planned）  
+**Date:** 2026-07-27  
+**Audience:** Org Harness 维护者 / 想复用 ClawTeam 做组织节拍的人  
+**Depends on:** [design-v0.md](./design-v0.md) §0 · §6 · [plugin-catalog-v0.md](./plugin-catalog-v0.md) · [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)
+
+> **一句话：** 若要用 [ClawTeam](https://github.com/HKUDS/ClawTeam) 驱动 ACN Org，应写**外部 Loop 适配器**（Org work ↔ CT task），**不是** `plugins.loop=clawteam`，也**不是** [待办执行器](./org-loop-spawn-sidecar-poc-v0.md) 里一行 `SPAWN_COMMAND`。
+
+---
+
+## 1. 和另外两条路的区别
+
+| | **本选型：Loop 适配器** | [Org 待办执行器](./org-loop-spawn-sidecar-poc-v0.md) | 成员互派 |
+|---|---|---|---|
+| 职责 | 组织节拍：看 ACN 队列 → 映射 CT → spawn/协调 → 回写 | 本机 poll → 跑**一条**命令 → 关单 | 成员自己 A2A / CLI |
+| SoT | **ACN Org work**（CT 看板若开，只是执行视图） | ACN Org work | ACN Org work |
+| ClawTeam 角色 | 多 worker **协调平面**（适配器对接） | 可选的 `spawnCommand` 配方 | 成员本机自用 |
+| `plugins.loop` | **不改**（仍 `heartbeat`）；适配器吃 tick/事件 | **不改** | 不需要 |
+
+旧文件名 `clawteam-loop-adapter-poc-v0.md` 曾指向待办执行器 POC，**勿按文件名理解**；见该页跳转说明。
+
+---
+
+## 2. 架构位置
+
+```text
+ACN 内：Kernel + builtin_work + heartbeat + events
+              │
+              │ poll open work / org.* / loop tick
+              ▼
+外部：ClawTeam Org Loop 适配器（本选型，未实现）
+              │
+              ├── Org work  ←→  CT task（映射）
+              ├── Org member / role  ←→  CT worker（可选）
+              └── 成功/失败 → governance PATCH work
+```
+
+硬约定：
+
+- **不设** `plugins.loop=clawteam`（v0 白名单会拒绝）。  
+- 适配器是 **外部 Pattern**，与 Paperclip 同级。  
+- Org 身份、成员、待办列表的权威仍在 ACN。
+
+---
+
+## 3. 建议映射（Accepted 方向）
+
+| ACN | ClawTeam | 规则 |
+|---|---|---|
+| `OrgWorkItem`（open） | CT task / job | 创建时带 `work_id`；幂等 key = `org_id` + `work_id` |
+| `assignee` / 角色 | worker 选择 | 优先映射 Org 成员 agent；无映射则本机 ephemeral worker（≠ Membership） |
+| work `done` / `failed` | CT 完成/失败 | **仅治理 key** PATCH（v0 API 约束） |
+| Org charter / 标题描述 | CT 任务 prompt 前缀 | 只读注入，不在 CT 侧改章程 |
+
+**反模式：**
+
+- 以 ClawTeam kanban 为 SoT，再镜像回 ACN。  
+- 把整个 CT 当 `SPAWN_COMMAND` 一行黑盒（层次过低，且双看板冲突）。  
+- 在 ACN 进程内热加载 ClawTeam。
+
+---
+
+## 4. 非目标（本选型）
+
+- 实现代码 / examples（有真实需求再开 C0）  
+- 替换 `heartbeat` Builtin  
+- 接管成员 L1 tool loop  
+- 联邦多机 CT 集群
+
+---
+
+## 5. 何时开做
+
+同时满足再立项实现：
+
+1. 有真实 Org 需要「本机多 CLI worker 协调」且成员互派不够；  
+2. 待办执行器单命令模型不够用；  
+3. 接受治理 key 关单与外部进程运维。
+
+在此之前：用 **heartbeat + 成员 CLI**，或 [Org 待办执行器](./org-loop-spawn-sidecar-poc-v0.md)。

--- a/docs/org-harness/clawteam-org-loop-adapter-v0.md
+++ b/docs/org-harness/clawteam-org-loop-adapter-v0.md
@@ -50,7 +50,7 @@ ACN 内：Kernel + builtin_work + heartbeat + events
 |---|---|---|
 | `OrgWorkItem`（open） | CT task / job | 创建时带 `work_id`；幂等 key = `org_id` + `work_id` |
 | `assignee` / 角色 | worker 选择 | 优先映射 Org 成员 agent；无映射则本机 ephemeral worker（≠ Membership） |
-| work `done` / `failed` | CT 完成/失败 | **仅治理 key** PATCH（v0 API 约束） |
+| work `done` / `cancelled` | CT 完成 / 失败或放弃 | **仅治理 key** PATCH；v0 状态仅 `todo`\|`in_progress`\|`done`\|`cancelled`（无 `failed`） |
 | Org charter / 标题描述 | CT 任务 prompt 前缀 | 只读注入，不在 CT 侧改章程 |
 
 **反模式：**

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -1,10 +1,79 @@
 # Org Harness 方案设计与架构 v0
 
 **Status:** Design v0 — mechanics decided in [ADR-0014](../adr/0014-org-harness-module.md)（Accepted）  
-**Date:** 2026-07-19 · **Narrative sync:** 2026-07-21（Org Graph · Control Loop · Work Graph）  
+**Date:** 2026-07-19 · **Narrative sync:** 2026-07-27（架构导读：Kernel / Ports / 外部 Pattern 分界）  
 **Audience:** ACN / AgentPlanet 产品与工程  
 **Supersedes (naming & ownership):** 本文纠正早期「ACN = Pasture System」「Org 只活在 Paperclip」的表述；Network Core 契约仍见 [api-surface-tiers.md](./api-surface-tiers.md)。  
 **P0/P1 风险收口:** 见 ADR-0014（无 owner 治理、Membership↔subnet、subnet steward、Phase 1 含最小 work、Loop/Work 边界）。
+
+---
+
+## 0. 架构导读（先读这个）
+
+> 口语里的「编排」常把三件事混在一起。本文只认下面这套分层。
+
+### 0.1 Org Harness 是什么
+
+```text
+L1  Agent = Model + Agent Harness（成员自带，不进本模块）
+L2  Org   = N × Agent + Org Harness（± 可选 Owner）
+
+ACN = Network Core（已有） + Org Harness Module（新）
+```
+
+**Org Harness = 固定 Kernel（组织是谁）+ 可插拔 Ports（组织怎么转）。**
+
+### 0.2 模块内三层（叠加，非二选一）
+
+```text
+Org Graph（Kernel，不可换）
+  谁在组织里、Owner、角色、绑哪个 subnet
+
+Control Loop（IOrgLoop Port）
+  组织何时巡检、叫醒谁、收回结果     ← 组织节拍，不是工单形状
+
+Work Graph（IWorkPattern Port）
+  这票活怎么建模、状态怎么走         ← 工单 / DAG / handoff 策略
+
+↓ 再往下是成员自己的 L1（tools / 会话 fan-out），Org Harness 不接管
+```
+
+| 层 | 问题 | 归属 |
+|---|---|---|
+| Org Graph | 组织是谁 | Kernel |
+| Control Loop | 组织怎么打节拍 | `plugins.loop`（默认 `heartbeat`） |
+| Work Graph | 活长什么样 | `plugins.work`（默认 `builtin_work`） |
+
+### 0.3 两种「插法」——勿混货架
+
+| 路径 | 含义 | v0 事实 |
+|---|---|---|
+| **`org.plugins.*`（进程内）** | ACN Builtin 白名单 | 今日仅 `builtin_work` / `heartbeat` / `noop` |
+| **外部 Pattern / 侧车** | 跑在 ACN **外面**，消费 Org API / `org.*` 事件 | **自定义主路径**；Paperclip、[Org 待办执行器](./org-loop-spawn-sidecar-poc-v0.md) 都走这里 |
+
+硬约定见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)：想换运转方式 → 优先外部 Pattern；**不要**伪造 `plugins.loop=clawteam` / `plugins.work=paperclip`（今日会拒绝或语义错误）。
+
+### 0.4 外部集成放哪（常见混淆）
+
+| 东西 | 正确位置 | 不是 |
+|---|---|---|
+| Paperclip | **外部 Pattern**（人看板 ↔ Org work） | 不是 Kernel，不是 `plugins.work=paperclip` |
+| Org 待办执行器 | **外部 Pattern**（本机 poll 待办 → 跑命令 → 回写） | 不是 Loop 槽 Builtin；见 [POC](./org-loop-spawn-sidecar-poc-v0.md) |
+| ClawTeam | **候选**：将来的 Loop **适配器**（[选型](./clawteam-org-loop-adapter-v0.md)），或待办执行器的 `spawnCommand` **配方** | **不是** Org Harness 本体；**不是** 已接线的 `plugins.loop` |
+| OpenHarness / Claude Code | **L1**，成员自带 | 不插进 Org Harness |
+| LangGraph / Swarm / CrewAI | 多挂 **Work 策略**或外部 Pattern | 不替代 Control Loop |
+
+```text
+今日真实形态（Phase 1–2）：
+
+  ACN 内：Kernel + builtin_work + heartbeat + events
+              │
+              │ API / org.* webhook
+              ▼
+  外部可选：Paperclip │ 待办执行器 │（将来）真·Loop/Work 适配器
+```
+
+细节从 §4 总体架构、§5 模块内设计展开；插件短名单见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。
 
 ---
 
@@ -25,7 +94,7 @@ Agent 可以入网、进围栏、互相通信、接任务。但**缺少「组织
 
 ### 1.2 要解决什么
 
-一批已注册 agent 需要**组成一个持续存在的组织**协同工作：有章程、有角色化的 agent 成员、有组织级控制环（Loop），并能换掉具体编排实现（Task Pool / Paperclip / ClawTeam / Swarm…）而不推翻网络层。Owner（人 / agent / 未认领）与 ACN 上 agent 的所有权模型同构——**可选，非必须**。
+一批已注册 agent 需要**组成一个持续存在的组织**协同工作：有章程、有角色化的 agent 成员、有组织级控制环（Loop），并能在**不推翻网络层**的前提下换运转方式（进程内 Builtin 或外部 Pattern：Paperclip / 待办执行器 / 将来的 ClawTeam·Swarm 适配等）。Owner（人 / agent / 未认领）与 ACN 上 agent 的所有权模型同构——**可选，非必须**。
 
 ### 1.3 非目标（v0）
 
@@ -117,7 +186,7 @@ Org:    unclaimed | owned_by human | owned_by agent
 | 层 | 职责 | 典型实现 |
 |---|---|---|
 | L1 Agent Harness | 单 agent loop / tools / memory / sandbox | OpenHarness、Claude Code、Codex |
-| 编排 / Swarm（回合内） | 一票活怎么交班、扇出、拉起 worker | Swarm/Agents SDK、ClawTeam、CrewAI、LangGraph |
+| 编排 / Swarm（回合内） | 一票活怎么交班、扇出、拉起 worker | Swarm/Agents SDK、CrewAI、LangGraph；ClawTeam 也可落此层，**若接 Org 节拍则作外部 Loop 适配（见 §0.4 / §6）** |
 | **Org Harness** | Org 内核 + 组织 Loop + 插件槽 | **ACN 新模块** |
 | Network | 跨宿主身份、围栏、消息、结算 | **ACN Core** |
 
@@ -150,8 +219,8 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 
 | Port | 问题 | v0 默认 | 可替换示例 |
 |---|---|---|---|
-| **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选）、Paperclip Issues、自研 DAG |
-| **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | ClawTeam 适配、自定义巡检 |
+| **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选/deferred）；自研 DAG；**Paperclip = 外部 Pattern**（非 `plugins.work`） |
+| **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | （将来）ClawTeam **Loop 适配器**、自定义巡检；今日自定义走**外部 Pattern** |
 | **`ICapabilityPool`** | 组织能力目录 | 聚合成员 ACN skills（可先内置非插件） | 外挂 MCP catalog |
 | **`IOrgMemory`** | 集体记忆 / SOP | `noop` | Mem0、PG+vector、Skills 包 |
 | **`IPolicyBudget`** | 角色权限、花费 | Kernel 角色枚举 | 审批流、月度硬停 |
@@ -159,6 +228,8 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 
 **v0 必要实现：** Kernel + `IWorkPattern` + 薄 `IOrgLoop` + `IEventSink`。  
 其余 Port **占位即可**，避免一次做成「小 OpenHarness 复刻」。
+
+> **Port 名 ≠ 货架上已有货。** 「可替换示例」是问题轴上的方向；进程内是否接线见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。Paperclip / 待办执行器走外部，不进 `plugins.*`。
 
 建议后续补：**统一 Plugin 宿主**（发现、按 org 启用、版本、失败隔离），以及 **Skills/SOP 与 Memory 分离**（或明确 SOP 为 Work/Loop 的只读输入）。
 
@@ -186,40 +257,55 @@ Work Graph（IWorkPattern 策略，易变）:
 
 ### 5.5 挂载粒度
 
-按 **Org** 配置插件组合，而非全局唯一：
+按 **Org** 配置插件组合，而非全局唯一。`plugins.*` 仅白名单；Paperclip 等走外部 Pattern（见 §0.3）：
 
 ```text
-Org A → Work=builtin_work  Loop=heartbeat      Memory=noop
-Org B → Work=task_pool     Loop=heartbeat      Memory=noop
-Org C → Work=paperclip     Loop=paperclip_wake Memory=vector
-```
+# 进程内 plugins.*（v0）
+Org A → work=builtin_work  loop=heartbeat  memory=noop     ← 默认
+Org B → work=task_pool     loop=heartbeat  memory=noop     ← deferred；选了会 plugin_unavailable
 
+# 外部 Pattern（不改 plugins.work / plugins.loop）
+Org A + Paperclip 适配器（Issues ↔ Org work）
+Org A + Org 待办执行器（本机 poll → spawnCommand）
+# 将来：Org A + ClawTeam Loop 适配器（外部进程，仍非 plugins.loop=clawteam）
+```
 ---
 
 ## 6. 与同类项目的关系（可插拔，非平替）
 
+> 分层导读见 **§0**。下表只回答「挂哪一层」，**不等于**今天已进 `plugins.*` 白名单。
+
 | 项目 | 层级 | 与 Org Harness 关系 |
 |---|---|---|
 | [OpenHarness](https://github.com/HKUDS/OpenHarness) | L1 Agent Harness | 成员自带；**不**插进 Org Harness |
-| [ClawTeam](https://github.com/HKUDS/ClawTeam) | Swarm / 本地编排 | 可作为 **`IOrgLoop` / 执行器插件**（spawn CLI workers）；Org 身份仍在 ACN |
-| OpenAI Swarm → Agents SDK | Handoff 协调 | 可作为 **`IWorkPattern` 策略插件** |
-| CrewAI / LangGraph / MAF | 角色队 / 图编排 | 同上，挂 Port |
-| Paperclip | 公司式控制面 + UI | **外部 Pattern**；[`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin) 是适配器，**不是** Org Harness 本体 |
-| ACN Task Pool | Builtin 轻量 WorkPattern | **可选**插件（`plugins.work=task_pool`）；**默认**是 `builtin_work`，不是 Task Pool |
+| [ClawTeam](https://github.com/HKUDS/ClawTeam) | 本机多 agent 协调 | **候选**：`IOrgLoop` **外部适配器**（[选型](./clawteam-org-loop-adapter-v0.md)）；或待办执行器的 `spawnCommand` 配方。Org 身份 / 待办 SoT 仍在 ACN。**不是** Builtin，**没有** `plugins.loop=clawteam` |
+| OpenAI Swarm → Agents SDK | Handoff 协调 | 可作为 **Work 策略**或外部 Pattern |
+| CrewAI / LangGraph / MAF | 角色队 / 图编排 | 同上；挂 Work 轴或外部，**不替代** Control Loop |
+| Paperclip | 公司式控制面 + UI | **外部 Pattern**；[`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin) 是适配器，**不是** Org Harness 本体，**勿**设 `plugins.work=paperclip` |
+| Org 待办执行器 | 本机 poll → spawn → 回写 | **外部 Pattern**（[POC](./org-loop-spawn-sidecar-poc-v0.md)）；**不是** `plugins.loop=*` |
+| ACN Task Pool | Builtin 轻量 WorkPattern | **可选**（`plugins.work=task_pool`，**deferred**）；**默认**是 `builtin_work` |
 
 ```text
-Org Harness
-└── Ports
-    ├── IOrgLoop      ◄── ClawTeam adapter（可选）
-    ├── IWorkPattern  ◄── Swarm / LangGraph / TaskPool / Paperclip Issues
+Org Harness（ACN 内）
+├── Kernel（固定）
+└── Ports（进程内白名单极窄）
+    ├── IOrgLoop     = heartbeat（今日）
+    ├── IWorkPattern = builtin_work（今日）
     └── …
+         │
+         │ API / org.* 事件
+         ▼
+外部 Pattern（自定义主路径）
+├── Paperclip
+├── Org 待办执行器（spawnCommand 可指向 ClawTeam / 脚本 / CLI）
+└── （将来）ClawTeam Loop 适配器、LangGraph Work 适配器…
          │
          ▼
     ACN Network Core
 ```
 
 **本地打一仗、不要持久 Org** → 可直接用 ClawTeam/Swarm。  
-**跨宿主、持久 Org、可结算、可换 L1 harness**（Owner 可有可无）→ 先 Org Harness + ACN，再选插件。
+**跨宿主、持久 Org、可结算、可换 L1 harness**（Owner 可有可无）→ 先 Org Harness + ACN，再选 **外部 Pattern** 或（Phase 3）进程内插件。
 
 ---
 
@@ -342,10 +428,11 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 | D4 | 协作主体是 **agent**；Org Owner **可选**（`none` / human / agent），对称 ACN agent 所有权，**人不是必须** |
 | D5 | 模块内 = **Kernel + Ports**；可插拔的是运转方式 |
 | D6 | 三层：**Org Graph**（Kernel）+ **Control Loop**（节拍）+ **Work Graph**（Port 策略）；禁止用回合内 DAG 替代组织控制平面 |
-| D7 | ClawTeam / Swarm = **Port 插件候选**，不是 Org Harness 平替 |
+| D7 | ClawTeam / Swarm = **外部适配候选**（Loop 或 Work 轴），不是 Org Harness 平替；v0 **无** `plugins.loop=clawteam` |
 | D8 | OpenHarness 等 = **L1**，成员自带 |
 | D9 | v0 不做「加人」叙事；复用 subnet 围栏 |
 | D10 | v0 只做满 Kernel + Work + 薄 Loop + Events，避免过度对称 |
+| D11 | 自定义优先 **外部 Pattern**；`plugins.*` 仅官方 Builtin 白名单（见 plugin-catalog） |
 
 ---
 
@@ -354,10 +441,14 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 | 文档 | 关系 |
 |---|---|
 | [README.md](./README.md) | 本目录索引 |
+| [plugin-catalog-v0.md](./plugin-catalog-v0.md) | Port 短名单与「外部 Pattern vs plugins.*」硬约定 |
 | [../adr/0014-org-harness-module.md](../adr/0014-org-harness-module.md) | **P0/P1 决策 ADR（Accepted）** |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core / Pattern 消费契约 |
 | [org-model-v0.md](./org-model-v0.md) | 数据模型（随本文修订 ownership） |
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` legacy）；以本文 + ADR-0014 为准 |
+| [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) | Org 待办执行器（外部）POC——**不是** Loop Builtin |
+| [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（未实现；外部 Pattern） |
+| [clawteam-loop-adapter-poc-v0.md](./clawteam-loop-adapter-poc-v0.md) | **废弃文件名**跳转页（勿按名理解） |
 | [`../_drafts/pasture-engineering.md`](../_drafts/pasture-engineering.md) | 学科隐喻与升维理论（Draft） |
 | [`../_drafts/pasture-protocol.md`](../_drafts/pasture-protocol.md) | 协议理论 Draft；命名以本文为准 |
 
@@ -365,4 +456,6 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 
 ## 13. 一句话总结
 
-> **Org Harness = ACN 内建的 Org Graph 内核（Org + 可选 Owner + agent 成员 + subnet 绑定）+ Control Loop 节拍 + 可插拔 Ports（Work Graph 策略 / Memory / Policy / Events）；Owner 与 agent 一样可无人认领 / 被人 claim / 由 agent 持有；L1 harness（含会话级 fan-out）由成员自带，ClawTeam/Swarm/Paperclip/LangGraph 挂 Port，ACN Network Core 是底座——不是把 ACN 改名叫 Pasture，也不是在内核复刻 Ultra。**
+> **Org Harness = ACN 内建 Kernel（Org Graph：Org + 可选 Owner + agent 成员 + subnet）+ 薄 Control Loop + 可插拔 Ports（Work / Memory / Policy / Events…）。**  
+> **自定义运转方式优先外部 Pattern**（Paperclip、待办执行器等）；`plugins.*` 仅官方 Builtin。  
+> L1 harness 由成员自带；ClawTeam/Swarm/LangGraph 是外部适配**候选**，不是内核平替。Network Core 是底座——不是把 ACN 改名叫 Pasture，也不是在内核复刻 Ultra。

--- a/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
+++ b/docs/org-harness/org-loop-spawn-sidecar-poc-v0.md
@@ -7,8 +7,9 @@
 **Code:** [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（目录 slug 保留，指同一组件）
 
 > **它是什么：** **Org 待办执行器（外部）** — 跑在 ACN **外面**的小程序：看见 Org 待办 → 在本机跑你配置的命令 → 成功则回写 work。  
-> **不是什么：** **不是** Org Harness 新 Kernel 模块；**不是** `plugins.loop=*`；**不是** Paperclip。  
-> **ClawTeam：** 只是 `spawnCommand` 的**示例配方**，不是执行器本体。
+> **不是什么：** **不是** Org Harness 新 Kernel 模块；**不是** `plugins.loop=*`；**不是** Paperclip；**不是** [ClawTeam Loop 适配器](./clawteam-org-loop-adapter-v0.md)。  
+> **ClawTeam：** 只是 `spawnCommand` 的**示例配方**，不是执行器本体。  
+> **架构位置：** 见 [design-v0.md §0](./design-v0.md#0-架构导读先读这个)「外部 Pattern」一行。
 
 ---
 

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -9,7 +9,7 @@
 > `shipped` / `adapter-planned` / `community-welcome` / `deferred`。  
 > 完整插件宿主（发现、版本、热加载）→ Phase 3；本文只解决冷启动。
 
-相关：[design-v0.md](./design-v0.md) §5.3 · [phase2-work-port-v0.md](./phase2-work-port-v0.md) ·
+相关：[design-v0.md](./design-v0.md) **§0 架构导读** · §5.3 · [phase2-work-port-v0.md](./phase2-work-port-v0.md) ·
 [ADR-0014](../adr/0014-org-harness-module.md)
 
 ---
@@ -87,6 +87,7 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 | **`heartbeat`** | **shipped** | 默认薄 tick（`POST …/loop/tick`）。别名 `thin` → `heartbeat`。 |
 | Paperclip / harness 唤醒 | **shipped**（外部） | Pattern 或 subnet harness 收 `org.*` 后驱动成员 L1；不必换 loop id。 |
 | **Org 待办执行器（外部）**（任意 `spawnCommand`；ClawTeam 等为配方） | **adapter-planned**（C1–C2 in examples） | 外部 Pattern，非 `plugins.loop=*`；见 [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)。 |
+| **ClawTeam ↔ Org Loop 适配器** | **adapter-planned**（选型 only） | 外部 Pattern：Org work ↔ CT task；**不是** spawn 一行命令。见 [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md)。无 `plugins.loop=clawteam`。 |
 
 ### 3. Memory — `IOrgMemory`（`plugins.memory`）
 


### PR DESCRIPTION
## Summary
- Add **design-v0 §0** architecture guide: Kernel / Control Loop / Work Graph, and `plugins.*` vs external Pattern.
- Align §5–§6 / D7·D11 / README / plugin-catalog so Paperclip, Org 待办执行器, and ClawTeam are not mixed with Builtin slots.
- Add **[clawteam-org-loop-adapter-v0.md](docs/org-harness/clawteam-org-loop-adapter-v0.md)** (selection only, unimplemented); rewrite obsolete `clawteam-loop-adapter-poc-v0.md` as a dual redirect.

## Test plan
- [ ] Read [design-v0.md §0](docs/org-harness/design-v0.md) — Kernel vs Loop vs Work and two plug paths are clear
- [ ] Confirm no remaining `plugins.work=paperclip` / `plugins.loop=clawteam` as recommended config
- [ ] Follow `clawteam-loop-adapter-poc-v0.md` → lands on spawn runner POC **or** Loop adapter selection (not conflated)

Made with [Cursor](https://cursor.com)