### PR TITLE
feat(org): Org knowledge base Port + filesystem sidecar (K0–K2)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -896,7 +896,8 @@ Still deferred (Phase 2b / 3+):
 - **DEF-WORK-PLUGIN** — ~~P2a `builtin_work`~~ / ~~P2c Paperclip Org path~~ done；
   remaining **P2b** `plugins.work=task_pool` in-process（按需）— 见
   [`org-harness/phase2-work-port-v0.md`](org-harness/phase2-work-port-v0.md)
-- **DEF-MEM** — Org Memory / SOPs (Pattern-local; Mem0/Zep/PG+vector)
+- **DEF-KB** — Org Knowledge (`IOrgKnowledge`; charter/SOP/Skills sidecar; see [`org-harness/org-knowledge-base-v0.md`](org-harness/org-knowledge-base-v0.md))
+- **DEF-MEM** — Org Memory (facts/narrative; Mem0/Zep/PG+vector; ≠ SOP)
 - **DEF-ORGREP** — Cross-org reputation (beyond per-agent ERC-8004 reads)
 - **DEF-DISPUTE** — Dispute / jury after escrow window (ADR-0010 Future)
 - **DEF-FED** — Federation across ACN instances ([federation.md](federation.md))

--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -32,6 +32,8 @@
 | **[org-orchestrator-v0.md](./org-orchestrator-v0.md)** | **ACN Org 编排器产品定义（P0 Accepted；未实现代码）** |
 | [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) | Org 编排器唤醒契约 P1（`acn.org.work_wake`） |
 | [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员侧：收到 wake → 干活 → 治理关单 |
+| **[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)** | **Org 知识库 Port（`IOrgKnowledge`；与 Memory 分界；侧车路径）** |
+| [`examples/org-knowledge/`](../../examples/org-knowledge/) | 知识库 K1：`read_kb.py` + `org_demo` 目录树 |
 | [`examples/org-orchestrator/`](../../examples/org-orchestrator/) | 编排器侧车 + `handle_wake.py` + smoke |
 | [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md) | ClawTeam ↔ Org Loop 适配器选型（编排器的可选实现；≠ 待办执行器） |
 | [org-task-bridge-v0.md](./org-task-bridge-v0.md) | Org → Task Pool 发布约定（约定桥，不是 Work Port） |
@@ -50,10 +52,10 @@ Org Harness Module = Kernel（固定） + Ports（可插拔）
   Org Graph（Kernel）: Org · 可选 Owner · agent 成员 · subnet 绑定
   Control Loop（Port）: 今日 heartbeat — 观察队列 → 分派/唤醒 → 回收
   Work Graph（Port）: 今日 builtin_work（默认）；TaskPool deferred
-  其它 Ports: Memory · Capability · Policy · Events
+  其它 Ports: Knowledge · Memory · Capability · Policy · Events
 
 自定义主路径 = 外部 Pattern（非 plugins.*）
-  Paperclip · Org 待办执行器 ·（将来）ClawTeam Loop 适配器等
+  Paperclip · Org 待办执行器 · 知识库侧车 ·（将来）ClawTeam Loop 适配器等
 
 L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 ```
@@ -64,8 +66,9 @@ L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 - **试用入口：** [quickstart-org-paperclip.md](./quickstart-org-paperclip.md)（本地可不填公网 URL；含 Org-paid 软验与 topup curl）。  
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
 - **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
-- **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Memory 等 adapter-planned）。  
-- **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配。  
+- **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Knowledge / Memory 等 adapter-planned）。  
+- **Org 知识库：** [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) + [K1/K2 侧车](../../examples/org-knowledge/) · [`smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)（K3 向量/`plugins.knowledge` 按需）。  
+- **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配；知识库 K3。  
 - **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
 - **Org 编排器：** [产品定义](./org-orchestrator-v0.md) P0 + [唤醒契约](./org-orchestrator-wake-contract-v0.md) P1 + [P2 侧车](../../examples/org-orchestrator/)；P3 webhook/催办按需。  
 - **选型（未实现）：** [ClawTeam ↔ Org Loop 适配器](./clawteam-org-loop-adapter-v0.md)（编排器可选后端，有需求再开）。  

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -1,7 +1,7 @@
 # Org Harness 方案设计与架构 v0
 
 **Status:** Design v0 — mechanics decided in [ADR-0014](../adr/0014-org-harness-module.md)（Accepted）  
-**Date:** 2026-07-19 · **Narrative sync:** 2026-07-27（架构导读：Kernel / Ports / 外部 Pattern 分界）  
+**Date:** 2026-07-19 · **Narrative sync:** 2026-07-27（架构导读：Kernel / Ports / 外部 Pattern 分界；补 `IOrgKnowledge`）  
 **Audience:** ACN / AgentPlanet 产品与工程  
 **Supersedes (naming & ownership):** 本文纠正早期「ACN = Pasture System」「Org 只活在 Paperclip」的表述；Network Core 契约仍见 [api-surface-tiers.md](./api-surface-tiers.md)。  
 **P0/P1 风险收口:** 见 ADR-0014（无 owner 治理、Membership↔subnet、subnet steward、Phase 1 含最小 work、Loop/Work 边界）。
@@ -197,7 +197,7 @@ Org:    unclaimed | owned_by human | owned_by agent
 ### 5.1 原则
 
 - **Kernel 不可替换**：Org 是什么（身份、可选 Owner、agent 成员、subnet 绑定）——即持久 **Org Graph**。
-- **Ports 可替换**：Org 怎么运转（活、环、记忆、能力池、策略、事件出口）。
+- **Ports 可替换**：Org 怎么运转（活、环、知识库、记忆、能力池、策略、事件出口）。
 - **三层叠加，不是二选一**（对齐业界 loop/graph 讨论的硬共识）：
   - **Org Graph**（Kernel）——谁长期在组织里、角色与围栏；
   - **Control Loop**（`IOrgLoop`）——组织心跳：观察队列 → 分派/唤醒 → 回收；
@@ -222,16 +222,18 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 | **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选/deferred）；自研 DAG；**Paperclip = 外部 Pattern**（非 `plugins.work`） |
 | **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | （将来）ClawTeam **Loop 适配器**、自定义巡检；今日自定义走**外部 Pattern** |
 | **`ICapabilityPool`** | 组织能力目录 | 聚合成员 ACN skills（可先内置非插件） | 外挂 MCP catalog |
-| **`IOrgMemory`** | 集体记忆 / SOP | `noop` | Mem0、PG+vector、Skills 包 |
+| **`IOrgKnowledge`** | 权威知识（章程 / SOP / Skills） | 外部侧车（见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)）；`plugins.knowledge` 预留 | git/文件、外挂 KB、RAG 侧车 |
+| **`IOrgMemory`** | 集体记忆（事实 / 偏好 / 叙事） | `noop` | Mem0、Zep/Graphiti、PG+vector |
 | **`IPolicyBudget`** | 角色权限、花费 | Kernel 角色枚举 | 审批流、月度硬停 |
 | **`IEventSink`** | 生命周期外推 | subnet harness webhook | 多 webhook、OTel |
 
 **v0 必要实现：** Kernel + `IWorkPattern` + 薄 `IOrgLoop` + `IEventSink`。  
-其余 Port **占位即可**，避免一次做成「小 OpenHarness 复刻」。
+其余 Port **占位即可**，避免一次做成「小 OpenHarness 复刻」。  
+**知识库**与 Memory 同级问题轴：内容用成熟栈侧车交货，**不进 Kernel**；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。
 
-> **Port 名 ≠ 货架上已有货。** 「可替换示例」是问题轴上的方向；进程内是否接线见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。Paperclip / 待办执行器走外部，不进 `plugins.*`。
+> **Port 名 ≠ 货架上已有货。** 「可替换示例」是问题轴上的方向；进程内是否接线见 [plugin-catalog-v0.md](./plugin-catalog-v0.md)。Paperclip / 待办执行器 / 知识库侧车走外部，不进 `plugins.*`。
 
-建议后续补：**统一 Plugin 宿主**（发现、按 org 启用、版本、失败隔离），以及 **Skills/SOP 与 Memory 分离**（或明确 SOP 为 Work/Loop 的只读输入）。
+建议后续补：**统一 Plugin 宿主**（发现、按 org 启用、版本、失败隔离）。**Skills/SOP 已从 Memory 拆出** → `IOrgKnowledge`。
 
 ### 5.4 Org Graph · Control Loop · Work Graph
 
@@ -408,13 +410,14 @@ Org Harness **消费** Core，不重新实现：
 
 ### Phase 3 — 增强 Port
 
-- Policy/Budget、Memory、Capability 真插件化  
+- Policy/Budget、Memory、Knowledge、Capability 真插件化  
 - ClawTeam / Swarm 适配器实验  
 - 统一 Plugin 宿主（发现 / 版本 / 热加载；Phase 2 仅最小 resolve）  
 
 ### 明确后置
 
-Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（见 [org-pattern-adapter-spec-v0.md § Deferred](./org-pattern-adapter-spec-v0.md#7-deferred-enhancements) / BACKLOG）。
+Org Memory 深度、知识库进程内多后端、跨 org 信誉、Dispute、Federation、agentic 支付轨（见 [org-pattern-adapter-spec-v0.md § Deferred](./org-pattern-adapter-spec-v0.md#7-deferred-enhancements) / BACKLOG）。  
+知识库 **K0–K2 已补**（问题轴 + sidecar + wake `kb_refs`）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。
 
 ---
 
@@ -433,6 +436,7 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 | D9 | v0 不做「加人」叙事；复用 subnet 围栏 |
 | D10 | v0 只做满 Kernel + Work + 薄 Loop + Events，避免过度对称 |
 | D11 | 自定义优先 **外部 Pattern**；`plugins.*` 仅官方 Builtin 白名单（见 plugin-catalog） |
+| D12 | **`IOrgKnowledge`** 与 Memory 并列；权威 SOP/Skills ≠ 可写记忆；不进 Kernel；v0 侧车交货（[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)） |
 
 ---
 
@@ -442,6 +446,7 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 |---|---|
 | [README.md](./README.md) | 本目录索引 |
 | [plugin-catalog-v0.md](./plugin-catalog-v0.md) | Port 短名单与「外部 Pattern vs plugins.*」硬约定 |
+| [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | Org 知识库 Port / 与 Memory 分界 / 侧车路径 |
 | [../adr/0014-org-harness-module.md](../adr/0014-org-harness-module.md) | **P0/P1 决策 ADR（Accepted）** |
 | [api-surface-tiers.md](./api-surface-tiers.md) | Network Core / Pattern 消费契约 |
 | [org-model-v0.md](./org-model-v0.md) | 数据模型（随本文修订 ownership） |
@@ -459,6 +464,6 @@ Org Memory 深度、跨 org 信誉、Dispute、Federation、agentic 支付轨（
 
 ## 13. 一句话总结
 
-> **Org Harness = ACN 内建 Kernel（Org Graph：Org + 可选 Owner + agent 成员 + subnet）+ 薄 Control Loop + 可插拔 Ports（Work / Memory / Policy / Events…）。**  
-> **自定义运转方式优先外部 Pattern**（Paperclip、待办执行器等）；`plugins.*` 仅官方 Builtin。  
+> **Org Harness = ACN 内建 Kernel（Org Graph：Org + 可选 Owner + agent 成员 + subnet）+ 薄 Control Loop + 可插拔 Ports（Work / Knowledge / Memory / Policy / Events…）。**  
+> **自定义运转方式优先外部 Pattern**（Paperclip、待办执行器、知识库侧车等）；`plugins.*` 仅官方 Builtin。  
 > L1 harness 由成员自带；ClawTeam/Swarm/LangGraph 是外部适配**候选**，不是内核平替。Network Core 是底座——不是把 ACN 改名叫 Pasture，也不是在内核复刻 Ultra。

--- a/docs/org-harness/org-knowledge-base-v0.md
+++ b/docs/org-harness/org-knowledge-base-v0.md
@@ -1,0 +1,242 @@
+# Org 知识库 — 产品与 Port 定义 v0
+
+**Status:** Design Accepted · **K1+K2 examples 已落地**；进程内 `plugins.knowledge` 尚未接线  
+**Code：** [`examples/org-knowledge/`](../../examples/org-knowledge/) · wake `kb_refs` + `handle_wake` 加载  
+**Smoke：** [`scripts/smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)  
+
+**Date:** 2026-07-27  
+**Audience:** 产品 / Org Harness 维护者 / Pattern 作者  
+**Depends on:** [design-v0.md](./design-v0.md) §5.3 · [plugin-catalog-v0.md](./plugin-catalog-v0.md)  
+**Adjacent:** [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) · [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md)
+
+> **一句话：** 组织知识库是 Org Harness 的**一等能力**（问题轴 `IOrgKnowledge`）——权威、可版本的章程 / SOP / Skills，供 Work·Loop·成员**只读**消费。  
+> **不是** Kernel，**不是** `IOrgMemory`（记忆是可写沉淀）。  
+> **不自研**检索引擎；用成熟栈做侧车 / 将来薄适配。
+
+### 为什么现在补
+
+Org = 人/agent 边界 + 活 + **知识**。前两块已有 Kernel / Work / Loop；知识库在 v0 叙事里被并进 Memory「集体记忆 / SOP」，属于**规划遗漏**。  
+补法与其它 Port 相同：**先占问题轴 + 默认推荐路径**，实现用现成技术，不要求「先跑稳再转正」。
+
+---
+
+## 1. 要解决什么
+
+成员接到活时需要知道：
+
+- 组织章程与红线是什么；  
+- 这类活的标准作业程序（SOP）怎么走；  
+- 可复用的 Skills / playbook 片段在哪。
+
+没有组织知识库，每个 agent 只能靠各自 L1 记忆或口头约定——**Org 级真相缺失**。
+
+**不做（本 Port）：**
+
+- 对话轨迹 / 长期事实沉淀 → **`IOrgMemory`**  
+- 成员私有笔记 → L1 harness memory  
+- 把语雀/Notion 再实现一遍 → 选型接入
+
+---
+
+## 2. 在架构里的位置
+
+```text
+Org Graph（Kernel）          ← 不管文档内容
+Work / Loop                  ← 干活时读知识（指针或检索）
+IOrgKnowledge（本 Port）     ← 权威知识：章程 / SOP / Skills
+IOrgMemory                   ← 运行中沉淀：事实 / 偏好 / 叙事（可脏）
+```
+
+| 项 | 决定 |
+|---|---|
+| 问题轴 | **`IOrgKnowledge`**（与 Memory 并列） |
+| Kernel | **不进**；不在 Org 表塞文档 blob |
+| SoT（内容） | 知识库后端（git / 对象存储 / 外挂 KB）；ACN 只认 `org_id` 边界与可选指针 |
+| 插法 v0 | **外部侧车**（与编排器同级节奏）；`plugins.knowledge` **预留**，接线前勿伪造 id |
+| 读写 | v0：**读多写少**；写入走人/Owner 流程（PR、外挂 KB 权限），agent 默认只读 |
+| 自研 | **否**——不造向量引擎 / CMS |
+
+### 与 Memory 的硬边界
+
+| | **知识库 `IOrgKnowledge`** | **记忆 `IOrgMemory`** |
+|---|---|---|
+| 性质 | 权威资产 | 运行沉淀 |
+| 变更 | 宜审、可回滚 | 可脏、可遗忘 |
+| 典型内容 | charter、SOP、Skills 包 | 事实、偏好、多会话实体 |
+| 消费 | Work / Loop / 成员执行前注入 | 检索增强、画像 |
+| 默认 | 见 §4（侧车推荐） | 今日 `plugins.memory=noop` |
+
+可以共用同一向量库做索引，但**产品与 Port 名必须分开**，避免 SOP 被当成聊天记忆乱写。
+
+### 信任边界（文件系统侧车）
+
+- Sidecar **不**做 ACN Membership / 角色鉴权。  
+- 能读 `ORG_KB_ROOT` 即可读其下任意 `orgs/<org_id>/`。  
+- 多租户须在**部署层**隔离（每 runner 一 org，或受控挂载）；勿把不可信进程挂到共享多 org root。  
+- 实现侧已做：path traversal / 出树 symlink 拒绝；单文件默认 ≤512KB；`--org` / `expected_org_id` 拒绝跨 org URI。
+
+### 行业对照（2025–2026）
+
+主流结论：**知识库（RAG）与 Agent Memory 不是竞品，是两套生命周期；生产系统几乎都「两个都要」。**  
+分水岭是有没有 **agent 写回路径**，不是用不用向量库。
+
+| | **知识库 / RAG** | **Agent Memory** |
+|---|---|---|
+| 回答 | 「文档/制度说什么？」 | 「关于这个人/这段协作，我记得什么？」 |
+| 读写 | 对人/运营可写；对 agent **基本只读** | agent **持续写**：抽取、更新、遗忘 |
+| 作用域 | 人人（或按 org）一样 | 按 user / session / agent（需租户隔离） |
+| 失败模式 | 检索错、索引旧 | 记忆投毒、矛盾堆积 |
+
+代表口径（与本 Port 对齐）：
+
+- **Mem0：** RAG = 通用/领域知识；Memory = 用户专属上下文；推荐 hybrid（先记忆、再文档、再进 prompt）。  
+- **AWS Bedrock AgentCore：** LTM 管「谁是用户、以前发生过什么」；Knowledge Base/RAG 管「权威源现在怎么说」。  
+- **Zep / Graphiti：** 偏 Memory（时序图谱、对话与业务数据持续写入）；与静态文档 GraphRAG 刻意区分。  
+- 另有 **LLM Wiki** 一类：ingest 时编译领域笔记——仍属权威/领域层，不是会话记忆。
+
+典型请求循环：
+
+```text
+Memory.search(user|org) → KB.retrieve(query) → LLM(两路 context) → Memory.add(本轮)
+                                                                    （不写回 KB）
+```
+
+冲突习惯：**人设/偏好听 Memory，事实/合规听 Knowledge。**  
+映射：行业 KB/RAG → **`IOrgKnowledge`**；行业 Agent Memory → **`IOrgMemory`**；会话窗口 → 成员 L1。
+
+---
+
+## 3. 推荐栈（不自研）
+
+| 层级 | 推荐 | 说明 |
+|---|---|---|
+| **P0 默认路径** | **git / 文件树** 按 `org_id` 隔离 | 人用 PR 审；agent 按 path 读。零新依赖。 |
+| **P1 检索** | 侧车 + PG+vector / 现成 RAG API | 仍按 `org_id` 过滤；ACN 不持有全文索引 |
+| **外挂 KB** | 语雀 / Notion / 飞书文档等 | community：用其 API 做只读适配；官方不绑定一家 |
+
+目录约定（P0 侧车示例）：
+
+```text
+orgs/<org_id>/
+  charter.md          # 章程 / 红线
+  sop/                # 标准作业
+  playbooks/          # 场景剧本
+  skills/             # 可复用技能片段
+```
+
+---
+
+## 4. v0 范围
+
+**做（设计 + 推荐路径）：**
+
+1. 问题轴与 catalog 正式立项（本文 + design / plugin-catalog 回链）。  
+2. **P0 交付形态：** 外部知识库侧车（文件/git）；成员 playbook：接活 → 按指针读条目 → 再执行。  
+3. **可选指针：** 编排器 / 发单方在 work 或 `acn.org.work_wake` 上带 `kb_refs[]`（path 或 URI），**不塞全文**进 ACN 消息。  
+4. 与 Memory 拆表：SOP/Skills **移出** Memory 短名单，归本 Port。
+
+**不做（v0）：**
+
+- 进程内 `plugins.knowledge=*` 白名单接线（与 Memory 薄适配同批，Phase 3 / 有需求时）  
+- Kernel CRUD 文档 API  
+- 自研 embedding / 图谱引擎  
+- 跨 org 知识联邦  
+
+### `plugins.knowledge` 预留
+
+与 `plugins.memory` 对称，设计上预留：
+
+```json
+{
+  "work": "builtin_work",
+  "loop": "heartbeat",
+  "memory": "noop",
+  "knowledge": "noop"
+}
+```
+
+| id（规划） | 状态 | 说明 |
+|---|---|---|
+| `noop` | **plugin-planned**（未接线） | 无组织知识库；成员自行找文档 |
+| `fs` / git 侧车（官方示例） | **examples-shipped**（K1+K2） | 推荐默认交货；见 [`examples/org-knowledge/`](../../examples/org-knowledge/) |
+| 外挂 KB / RAG | **community-welcome** | 按 `org_id` 隔离即可 |
+
+今日创建 Org **不要**传 `knowledge: …`（未知键应被忽略或拒绝——以实现为准）；开工请走**外部侧车**，与「勿伪造 `plugins.memory=mem0`」同一纪律。
+
+---
+
+## 5. 消费契约（最小）
+
+### 5.1 `kb_refs`（可选，给 Work / wake）
+
+```json
+{
+  "kb_refs": [
+    { "uri": "orgkb://<org_id>/sop/release.md", "title": "发版 SOP" },
+    { "uri": "orgkb://<org_id>/charter.md" }
+  ]
+}
+```
+
+- `orgkb://` 为逻辑 scheme；侧车解析为本地 path 或外挂 URL。  
+- 唤醒消息只带 refs；全文由成员侧拉取。  
+- 无 `kb_refs` 时：成员按 playbook 默认读 `charter.md` + 与 work 类型相关的 sop（侧车约定）。
+
+### 5.2 成员侧最小循环
+
+```text
+收到 work / wake
+  → 解析 kb_refs（或默认路径）
+  → 只读拉取片段
+  → 执行并回写 work
+  → （可选）事实沉淀写入 Memory——不写回 Knowledge
+```
+
+---
+
+## 6. 权限与治理（v0 基线）
+
+| 动作 | 谁 |
+|---|---|
+| 读知识 | Org 成员 agent（及 Owner 工具链） |
+| 改章程 / SOP | **人 Owner 或外挂 KB 的人类权限**；v0 不强制 agent 写入 API |
+| 删 org | 随 Org 生命周期；侧车数据保留策略由运营定（ACN 不级联删外挂仓） |
+
+细粒度 ACL（按 path 的 manager-only）→ 后置，有真实需求再进 Policy Port。
+
+---
+
+## 7. 里程碑
+
+| 阶段 | 内容 | 状态 |
+|---|---|---|
+| **K0** | 本文 + design/catalog 升格问题轴 | **done** |
+| **K1** | `examples/org-knowledge/`：目录约定 + 读文件 helper + playbook 一段 | **done** |
+| **K2** | wake 可选 `kb_refs`；编排器可附带；`handle_wake` 加载 sidecar | **done** |
+| **K3** | 可选向量检索侧车；或 `plugins.knowledge` noop 接线 | 按需 |
+| **后置** | 真·进程内多后端、审批流改章程 | Phase 3+ |
+
+---
+
+## 8. 决策记录
+
+| # | 决策 |
+|---|---|
+| K-D1 | 知识库是 **Org 一等能力**，规划遗漏现补；不与「等契约跑稳」挂钩 |
+| K-D2 | Port 名 **`IOrgKnowledge`**；**不进 Kernel** |
+| K-D3 | **与 `IOrgMemory` 分离**；SOP/Skills 归知识库 |
+| K-D4 | **不自研**引擎；成熟栈侧车优先 |
+| K-D5 | v0 交货 = **外部侧车**；`plugins.knowledge` 预留，接线前不伪造 |
+| K-D6 | 消息只传 **`kb_refs`**，不传全文 |
+
+---
+
+## 9. 相关文档
+
+| 文档 | 关系 |
+|---|---|
+| [design-v0.md](./design-v0.md) | Port 表与决策 D12 |
+| [plugin-catalog-v0.md](./plugin-catalog-v0.md) | Knowledge 短名单 |
+| [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员读 KB 的挂载点 |
+| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | DEF-KB / DEF-MEM 拆分 |
+| [`../../examples/org-knowledge/`](../../examples/org-knowledge/) | K1 文件系统侧车（`read_kb.py` + `org_demo`） |

--- a/docs/org-harness/org-orchestrator-member-playbook-v0.md
+++ b/docs/org-harness/org-orchestrator-member-playbook-v0.md
@@ -29,6 +29,7 @@
   → 解析 type == acn.org.work_wake（见契约）
   → list work 找到 work_id，确认仍 open 且 **API assignee = 自己**（空 assignee 不干）
   → 同一 `idempotency_key` 只处理一次（`handle_wake.py` 写本地 idem 文件）
+  → 只读拉组织知识：`examples/org-knowledge/read_kb.py`（默认 charter；或信封 `kb_refs` → `--from-json -`）
   → L1 执行 title/描述要求的活
   → 完成：通知治理方 PATCH done（或 Owner/编排器代关）
   → 放弃：治理 PATCH cancelled
@@ -95,3 +96,5 @@ v0 不要求编排器自动 `done`（避免未干完误关）。
 | [`handle_wake.py`](../../examples/org-orchestrator/handle_wake.py) | 成员侧解析 + work show |
 | [`run_orchestrator.py`](../../examples/org-orchestrator/run_orchestrator.py) | 编排器侧车 |
 | [`smoke_org_orchestrator.sh`](../../scripts/smoke_org_orchestrator.sh) | 狗粮 A（无成员 listen） |
+| [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | 组织知识库 / `kb_refs`（可选） |
+| [`examples/org-knowledge/read_kb.py`](../../examples/org-knowledge/read_kb.py) | K1：接活前读 charter/SOP |

--- a/docs/org-harness/org-orchestrator-wake-contract-v0.md
+++ b/docs/org-harness/org-orchestrator-wake-contract-v0.md
@@ -63,7 +63,10 @@
   "title": "…",
   "status": "todo",
   "assignee": "agt_…",
-  "hint": "Fetch work with acn org work show; complete then ask governance to mark done."
+  "hint": "Fetch work with acn org work show; complete then ask governance to mark done.",
+  "kb_refs": [
+    { "uri": "orgkb://org_…/charter.md", "title": "charter.md" }
+  ]
 }
 ```
 
@@ -76,8 +79,10 @@
 | `title` | 是 | 便于展示；权威仍以 API 为准 |
 | `status` / `assignee` | 建议 | 发送时快照 |
 | `hint` | 否 | 给人/agent 的操作提示 |
+| `kb_refs` | 否 | 组织知识指针（**不塞全文**）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。成员用 sidecar 解析 `orgkb://` |
 
-成员侧：**以 `work_id` 再拉一次 Org API 为准**，勿盲信快照字段。
+成员侧：**以 `work_id` 再拉一次 Org API 为准**，勿盲信快照字段。  
+`kb_refs` 的 org_id 须与信封 `org_id` 一致；全文由 [`examples/org-knowledge/`](../../examples/org-knowledge/) 拉取（`handle_wake.py` 已接）。
 
 ### 3.2 与 Mode B runtime 的关系
 
@@ -118,6 +123,7 @@
 ## 6. 成员收到后怎么做（契约期望）
 
 1. 解析 `type == acn.org.work_wake`。  
+1b. （可选）按 `kb_refs` 或默认 `charter.md` 只读拉组织知识，再开工。  
 2. `acn org work list` / 等价 list API 找到该 `work_id`，确认仍 open 且自己是 assignee（v0 **无** `GET /work/{id}`）。  
 3. 用自身 L1 执行。  
 4. 完成：经治理路径 `PATCH` → `done`（成员 key 若无治理权，则回报 Owner/编排器代关，或人工/脚本）。  

--- a/docs/org-harness/org-pattern-adapter-spec-v0.md
+++ b/docs/org-harness/org-pattern-adapter-spec-v0.md
@@ -207,7 +207,7 @@ create/accept/review on the new path.
 
 ### Explicit non-goals for v0 acceptance
 
-- Org-wide vector memory / SOP search
+- Org-wide vector memory / Knowledge Port search（见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)；侧车路径不阻塞本 Spec）
 - Cross-org reputation aggregation
 - Automated dispute / jury
 - Federation across Pasture instances
@@ -223,7 +223,8 @@ when scheduled.
 
 | ID | Module | Notes | Suggested owners |
 |---|---|---|---|
-| DEF-MEM | **Org Memory / SOPs** | Cross-member memory, playbooks; Pattern-local store (Mem0/Zep/PG+vector) or Skills packs | Org Pattern |
+| DEF-KB | **Org Knowledge** | Authoritative charter / SOP / Skills; sidecar first (`IOrgKnowledge`); see [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | Org Pattern |
+| DEF-MEM | **Org Memory** | Cross-member facts / narrative (Mem0/Zep/PG+vector); **not** SOP (that is DEF-KB) | Org Pattern |
 | DEF-ORGREP | **Cross-org reputation** | Org-level trust, not only ERC-8004 agent reads | ACN + Pattern |
 | DEF-DISPUTE | **Dispute** | Arbitration after escrow window (ADR-0010 Future) | Backend ledger + ACN events |
 | DEF-FED | **Federation** | Cross-Pasture discovery/messaging ([../federation.md](../federation.md)) | ACN |

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -1,7 +1,7 @@
 # Org Harness — Plugin catalog v0（官方推荐短名单）
 
 **Status:** Draft for operators · not a marketplace  
-**Last updated:** 2026-07-25  
+**Last updated:** 2026-07-27  
 **Audience:** Org 创建者、Pattern 作者、ACN 维护者
 
 > **官方先筛一波，不自研全家桶。**  
@@ -9,8 +9,8 @@
 > `shipped` / `adapter-planned` / `community-welcome` / `deferred`。  
 > 完整插件宿主（发现、版本、热加载）→ Phase 3；本文只解决冷启动。
 
-相关：[design-v0.md](./design-v0.md) **§0 架构导读** · §5.3 · [phase2-work-port-v0.md](./phase2-work-port-v0.md) ·
-[ADR-0014](../adr/0014-org-harness-module.md)
+相关：[design-v0.md](./design-v0.md) **§0 架构导读** · §5.3 · [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) ·
+[phase2-work-port-v0.md](./phase2-work-port-v0.md) · [ADR-0014](../adr/0014-org-harness-module.md)
 
 ---
 
@@ -32,7 +32,8 @@
 |---|---|
 | 组织内派活 + Paperclip Issues | **默认** `builtin_work` + 装 [`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin)（外部 Pattern，**不是** `plugins.work=paperclip`） |
 | 面向网络发赏金 | **旁路** [org-task-bridge](./org-task-bridge-v0.md) / Org wallet；**不要**改 `plugins.work` |
-| 组织共享记忆 / SOP | 先 `noop`；需要时按下方 Memory 短名单自建侧车，等 `adapter-planned` |
+| 组织知识库（章程 / SOP / Skills） | **外部侧车**（[`examples/org-knowledge/`](../../examples/org-knowledge/) · smoke）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。勿伪造 `plugins.knowledge=*` |
+| 组织共享记忆（事实 / 叙事） | 先 `memory=noop`；需要时按下方 Memory 短名单自建侧车 |
 | Task Pool 当组织工单后端 | **`deferred`**（`plugins.work=task_pool` 会 `plugin_unavailable`） |
 
 非法或未接线的 id → API 明确报错（`unknown_plugin` / `plugin_unavailable`），不会静默忽略。
@@ -52,9 +53,10 @@
 
 - 「我想换一套组织编排」→ 写/装 **外部 Pattern**，Kernel 仍用默认 `builtin_work`。  
 - 「我想接 Mem0」→ **侧车** + 文档契约；等标成 `adapter-planned` 落地前，不必也不该伪造 `plugins.memory=mem0`（今日会失败）。  
+- 「我想建组织知识库」→ **外部侧车**（git/SOP）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。勿伪造 `plugins.knowledge=*`。  
 - 「我想把自研代码热加载进 ACN」→ **非目标**（见文末）；请走外部进程。
 
-Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构对话；**不是**「每个轴今天都有可选货架」。v0 必要落地仍是 Kernel + Work + 薄 Loop + Events；其余槽位先占位、再官方筛选适配。
+Port 划分（Work / Loop / Knowledge / Memory / …）是**问题轴**，充分用于架构对话；**不是**「每个轴今天都有可选货架」。v0 必要落地仍是 Kernel + Work + 薄 Loop + Events；其余槽位先占位、再官方筛选适配。
 
 ---
 
@@ -63,7 +65,9 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 | 状态 | 含义 |
 |---|---|
 | **shipped** | ACN 进程内已接线，或官方外部适配已可用 |
+| **examples-shipped** | 官方 examples / smoke 已可用；进程内 `plugins.*` 未必接线 |
 | **adapter-planned** | 官方打算写薄适配 / 文档契约；组件本身用现成 OSS |
+| **plugin-planned** | `plugins.*` id 预留，尚未进白名单 |
 | **community-welcome** | 欢迎按 Port 契约接；暂不承诺官方维护 |
 | **deferred** | 已知 id 或方向，当前刻意不做 |
 
@@ -90,18 +94,27 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 | **ACN Org 编排器**（叫醒成员 agent） | **adapter-planned**（P2 examples） | Loop 轴外部 Pattern；[产品定义](./org-orchestrator-v0.md) · [唤醒契约](./org-orchestrator-wake-contract-v0.md) · [`examples/org-orchestrator/`](../../examples/org-orchestrator/)。无 `plugins.loop=orchestrator`。 |
 | **ClawTeam ↔ Org Loop 适配器** | **adapter-planned**（选型 only） | 编排器的**可选**执行后端：Org work ↔ CT task；见 [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md)。 |
 
-### 3. Memory — `IOrgMemory`（`plugins.memory`）
+### 3. Knowledge — `IOrgKnowledge`（`plugins.knowledge` 预留）
+
+| id / 方向 | 状态 | 说明 |
+|---|---|---|
+| **git / 文件侧车**（按 `org_id`） | **examples-shipped**（K1+K2） | **推荐默认交货**。章程 / SOP / Skills；成员只读；wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) · [`examples/org-knowledge/`](../../examples/org-knowledge/) · `smoke_org_knowledge.sh`。 |
+| `noop`（进程内） | **plugin-planned**（未接线） | 预留；接线前不要传 `plugins.knowledge`。 |
+| 外挂 KB / RAG（语雀、Notion、PG+vector…） | **community-welcome** | 成熟栈接入；ACN **不自研**引擎。 |
+
+组织刚需；与 Memory **分开选型**。
+
+### 4. Memory — `IOrgMemory`（`plugins.memory`）
 
 | id / 方向 | 状态 | 说明 |
 |---|---|---|
 | **`noop`** | **shipped** | 默认占位：无组织共享记忆，成员靠各自 L1。 |
 | **Mem0**（或兼容「事实/画像」记忆服务） | **adapter-planned** | 适合组织级「长期事实 / 偏好」侧车；官方后续薄适配，**不自研记忆引擎**。 |
 | **Zep / Graphiti** 一类（时序 + 图谱） | **adapter-planned** | 适合多会话、多成员共享叙事与实体关系。 |
-| SOP / Skills 包（文件或 git） | **community-welcome** | 流程文档当只读输入给 Work/Loop；可与向量记忆分离（见 design-v0）。 |
 
-选型提示：先问「要记住的是事实、对话轨迹，还是 SOP」——三类可以不同组件，不必一个 OSS 打满。
+选型提示：先问「要的是 **SOP（→ Knowledge）**、事实，还是对话轨迹」——三类可以不同组件，不必一个 OSS 打满。
 
-### 4. Capability — `ICapabilityPool`
+### 5. Capability — `ICapabilityPool`
 
 | 方向 | 状态 | 说明 |
 |---|---|---|
@@ -110,14 +123,14 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 
 今日**无** `plugins.capability` 字段强制项；能力发现仍靠成员 agent 自身。
 
-### 5. Policy / Budget — `IPolicyBudget`
+### 6. Policy / Budget — `IPolicyBudget`
 
 | 方向 | 状态 | 说明 |
 |---|---|---|
 | **Kernel 角色**（owner / manager / worker…） | **shipped** | 治理与 treasury 规则在 Kernel；见 ADR-0014。 |
 | 审批流 / 月度硬停 / manager mandate | **deferred** | Org wallet 亦将 mandate 后置；有真实需求再开 Port。 |
 
-### 6. Events — `IEventSink`
+### 7. Events — `IEventSink`
 
 | 方向 | 状态 | 说明 |
 |---|---|---|
@@ -165,3 +178,5 @@ Port 划分（Work / Loop / Memory / …）是**问题轴**，充分用于架构
 |---|---|
 | 2026-07-25 | 初稿：冷启动短名单 + 创建 Org 选择表 |
 | 2026-07-25 | 硬约定：自定义优先外部适配；`plugins.*` 仅官方/进程内 |
+| 2026-07-27 | 升格 **Knowledge** Port；SOP/Skills 从 Memory 拆出；链 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) |
+| 2026-07-27 | Knowledge：**examples-shipped**（K1+K2）；图例补 examples-shipped / plugin-planned |

--- a/examples/org-knowledge/README.md
+++ b/examples/org-knowledge/README.md
@@ -1,0 +1,70 @@
+# Org 知识库（外部侧车）— K1 / K2 消费端
+
+按 `org_id` 的**文件系统 / git** 知识树：章程、SOP、playbooks、skills。  
+成员接活时**只读**拉取；**不是** ACN Kernel，**不是** `plugins.knowledge`（未接线），**不是** Memory。
+
+| 文档 | 链接 |
+|---|---|
+| Port 定义 | [org-knowledge-base-v0.md](../../docs/org-harness/org-knowledge-base-v0.md) |
+| 唤醒契约（`kb_refs`） | [org-orchestrator-wake-contract-v0.md](../../docs/org-harness/org-orchestrator-wake-contract-v0.md) |
+| 成员 playbook | [org-orchestrator-member-playbook-v0.md](../../docs/org-harness/org-orchestrator-member-playbook-v0.md) |
+
+## 信任边界（必读）
+
+- 本侧车**不**查 ACN Membership / 角色。  
+- 能跑进程且能读 `ORG_KB_ROOT` 的主体，就能读其下**任意** `orgs/<org_id>/`。  
+- **不要**把多租户知识树裸放在同一 root 上，再交给不可信 runner。部署上按 org 隔离挂载（或每 runner 只挂一个 org）。  
+- Path traversal 与指向树外的 symlink 会被拒绝；单文件默认上限 **512KB**（`ORG_KB_MAX_FILE_BYTES`）。
+
+## 目录约定
+
+```text
+$ORG_KB_ROOT/orgs/<org_id>/
+  charter.md
+  sop/
+  playbooks/
+  skills/
+```
+
+默认 `ORG_KB_ROOT` = 本目录下 `data/`（含示例 `org_demo`）。
+
+## 环境变量
+
+| 变量 | 说明 |
+|---|---|
+| `ORG_KB_ROOT` | 知识树根；默认 `./data` |
+| `ORG_KB_ORG_ID` | 默认 org；与 `--org` 一起会**钉死** URI 的 org_id |
+| `ORG_KB_MAX_FILE_BYTES` | 单文件上限，默认 `524288` |
+
+## 试用
+
+```bash
+cd examples/org-knowledge
+
+python3 read_kb.py --org org_demo
+python3 read_kb.py --org org_demo --ref orgkb://org_demo/sop/release.md
+
+# 跨 org URI 会被拒绝
+python3 read_kb.py --org org_demo --ref orgkb://org_other/charter.md   # exit 1
+
+echo '{"kb_refs":[{"uri":"orgkb://org_demo/charter.md"},{"uri":"orgkb://org_demo/sop/release.md","title":"发版"}]}' \
+  | python3 read_kb.py --org org_demo --from-json -
+```
+
+本地 smoke（无 ACN）：
+
+```bash
+./scripts/smoke_org_knowledge.sh
+```
+
+## 与编排器（K2）
+
+- 编排器信封可带可选 `kb_refs[]`（work 字段 / `ORG_KB_REFS_JSON` / `ORG_KB_ATTACH_DEFAULTS=1`）。  
+- `handle_wake.py` 在校验通过后加载 sidecar（`HANDLE_WAKE_SKIP_KB=1` 可关）。
+
+```bash
+export ORG_KB_ROOT=$(pwd)/data
+export HANDLE_WAKE_SKIP_FETCH=1
+echo '{"type":"acn.org.work_wake","org_id":"org_demo","work_id":"work_x","assignee":"agt","idempotency_key":"k","kb_refs":[{"uri":"orgkb://org_demo/charter.md"}]}' \
+  | python3 ../org-orchestrator/handle_wake.py
+```

--- a/examples/org-knowledge/data/orgs/org_demo/charter.md
+++ b/examples/org-knowledge/data/orgs/org_demo/charter.md
@@ -1,0 +1,6 @@
+# org_demo — Charter
+
+- Collaboration subjects are **agents**; humans are optional Owners.
+- Follow Org work status; do not invent Task Pool IDs.
+- Prefer reading SOP under `sop/` before ad-hoc process.
+- Do not write secrets into the knowledge tree; use Memory or vaults for that.

--- a/examples/org-knowledge/data/orgs/org_demo/playbooks/on_wake.md
+++ b/examples/org-knowledge/data/orgs/org_demo/playbooks/on_wake.md
@@ -1,0 +1,6 @@
+# Playbook — on `acn.org.work_wake`
+
+1. Parse wake; verify assignee is you via Org work API.
+2. Load knowledge: `read_kb.py --org <org_id>` or use `kb_refs` from the envelope.
+3. Do the work with L1 harness.
+4. Ask governance to close the work item.

--- a/examples/org-knowledge/data/orgs/org_demo/skills/README.md
+++ b/examples/org-knowledge/data/orgs/org_demo/skills/README.md
@@ -1,0 +1,4 @@
+# Skills fragments
+
+Drop reusable skill snippets here (markdown or skill packs).
+Members pull by `orgkb://org_demo/skills/…` when a work item references them.

--- a/examples/org-knowledge/data/orgs/org_demo/sop/release.md
+++ b/examples/org-knowledge/data/orgs/org_demo/sop/release.md
@@ -1,0 +1,6 @@
+# SOP — Release checklist
+
+1. Confirm work item is assigned to you and still open.
+2. Run tests / smoke required by the work description.
+3. Post a short completion note to the Org Owner / governance channel.
+4. Ask governance to `PATCH` work → `done` (member keys usually cannot).

--- a/examples/org-knowledge/kb.py
+++ b/examples/org-knowledge/kb.py
@@ -1,0 +1,213 @@
+"""Org knowledge base (filesystem sidecar) — resolve orgkb:// and read paths.
+
+Layout (under ORG_KB_ROOT, default: alongside this package):
+
+  orgs/<org_id>/
+    charter.md
+    sop/
+    playbooks/
+    skills/
+
+Trust boundary: this sidecar does **not** call ACN Membership. Anyone who can
+run the process and read ORG_KB_ROOT can read any org tree under it. Do not put
+multiple tenants' trees on one root shared with untrusted runners.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import unquote, urlparse
+
+ORGKB_SCHEME = "orgkb"
+DEFAULT_ENTRYPOINTS = ("charter.md",)
+# Reject whole-file reads above this (bytes). Override with ORG_KB_MAX_FILE_BYTES.
+DEFAULT_MAX_FILE_BYTES = 512_000
+
+_ORG_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class KbRef:
+    """One knowledge pointer (from wake/work or CLI)."""
+
+    uri: str
+    title: str = ""
+
+    @classmethod
+    def from_mapping(cls, raw: dict) -> "KbRef":
+        uri = str(raw.get("uri") or "").strip()
+        if not uri:
+            raise ValueError("kb_ref missing uri")
+        return cls(uri=uri, title=str(raw.get("title") or "").strip())
+
+
+def max_file_bytes() -> int:
+    raw = os.environ.get("ORG_KB_MAX_FILE_BYTES", "").strip()
+    if not raw:
+        return DEFAULT_MAX_FILE_BYTES
+    n = int(raw)
+    if n < 1:
+        raise ValueError("ORG_KB_MAX_FILE_BYTES must be >= 1")
+    return n
+
+
+def default_kb_root() -> Path:
+    env = os.environ.get("ORG_KB_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    return (Path(__file__).resolve().parent / "data").resolve()
+
+
+def org_dir(org_id: str, root: Path | None = None) -> Path:
+    if not _ORG_ID_RE.match(org_id or ""):
+        raise ValueError(f"invalid org_id: {org_id!r}")
+    base = (root or default_kb_root()).resolve()
+    return (base / "orgs" / org_id).resolve()
+
+
+def resolve_orgkb_uri(uri: str, *, root: Path | None = None) -> tuple[str, Path]:
+    """Return (org_id, absolute file path) for orgkb://org_id/rel/path.
+
+    Rejects path traversal outside that org's tree (including symlinks out).
+    """
+    raw = (uri or "").strip()
+    if not raw:
+        raise ValueError("empty uri")
+
+    # Bare relative paths when ORG_KB_ORG_ID is set (CLI convenience).
+    if not raw.startswith(f"{ORGKB_SCHEME}:"):
+        org_id = os.environ.get("ORG_KB_ORG_ID", "").strip()
+        if not org_id:
+            raise ValueError(
+                f"relative path {raw!r} needs orgkb://… or ORG_KB_ORG_ID"
+            )
+        return org_id, _safe_file(org_id, raw, root=root)
+
+    # Accept orgkb://org/path, orgkb:/org/path, orgkb:///org/path
+    normalized = raw if "://" in raw else raw.replace("orgkb:", "orgkb://", 1)
+    parsed = urlparse(normalized)
+    if parsed.scheme != ORGKB_SCHEME:
+        raise ValueError(f"unsupported scheme: {parsed.scheme!r} (want orgkb)")
+    org_id = unquote(parsed.netloc or "").strip()
+    rel = unquote(parsed.path or "").lstrip("/")
+    if not org_id:
+        path_parts = [p for p in rel.split("/") if p]
+        if len(path_parts) < 2:
+            raise ValueError(f"orgkb uri missing org_id: {raw!r}")
+        org_id, rel = path_parts[0], "/".join(path_parts[1:])
+    if not rel:
+        raise ValueError(f"orgkb uri missing path: {raw!r}")
+    return org_id, _safe_file(org_id, rel, root=root)
+
+
+def _safe_file(org_id: str, rel: str, *, root: Path | None = None) -> Path:
+    odir = org_dir(org_id, root=root)
+    candidate = (odir / rel).resolve()
+    try:
+        candidate.relative_to(odir)
+    except ValueError as e:
+        raise ValueError(f"path escapes org tree: {rel!r}") from e
+    return candidate
+
+
+def assert_refs_match_org(
+    refs: Iterable[KbRef | str | dict],
+    expected_org_id: str,
+    *,
+    root: Path | None = None,
+) -> None:
+    """Reject any ref whose URI resolves to a different org_id."""
+    if not expected_org_id:
+        raise ValueError("expected_org_id required")
+    for item in refs:
+        if isinstance(item, dict):
+            ref = KbRef.from_mapping(item)
+        elif isinstance(item, KbRef):
+            ref = item
+        else:
+            ref = KbRef(uri=str(item))
+        org_id, _path = resolve_orgkb_uri(ref.uri, root=root)
+        if org_id != expected_org_id:
+            raise ValueError(
+                f"kb_ref org_id {org_id!r} != expected {expected_org_id!r} ({ref.uri})"
+            )
+
+
+def read_ref(
+    ref: KbRef | str,
+    *,
+    root: Path | None = None,
+    max_bytes: int | None = None,
+) -> tuple[KbRef, str]:
+    kb_ref = ref if isinstance(ref, KbRef) else KbRef(uri=str(ref))
+    _org_id, path = resolve_orgkb_uri(kb_ref.uri, root=root)
+    if not path.is_file():
+        raise FileNotFoundError(str(path))
+    limit = max_file_bytes() if max_bytes is None else max_bytes
+    size = path.stat().st_size
+    if size > limit:
+        raise ValueError(
+            f"file too large ({size} bytes > {limit}): {path}"
+        )
+    text = path.read_text(encoding="utf-8")
+    return kb_ref, text
+
+
+def read_refs(
+    refs: Iterable[KbRef | str | dict],
+    *,
+    root: Path | None = None,
+    expected_org_id: str | None = None,
+    max_bytes: int | None = None,
+) -> list[tuple[KbRef, str]]:
+    items = list(refs)
+    if expected_org_id:
+        assert_refs_match_org(items, expected_org_id, root=root)
+    out: list[tuple[KbRef, str]] = []
+    for item in items:
+        if isinstance(item, dict):
+            ref = KbRef.from_mapping(item)
+        elif isinstance(item, KbRef):
+            ref = item
+        else:
+            ref = KbRef(uri=str(item))
+        out.append(read_ref(ref, root=root, max_bytes=max_bytes))
+    return out
+
+
+def default_refs_for_org(org_id: str) -> list[KbRef]:
+    """Minimal defaults when wake/work has no kb_refs."""
+    return [
+        KbRef(uri=f"orgkb://{org_id}/{name}", title=name)
+        for name in DEFAULT_ENTRYPOINTS
+    ]
+
+
+def default_refs_as_dicts(org_id: str) -> list[dict]:
+    return [{"uri": r.uri, "title": r.title} for r in default_refs_for_org(org_id)]
+
+
+def format_bundle(pairs: list[tuple[KbRef, str]], *, max_chars: int = 24_000) -> str:
+    """Concatenate refs for L1 prompt injection; truncate fairly if huge."""
+    parts: list[str] = []
+    used = 0
+    for ref, body in pairs:
+        header = f"### {ref.title or ref.uri}\n"
+        chunk = header + body.rstrip() + "\n"
+        if used + len(chunk) > max_chars and parts:
+            parts.append(
+                f"\n… truncated ({len(pairs) - len(parts)} more ref(s) omitted)\n"
+            )
+            break
+        if used + len(chunk) > max_chars:
+            remain = max_chars - used - len(header) - 20
+            chunk = header + body[: max(0, remain)] + "\n… truncated\n"
+            parts.append(chunk)
+            break
+        parts.append(chunk)
+        used += len(chunk)
+    return "\n".join(parts)

--- a/examples/org-knowledge/kb.py
+++ b/examples/org-knowledge/kb.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 from urllib.parse import unquote, urlparse
 
 ORGKB_SCHEME = "orgkb"
@@ -38,7 +38,7 @@ class KbRef:
     title: str = ""
 
     @classmethod
-    def from_mapping(cls, raw: dict) -> "KbRef":
+    def from_mapping(cls, raw: dict) -> KbRef:
         uri = str(raw.get("uri") or "").strip()
         if not uri:
             raise ValueError("kb_ref missing uri")

--- a/examples/org-knowledge/read_kb.py
+++ b/examples/org-knowledge/read_kb.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""CLI: load Org knowledge (filesystem sidecar) for a member agent before work.
+
+Examples:
+  ORG_KB_ORG_ID=org_demo python3 read_kb.py
+  python3 read_kb.py --org org_demo --ref orgkb://org_demo/sop/release.md
+  echo '{"kb_refs":[{"uri":"orgkb://org_demo/charter.md"}]}' | python3 read_kb.py --from-json -
+
+Trust: see kb.py module docstring / README — no ACN ACL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow `python3 read_kb.py` from any cwd.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from kb import (  # noqa: E402
+    KbRef,
+    default_kb_root,
+    default_refs_for_org,
+    format_bundle,
+    read_refs,
+    resolve_orgkb_uri,
+)
+
+
+def _parse_refs_from_json(raw: str) -> list[KbRef]:
+    data = json.loads(raw)
+    if isinstance(data, list):
+        items = data
+    elif isinstance(data, dict):
+        items = data.get("kb_refs") or data.get("refs") or []
+    else:
+        raise ValueError("JSON must be object with kb_refs or a list")
+    return [
+        KbRef.from_mapping(x) if isinstance(x, dict) else KbRef(uri=str(x))
+        for x in items
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Read Org knowledge base (sidecar)")
+    p.add_argument("--org", default="", help="org_id (or ORG_KB_ORG_ID); pins URI org")
+    p.add_argument(
+        "--root",
+        default="",
+        help="ORG_KB_ROOT (default: examples/org-knowledge/data)",
+    )
+    p.add_argument(
+        "--ref",
+        action="append",
+        default=[],
+        help="orgkb://… or relative path (repeatable)",
+    )
+    p.add_argument(
+        "--from-json",
+        default="",
+        help="path to JSON with kb_refs, or '-' for stdin",
+    )
+    p.add_argument(
+        "--max-chars",
+        type=int,
+        default=24_000,
+        help="truncate bundled output (default 24000)",
+    )
+    p.add_argument(
+        "--json-out",
+        action="store_true",
+        help="emit JSON list of {uri,title,path,text} instead of markdown bundle",
+    )
+    args = p.parse_args(argv)
+
+    if args.root:
+        os.environ["ORG_KB_ROOT"] = args.root
+    root = default_kb_root()
+
+    org_id = (args.org or os.environ.get("ORG_KB_ORG_ID", "")).strip()
+    refs: list[KbRef] = []
+
+    if args.from_json:
+        raw = (
+            sys.stdin.read()
+            if args.from_json == "-"
+            else Path(args.from_json).read_text(encoding="utf-8")
+        )
+        refs.extend(_parse_refs_from_json(raw))
+
+    for r in args.ref:
+        refs.append(KbRef(uri=r.strip()))
+
+    if not refs:
+        if not org_id:
+            print(
+                "Need --org / ORG_KB_ORG_ID, or --ref / --from-json",
+                file=sys.stderr,
+            )
+            return 2
+        refs = default_refs_for_org(org_id)
+        os.environ.setdefault("ORG_KB_ORG_ID", org_id)
+
+    # Pin org when provided: reject cross-org URIs.
+    if org_id:
+        os.environ.setdefault("ORG_KB_ORG_ID", org_id)
+
+    try:
+        pairs = read_refs(refs, root=root, expected_org_id=org_id or None)
+    except (ValueError, FileNotFoundError, OSError, json.JSONDecodeError) as e:
+        print(f"[read_kb] error: {e}", file=sys.stderr)
+        return 1
+
+    if args.json_out:
+        payload = []
+        for ref, text in pairs:
+            _oid, path = resolve_orgkb_uri(ref.uri, root=root)
+            payload.append(
+                {
+                    "uri": ref.uri,
+                    "title": ref.title,
+                    "path": str(path),
+                    "text": text,
+                }
+            )
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(format_bundle(pairs, max_chars=args.max_chars), end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/org-orchestrator/README.md
+++ b/examples/org-orchestrator/README.md
@@ -18,6 +18,8 @@
 | `ACN_API_KEY` | 发送方 agent key（`from_agent` = `agents/me`）；若要标 `in_progress` 需**治理**权限 |
 | `POLL_INTERVAL_SEC` | 默认 `30` |
 | `ORCHESTRATOR_IDEM_PATH` | 幂等文件，默认 `./.org-orchestrator-idem.json` |
+| `ORG_KB_ATTACH_DEFAULTS` | `1` 时 wake 附带 `kb_refs` → `orgkb://{org}/charter.md` |
+| `ORG_KB_REFS_JSON` | 全局默认 `kb_refs` JSON（list 或 `{kb_refs:[…]}`） |
 
 ## 跑一轮
 
@@ -61,6 +63,9 @@ ACN_BASE_URL=… ACN_API_KEY=acn_… ./scripts/smoke_org_orchestrator_member_e2e
 # 仅解析（无网络）
 echo '{"type":"acn.org.work_wake","org_id":"org_x","work_id":"work_y","assignee":"agt_z"}' \
   | HANDLE_WAKE_SKIP_FETCH=1 python3 handle_wake.py
+
+# 知识库 sidecar（无 ACN）
+../scripts/smoke_org_knowledge.sh
 ```
 
 ## 成员侧 `handle_wake.py`
@@ -70,8 +75,10 @@ Mode B：
 ```bash
 export ACN_BASE_URL=… ACN_API_KEY=acn_member_…
 # optional: HANDLE_WAKE_IDEM_PATH=./.handle-wake-idem.json
+# optional: ORG_KB_ROOT=…  HANDLE_WAKE_SKIP_KB=1
 acn listen --runtime command --wake-exec "python3 $(pwd)/handle_wake.py"
 ```
 
 校验：work 必须 open 且 **API assignee = 自己**（空 assignee → 不 OK）；同一
-`idempotency_key` 只 OK 一次。
+`idempotency_key` 只 OK 一次。校验通过后按信封 `kb_refs`（或默认 charter）加载
+[`../org-knowledge/`](../org-knowledge/)（见知识库信任边界）。

--- a/examples/org-orchestrator/handle_wake.py
+++ b/examples/org-orchestrator/handle_wake.py
@@ -8,6 +8,8 @@ Env:
   ACN_BASE_URL, ACN_API_KEY — member key (list work / agents/me)
   HANDLE_WAKE_IDEM_PATH — member-side seen keys (default ./.handle-wake-idem.json)
   HANDLE_WAKE_SKIP_FETCH — if set, parse only (no API / no dedupe claim)
+  HANDLE_WAKE_SKIP_KB — if set, do not load Org knowledge sidecar
+  ORG_KB_ROOT — filesystem knowledge root (default: ../org-knowledge/data)
 
 Exit 0: handled, deduped, ignored non-wake, or skip-fetch parse ok.
 Exit 1: wake recognized but validation/API failed.
@@ -20,12 +22,14 @@ import json
 import os
 import sys
 import urllib.error
+from pathlib import Path
 from typing import Any
 
 from acn_client_min import WorkNotFoundError, agents_me, get_work, normalize_base
 from idempotency import IdempotencyStore
 
 WAKE_TYPE = "acn.org.work_wake"
+_KB_DIR = Path(__file__).resolve().parent.parent / "org-knowledge"
 
 
 def _load_stdin() -> Any:
@@ -138,10 +142,56 @@ def assignee_matches_me(
     return True, ""
 
 
+def load_knowledge_bundle(wake: dict[str, Any]) -> str | None:
+    """Read Org KB sidecar using wake.kb_refs or default charter. None if skipped/missing."""
+    if str(_KB_DIR) not in sys.path:
+        sys.path.insert(0, str(_KB_DIR))
+    try:
+        from kb import (  # type: ignore
+            default_kb_root,
+            default_refs_for_org,
+            format_bundle,
+            read_refs,
+        )
+    except ImportError as e:
+        print(f"[handle_wake] kb import failed: {e}", flush=True)
+        return None
+
+    org_id = str(wake.get("org_id") or "").strip()
+    if not org_id:
+        return None
+
+    if not os.environ.get("ORG_KB_ROOT", "").strip():
+        # Prefer example data next to this repo layout.
+        os.environ.setdefault("ORG_KB_ROOT", str(default_kb_root()))
+
+    raw_refs = wake.get("kb_refs")
+    refs: list[Any]
+    if isinstance(raw_refs, list) and raw_refs:
+        refs = raw_refs
+    else:
+        refs = default_refs_for_org(org_id)
+
+    try:
+        pairs = read_refs(refs, expected_org_id=org_id)
+    except FileNotFoundError as e:
+        print(f"[handle_wake] kb missing (ok to continue): {e}", flush=True)
+        return None
+    except (ValueError, OSError) as e:
+        print(f"[handle_wake] kb load failed: {e}", flush=True)
+        return None
+    return format_bundle(pairs)
+
+
 def main() -> int:
     base_url = os.environ.get("ACN_BASE_URL", "").strip()
     api_key = os.environ.get("ACN_API_KEY", "").strip()
     skip_fetch = os.environ.get("HANDLE_WAKE_SKIP_FETCH", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+    skip_kb = os.environ.get("HANDLE_WAKE_SKIP_KB", "").strip().lower() in (
         "1",
         "true",
         "yes",
@@ -174,6 +224,11 @@ def main() -> int:
     if skip_fetch:
         print("[handle_wake] HANDLE_WAKE_SKIP_FETCH set — not calling API", flush=True)
         print(json.dumps(wake, ensure_ascii=False, indent=2), flush=True)
+        if not skip_kb:
+            bundle = load_knowledge_bundle(wake)
+            if bundle:
+                print("[handle_wake] knowledge bundle:", flush=True)
+                print(bundle, end="" if bundle.endswith("\n") else "\n", flush=True)
         return 0
 
     if not base_url or not api_key:
@@ -252,7 +307,28 @@ def main() -> int:
         "ask governance to PATCH done|cancelled when finished.",
         flush=True,
     )
-    print(json.dumps({"wake": wake, "work": work}, ensure_ascii=False, indent=2), flush=True)
+    kb_bundle = None
+    if not skip_kb:
+        kb_bundle = load_knowledge_bundle(wake)
+        if kb_bundle:
+            print("[handle_wake] knowledge bundle:", flush=True)
+            print(
+                kb_bundle,
+                end="" if kb_bundle.endswith("\n") else "\n",
+                flush=True,
+            )
+    print(
+        json.dumps(
+            {
+                "wake": wake,
+                "work": work,
+                "knowledge_loaded": bool(kb_bundle),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        flush=True,
+    )
     try:
         store.confirm(idem)
     except OSError as e:

--- a/examples/org-orchestrator/run_orchestrator.py
+++ b/examples/org-orchestrator/run_orchestrator.py
@@ -32,10 +32,41 @@ def wake_key(org_id: str, wid: str, assignee: str) -> str:
     return f"{org_id}:{wid}:wake:{WAKE_GENERATION}:{assignee}"
 
 
+def _kb_refs_for_item(org_id: str, item: dict) -> list[dict]:
+    """Optional kb_refs: work field → ORG_KB_REFS_JSON → ORG_KB_ATTACH_DEFAULTS."""
+    raw = item.get("kb_refs")
+    if isinstance(raw, list) and raw:
+        return [x for x in raw if isinstance(x, dict) and x.get("uri")]
+
+    env_json = os.environ.get("ORG_KB_REFS_JSON", "").strip()
+    if env_json:
+        try:
+            parsed = json.loads(env_json)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list) and parsed:
+            return [x for x in parsed if isinstance(x, dict) and x.get("uri")]
+        if isinstance(parsed, dict) and isinstance(parsed.get("kb_refs"), list):
+            return [
+                x
+                for x in parsed["kb_refs"]
+                if isinstance(x, dict) and x.get("uri")
+            ]
+
+    attach = os.environ.get("ORG_KB_ATTACH_DEFAULTS", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if attach:
+        return [{"uri": f"orgkb://{org_id}/charter.md", "title": "charter.md"}]
+    return []
+
+
 def build_envelope(org_id: str, item: dict) -> dict:
     wid = work_id(item)
     assignee = assignee_id(item)
-    return {
+    envelope = {
         "type": WAKE_TYPE,
         "schema_version": 1,
         "idempotency_key": wake_key(org_id, wid, assignee),
@@ -48,6 +79,10 @@ def build_envelope(org_id: str, item: dict) -> dict:
             "Fetch work with acn org work show; complete then ask governance to mark done."
         ),
     }
+    kb_refs = _kb_refs_for_item(org_id, item)
+    if kb_refs:
+        envelope["kb_refs"] = kb_refs
+    return envelope
 
 
 def process_item(

--- a/scripts/smoke_org_knowledge.sh
+++ b/scripts/smoke_org_knowledge.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Smoke: Org knowledge sidecar (no ACN required)
+#
+# Usage:
+#   ./scripts/smoke_org_knowledge.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KB="${ROOT}/examples/org-knowledge"
+ORCH="${ROOT}/examples/org-orchestrator"
+PY="${ROOT}/.venv/bin/python"
+if [[ ! -x "$PY" ]]; then
+  PY="python3"
+fi
+
+echo "==> Unit tests (org-knowledge)"
+"$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q --no-cov 2>/dev/null \
+  || "$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q -p no:cov 2>/dev/null \
+  || "$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q
+
+echo "==> read_kb.py --org org_demo"
+out="$("$PY" "${KB}/read_kb.py" --org org_demo)"
+echo "$out" | grep -q Charter
+
+echo "==> reject cross-org ref"
+set +e
+"$PY" "${KB}/read_kb.py" --org org_demo --ref 'orgkb://org_other/charter.md' >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 1 ]]
+
+echo "==> handle_wake SKIP_FETCH + kb_refs (uses sample tree)"
+export ORG_KB_ROOT="${KB}/data"
+export HANDLE_WAKE_SKIP_FETCH=1
+wake="$(cat <<EOF
+{"type":"acn.org.work_wake","schema_version":1,"org_id":"org_demo","work_id":"work_smoke","assignee":"agt_x","idempotency_key":"org_demo:work_smoke:wake:1:agt_x","kb_refs":[{"uri":"orgkb://org_demo/sop/release.md","title":"发版"}]}
+EOF
+)"
+out="$(echo "$wake" | "$PY" "${ORCH}/handle_wake.py")"
+echo "$out" | grep -q "knowledge bundle"
+echo "$out" | grep -qiE "Release|SOP"
+
+echo "==> OK smoke_org_knowledge"

--- a/tests/examples/test_org_knowledge_kb.py
+++ b/tests/examples/test_org_knowledge_kb.py
@@ -1,0 +1,149 @@
+"""Unit tests for examples/org-knowledge filesystem sidecar."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EX_DIR = Path(__file__).resolve().parents[2] / "examples" / "org-knowledge"
+sys.path.insert(0, str(EX_DIR))
+
+from kb import (  # noqa: E402
+    KbRef,
+    assert_refs_match_org,
+    default_refs_for_org,
+    format_bundle,
+    org_dir,
+    read_ref,
+    read_refs,
+    resolve_orgkb_uri,
+)
+
+
+@pytest.fixture
+def root() -> Path:
+    return EX_DIR / "data"
+
+
+def test_resolve_orgkb_and_read_charter(root: Path) -> None:
+    org_id, path = resolve_orgkb_uri("orgkb://org_demo/charter.md", root=root)
+    assert org_id == "org_demo"
+    assert path.is_file()
+    pairs = read_refs([KbRef(uri="orgkb://org_demo/charter.md")], root=root)
+    assert "Charter" in pairs[0][1]
+
+
+def test_resolve_path_form_without_netloc(root: Path) -> None:
+    org_id, path = resolve_orgkb_uri("orgkb:/org_demo/sop/release.md", root=root)
+    assert org_id == "org_demo"
+    assert path.name == "release.md"
+
+
+def test_reject_path_traversal(root: Path) -> None:
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_orgkb_uri("orgkb://org_demo/../../etc/passwd", root=root)
+
+
+def test_reject_bad_org_id(root: Path) -> None:
+    with pytest.raises(ValueError, match="invalid org_id"):
+        org_dir("../evil", root=root)
+
+
+def test_reject_cross_org_refs(root: Path) -> None:
+    with pytest.raises(ValueError, match="!= expected"):
+        assert_refs_match_org(
+            [KbRef(uri="orgkb://org_other/charter.md")],
+            "org_demo",
+            root=root,
+        )
+
+
+def test_file_too_large(root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    odir = tmp_path / "orgs" / "org_big"
+    odir.mkdir(parents=True)
+    big = odir / "huge.md"
+    big.write_bytes(b"x" * 1000)
+    monkeypatch.setenv("ORG_KB_MAX_FILE_BYTES", "100")
+    with pytest.raises(ValueError, match="too large"):
+        read_ref(KbRef(uri="orgkb://org_big/huge.md"), root=tmp_path)
+
+
+def test_default_refs_and_bundle(root: Path) -> None:
+    refs = default_refs_for_org("org_demo")
+    pairs = read_refs(refs, root=root, expected_org_id="org_demo")
+    bundle = format_bundle(pairs, max_chars=500)
+    assert "charter" in bundle.lower() or "Charter" in bundle
+
+
+def test_read_kb_cli(root: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(EX_DIR / "read_kb.py"),
+            "--root",
+            str(root),
+            "--org",
+            "org_demo",
+            "--json-out",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data and "text" in data[0]
+
+
+def test_read_kb_cli_rejects_cross_org(root: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(EX_DIR / "read_kb.py"),
+            "--root",
+            str(root),
+            "--org",
+            "org_demo",
+            "--ref",
+            "orgkb://org_other/charter.md",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "ORG_KB_ROOT": str(root)},
+    )
+    assert proc.returncode == 1
+    assert "expected" in proc.stderr or "org_id" in proc.stderr
+
+
+def test_read_kb_cli_from_json_stdin(root: Path) -> None:
+    payload = json.dumps(
+        {
+            "kb_refs": [
+                {"uri": "orgkb://org_demo/sop/release.md", "title": "发版"},
+            ]
+        }
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(EX_DIR / "read_kb.py"),
+            "--root",
+            str(root),
+            "--org",
+            "org_demo",
+            "--from-json",
+            "-",
+        ],
+        check=False,
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Release" in proc.stdout or "SOP" in proc.stdout

--- a/tests/examples/test_org_orchestrator_handle_wake.py
+++ b/tests/examples/test_org_orchestrator_handle_wake.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/tests/examples/test_org_orchestrator_handle_wake.py
+++ b/tests/examples/test_org_orchestrator_handle_wake.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
+import pytest
+
 EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "org-orchestrator"
+KB_DATA = Path(__file__).resolve().parents[2] / "examples" / "org-knowledge" / "data"
 sys.path.insert(0, str(EXAMPLES))
 
-from handle_wake import assignee_matches_me, parse_wake, resolve_idempotency_key  # noqa: E402
+from handle_wake import (  # noqa: E402
+    assignee_matches_me,
+    load_knowledge_bundle,
+    parse_wake,
+    resolve_idempotency_key,
+)
+from run_orchestrator import build_envelope  # noqa: E402
 
 
 def test_parse_direct_wake_object() -> None:
@@ -91,3 +101,42 @@ def test_assignee_matches_me() -> None:
         my_id="agt_a",
     )
     assert ok is True
+
+
+def test_build_envelope_includes_work_kb_refs() -> None:
+    env = build_envelope(
+        "org_1",
+        {
+            "work_id": "work_1",
+            "assignee_agent_id": "agt_a",
+            "title": "t",
+            "status": "todo",
+            "kb_refs": [{"uri": "orgkb://org_1/sop/x.md", "title": "x"}],
+        },
+    )
+    assert env["kb_refs"][0]["uri"] == "orgkb://org_1/sop/x.md"
+
+
+def test_build_envelope_attach_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORG_KB_ATTACH_DEFAULTS", "1")
+    monkeypatch.delenv("ORG_KB_REFS_JSON", raising=False)
+    env = build_envelope(
+        "org_demo",
+        {
+            "work_id": "work_1",
+            "assignee_agent_id": "agt_a",
+            "title": "t",
+            "status": "todo",
+        },
+    )
+    assert env["kb_refs"][0]["uri"] == "orgkb://org_demo/charter.md"
+
+
+def test_load_knowledge_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORG_KB_ROOT", str(KB_DATA))
+    wake = {
+        "org_id": "org_demo",
+        "kb_refs": [{"uri": "orgkb://org_demo/charter.md"}],
+    }
+    bundle = load_knowledge_bundle(wake)
+    assert bundle and "Charter" in bundle


### PR DESCRIPTION
## Summary
- Elevate **`IOrgKnowledge`** as a first-class Org Port (charter/SOP/Skills), split from `IOrgMemory`, with design/catalog/BACKLOG wiring.
- Ship **`examples/org-knowledge/`** filesystem sidecar (`orgkb://`, size limits, org pin, trust-boundary docs) + `smoke_org_knowledge.sh`.
- **K2:** optional wake `kb_refs`; orchestrator can attach defaults; `handle_wake` loads KB before L1.

## Test plan
- [x] `pytest tests/examples/test_org_knowledge_kb.py tests/examples/test_org_orchestrator_handle_wake.py`
- [x] `./scripts/smoke_org_knowledge.sh`
- [ ] Skim [org-knowledge-base-v0.md](docs/org-harness/org-knowledge-base-v0.md) + wake contract `kb_refs` section


Made with [Cursor](https://cursor.com)