### PR TITLE
fix(org): harden Org orchestrator idempotency + skill 0.17.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Org orchestrator idempotency** — wake key includes `assignee` (reassignment
+  wakes the new member); file store uses `flock` + `try_claim`/`confirm`/`release`
+  (disk before memory). Example: `examples/org-orchestrator/`.
+
+### Docs
+
+- **Agent skill 0.17.14** — Org 编排器（外部）入口与 wake 契约链接。
+
 ## [0.15.8] - 2026-07-25
 
 Server patch: Org wallet **S6** soft-val proxy + Org Harness docs/skill closeout.

--- a/docs/org-harness/org-orchestrator-wake-contract-v0.md
+++ b/docs/org-harness/org-orchestrator-wake-contract-v0.md
@@ -57,7 +57,7 @@
 {
   "type": "acn.org.work_wake",
   "schema_version": 1,
-  "idempotency_key": "org_…:work_…:wake:1",
+  "idempotency_key": "org_…:work_…:wake:1:agt_…",
   "org_id": "org_…",
   "work_id": "work_…",
   "title": "…",
@@ -91,13 +91,14 @@
 
 | 项 | 规则 |
 |---|---|
-| **幂等键** | `{org_id}:{work_id}:wake:{wake_generation}` |
-| **wake_generation** | v0 固定从 `1` 起；同一 open work 在状态仍为 `todo`/`in_progress` 且未成功投递前，重试**复用**同一 generation |
-| **何时 +1** | 仅当产品允许「再次唤醒」（例如超时催办）时递增；v0 默认可不做催办 |
-| **编排器本地** | 成功 `send` 后记录 `(idempotency_key → sent_at)`；进程重启后对已记录键跳过，除非 generation 增加 |
+| **幂等键** | `{org_id}:{work_id}:wake:{wake_generation}:{assignee_agent_id}` |
+| **为何含 assignee** | 改派后新成员必须能收到新 wake；旧 assignee 的键仍保留，避免对其重复投递 |
+| **wake_generation** | v0 固定从 `1` 起；同一 `(work, assignee)` 未成功投递前重试复用同一 generation |
+| **何时 +1** | 仅当产品允许「再次唤醒同一 assignee」（例如超时催办）时递增；v0 默认可不做催办 |
+| **编排器本地** | `try_claim`（flock）→ `send` → `confirm`；`send` 失败则 `release` 以便重试；落盘失败不更新成功语义 |
 | **成员侧** | 同一 `idempotency_key` 只开工一次；重复消息忽略或仅打日志 |
 
-投递失败（网络/对方 `closed`）：可退避重试同一 key；**不要**因此 PATCH work。
+投递失败（网络/对方 `closed`）：释放 claim 后可重试同一 key；**不要**因此 PATCH work。
 
 ---
 

--- a/examples/org-orchestrator/README.md
+++ b/examples/org-orchestrator/README.md
@@ -44,9 +44,10 @@ python3 run_orchestrator.py --once --no-mark-in-progress
 
 1. 无 `assignee_agent_id` → 跳过 + 日志  
 2. assignee 非 active 成员 → 跳过  
-3. 幂等键已发送 → 跳过  
-4. `communication/send` 成功 → 记幂等；默认 `todo` → `in_progress`  
-5. **不**自动关 `done`（成员干活后走治理 PATCH）
+3. 幂等键 `{org}:{work}:wake:1:{assignee}` 已 claim/发送 → 跳过（**改派会换键，新成员可叫醒**）  
+4. flock 文件锁 + `try_claim` → `send` → `confirm`（失败 `release`）  
+5. 默认 `todo` → `in_progress`（需治理 key）  
+6. **不**自动关 `done`（成员干活后走治理 PATCH）
 
 ## 狗粮
 

--- a/examples/org-orchestrator/idempotency.py
+++ b/examples/org-orchestrator/idempotency.py
@@ -1,7 +1,9 @@
-"""File-backed wake idempotency store."""
+"""File-backed wake idempotency store (flock + reload; disk before memory)."""
 
 from __future__ import annotations
 
+# fcntl is POSIX-only; orchestrator examples target Unix runners (same as smoke).
+import fcntl
 import json
 import os
 import time
@@ -12,32 +14,137 @@ from typing import Any
 class IdempotencyStore:
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
+        self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
         self._data: dict[str, Any] = {"sent": {}}
-        self._load()
 
-    def _load(self) -> None:
+    def _load_unlocked(self) -> None:
         if not self.path.is_file():
+            self._data = {"sent": {}}
             return
         try:
             raw = json.loads(self.path.read_text())
             if isinstance(raw, dict) and isinstance(raw.get("sent"), dict):
                 self._data = raw
+            else:
+                self._data = {"sent": {}}
         except (OSError, json.JSONDecodeError):
             self._data = {"sent": {}}
 
-    def _save(self) -> None:
+    def _save_unlocked(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(self._data, indent=2, sort_keys=True) + "\n")
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        payload = json.dumps(self._data, indent=2, sort_keys=True) + "\n"
+        tmp.write_text(payload)
         os.replace(tmp, self.path)
 
+    def _with_lock(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        return open(self.lock_path, "a+", encoding="utf-8")
+
     def has(self, key: str) -> bool:
-        return key in self._data["sent"]
+        with self._with_lock() as lockf:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+            try:
+                self._load_unlocked()
+                return key in self._data["sent"]
+            finally:
+                fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)
 
     def mark(self, key: str, *, work_id: str, assignee: str) -> None:
-        self._data["sent"][key] = {
+        """Persist then update memory. Raises OSError if disk write fails."""
+        entry = {
             "work_id": work_id,
             "assignee": assignee,
             "sent_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
-        self._save()
+        with self._with_lock() as lockf:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+            try:
+                self._load_unlocked()
+                # Copy-on-write style: mutate a working dict, save, then adopt.
+                working = {
+                    "sent": dict(self._data.get("sent") or {}),
+                }
+                working["sent"][key] = entry
+                prev = self._data
+                self._data = working
+                try:
+                    self._save_unlocked()
+                except OSError:
+                    self._data = prev
+                    raise
+            finally:
+                fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)
+
+    def try_claim(self, key: str, *, work_id: str, assignee: str) -> bool:
+        """Atomically claim key if absent. True = caller should send; False = skip.
+
+        Claims before send to reduce multi-instance double-send. On send failure,
+        caller should ``release`` so a later tick can retry.
+        """
+        entry = {
+            "work_id": work_id,
+            "assignee": assignee,
+            "sent_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "pending": True,
+        }
+        with self._with_lock() as lockf:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+            try:
+                self._load_unlocked()
+                if key in self._data["sent"]:
+                    return False
+                working = {"sent": dict(self._data.get("sent") or {})}
+                working["sent"][key] = entry
+                prev = self._data
+                self._data = working
+                try:
+                    self._save_unlocked()
+                except OSError:
+                    self._data = prev
+                    raise
+                return True
+            finally:
+                fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)
+
+    def confirm(self, key: str) -> None:
+        """Clear pending after successful send."""
+        with self._with_lock() as lockf:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+            try:
+                self._load_unlocked()
+                row = self._data.get("sent", {}).get(key)
+                if not isinstance(row, dict):
+                    return
+                working = {"sent": dict(self._data.get("sent") or {})}
+                working["sent"][key] = {**row, "pending": False}
+                prev = self._data
+                self._data = working
+                try:
+                    self._save_unlocked()
+                except OSError:
+                    self._data = prev
+                    raise
+            finally:
+                fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)
+
+    def release(self, key: str) -> None:
+        """Drop claim after failed send so another tick can retry."""
+        with self._with_lock() as lockf:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+            try:
+                self._load_unlocked()
+                if key not in self._data.get("sent", {}):
+                    return
+                working = {"sent": dict(self._data.get("sent") or {})}
+                working["sent"].pop(key, None)
+                prev = self._data
+                self._data = working
+                try:
+                    self._save_unlocked()
+                except OSError:
+                    self._data = prev
+                    raise
+            finally:
+                fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)

--- a/examples/org-orchestrator/run_orchestrator.py
+++ b/examples/org-orchestrator/run_orchestrator.py
@@ -27,8 +27,9 @@ WAKE_TYPE = "acn.org.work_wake"
 WAKE_GENERATION = 1
 
 
-def wake_key(org_id: str, wid: str) -> str:
-    return f"{org_id}:{wid}:wake:{WAKE_GENERATION}"
+def wake_key(org_id: str, wid: str, assignee: str) -> str:
+    """Include assignee so reassignment wakes the new member."""
+    return f"{org_id}:{wid}:wake:{WAKE_GENERATION}:{assignee}"
 
 
 def build_envelope(org_id: str, item: dict) -> dict:
@@ -37,7 +38,7 @@ def build_envelope(org_id: str, item: dict) -> dict:
     return {
         "type": WAKE_TYPE,
         "schema_version": 1,
-        "idempotency_key": wake_key(org_id, wid),
+        "idempotency_key": wake_key(org_id, wid, assignee),
         "org_id": org_id,
         "work_id": wid,
         "title": str(item.get("title") or ""),
@@ -77,22 +78,36 @@ def process_item(
         )
         return
 
-    key = wake_key(org_id, wid)
-    if store.has(key):
-        print(f"[org-orchestrator] skip {wid}: already sent {key}", flush=True)
-        return
-
+    key = wake_key(org_id, wid, assignee)
     envelope = build_envelope(org_id, item)
     text = json.dumps(envelope, ensure_ascii=False)
     title = item.get("title") or ""
+
+    if dry_run:
+        # Dry-run does not claim; still surface skip if already recorded.
+        if store.has(key):
+            print(f"[org-orchestrator] skip {wid}: already sent {key}", flush=True)
+            return
+        print(
+            f"[org-orchestrator] wake work={wid} assignee={assignee} title={title!r}",
+            flush=True,
+        )
+        print(f"  dry-run payload: {text}", flush=True)
+        return
+
+    try:
+        claimed = store.try_claim(key, work_id=wid, assignee=assignee)
+    except OSError as e:
+        print(f"[org-orchestrator] idempotency claim failed: {e}", file=sys.stderr)
+        return
+    if not claimed:
+        print(f"[org-orchestrator] skip {wid}: already sent {key}", flush=True)
+        return
+
     print(
         f"[org-orchestrator] wake work={wid} assignee={assignee} title={title!r}",
         flush=True,
     )
-
-    if dry_run:
-        print(f"  dry-run payload: {text}", flush=True)
-        return
 
     try:
         send_message(
@@ -105,9 +120,22 @@ def process_item(
         print("  send → ok", flush=True)
     except urllib.error.HTTPError as e:
         print(f"  send failed HTTP {e.code}: {e.reason}", file=sys.stderr)
+        try:
+            store.release(key)
+        except OSError as release_err:
+            print(
+                f"  idempotency release failed: {release_err}",
+                file=sys.stderr,
+            )
         return
 
-    store.mark(key, work_id=wid, assignee=assignee)
+    try:
+        store.confirm(key)
+    except OSError as e:
+        print(
+            f"  idempotency confirm failed: {e} (wake already sent)",
+            file=sys.stderr,
+        )
 
     if mark_in_progress and item.get("status") == "todo":
         try:

--- a/scripts/smoke_org_orchestrator.sh
+++ b/scripts/smoke_org_orchestrator.sh
@@ -46,12 +46,13 @@ export ACN_API_KEY="$KEY"
 export ORCHESTRATOR_IDEM_PATH="$IDEM"
 python3 "${ORCH}/run_orchestrator.py" --once
 
-echo "==> Verify idempotency recorded"
+echo "==> Verify idempotency recorded (includes assignee)"
 python3 -c "
 import json
 d=json.load(open('${IDEM}'))
-key='${ORG_ID}:${WORK_ID}:wake:1'
+key='${ORG_ID}:${WORK_ID}:wake:1:${AGENT_ID}'
 assert key in d.get('sent', {}), (key, d)
+assert d['sent'][key].get('pending') is False
 print('    idem ok', key)
 "
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.13"
+  version: "0.17.14"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -879,11 +879,20 @@ Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
 | [`org-task-bridge-v0.md`](../../docs/org-harness/org-task-bridge-v0.md) | Publish/import network Tasks (≠ Work Port, ≠ P2b) |
 | [`org-wallet-v0.md`](../../docs/org-harness/org-wallet-v0.md) | Org Credits wallet (S0–S6 done; fund via Backend) |
 | [`plugin-catalog-v0.md`](../../docs/org-harness/plugin-catalog-v0.md) | Official Port shortlist + **custom = external Pattern/sidecar** |
+| [`org-orchestrator-v0.md`](../../docs/org-harness/org-orchestrator-v0.md) | **Org 编排器**（外部）：叫醒成员 agent；**不需要 Paperclip** |
+| [`org-orchestrator-wake-contract-v0.md`](../../docs/org-harness/org-orchestrator-wake-contract-v0.md) | Wake envelope `acn.org.work_wake` |
 
 **Plugins hard rule:** customize via **external Pattern / sidecar**;
 `org.plugins.*` is an **allowlist of builtins** only (`builtin_work` /
 `heartbeat` / `noop`). Do not invent `plugins.work=paperclip` or
 `plugins.memory=mem0` — those ids are not process-local plugins today.
+
+**Org 编排器（外部 Pattern，可选）：** 无 Paperclip 时也可自动派活。侧车 poll
+带 `assignee` 的 open work → `POST /communication/send` 发 `acn.org.work_wake`
+→ 成员用自己的 L1 干活；关单仍走 **governance** PATCH。示例：
+[`examples/org-orchestrator/`](../../examples/org-orchestrator/) ·
+`scripts/smoke_org_orchestrator.sh`。  
+这不是 `plugins.loop=*`，也不是 [待办执行器](../../docs/org-harness/org-loop-spawn-sidecar-poc-v0.md)（本机跑命令）。
 
 ```bash
 # Create Org (binds or creates a subnet fence; plugins default as above)

--- a/tests/examples/test_org_orchestrator_idempotency.py
+++ b/tests/examples/test_org_orchestrator_idempotency.py
@@ -1,0 +1,51 @@
+"""Unit tests for examples/org-orchestrator idempotency store."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "org-orchestrator"
+sys.path.insert(0, str(EXAMPLES))
+
+from idempotency import IdempotencyStore  # noqa: E402
+from run_orchestrator import wake_key  # noqa: E402
+
+
+def test_wake_key_includes_assignee() -> None:
+    a = wake_key("org_1", "work_1", "agt_a")
+    b = wake_key("org_1", "work_1", "agt_b")
+    assert a != b
+    assert a.endswith(":agt_a")
+    assert b.endswith(":agt_b")
+
+
+def test_try_claim_confirm_release(tmp_path: Path) -> None:
+    store = IdempotencyStore(tmp_path / "idem.json")
+    key = "org_1:work_1:wake:1:agt_a"
+    assert store.try_claim(key, work_id="work_1", assignee="agt_a") is True
+    assert store.try_claim(key, work_id="work_1", assignee="agt_a") is False
+    store.release(key)
+    assert store.try_claim(key, work_id="work_1", assignee="agt_a") is True
+    store.confirm(key)
+    assert store.has(key) is True
+    assert store.try_claim(key, work_id="work_1", assignee="agt_a") is False
+
+
+def test_disk_before_memory_on_save_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "idem.json"
+    store = IdempotencyStore(path)
+    key = "org_1:work_1:wake:1:agt_a"
+    assert store.try_claim(key, work_id="work_1", assignee="agt_a") is True
+
+    def boom() -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store, "_save_unlocked", boom)
+    with pytest.raises(OSError):
+        store.confirm(key)
+    # Memory rolled back for confirm failure; reloaded has still has pending claim
+    store2 = IdempotencyStore(path)
+    assert store2.has(key) is True


### PR DESCRIPTION
## Summary
- Wake idempotency key is now `{org}:{work}:wake:{gen}:{assignee}` so **reassignment** delivers a new wake.
- File store: `flock` + `try_claim` → `send` → `confirm` / `release`; persist before adopting memory.
- Unit tests: `tests/examples/test_org_orchestrator_idempotency.py`.
- Skill **0.17.14** + wake-contract docs + smoke key assertion.

## Test plan
- [ ] `uv run pytest tests/examples/test_org_orchestrator_idempotency.py -q`
- [ ] `uv run ruff check examples/org-orchestrator/ tests/examples/test_org_orchestrator_idempotency.py`
- [ ] Optional live: `./scripts/smoke_org_orchestrator.sh`

Made with [Cursor](https://cursor.com)