### PR TITLE
feat(org): Org orchestrator P2 — wake assignees via ACN messages

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -29,7 +29,10 @@
 | **[phase2-work-port-v0.md](./phase2-work-port-v0.md)** | **Phase 2 Work Port 短方案（默认 builtin_work · P2a/P2c 完成 · P2b 按需）** |
 | **[plugin-catalog-v0.md](./plugin-catalog-v0.md)** | **官方 Port 推荐短名单（冷启动：默认 + ≤2 候选 / 状态）** |
 | **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)** | **Org 待办执行器（外部）— agent 自动跑命令 POC（C1–C2）** |
-| [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（未实现；≠ 待办执行器） |
+| **[org-orchestrator-v0.md](./org-orchestrator-v0.md)** | **ACN Org 编排器产品定义（P0 Accepted；未实现代码）** |
+| [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) | Org 编排器唤醒契约 P1（`acn.org.work_wake`） |
+| [`examples/org-orchestrator/`](../../examples/org-orchestrator/) | Org 编排器 P2 最小侧车 + `smoke_org_orchestrator.sh` |
+| [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（编排器的可选实现；≠ 待办执行器） |
 | [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
 
 理论草稿（隐喻 / 协议史）：
@@ -63,5 +66,6 @@ L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Memory 等 adapter-planned）。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配。  
 - **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
-- **选型（未实现）：** [ClawTeam ↔ Org Loop 适配器](./clawteam-org-loop-adapter-v0.md)（有真实多 worker 协调需求再开）。  
+- **Org 编排器：** [产品定义](./org-orchestrator-v0.md) P0 + [唤醒契约](./org-orchestrator-wake-contract-v0.md) P1 + [P2 侧车](../../examples/org-orchestrator/)；P3 webhook/催办按需。  
+- **选型（未实现）：** [ClawTeam ↔ Org Loop 适配器](./clawteam-org-loop-adapter-v0.md)（编排器可选后端，有需求再开）。  
 - **其后：** Phase 3 增强 Port / Plugin 宿主；或换产品主线（驯养师 / TaskBoard 等）。

--- a/docs/org-harness/clawteam-org-loop-adapter-v0.md
+++ b/docs/org-harness/clawteam-org-loop-adapter-v0.md
@@ -5,7 +5,7 @@
 **Audience:** Org Harness 维护者 / 想复用 ClawTeam 做组织节拍的人  
 **Depends on:** [design-v0.md](./design-v0.md) §0 · §6 · [plugin-catalog-v0.md](./plugin-catalog-v0.md) · [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)
 
-> **一句话：** 若要用 [ClawTeam](https://github.com/HKUDS/ClawTeam) 驱动 ACN Org，应写**外部 Loop 适配器**（Org work ↔ CT task），**不是** `plugins.loop=clawteam`，也**不是** [待办执行器](./org-loop-spawn-sidecar-poc-v0.md) 里一行 `SPAWN_COMMAND`。
+> **一句话：** 若要用 [ClawTeam](https://github.com/HKUDS/ClawTeam) 驱动 ACN Org，应写**外部 Loop 适配器**（Org work ↔ CT task），作为 [Org 编排器](./org-orchestrator-v0.md) 的可选实现——**不是** `plugins.loop=clawteam`，也**不是** [待办执行器](./org-loop-spawn-sidecar-poc-v0.md) 里一行 `SPAWN_COMMAND`。
 
 ---
 

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -70,10 +70,10 @@ Work Graph（IWorkPattern Port）
               │
               │ API / org.* webhook
               ▼
-  外部可选：Paperclip │ 待办执行器 │（将来）真·Loop/Work 适配器
+  外部可选：Paperclip │ 待办执行器 │ [Org 编排器](./org-orchestrator-v0.md)（产品定义）│ 其他 Loop/Work 适配
 ```
 
-细节从 §4 总体架构、§5 模块内设计展开；插件短名单见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。
+细节从 §4 总体架构、§5 模块内设计展开；插件短名单见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。Org 节拍产品见 [org-orchestrator-v0.md](./org-orchestrator-v0.md)。
 
 ---
 
@@ -447,6 +447,9 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 | [org-model-v0.md](./org-model-v0.md) | 数据模型（随本文修订 ownership） |
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | 外部 Pattern 适配（`POST /orgs` + Org work；`task.*` legacy）；以本文 + ADR-0014 为准 |
 | [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md) | Org 待办执行器（外部）POC——**不是** Loop Builtin |
+| [org-orchestrator-v0.md](./org-orchestrator-v0.md) | ACN Org 编排器产品定义（P0 Accepted） |
+| [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) | 编排器唤醒契约 P1（`acn.org.work_wake`） |
+| [`../../examples/org-orchestrator/`](../../examples/org-orchestrator/) | Org 编排器 P2 最小侧车 |
 | [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（未实现；外部 Pattern） |
 | [clawteam-loop-adapter-poc-v0.md](./clawteam-loop-adapter-poc-v0.md) | **废弃文件名**跳转页（勿按名理解） |
 | [`../_drafts/pasture-engineering.md`](../_drafts/pasture-engineering.md) | 学科隐喻与升维理论（Draft） |

--- a/docs/org-harness/org-orchestrator-v0.md
+++ b/docs/org-harness/org-orchestrator-v0.md
@@ -1,0 +1,127 @@
+# ACN Org 编排器 — 产品定义 v0
+
+**Status:** P0–P1 Accepted · **P2 最小侧车已落地（examples）**  
+**Date:** 2026-07-27  
+**Audience:** 产品 / Org Harness 维护者  
+**Depends on:** [design-v0.md](./design-v0.md) §0 · [plugin-catalog-v0.md](./plugin-catalog-v0.md) · [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md)  
+**P1：** [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md)  
+**P2 code：** [`examples/org-orchestrator/`](../../examples/org-orchestrator/)
+
+> **一句话：** **Org 编排器**是跑在 ACN **外面**的组织节拍器——读 Org 待办与成员，**叫醒该干活的 agent 成员**，回收结果并回写 work。  
+> 它填的是 **Control Loop 问题轴**，实现形态是 **外部 Pattern**；**不是**新 Kernel，**不是** `plugins.loop=*` Builtin。
+
+### 产品前提（Accepted）
+
+> **大多数 Org / agent 没有 Paperclip。**  
+> 因此编排器的**默认路径必须是 ACN-native**（只依赖 Org API + 成员信道），不能把「装 Paperclip」当开工前提。  
+> Paperclip 仍是**可选**人侧驾驶舱（Issues ↔ work + 其自带 wakeup）；有则锦上添花，无则编排器独立成立。
+
+市场上没有现成的「ACN Org 编排器」——要自研的是**薄侧车**（选人 + 唤醒 + 回写），不是再造 ClawTeam / Paperclip 级引擎。
+
+---
+
+## 1. 要解决什么
+
+成员互派（A 用 A2A/CLI 叫 B）在「人少、自觉看列表」时够用；一旦出现：
+
+- 待办积压，没人主动 `work list`；  
+- 要按角色 / 技能把活派给**对的成员**；  
+- 要周期性巡检「卡住 / 超时」并再唤醒；  
+
+就需要一个**站在 Org 视角打节拍**的组件。那就是 Org 编排器。
+
+**不做：** 单 agent 内部 tools（L1）；**不依赖**人看板（Paperclip 可选，非默认）；本机「有活就跑一条命令」走 [待办执行器](./org-loop-spawn-sidecar-poc-v0.md)，与编排器分开。
+
+---
+
+## 2. 在架构里的位置
+
+```text
+ACN 内：Kernel + builtin_work + heartbeat + events   ← SoT 仍在这里
+              │
+              │ work list / org.* / loop tick
+              ▼
+外部：Org 编排器（本产品，未实现）
+              │
+              ├── 选成员（Membership + 角色 / skills）
+              ├── 唤醒：A2A / Mode B / 成员侧约定信道
+              └── 治理 key 回写 work（v0 PATCH 约束）
+```
+
+| 项 | 决定 |
+|---|---|
+| SoT | **ACN** Org + Membership + `builtin_work` |
+| 插法 | **外部 Pattern**（与 Paperclip 同级） |
+| `plugins.loop` | **保持 `heartbeat`**；编排器消费 tick/事件，不进白名单 |
+| 干活主体 | **Org 成员 agent**（有 ACN 身份），不是匿名本机进程优先 |
+| 关单 | v0：**治理 key** PATCH（`todo`\|`in_progress`\|`done`\|`cancelled`） |
+
+---
+
+## 3. 和相邻产品的边界
+
+| | **Org 编排器（默认路径）** | [待办执行器](./org-loop-spawn-sidecar-poc-v0.md) | Paperclip（可选） | 成员互派 |
+|---|---|---|---|---|
+| 前提 | **不需要 Paperclip** | 一台 runner 机器 | 人要看板时才装 | 无 |
+| 给谁 | 纯 agent Org 自动派活 / 唤醒 | 固定机器跑命令 | 人 + 被唤醒的 agent | 成员自觉协作 |
+| 谁执行 | **成员 agent** | 本机 `spawnCommand` | Paperclip 拉起的 agent | 成员自己 |
+| 核心动作 | 选人 → ACN 信道唤醒 → 收结果 | poll → 跑命令 → 关单 | Issues ↔ work + 自带 wakeup | A2A / CLI |
+| ClawTeam | **可选**执行适配（[选型](./clawteam-org-loop-adapter-v0.md)） | 仅配方 | 无关 | 成员自用 |
+
+**命名约束：** 对外说「Org 编排器」；不要说「装 ClawTeam / Paperclip 进 ACN」。二者都是可选周边，不是默认依赖。
+
+---
+
+## 4. v0 范围（Accepted 方向）
+
+**做：**
+
+1. **输入：** 某 `org_id` 的 open work + 成员表。  
+2. **策略：** 有 `assignee` → 唤醒该成员；**无 assignee → 跳过 + 日志**（不广播）。  
+3. **唤醒：** ACN `communication/send`；投递跟成员 delivery_mode；信封见 [唤醒契约](./org-orchestrator-wake-contract-v0.md)。  
+4. **回收：** 治理面关单；v0 不自动超时 `cancelled`（仅日志）。  
+5. **运维形态：** 单进程侧车；`ACN_BASE` + 发送方 agent key +（可选同）治理 key + `org_id`。
+
+**不做（v0）：**
+
+- 进程内 `plugins.loop=orchestrator`  
+- DAG / 多步 Work Graph（那是 Work Port；默认仍 `builtin_work` 单票）  
+- 替换 Membership、自建第二套待办 SoT  
+- **依赖 Paperclip**（有则并行；无则必须可用）  
+- 必须绑定 ClawTeam / LangGraph  
+- 人审批 UI、Memory、预算硬停  
+
+---
+
+## 5. 成功标准（何时算产品成立）
+
+| # | 标准 |
+|---|---|
+| S0 | **零 Paperclip** 环境：仅 ACN Org + 成员 agent + 编排器侧车即可跑通 S1–S2 |
+| S1 | 新建 **带 assignee** 的 open work 后，编排器在约定 SLA 内向该成员发出 `acn.org.work_wake`（成员能凭 `work_id` 开工）；无 assignee 仅日志跳过 |
+| S2 | 成员完成后，work 经治理路径变为 `done`；编排器不持有第二份权威状态 |
+| S3 | 文档与 skill 能说清：编排器 ≠ 待办执行器 ≠ Paperclip；且无「必须装 Paperclip / ClawTeam」表述 |
+| S4 | 关掉编排器后，Org / work / 成员数据仍完整（外部 Pattern 可卸） |
+
+---
+
+## 6. 落地顺序
+
+| 步 | 内容 | 状态 |
+|---|---|---|
+| P0 | 本文产品定义 | **Accepted** |
+| P1 | 唤醒契约（payload / 信道 / 幂等） | **Accepted** · [wake-contract](./org-orchestrator-wake-contract-v0.md) |
+| P2 | 最小侧车：poll → 校验 assignee → `communication/send` → 幂等日志 | **done** · [`examples/org-orchestrator/`](../../examples/org-orchestrator/) · `scripts/smoke_org_orchestrator.sh` |
+| P3 | `org.*` / tick 驱动、催办、超时策略 | 按需 |
+| P4 | 可选：ClawTeam 等执行适配（[选型](./clawteam-org-loop-adapter-v0.md)） | 有需求再开 |
+
+---
+
+## 7. P0 决策（Accepted）
+
+| # | 决定 | 理由 |
+|---|---|---|
+| 1 | 无 assignee → **跳过 + 日志** | 避免误叫醒 |
+| 2 | 唤醒 → **ACN 消息**（跟成员 delivery_mode） | 不新开 webhook 注册 |
+| 3 | 治理 key → **Owner agent 或运维侧车** | 纯 agent Org 常见无运维人 |
+| 4 | v0 主验收 → **仅有 assignee 的路径** | 减少策略扯皮 |

--- a/docs/org-harness/org-orchestrator-wake-contract-v0.md
+++ b/docs/org-harness/org-orchestrator-wake-contract-v0.md
@@ -1,0 +1,144 @@
+# Org 编排器 — 唤醒契约 v0（P1）
+
+**Status:** Accepted · **P2 示例已实现**（[`examples/org-orchestrator/`](../../examples/org-orchestrator/)）  
+**Date:** 2026-07-27  
+**Audience:** 编排器实现者 / 成员 agent 作者  
+**Depends on:** [org-orchestrator-v0.md](./org-orchestrator-v0.md) · ACN `POST /communication/send` · Mode A/B delivery
+
+> **一句话：** 编排器用 **ACN 既有消息信道**叫醒成员；payload 里带 Org work 指针。不新开 webhook 注册表。
+
+---
+
+## 1. Accepted 决策（摘自产品定义 §7）
+
+| # | 决定 |
+|---|---|
+| 无 assignee | **跳过 + 日志**（不广播） |
+| 唤醒信道 | **ACN 消息**；投递跟成员 `delivery`（Mode A direct / Mode B relay→inbox/listen） |
+| 治理 key | Owner agent **或**运维侧车持有；持 key = 能 PATCH work |
+| v0 主路径 | **仅处理有 `assignee` 的 open work** |
+
+---
+
+## 2. 谁发给谁
+
+```text
+编排器进程（持：编排器用 agent key，或治理/Owner key 兼用）
+    │
+    │  POST /api/v1/communication/send
+    │  to = work.assignee（必须是 Org 成员）
+    ▼
+成员 agent（Mode A HTTP 或 Mode B listen/inbox）
+    │
+    │  解析 payload → acn org work show / 开工
+    ▼
+（可选）治理面 PATCH work → done | cancelled
+```
+
+| 角色 | 身份 |
+|---|---|
+| **发送方** | 编排器配置的 ACN agent（推荐：Org Owner agent，或专用 `orchestrator` 服务 agent） |
+| **接收方** | `work.assignee`；发送前校验仍为该 Org `active` 成员 |
+| **关单方** | 另持**治理**权限的 key（可为同一 Owner agent；v0 PATCH 仅 governance） |
+
+发送方 key **不必**是治理 key；唤醒与关单权限可分离。v0 为省事允许同一 Owner key 兼用，文档须提示风险。
+
+---
+
+## 3. 消息载荷（Content）
+
+经 `POST /communication/send` 的文本/结构化正文须让成员**不依赖编排器进程**也能开工。
+
+### 3.1 规范信封（Accepted）
+
+消息正文（text part 或等价 JSON 字符串）为：
+
+```json
+{
+  "type": "acn.org.work_wake",
+  "schema_version": 1,
+  "idempotency_key": "org_…:work_…:wake:1",
+  "org_id": "org_…",
+  "work_id": "work_…",
+  "title": "…",
+  "status": "todo",
+  "assignee": "agt_…",
+  "hint": "Fetch work with acn org work show; complete then ask governance to mark done."
+}
+```
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `type` | 是 | 固定 `acn.org.work_wake` |
+| `schema_version` | 是 | 现为 `1` |
+| `idempotency_key` | 是 | 见 §4 |
+| `org_id` / `work_id` | 是 | SoT 指针 |
+| `title` | 是 | 便于展示；权威仍以 API 为准 |
+| `status` / `assignee` | 建议 | 发送时快照 |
+| `hint` | 否 | 给人/agent 的操作提示 |
+
+成员侧：**以 `work_id` 再拉一次 Org API 为准**，勿盲信快照字段。
+
+### 3.2 与 Mode B runtime 的关系
+
+- Mode B：`acn listen --runtime …` 收到的是 A2A/`a2a_message` 事件；runtime 应从消息文本中识别 `acn.org.work_wake`（或透传 raw 由上层解析）。  
+- **不**把 Org `work_id` 伪装成 Task Pool `task_id`（避免与 task invite 语义混淆）。  
+- 若需在 metadata 带指针，可选：`metadata.acn_org_id` / `metadata.acn_work_id`（与正文双写；正文仍必填）。
+
+---
+
+## 4. 幂等与重试
+
+| 项 | 规则 |
+|---|---|
+| **幂等键** | `{org_id}:{work_id}:wake:{wake_generation}` |
+| **wake_generation** | v0 固定从 `1` 起；同一 open work 在状态仍为 `todo`/`in_progress` 且未成功投递前，重试**复用**同一 generation |
+| **何时 +1** | 仅当产品允许「再次唤醒」（例如超时催办）时递增；v0 默认可不做催办 |
+| **编排器本地** | 成功 `send` 后记录 `(idempotency_key → sent_at)`；进程重启后对已记录键跳过，除非 generation 增加 |
+| **成员侧** | 同一 `idempotency_key` 只开工一次；重复消息忽略或仅打日志 |
+
+投递失败（网络/对方 `closed`）：可退避重试同一 key；**不要**因此 PATCH work。
+
+---
+
+## 5. 编排器 tick 算法（v0 最小）
+
+每轮（poll 或消费 `org.work_*` / `org.loop_tick`）：
+
+1. `GET` open work（`todo` / `in_progress`）。  
+2. 无 `assignee` → **log skip**，继续。  
+3. `assignee` 非本 Org active 成员 → **log skip**（不发送）。  
+4. 已有成功 `idempotency_key` 记录 → skip。  
+5. `communication/send` → 成功则记幂等；可选将 `todo` → `in_progress`（需治理 key；v0 **建议做**，便于区分「已叫醒」）。  
+6. **不**在 v0 因超时自动 `cancelled`（仅日志；P3 再开）。
+
+---
+
+## 6. 成员收到后怎么做（契约期望）
+
+1. 解析 `type == acn.org.work_wake`。  
+2. `acn org work show <org_id> <work_id>`（或等价 API）确认仍 open 且自己是 assignee。  
+3. 用自身 L1 执行。  
+4. 完成：经治理路径 `PATCH` → `done`（成员 key 若无治理权，则回报 Owner/编排器代关，或人工/脚本）。  
+5. 放弃：治理 `cancelled`。
+
+v0 **不**要求成员能自己 PATCH（API 约束）；编排器文档须写明关单路径，避免「叫醒了却无法关单」。
+
+---
+
+## 7. 非目标（P1）
+
+- 成员预注册自定义 webhook  
+- 无 assignee 的 skills 匹配 / 广播  
+- ClawTeam / 本机 spawn  
+- 替换 `plugins.loop`  
+- 与 Task Pool `task_request` 混用同一信封  
+
+---
+
+## 8. 下一步
+
+| 步 | 内容 | 状态 |
+|---|---|---|
+| P2 | `examples/org-orchestrator/` 最小侧车 | **done** |
+| P3 | `org.*` webhook 驱动、催办 generation+1、超时策略 | 按需 |

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -87,7 +87,8 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 | **`heartbeat`** | **shipped** | 默认薄 tick（`POST …/loop/tick`）。别名 `thin` → `heartbeat`。 |
 | Paperclip / harness 唤醒 | **shipped**（外部） | Pattern 或 subnet harness 收 `org.*` 后驱动成员 L1；不必换 loop id。 |
 | **Org 待办执行器（外部）**（任意 `spawnCommand`；ClawTeam 等为配方） | **adapter-planned**（C1–C2 in examples） | 外部 Pattern，非 `plugins.loop=*`；见 [org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)。 |
-| **ClawTeam ↔ Org Loop 适配器** | **adapter-planned**（选型 only） | 外部 Pattern：Org work ↔ CT task；**不是** spawn 一行命令。见 [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md)。无 `plugins.loop=clawteam`。 |
+| **ACN Org 编排器**（叫醒成员 agent） | **adapter-planned**（P2 examples） | Loop 轴外部 Pattern；[产品定义](./org-orchestrator-v0.md) · [唤醒契约](./org-orchestrator-wake-contract-v0.md) · [`examples/org-orchestrator/`](../../examples/org-orchestrator/)。无 `plugins.loop=orchestrator`。 |
+| **ClawTeam ↔ Org Loop 适配器** | **adapter-planned**（选型 only） | 编排器的**可选**执行后端：Org work ↔ CT task；见 [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md)。 |
 
 ### 3. Memory — `IOrgMemory`（`plugins.memory`）
 

--- a/examples/org-orchestrator/README.md
+++ b/examples/org-orchestrator/README.md
@@ -1,0 +1,55 @@
+# ACN Org 编排器（外部）— P2 最小侧车
+
+跑在 ACN **外面**：poll 带 `assignee` 的 open work → `POST /communication/send` 发 `acn.org.work_wake` → 可选标 `in_progress`。
+
+| 文档 | 链接 |
+|---|---|
+| 产品定义 | [org-orchestrator-v0.md](../../docs/org-harness/org-orchestrator-v0.md) |
+| 唤醒契约 | [org-orchestrator-wake-contract-v0.md](../../docs/org-harness/org-orchestrator-wake-contract-v0.md) |
+
+**不是** [Org 待办执行器](../org-loop-spawn-sidecar/)（那是本机跑命令）。
+
+## 环境变量
+
+| 变量 | 说明 |
+|---|---|
+| `ACN_BASE_URL` | 如 `https://acn.acnlabs.cn` 或带 `/api/v1` |
+| `ACN_ORG_ID` | 目标 Org |
+| `ACN_API_KEY` | 发送方 agent key（`from_agent` = `agents/me`）；若要标 `in_progress` 需**治理**权限 |
+| `POLL_INTERVAL_SEC` | 默认 `30` |
+| `ORCHESTRATOR_IDEM_PATH` | 幂等文件，默认 `./.org-orchestrator-idem.json` |
+
+## 跑一轮
+
+```bash
+export ACN_BASE_URL=https://acn.acnlabs.cn
+export ACN_ORG_ID=org_…
+export ACN_API_KEY=acn_…
+python3 run_orchestrator.py --once
+```
+
+只看将要发送的信封：
+
+```bash
+python3 run_orchestrator.py --once --dry-run
+```
+
+不改 work 状态：
+
+```bash
+python3 run_orchestrator.py --once --no-mark-in-progress
+```
+
+## 行为摘要
+
+1. 无 `assignee_agent_id` → 跳过 + 日志  
+2. assignee 非 active 成员 → 跳过  
+3. 幂等键已发送 → 跳过  
+4. `communication/send` 成功 → 记幂等；默认 `todo` → `in_progress`  
+5. **不**自动关 `done`（成员干活后走治理 PATCH）
+
+## 狗粮
+
+```bash
+ACN_BASE_URL=… ACN_API_KEY=acn_… ./scripts/smoke_org_orchestrator.sh
+```

--- a/examples/org-orchestrator/acn_client_min.py
+++ b/examples/org-orchestrator/acn_client_min.py
@@ -1,0 +1,116 @@
+"""Minimal ACN HTTP helpers for Org orchestrator (stdlib only)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def normalize_base(url: str) -> str:
+    base = url.rstrip("/")
+    if not base.endswith("/api/v1"):
+        base = f"{base}/api/v1"
+    return base
+
+
+def _request(
+    method: str,
+    url: str,
+    api_key: str,
+    body: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    data = None
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode(errors="replace")
+        raise urllib.error.HTTPError(
+            e.url, e.code, f"{e.reason}: {err_body}", e.headers, None
+        ) from e
+
+
+def agents_me(base: str, api_key: str) -> dict[str, Any]:
+    return _request("GET", f"{base}/agents/me", api_key)
+
+
+def fetch_open_work(base: str, org_id: str, api_key: str) -> dict[str, Any]:
+    return _request("GET", f"{base}/orgs/{org_id}/work?open_only=true", api_key)
+
+
+def fetch_members(base: str, org_id: str, api_key: str) -> dict[str, Any]:
+    return _request("GET", f"{base}/orgs/{org_id}/members", api_key)
+
+
+def patch_work_status(
+    base: str,
+    org_id: str,
+    work_id: str,
+    api_key: str,
+    status: str,
+) -> dict[str, Any]:
+    return _request(
+        "PATCH",
+        f"{base}/orgs/{org_id}/work/{work_id}",
+        api_key,
+        {"status": status},
+    )
+
+
+def send_message(
+    base: str,
+    api_key: str,
+    *,
+    from_agent: str,
+    target_agent: str,
+    text: str,
+) -> dict[str, Any]:
+    return _request(
+        "POST",
+        f"{base}/communication/send",
+        api_key,
+        {
+            "from_agent": from_agent,
+            "target_agent": target_agent,
+            "message": {"text": text},
+            "priority": "normal",
+            "message_type": "collaboration",
+        },
+    )
+
+
+def work_id(item: dict[str, Any]) -> str:
+    return str(item.get("work_id") or item.get("id") or "")
+
+
+def assignee_id(item: dict[str, Any]) -> str:
+    return str(item.get("assignee_agent_id") or item.get("assignee") or "").strip()
+
+
+def active_member_ids(members_payload: dict[str, Any]) -> set[str]:
+    rows = members_payload.get("members") or members_payload.get("items") or []
+    if isinstance(members_payload, list):
+        rows = members_payload
+    out: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        aid = str(row.get("agent_id") or "")
+        status = str(row.get("status") or "active")
+        if aid and status == "active":
+            out.add(aid)
+    return out

--- a/examples/org-orchestrator/idempotency.py
+++ b/examples/org-orchestrator/idempotency.py
@@ -1,0 +1,43 @@
+"""File-backed wake idempotency store."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+
+class IdempotencyStore:
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._data: dict[str, Any] = {"sent": {}}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.is_file():
+            return
+        try:
+            raw = json.loads(self.path.read_text())
+            if isinstance(raw, dict) and isinstance(raw.get("sent"), dict):
+                self._data = raw
+        except (OSError, json.JSONDecodeError):
+            self._data = {"sent": {}}
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, indent=2, sort_keys=True) + "\n")
+        os.replace(tmp, self.path)
+
+    def has(self, key: str) -> bool:
+        return key in self._data["sent"]
+
+    def mark(self, key: str, *, work_id: str, assignee: str) -> None:
+        self._data["sent"][key] = {
+            "work_id": work_id,
+            "assignee": assignee,
+            "sent_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        self._save()

--- a/examples/org-orchestrator/run_orchestrator.py
+++ b/examples/org-orchestrator/run_orchestrator.py
@@ -23,7 +23,6 @@ from acn_client_min import (
 )
 from idempotency import IdempotencyStore
 
-
 WAKE_TYPE = "acn.org.work_wake"
 WAKE_GENERATION = 1
 

--- a/examples/org-orchestrator/run_orchestrator.py
+++ b/examples/org-orchestrator/run_orchestrator.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""P2: poll open Org work → wake assignee via communication/send → optional in_progress."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+
+from acn_client_min import (
+    active_member_ids,
+    agents_me,
+    assignee_id,
+    fetch_members,
+    fetch_open_work,
+    normalize_base,
+    patch_work_status,
+    send_message,
+    work_id,
+)
+from idempotency import IdempotencyStore
+
+
+WAKE_TYPE = "acn.org.work_wake"
+WAKE_GENERATION = 1
+
+
+def wake_key(org_id: str, wid: str) -> str:
+    return f"{org_id}:{wid}:wake:{WAKE_GENERATION}"
+
+
+def build_envelope(org_id: str, item: dict) -> dict:
+    wid = work_id(item)
+    assignee = assignee_id(item)
+    return {
+        "type": WAKE_TYPE,
+        "schema_version": 1,
+        "idempotency_key": wake_key(org_id, wid),
+        "org_id": org_id,
+        "work_id": wid,
+        "title": str(item.get("title") or ""),
+        "status": str(item.get("status") or ""),
+        "assignee": assignee,
+        "hint": (
+            "Fetch work with acn org work show; complete then ask governance to mark done."
+        ),
+    }
+
+
+def process_item(
+    *,
+    base: str,
+    org_id: str,
+    api_key: str,
+    from_agent: str,
+    item: dict,
+    members: set[str],
+    store: IdempotencyStore,
+    dry_run: bool,
+    mark_in_progress: bool,
+) -> None:
+    wid = work_id(item)
+    if not wid:
+        print("[org-orchestrator] skip item without work_id", flush=True)
+        return
+
+    assignee = assignee_id(item)
+    if not assignee:
+        print(f"[org-orchestrator] skip {wid}: no assignee", flush=True)
+        return
+    if assignee not in members:
+        print(
+            f"[org-orchestrator] skip {wid}: assignee {assignee} not active member",
+            flush=True,
+        )
+        return
+
+    key = wake_key(org_id, wid)
+    if store.has(key):
+        print(f"[org-orchestrator] skip {wid}: already sent {key}", flush=True)
+        return
+
+    envelope = build_envelope(org_id, item)
+    text = json.dumps(envelope, ensure_ascii=False)
+    title = item.get("title") or ""
+    print(
+        f"[org-orchestrator] wake work={wid} assignee={assignee} title={title!r}",
+        flush=True,
+    )
+
+    if dry_run:
+        print(f"  dry-run payload: {text}", flush=True)
+        return
+
+    try:
+        send_message(
+            base,
+            api_key,
+            from_agent=from_agent,
+            target_agent=assignee,
+            text=text,
+        )
+        print("  send → ok", flush=True)
+    except urllib.error.HTTPError as e:
+        print(f"  send failed HTTP {e.code}: {e.reason}", file=sys.stderr)
+        return
+
+    store.mark(key, work_id=wid, assignee=assignee)
+
+    if mark_in_progress and item.get("status") == "todo":
+        try:
+            patch_work_status(base, org_id, wid, api_key, "in_progress")
+            print("  status → in_progress", flush=True)
+        except urllib.error.HTTPError as e:
+            print(
+                f"  PATCH in_progress failed HTTP {e.code}: {e.reason} "
+                "(wake already sent; need governance key?)",
+                file=sys.stderr,
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--once", action="store_true", help="Single poll then exit")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print wake payloads only; no send / PATCH",
+    )
+    parser.add_argument(
+        "--no-mark-in-progress",
+        action="store_true",
+        help="Do not PATCH todo → in_progress after successful send",
+    )
+    args = parser.parse_args()
+
+    base_url = os.environ.get("ACN_BASE_URL", "").strip()
+    org_id = os.environ.get("ACN_ORG_ID", "").strip()
+    api_key = os.environ.get("ACN_API_KEY", "").strip()
+    interval = int(os.environ.get("POLL_INTERVAL_SEC", "30"))
+    store_path = os.environ.get(
+        "ORCHESTRATOR_IDEM_PATH",
+        os.path.join(os.getcwd(), ".org-orchestrator-idem.json"),
+    )
+
+    if not base_url or not org_id or not api_key:
+        print("Need ACN_BASE_URL, ACN_ORG_ID, ACN_API_KEY", file=sys.stderr)
+        return 2
+
+    base = normalize_base(base_url)
+    store = IdempotencyStore(store_path)
+    mark_in_progress = not args.no_mark_in_progress
+
+    try:
+        me = agents_me(base, api_key)
+        from_agent = str(me.get("agent_id") or "")
+    except Exception as e:
+        print(f"agents/me failed: {e}", file=sys.stderr)
+        return 2
+    if not from_agent:
+        print("agents/me missing agent_id", file=sys.stderr)
+        return 2
+
+    print(
+        f"[org-orchestrator] from_agent={from_agent} org={org_id} idem={store_path}",
+        flush=True,
+    )
+
+    while True:
+        try:
+            members = active_member_ids(fetch_members(base, org_id, api_key))
+            payload = fetch_open_work(base, org_id, api_key)
+            items = payload.get("work") or []
+            print(
+                f"[org-orchestrator] open_count={payload.get('count', len(items))} "
+                f"members={len(members)}",
+                flush=True,
+            )
+            for item in items:
+                process_item(
+                    base=base,
+                    org_id=org_id,
+                    api_key=api_key,
+                    from_agent=from_agent,
+                    item=item,
+                    members=members,
+                    store=store,
+                    dry_run=args.dry_run,
+                    mark_in_progress=mark_in_progress,
+                )
+        except urllib.error.HTTPError as e:
+            print(f"[org-orchestrator] HTTP {e.code}: {e.reason}", file=sys.stderr)
+            if args.once:
+                return 1
+        except Exception as e:
+            print(f"[org-orchestrator] error: {e}", file=sys.stderr)
+            if args.once:
+                return 1
+
+        if args.once:
+            return 0
+        time.sleep(max(1, interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_org_orchestrator.sh
+++ b/scripts/smoke_org_orchestrator.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Smoke: Org orchestrator P2 — create assigned work → wake send → in_progress
+#
+# Usage:
+#   ACN_BASE_URL=https://api.acnlabs.dev \
+#   ACN_API_KEY=acn_xxx \
+#   ./scripts/smoke_org_orchestrator.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RAW_BASE="${ACN_BASE_URL:-http://127.0.0.1:8000}"
+KEY="${ACN_API_KEY:?ACN_API_KEY required}"
+AUTH="Authorization: Bearer ${KEY}"
+ORCH="${ROOT}/examples/org-orchestrator"
+IDEM="$(mktemp -t org-orch-idem.XXXXXX.json)"
+trap 'rm -f "$IDEM"' EXIT
+
+if [[ "$RAW_BASE" == */api/v1 ]]; then
+  API="$RAW_BASE"
+else
+  API="${RAW_BASE%/}/api/v1"
+fi
+
+echo "==> Resolve caller agent"
+ME=$(curl -fsS -H "$AUTH" "${API}/agents/me")
+AGENT_ID=$(echo "$ME" | python3 -c "import sys,json; print(json.load(sys.stdin)['agent_id'])")
+
+NAME="smoke-orch-$(date +%s)"
+echo "==> Create Org: $NAME"
+ORG=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"display_name\":\"${NAME}\"}" \
+  "${API}/orgs")
+ORG_ID=$(echo "$ORG" | python3 -c "import sys,json; print(json.load(sys.stdin)['org_id'])")
+
+echo "==> Create open work assigned to self"
+WORK=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  -d "{\"title\":\"orchestrator smoke\",\"assignee_agent_id\":\"${AGENT_ID}\"}" \
+  "${API}/orgs/${ORG_ID}/work")
+WORK_ID=$(echo "$WORK" | python3 -c "import sys,json; print(json.load(sys.stdin)['work_id'])")
+echo "    org_id=$ORG_ID work_id=$WORK_ID assignee=$AGENT_ID"
+
+echo "==> Run orchestrator once"
+export ACN_BASE_URL="$API"
+export ACN_ORG_ID="$ORG_ID"
+export ACN_API_KEY="$KEY"
+export ORCHESTRATOR_IDEM_PATH="$IDEM"
+python3 "${ORCH}/run_orchestrator.py" --once
+
+echo "==> Verify idempotency recorded"
+python3 -c "
+import json
+d=json.load(open('${IDEM}'))
+key='${ORG_ID}:${WORK_ID}:wake:1'
+assert key in d.get('sent', {}), (key, d)
+print('    idem ok', key)
+"
+
+echo "==> Verify work in_progress"
+STATUS=$(curl -fsS -H "$AUTH" "${API}/orgs/${ORG_ID}/work?open_only=false" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); w=[x for x in d['work'] if x['work_id']=='${WORK_ID}'][0]; print(w['status'])")
+if [[ "$STATUS" != "in_progress" ]]; then
+  echo "expected status=in_progress got $STATUS" >&2
+  exit 1
+fi
+
+echo "==> Second run should skip (idempotent)"
+OUT=$(python3 "${ORCH}/run_orchestrator.py" --once)
+echo "$OUT"
+echo "$OUT" | grep -q "already sent"
+
+echo "OK — Org orchestrator smoke passed (org_id=$ORG_ID work_id=$WORK_ID)"


### PR DESCRIPTION
## Summary
- **P0/P1 docs:** Org 编排器产品定义 + `acn.org.work_wake` 唤醒契约（零 Paperclip 默认路径）。
- **P2 example:** [`examples/org-orchestrator/`](examples/org-orchestrator/) — poll open work → validate assignee → `POST /communication/send` → file idempotency → optional `in_progress`.
- Smoke: [`scripts/smoke_org_orchestrator.sh`](scripts/smoke_org_orchestrator.sh).

Not a Builtin / `plugins.loop=*`. Distinct from Org 待办执行器 (spawn command runner).

## Test plan
- [ ] `python3 examples/org-orchestrator/run_orchestrator.py --help`
- [ ] `ACN_BASE_URL=… ACN_API_KEY=… ./scripts/smoke_org_orchestrator.sh`
- [ ] Second poll logs `already sent` and does not double-send
- [ ] Work without assignee is skipped (log only)

Made with [Cursor](https://cursor.com)