### PR TITLE
feat(org): Org orchestrator member playbook + handle_wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wakes the new member); file store uses `flock` + `try_claim`/`confirm`/`release`
   (disk before memory). Example: `examples/org-orchestrator/`.
 
+### Added
+
+- **Org orchestrator member playbook** — `handle_wake.py` + dogfood steps
+  (`docs/org-harness/org-orchestrator-member-playbook-v0.md`).
+
 ### Docs
 
-- **Agent skill 0.17.14** — Org 编排器（外部）入口与 wake 契约链接。
+- **Agent skill 0.17.14 / 0.17.15** — Org 编排器入口、wake 契约、成员 playbook。
 
 ## [0.15.8] - 2026-07-25
 

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -31,7 +31,8 @@
 | **[org-loop-spawn-sidecar-poc-v0.md](./org-loop-spawn-sidecar-poc-v0.md)** | **Org 待办执行器（外部）— agent 自动跑命令 POC（C1–C2）** |
 | **[org-orchestrator-v0.md](./org-orchestrator-v0.md)** | **ACN Org 编排器产品定义（P0 Accepted；未实现代码）** |
 | [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) | Org 编排器唤醒契约 P1（`acn.org.work_wake`） |
-| [`examples/org-orchestrator/`](../../examples/org-orchestrator/) | Org 编排器 P2 最小侧车 + `smoke_org_orchestrator.sh` |
+| [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员侧：收到 wake → 干活 → 治理关单 |
+| [`examples/org-orchestrator/`](../../examples/org-orchestrator/) | 编排器侧车 + `handle_wake.py` + smoke |
 | [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（编排器的可选实现；≠ 待办执行器） |
 | [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
 

--- a/docs/org-harness/org-orchestrator-member-playbook-v0.md
+++ b/docs/org-harness/org-orchestrator-member-playbook-v0.md
@@ -1,0 +1,99 @@
+# Org 编排器 — 成员侧 playbook v0
+
+**Status:** Accepted · **示例脚本已提供**  
+**Date:** 2026-07-27  
+**Depends on:** [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) · [`examples/org-orchestrator/`](../../examples/org-orchestrator/)
+
+> **一句话：** 成员 agent 收到 `acn.org.work_wake` 后：校验 → 拉 work → 自己干活 → **请治理关单**（成员 key 通常不能 PATCH）。
+
+---
+
+## 1. 狗粮顺序（端到端）
+
+本机需 `ACN_API_KEY`（治理/Owner，兼编排器发送方）+ 可选第二把成员 key。
+
+| 步 | 动作 |
+|---|---|
+| A | `./scripts/smoke_org_orchestrator.sh` — 验证 send + `in_progress` + 幂等 |
+| B | 成员侧在线：Mode B `acn listen --runtime command --wake-exec '…/handle_wake.py'`，或 Mode A / `acn inbox` |
+| C | `acn org work create … --assignee <成员>`（治理） |
+| D | 跑 `run_orchestrator.py --once` |
+| E | 成员日志出现 `acn.org.work_wake`；`handle_wake.py` 打印 `work show` 摘要 |
+| F | 治理：`acn org work update … --status done` |
+
+零 Paperclip。编排器与成员可同机；生产上编排器常跟 Owner，成员各自 `listen`。
+
+---
+
+## 2. 收到 wake 后做什么
+
+```text
+收到消息/事件
+  → 解析 type == acn.org.work_wake（见契约）
+  → list work 找到 work_id，确认仍 open 且 assignee = 自己（v0 无单条 GET）
+  → 同一 idempotency_key 只处理一次（成员本地也可记）
+  → L1 执行 title/描述要求的活
+  → 完成：通知治理方 PATCH done（或 Owner/编排器代关）
+  → 放弃：治理 PATCH cancelled
+```
+
+**不要：**
+
+- 把 `work_id` 当成 Task Pool `task_id` 去 `tasks accept`  
+- 假设自己的 agent key 能 `PATCH` work（v0 仅 governance）  
+- 盲信信封里的 `title`/`status` 快照而不再拉 API  
+
+---
+
+## 3. Mode B：`listen` + `handle_wake.py`
+
+```bash
+# 成员终端（delivery=relay）
+export ACN_API_KEY=acn_member_…
+acn listen --runtime command \
+  --wake-exec "python3 /path/to/examples/org-orchestrator/handle_wake.py"
+```
+
+`handle_wake.py` 从 stdin 读 Mode B 规范化事件 / 原始 JSON，抽出文本中的
+`acn.org.work_wake`，再 `GET /orgs/{id}/work/{work_id}`，把摘要打到 stdout/stderr。
+**不**自动关单；退出码 0 = 已识别并校验（或可忽略的非 wake）。
+
+编排器侧（治理 key）：
+
+```bash
+export ACN_BASE_URL=… ACN_ORG_ID=org_… ACN_API_KEY=acn_owner_…
+python3 examples/org-orchestrator/run_orchestrator.py --once
+```
+
+---
+
+## 4. Mode A / inbox
+
+若成员是 Mode A（直连）或离线进 inbox：
+
+1. 编排器 `communication/send` 仍走同一信封。  
+2. 成员用 `acn inbox list` / 自身 A2A 入站解析文本 JSON。  
+3. 识别 `type` 后同样走 §2。  
+
+`handle_wake.py` 也支持：`echo '<wake json 或含 text 的事件>' | python3 handle_wake.py`。
+
+---
+
+## 5. 关单谁来做
+
+| 角色 | 动作 |
+|---|---|
+| 成员 | 干完活；可选 A2A 回执 Owner「请关 work_…」 |
+| 治理 / Owner / 编排器运维 | `acn org work update org_… work_… --status done\|cancelled` |
+
+v0 不要求编排器自动 `done`（避免未干完误关）。
+
+---
+
+## 6. 相关文件
+
+| 文件 | 用途 |
+|---|---|
+| [`handle_wake.py`](../../examples/org-orchestrator/handle_wake.py) | 成员侧解析 + work show |
+| [`run_orchestrator.py`](../../examples/org-orchestrator/run_orchestrator.py) | 编排器侧车 |
+| [`smoke_org_orchestrator.sh`](../../scripts/smoke_org_orchestrator.sh) | 狗粮 A（无成员 listen） |

--- a/docs/org-harness/org-orchestrator-member-playbook-v0.md
+++ b/docs/org-harness/org-orchestrator-member-playbook-v0.md
@@ -30,8 +30,8 @@
 ```text
 收到消息/事件
   → 解析 type == acn.org.work_wake（见契约）
-  → list work 找到 work_id，确认仍 open 且 assignee = 自己（v0 无单条 GET）
-  → 同一 idempotency_key 只处理一次（成员本地也可记）
+  → list work 找到 work_id，确认仍 open 且 **API assignee = 自己**（空 assignee 不干）
+  → 同一 `idempotency_key` 只处理一次（`handle_wake.py` 写本地 idem 文件）
   → L1 执行 title/描述要求的活
   → 完成：通知治理方 PATCH done（或 Owner/编排器代关）
   → 放弃：治理 PATCH cancelled
@@ -55,8 +55,9 @@ acn listen --runtime command \
 ```
 
 `handle_wake.py` 从 stdin 读 Mode B 规范化事件 / 原始 JSON，抽出文本中的
-`acn.org.work_wake`，再 `GET /orgs/{id}/work/{work_id}`，把摘要打到 stdout/stderr。
-**不**自动关单；退出码 0 = 已识别并校验（或可忽略的非 wake）。
+`acn.org.work_wake`，再 **list** `GET /orgs/{id}/work?open_only=false` 定位该
+`work_id`（v0 无单条 GET），校验 assignee=自己，并用 `idempotency_key` 本地去重
+（`HANDLE_WAKE_IDEM_PATH`）。**不**自动关单；退出码 0 = 已处理 / 去重 / 可忽略。
 
 编排器侧（治理 key）：
 

--- a/docs/org-harness/org-orchestrator-v0.md
+++ b/docs/org-harness/org-orchestrator-v0.md
@@ -112,6 +112,7 @@ ACN 内：Kernel + builtin_work + heartbeat + events   ← SoT 仍在这里
 | P0 | 本文产品定义 | **Accepted** |
 | P1 | 唤醒契约（payload / 信道 / 幂等） | **Accepted** · [wake-contract](./org-orchestrator-wake-contract-v0.md) |
 | P2 | 最小侧车：poll → 校验 assignee → `communication/send` → 幂等日志 | **done** · [`examples/org-orchestrator/`](../../examples/org-orchestrator/) · `scripts/smoke_org_orchestrator.sh` |
+| P2.1 | 成员 playbook + `handle_wake.py` | **done** · [playbook](./org-orchestrator-member-playbook-v0.md) |
 | P3 | `org.*` / tick 驱动、催办、超时策略 | 按需 |
 | P4 | 可选：ClawTeam 等执行适配（[选型](./clawteam-org-loop-adapter-v0.md)） | 有需求再开 |
 

--- a/docs/org-harness/org-orchestrator-wake-contract-v0.md
+++ b/docs/org-harness/org-orchestrator-wake-contract-v0.md
@@ -118,7 +118,7 @@
 ## 6. 成员收到后怎么做（契约期望）
 
 1. 解析 `type == acn.org.work_wake`。  
-2. `acn org work show <org_id> <work_id>`（或等价 API）确认仍 open 且自己是 assignee。  
+2. `acn org work list` / 等价 list API 找到该 `work_id`，确认仍 open 且自己是 assignee（v0 **无** `GET /work/{id}`）。  
 3. 用自身 L1 执行。  
 4. 完成：经治理路径 `PATCH` → `done`（成员 key 若无治理权，则回报 Owner/编排器代关，或人工/脚本）。  
 5. 放弃：治理 `cancelled`。

--- a/examples/org-orchestrator/README.md
+++ b/examples/org-orchestrator/README.md
@@ -69,5 +69,9 @@ Mode B：
 
 ```bash
 export ACN_BASE_URL=… ACN_API_KEY=acn_member_…
+# optional: HANDLE_WAKE_IDEM_PATH=./.handle-wake-idem.json
 acn listen --runtime command --wake-exec "python3 $(pwd)/handle_wake.py"
 ```
+
+校验：work 必须 open 且 **API assignee = 自己**（空 assignee → 不 OK）；同一
+`idempotency_key` 只 OK 一次。

--- a/examples/org-orchestrator/README.md
+++ b/examples/org-orchestrator/README.md
@@ -52,5 +52,22 @@ python3 run_orchestrator.py --once --no-mark-in-progress
 ## 狗粮
 
 ```bash
+# A — 编排器 alone（需治理 key）
 ACN_BASE_URL=… ACN_API_KEY=acn_… ./scripts/smoke_org_orchestrator.sh
+
+# B — 成员侧解析（无网络：跳过 fetch）
+echo '{"type":"acn.org.work_wake","org_id":"org_x","work_id":"work_y","assignee":"agt_z"}' \
+  | HANDLE_WAKE_SKIP_FETCH=1 python3 handle_wake.py
+
+# 端到端成员步骤见：
+# docs/org-harness/org-orchestrator-member-playbook-v0.md
+```
+
+## 成员侧 `handle_wake.py`
+
+Mode B：
+
+```bash
+export ACN_BASE_URL=… ACN_API_KEY=acn_member_…
+acn listen --runtime command --wake-exec "python3 $(pwd)/handle_wake.py"
 ```

--- a/examples/org-orchestrator/acn_client_min.py
+++ b/examples/org-orchestrator/acn_client_min.py
@@ -56,6 +56,28 @@ def fetch_members(base: str, org_id: str, api_key: str) -> dict[str, Any]:
     return _request("GET", f"{base}/orgs/{org_id}/members", api_key)
 
 
+class WorkNotFoundError(LookupError):
+    """Raised when list-work does not contain the requested work_id."""
+
+
+def get_work(
+    base: str,
+    org_id: str,
+    work_id: str,
+    api_key: str,
+) -> dict[str, Any]:
+    """Fetch one work item via list API (v0 has no GET /work/{id})."""
+    payload = _request(
+        "GET",
+        f"{base}/orgs/{org_id}/work?open_only=false",
+        api_key,
+    )
+    for item in payload.get("work") or []:
+        if str(item.get("work_id") or item.get("id") or "") == work_id:
+            return item
+    raise WorkNotFoundError(work_id)
+
+
 def patch_work_status(
     base: str,
     org_id: str,

--- a/examples/org-orchestrator/handle_wake.py
+++ b/examples/org-orchestrator/handle_wake.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Member-side: parse acn.org.work_wake from stdin event/text, then GET work.
+"""Member-side: parse acn.org.work_wake from stdin, validate work, dedupe by key.
 
 For Mode B:
   acn listen --runtime command --wake-exec 'python3 handle_wake.py'
 
-Env: ACN_BASE_URL, ACN_API_KEY (member key; read work / membership).
-Exit 0: handled wake, non-wake ignored, or dry parse ok.
+Env:
+  ACN_BASE_URL, ACN_API_KEY — member key (list work / agents/me)
+  HANDLE_WAKE_IDEM_PATH — member-side seen keys (default ./.handle-wake-idem.json)
+  HANDLE_WAKE_SKIP_FETCH — if set, parse only (no API / no dedupe claim)
+
+Exit 0: handled, deduped, ignored non-wake, or skip-fetch parse ok.
 Exit 1: wake recognized but validation/API failed.
 Exit 2: misconfiguration.
 """
@@ -19,6 +23,7 @@ import urllib.error
 from typing import Any
 
 from acn_client_min import WorkNotFoundError, agents_me, get_work, normalize_base
+from idempotency import IdempotencyStore
 
 WAKE_TYPE = "acn.org.work_wake"
 
@@ -56,11 +61,9 @@ def _candidate_strings(payload: Any) -> list[str]:
         return [str(payload)]
 
     texts: list[str] = []
-    # Direct wake JSON object
     if payload.get("type") == WAKE_TYPE:
         texts.append(json.dumps(payload, ensure_ascii=False))
 
-    # Mode B normalized event: raw = JSON-RPC body
     raw = payload.get("raw")
     if isinstance(raw, dict):
         params = raw.get("params") if isinstance(raw.get("params"), dict) else {}
@@ -69,27 +72,23 @@ def _candidate_strings(payload: Any) -> list[str]:
             texts.extend(_texts_from_a2a_message(message))
         texts.append(json.dumps(raw, ensure_ascii=False))
 
-    # Convenience shapes
     if isinstance(payload.get("message"), dict):
         texts.extend(_texts_from_a2a_message(payload["message"]))
     if isinstance(payload.get("text"), str):
         texts.append(payload["text"])
 
-    # Whole payload as last resort string search
     texts.append(json.dumps(payload, ensure_ascii=False))
     return texts
 
 
 def parse_wake(payload: Any) -> dict[str, Any] | None:
     for text in _candidate_strings(payload):
-        # Exact JSON object
         try:
             obj = json.loads(text) if isinstance(text, str) else text
         except json.JSONDecodeError:
             obj = None
         if isinstance(obj, dict) and obj.get("type") == WAKE_TYPE:
             return obj
-        # Embedded JSON object in a larger string
         if not isinstance(text, str):
             continue
         start = text.find('{"type": "acn.org.work_wake"')
@@ -106,6 +105,39 @@ def parse_wake(payload: Any) -> dict[str, Any] | None:
     return None
 
 
+def resolve_idempotency_key(wake: dict[str, Any]) -> str:
+    """Prefer envelope key; else derive org:work:wake:1:assignee."""
+    key = str(wake.get("idempotency_key") or "").strip()
+    if key:
+        return key
+    org_id = str(wake.get("org_id") or "").strip()
+    work_id = str(wake.get("work_id") or "").strip()
+    assignee = str(wake.get("assignee") or "").strip()
+    if org_id and work_id and assignee:
+        return f"{org_id}:{work_id}:wake:1:{assignee}"
+    return ""
+
+
+def assignee_matches_me(
+    *,
+    envelope_assignee: str,
+    work_assignee: str | None,
+    my_id: str,
+) -> tuple[bool, str]:
+    """Require API assignee == me. Envelope assignee, if set, must also match."""
+    api = str(work_assignee or "").strip()
+    if not api:
+        return False, "work has no assignee"
+    if not my_id:
+        return False, "agents/me missing agent_id"
+    if api != my_id:
+        return False, f"API assignee {api} != me {my_id}"
+    env = str(envelope_assignee or "").strip()
+    if env and env != my_id:
+        return False, f"envelope assignee {env} != me {my_id}"
+    return True, ""
+
+
 def main() -> int:
     base_url = os.environ.get("ACN_BASE_URL", "").strip()
     api_key = os.environ.get("ACN_API_KEY", "").strip()
@@ -113,6 +145,10 @@ def main() -> int:
         "1",
         "true",
         "yes",
+    )
+    idem_path = os.environ.get(
+        "HANDLE_WAKE_IDEM_PATH",
+        os.path.join(os.getcwd(), ".handle-wake-idem.json"),
     )
 
     payload = _load_stdin()
@@ -127,7 +163,7 @@ def main() -> int:
 
     org_id = str(wake.get("org_id") or "")
     work_id = str(wake.get("work_id") or "")
-    idem = str(wake.get("idempotency_key") or "")
+    idem = resolve_idempotency_key(wake)
     assignee = str(wake.get("assignee") or "")
     print(
         f"[handle_wake] wake org={org_id} work={work_id} "
@@ -146,6 +182,13 @@ def main() -> int:
     if not org_id or not work_id:
         print("[handle_wake] wake missing org_id/work_id", file=sys.stderr)
         return 1
+    if not idem:
+        print(
+            "[handle_wake] wake missing idempotency_key "
+            "(and cannot derive from org/work/assignee)",
+            file=sys.stderr,
+        )
+        return 1
 
     base = normalize_base(base_url)
     try:
@@ -157,7 +200,7 @@ def main() -> int:
 
     if assignee and my_id and assignee != my_id:
         print(
-            f"[handle_wake] assignee {assignee} != me {my_id} — ignore",
+            f"[handle_wake] envelope assignee {assignee} != me {my_id} — ignore",
             flush=True,
         )
         return 0
@@ -168,7 +211,10 @@ def main() -> int:
         print(f"[handle_wake] work not found: {work_id}", file=sys.stderr)
         return 1
     except urllib.error.HTTPError as e:
-        print(f"[handle_wake] GET work failed HTTP {e.code}: {e.reason}", file=sys.stderr)
+        print(
+            f"[handle_wake] list work failed HTTP {e.code}: {e.reason}",
+            file=sys.stderr,
+        )
         return 1
 
     status = work.get("status")
@@ -181,11 +227,24 @@ def main() -> int:
     if status not in ("todo", "in_progress"):
         print(f"[handle_wake] work not open ({status}) — stop", flush=True)
         return 0
-    if work_assignee and my_id and str(work_assignee) != my_id:
-        print(
-            f"[handle_wake] API assignee {work_assignee} != me {my_id} — stop",
-            flush=True,
-        )
+
+    ok, reason = assignee_matches_me(
+        envelope_assignee=assignee,
+        work_assignee=str(work_assignee) if work_assignee is not None else None,
+        my_id=my_id,
+    )
+    if not ok:
+        print(f"[handle_wake] {reason} — stop", flush=True)
+        return 0
+
+    store = IdempotencyStore(idem_path)
+    try:
+        claimed = store.try_claim(idem, work_id=work_id, assignee=my_id)
+    except OSError as e:
+        print(f"[handle_wake] idempotency claim failed: {e}", file=sys.stderr)
+        return 1
+    if not claimed:
+        print(f"[handle_wake] deduped idem={idem} — already handled", flush=True)
         return 0
 
     print(
@@ -194,6 +253,10 @@ def main() -> int:
         flush=True,
     )
     print(json.dumps({"wake": wake, "work": work}, ensure_ascii=False, indent=2), flush=True)
+    try:
+        store.confirm(idem)
+    except OSError as e:
+        print(f"[handle_wake] idempotency confirm failed: {e}", file=sys.stderr)
     return 0
 
 

--- a/examples/org-orchestrator/handle_wake.py
+++ b/examples/org-orchestrator/handle_wake.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Member-side: parse acn.org.work_wake from stdin event/text, then GET work.
+
+For Mode B:
+  acn listen --runtime command --wake-exec 'python3 handle_wake.py'
+
+Env: ACN_BASE_URL, ACN_API_KEY (member key; read work / membership).
+Exit 0: handled wake, non-wake ignored, or dry parse ok.
+Exit 1: wake recognized but validation/API failed.
+Exit 2: misconfiguration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+from typing import Any
+
+from acn_client_min import WorkNotFoundError, agents_me, get_work, normalize_base
+
+WAKE_TYPE = "acn.org.work_wake"
+
+
+def _load_stdin() -> Any:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip()
+
+
+def _texts_from_a2a_message(msg: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    if isinstance(msg.get("text"), str):
+        out.append(msg["text"])
+    parts = msg.get("parts")
+    if isinstance(parts, list):
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            if isinstance(part.get("text"), str):
+                out.append(part["text"])
+    return out
+
+
+def _candidate_strings(payload: Any) -> list[str]:
+    if payload is None:
+        return []
+    if isinstance(payload, str):
+        return [payload]
+    if not isinstance(payload, dict):
+        return [str(payload)]
+
+    texts: list[str] = []
+    # Direct wake JSON object
+    if payload.get("type") == WAKE_TYPE:
+        texts.append(json.dumps(payload, ensure_ascii=False))
+
+    # Mode B normalized event: raw = JSON-RPC body
+    raw = payload.get("raw")
+    if isinstance(raw, dict):
+        params = raw.get("params") if isinstance(raw.get("params"), dict) else {}
+        message = params.get("message") if isinstance(params, dict) else None
+        if isinstance(message, dict):
+            texts.extend(_texts_from_a2a_message(message))
+        texts.append(json.dumps(raw, ensure_ascii=False))
+
+    # Convenience shapes
+    if isinstance(payload.get("message"), dict):
+        texts.extend(_texts_from_a2a_message(payload["message"]))
+    if isinstance(payload.get("text"), str):
+        texts.append(payload["text"])
+
+    # Whole payload as last resort string search
+    texts.append(json.dumps(payload, ensure_ascii=False))
+    return texts
+
+
+def parse_wake(payload: Any) -> dict[str, Any] | None:
+    for text in _candidate_strings(payload):
+        # Exact JSON object
+        try:
+            obj = json.loads(text) if isinstance(text, str) else text
+        except json.JSONDecodeError:
+            obj = None
+        if isinstance(obj, dict) and obj.get("type") == WAKE_TYPE:
+            return obj
+        # Embedded JSON object in a larger string
+        if not isinstance(text, str):
+            continue
+        start = text.find('{"type": "acn.org.work_wake"')
+        if start < 0:
+            start = text.find('{"type":"acn.org.work_wake"')
+        if start < 0:
+            continue
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(text[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("type") == WAKE_TYPE:
+            return obj
+    return None
+
+
+def main() -> int:
+    base_url = os.environ.get("ACN_BASE_URL", "").strip()
+    api_key = os.environ.get("ACN_API_KEY", "").strip()
+    skip_fetch = os.environ.get("HANDLE_WAKE_SKIP_FETCH", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+    payload = _load_stdin()
+    if payload is None:
+        print("[handle_wake] empty stdin — ignore", flush=True)
+        return 0
+
+    wake = parse_wake(payload)
+    if wake is None:
+        print("[handle_wake] not an acn.org.work_wake — ignore", flush=True)
+        return 0
+
+    org_id = str(wake.get("org_id") or "")
+    work_id = str(wake.get("work_id") or "")
+    idem = str(wake.get("idempotency_key") or "")
+    assignee = str(wake.get("assignee") or "")
+    print(
+        f"[handle_wake] wake org={org_id} work={work_id} "
+        f"assignee={assignee} idem={idem}",
+        flush=True,
+    )
+
+    if skip_fetch:
+        print("[handle_wake] HANDLE_WAKE_SKIP_FETCH set — not calling API", flush=True)
+        print(json.dumps(wake, ensure_ascii=False, indent=2), flush=True)
+        return 0
+
+    if not base_url or not api_key:
+        print("Need ACN_BASE_URL and ACN_API_KEY", file=sys.stderr)
+        return 2
+    if not org_id or not work_id:
+        print("[handle_wake] wake missing org_id/work_id", file=sys.stderr)
+        return 1
+
+    base = normalize_base(base_url)
+    try:
+        me = agents_me(base, api_key)
+        my_id = str(me.get("agent_id") or "")
+    except Exception as e:
+        print(f"[handle_wake] agents/me failed: {e}", file=sys.stderr)
+        return 1
+
+    if assignee and my_id and assignee != my_id:
+        print(
+            f"[handle_wake] assignee {assignee} != me {my_id} — ignore",
+            flush=True,
+        )
+        return 0
+
+    try:
+        work = get_work(base, org_id, work_id, api_key)
+    except WorkNotFoundError:
+        print(f"[handle_wake] work not found: {work_id}", file=sys.stderr)
+        return 1
+    except urllib.error.HTTPError as e:
+        print(f"[handle_wake] GET work failed HTTP {e.code}: {e.reason}", file=sys.stderr)
+        return 1
+
+    status = work.get("status")
+    work_assignee = work.get("assignee_agent_id") or work.get("assignee")
+    print(
+        f"[handle_wake] work status={status!r} assignee={work_assignee!r} "
+        f"title={work.get('title')!r}",
+        flush=True,
+    )
+    if status not in ("todo", "in_progress"):
+        print(f"[handle_wake] work not open ({status}) — stop", flush=True)
+        return 0
+    if work_assignee and my_id and str(work_assignee) != my_id:
+        print(
+            f"[handle_wake] API assignee {work_assignee} != me {my_id} — stop",
+            flush=True,
+        )
+        return 0
+
+    print(
+        "[handle_wake] OK — run your L1 on this work; "
+        "ask governance to PATCH done|cancelled when finished.",
+        flush=True,
+    )
+    print(json.dumps({"wake": wake, "work": work}, ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.14"
+  version: "0.17.15"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -881,6 +881,7 @@ Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
 | [`plugin-catalog-v0.md`](../../docs/org-harness/plugin-catalog-v0.md) | Official Port shortlist + **custom = external Pattern/sidecar** |
 | [`org-orchestrator-v0.md`](../../docs/org-harness/org-orchestrator-v0.md) | **Org 编排器**（外部）：叫醒成员 agent；**不需要 Paperclip** |
 | [`org-orchestrator-wake-contract-v0.md`](../../docs/org-harness/org-orchestrator-wake-contract-v0.md) | Wake envelope `acn.org.work_wake` |
+| [`org-orchestrator-member-playbook-v0.md`](../../docs/org-harness/org-orchestrator-member-playbook-v0.md) | 成员收到 wake 后怎么干 / 关单 |
 
 **Plugins hard rule:** customize via **external Pattern / sidecar**;
 `org.plugins.*` is an **allowlist of builtins** only (`builtin_work` /
@@ -892,6 +893,9 @@ Harness itself. Design: [`docs/org-harness/`](../../docs/org-harness/README.md).
 → 成员用自己的 L1 干活；关单仍走 **governance** PATCH。示例：
 [`examples/org-orchestrator/`](../../examples/org-orchestrator/) ·
 `scripts/smoke_org_orchestrator.sh`。  
+成员侧：[`handle_wake.py`](../../examples/org-orchestrator/handle_wake.py) +
+[playbook](../../docs/org-harness/org-orchestrator-member-playbook-v0.md)
+（Mode B：`acn listen --runtime command --wake-exec 'python3 handle_wake.py'`）。  
 这不是 `plugins.loop=*`，也不是 [待办执行器](../../docs/org-harness/org-loop-spawn-sidecar-poc-v0.md)（本机跑命令）。
 
 ```bash

--- a/tests/examples/test_org_orchestrator_handle_wake.py
+++ b/tests/examples/test_org_orchestrator_handle_wake.py
@@ -1,0 +1,59 @@
+"""Unit tests for examples/org-orchestrator/handle_wake.py parsers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "org-orchestrator"
+sys.path.insert(0, str(EXAMPLES))
+
+from handle_wake import parse_wake  # noqa: E402
+
+
+def test_parse_direct_wake_object() -> None:
+    wake = {
+        "type": "acn.org.work_wake",
+        "schema_version": 1,
+        "org_id": "org_1",
+        "work_id": "work_1",
+        "assignee": "agt_a",
+        "idempotency_key": "org_1:work_1:wake:1:agt_a",
+    }
+    assert parse_wake(wake)["work_id"] == "work_1"
+
+
+def test_parse_text_field() -> None:
+    wake = {
+        "type": "acn.org.work_wake",
+        "org_id": "org_1",
+        "work_id": "work_2",
+        "assignee": "agt_a",
+    }
+    assert parse_wake({"text": json.dumps(wake)})["work_id"] == "work_2"
+
+
+def test_parse_mode_b_raw_envelope() -> None:
+    wake = {
+        "type": "acn.org.work_wake",
+        "org_id": "org_1",
+        "work_id": "work_3",
+        "assignee": "agt_b",
+    }
+    event = {
+        "event_type": "a2a_message",
+        "raw": {
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": json.dumps(wake)}],
+                }
+            }
+        },
+    }
+    assert parse_wake(event)["work_id"] == "work_3"
+
+
+def test_parse_ignores_unrelated() -> None:
+    assert parse_wake({"hello": "world"}) is None

--- a/tests/examples/test_org_orchestrator_handle_wake.py
+++ b/tests/examples/test_org_orchestrator_handle_wake.py
@@ -9,7 +9,7 @@ from pathlib import Path
 EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "org-orchestrator"
 sys.path.insert(0, str(EXAMPLES))
 
-from handle_wake import parse_wake  # noqa: E402
+from handle_wake import assignee_matches_me, parse_wake, resolve_idempotency_key  # noqa: E402
 
 
 def test_parse_direct_wake_object() -> None:
@@ -57,3 +57,37 @@ def test_parse_mode_b_raw_envelope() -> None:
 
 def test_parse_ignores_unrelated() -> None:
     assert parse_wake({"hello": "world"}) is None
+
+
+def test_resolve_idempotency_key_prefers_envelope() -> None:
+    wake = {
+        "idempotency_key": "custom-key",
+        "org_id": "org_1",
+        "work_id": "work_1",
+        "assignee": "agt_a",
+    }
+    assert resolve_idempotency_key(wake) == "custom-key"
+
+
+def test_resolve_idempotency_key_derives() -> None:
+    wake = {"org_id": "org_1", "work_id": "work_1", "assignee": "agt_a"}
+    assert resolve_idempotency_key(wake) == "org_1:work_1:wake:1:agt_a"
+
+
+def test_assignee_matches_requires_api_assignee() -> None:
+    ok, reason = assignee_matches_me(
+        envelope_assignee="agt_a",
+        work_assignee=None,
+        my_id="agt_a",
+    )
+    assert ok is False
+    assert "no assignee" in reason
+
+
+def test_assignee_matches_me() -> None:
+    ok, _ = assignee_matches_me(
+        envelope_assignee="agt_a",
+        work_assignee="agt_a",
+        my_id="agt_a",
+    )
+    assert ok is True


### PR DESCRIPTION
## Summary
- **Playbook:** [org-orchestrator-member-playbook-v0.md](docs/org-harness/org-orchestrator-member-playbook-v0.md) — dogfood A→F, Mode B listen, governance closeout.
- **`handle_wake.py`:** parse wake from stdin (Mode B event / text JSON) → list-work validate → print L1 next step (no auto done).
- Skill **0.17.15** + unit tests for parser.

## Test plan
- [x] `pytest tests/examples/test_org_orchestrator_*.py`
- [x] `HANDLE_WAKE_SKIP_FETCH=1` pipe wake JSON into `handle_wake.py`
- [ ] Live (needs key): `./scripts/smoke_org_orchestrator.sh` then Mode B + orchestrator once

Made with [Cursor](https://cursor.com)