### PR TITLE
docs(org): knowledge base is agent-contributed with governance

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -67,7 +67,7 @@ L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
 - **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Knowledge / Memory 等 adapter-planned）。  
-- **Org 知识库：** [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) + [K1/K2 侧车](../../examples/org-knowledge/) · [`smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)（K3 向量/`plugins.knowledge` 按需）。  
+- **Org 知识库：** [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)（**agent 主贡献**；读路径 K1/K2 已落地；**K4 contribute** 下一步）· [侧车](../../examples/org-knowledge/) · [`smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配；知识库 K3。  
 - **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
 - **Org 编排器：** [产品定义](./org-orchestrator-v0.md) P0 + [唤醒契约](./org-orchestrator-wake-contract-v0.md) P1 + [P2 侧车](../../examples/org-orchestrator/)；P3 webhook/催办按需。  

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -222,7 +222,7 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 | **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选/deferred）；自研 DAG；**Paperclip = 外部 Pattern**（非 `plugins.work`） |
 | **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | （将来）ClawTeam **Loop 适配器**、自定义巡检；今日自定义走**外部 Pattern** |
 | **`ICapabilityPool`** | 组织能力目录 | 聚合成员 ACN skills（可先内置非插件） | 外挂 MCP catalog |
-| **`IOrgKnowledge`** | 权威知识（章程 / SOP / Skills） | 外部侧车（见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)）；`plugins.knowledge` 预留 | git/文件、外挂 KB、RAG 侧车 |
+| **`IOrgKnowledge`** | 组织知识（**agent 主贡献**；章程红线 + SOP/Skills/wiki） | 外部侧车读路径已落地；写路径见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | git（默认可选）、llm_wiki 配方、外挂 KB |
 | **`IOrgMemory`** | 集体记忆（事实 / 偏好 / 叙事） | `noop` | Mem0、Zep/Graphiti、PG+vector |
 | **`IPolicyBudget`** | 角色权限、花费 | Kernel 角色枚举 | 审批流、月度硬停 |
 | **`IEventSink`** | 生命周期外推 | subnet harness webhook | 多 webhook、OTel |
@@ -436,7 +436,7 @@ Org Memory 深度、知识库进程内多后端、跨 org 信誉、Dispute、Fed
 | D9 | v0 不做「加人」叙事；复用 subnet 围栏 |
 | D10 | v0 只做满 Kernel + Work + 薄 Loop + Events，避免过度对称 |
 | D11 | 自定义优先 **外部 Pattern**；`plugins.*` 仅官方 Builtin 白名单（见 plugin-catalog） |
-| D12 | **`IOrgKnowledge`** 与 Memory 并列；权威 SOP/Skills ≠ 可写记忆；不进 Kernel；v0 侧车交货（[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)） |
+| D12 | **`IOrgKnowledge`** 与 Memory 并列；**成员 agent 主贡献**，Owner 管红线/仲裁；不进 Kernel；读侧车已交货、写路径设计中（[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)） |
 
 ---
 

--- a/docs/org-harness/org-knowledge-base-v0.md
+++ b/docs/org-harness/org-knowledge-base-v0.md
@@ -1,7 +1,7 @@
 # Org 知识库 — 产品与 Port 定义 v0
 
-**Status:** Design Accepted · **K1+K2 examples 已落地**；进程内 `plugins.knowledge` 尚未接线  
-**Code：** [`examples/org-knowledge/`](../../examples/org-knowledge/) · wake `kb_refs` + `handle_wake` 加载  
+**Status:** Design Accepted（**2026-07-27 修订：agent 主贡献**）· K1+K2 只读侧车已落地；写路径设计中  
+**Code（读路径）：** [`examples/org-knowledge/`](../../examples/org-knowledge/) · wake `kb_refs` + `handle_wake` 加载  
 **Smoke：** [`scripts/smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)  
 
 **Date:** 2026-07-27  
@@ -9,32 +9,30 @@
 **Depends on:** [design-v0.md](./design-v0.md) §5.3 · [plugin-catalog-v0.md](./plugin-catalog-v0.md)  
 **Adjacent:** [org-orchestrator-wake-contract-v0.md](./org-orchestrator-wake-contract-v0.md) · [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md)
 
-> **一句话：** 组织知识库是 Org Harness 的**一等能力**（问题轴 `IOrgKnowledge`）——权威、可版本的章程 / SOP / Skills，供 Work·Loop·成员**只读**消费。  
-> **不是** Kernel，**不是** `IOrgMemory`（记忆是可写沉淀）。  
-> **不自研**检索引擎；用成熟栈做侧车 / 将来薄适配。
+> **一句话：** 组织知识库是 Org Harness 的**一等能力**（`IOrgKnowledge`）——**主要由成员 agent 贡献与维护**的共享知识资产（SOP、复盘、Skills、编译页），供后续 Work 消费。  
+> **不是** Kernel，**不是** `IOrgMemory`（记忆可脏可忘；知识库是组织可治理资产）。  
+> **人 / Owner** 管红线与冲突仲裁，**不是**默认主笔。  
+> **不自研**检索引擎；用成熟栈（git/markdown、可选 LLM Wiki / Obsidian 前端）做侧车。
 
 ### 为什么现在补
 
-Org = 人/agent 边界 + 活 + **知识**。前两块已有 Kernel / Work / Loop；知识库在 v0 叙事里被并进 Memory「集体记忆 / SOP」，属于**规划遗漏**。  
-补法与其它 Port 相同：**先占问题轴 + 默认推荐路径**，实现用现成技术，不要求「先跑稳再转正」。
+Org = 边界 + 活 + **知识**。协作主体是 **agent**，知识也应主要由 agent 在干活中沉淀，而不是假设「人写手册、agent 只读」。  
+早期 K1/K2 只做了**读路径**（冷启动）；本文修订把**贡献模型**订正为终局口径。
 
 ---
 
 ## 1. 要解决什么
 
-成员接到活时需要知道：
+成员接到活时需要知道：组织红线、同类活怎么做、可复用技能在哪。  
+更重要：干完活后要把**可复用结论**写回组织，而不是只留在单个 agent 的 L1 记忆里。
 
-- 组织章程与红线是什么；  
-- 这类活的标准作业程序（SOP）怎么走；  
-- 可复用的 Skills / playbook 片段在哪。
-
-没有组织知识库，每个 agent 只能靠各自 L1 记忆或口头约定——**Org 级真相缺失**。
+没有组织知识库 → Org 级真相缺失，也**无法跨成员复利**。
 
 **不做（本 Port）：**
 
-- 对话轨迹 / 长期事实沉淀 → **`IOrgMemory`**  
+- 对话轨迹 / 偏好抽取 → **`IOrgMemory`**  
 - 成员私有笔记 → L1 harness memory  
-- 把语雀/Notion 再实现一遍 → 选型接入
+- 自研语雀/Notion 级 CMS  
 
 ---
 
@@ -42,167 +40,182 @@ Org = 人/agent 边界 + 活 + **知识**。前两块已有 Kernel / Work / Loop
 
 ```text
 Org Graph（Kernel）          ← 不管文档内容
-Work / Loop                  ← 干活时读知识（指针或检索）
-IOrgKnowledge（本 Port）     ← 权威知识：章程 / SOP / Skills
-IOrgMemory                   ← 运行中沉淀：事实 / 偏好 / 叙事（可脏）
+Work / Loop                  ← 读知识干活；干完可提议写入
+IOrgKnowledge（本 Port）     ← 组织共享知识（agent 主贡献）
+IOrgMemory                   ← 运行沉淀：事实 / 偏好 / 叙事（可脏）
 ```
 
 | 项 | 决定 |
 |---|---|
 | 问题轴 | **`IOrgKnowledge`**（与 Memory 并列） |
-| Kernel | **不进**；不在 Org 表塞文档 blob |
-| SoT（内容） | 知识库后端（git / 对象存储 / 外挂 KB）；ACN 只认 `org_id` 边界与可选指针 |
-| 插法 v0 | **外部侧车**（与编排器同级节奏）；`plugins.knowledge` **预留**，接线前勿伪造 id |
-| 读写 | v0：**读多写少**；写入走人/Owner 流程（PR、外挂 KB 权限），agent 默认只读 |
-| 自研 | **否**——不造向量引擎 / CMS |
+| Kernel | **不进** |
+| SoT（内容） | 知识库后端（git / markdown vault 等）；ACN 认 `org_id` + 指针 / 将来写契约 |
+| 插法 | **外部侧车**；`plugins.knowledge` 预留，接线前勿伪造 |
+| **贡献者** | **成员 agent 为主**；Owner（人/agent）定红线与仲裁 |
+| 自研 | **否** |
+
+### 2.1 贡献模型（Accepted 修订）
+
+| 层 | 谁写 | 说明 |
+|---|---|---|
+| **charter / 红线** | Owner（人 or agent） | 少而稳；改动宜审 |
+| **知识主体**（sop / playbooks / skills / wiki） | **成员 agent** | 完成 work 后提议写入；组织共享 |
+| **记忆** | agent 自动抽 | 不进本 Port |
+
+```text
+agent 干活 → 读 KB → 产出
+           → 提议 contribute（新页 / 补丁）
+           → 治理：自动收 | manager 批 | 标争议
+           → 写入侧车（git commit / vault 更新）
+```
+
+**K1/K2 现状：** 只读侧车——视为冷启动，**不是**终局。  
+**终局：** 读 + **可治理的写** 都是一等能力。
 
 ### 与 Memory 的硬边界
 
 | | **知识库 `IOrgKnowledge`** | **记忆 `IOrgMemory`** |
 |---|---|---|
-| 性质 | 权威资产 | 运行沉淀 |
-| 变更 | 宜审、可回滚 | 可脏、可遗忘 |
-| 典型内容 | charter、SOP、Skills 包 | 事实、偏好、多会话实体 |
-| 消费 | Work / Loop / 成员执行前注入 | 检索增强、画像 |
-| 默认 | 见 §4（侧车推荐） | 今日 `plugins.memory=noop` |
-
-可以共用同一向量库做索引，但**产品与 Port 名必须分开**，避免 SOP 被当成聊天记忆乱写。
+| 性质 | 组织可治理资产（可版本、可争议） | 运行沉淀 |
+| 主作者 | **agent（贡献）** + Owner 红线 | agent 自动抽取 |
+| 变更 | 提议 → 治理 → 落库 | 可脏、可遗忘、冲突消解 |
+| 典型内容 | SOP、复盘、Skills、编译 wiki 页 | 事实、偏好、多会话实体 |
+| 消费 | Work / Loop / 成员执行前 | 检索增强、画像 |
 
 ### 信任边界（文件系统侧车）
 
-- Sidecar **不**做 ACN Membership / 角色鉴权。  
-- 能读 `ORG_KB_ROOT` 即可读其下任意 `orgs/<org_id>/`。  
-- 多租户须在**部署层**隔离（每 runner 一 org，或受控挂载）；勿把不可信进程挂到共享多 org root。  
-- 实现侧已做：path traversal / 出树 symlink 拒绝；单文件默认 ≤512KB；`--org` / `expected_org_id` 拒绝跨 org URI。
+- Sidecar **不**做 ACN Membership 鉴权（部署隔离多租户）。  
+- 写路径落地后：须校验「写作者是该 Org 成员」——优先在**治理/编排侧**做，或侧车校 ACN；勿裸写共享盘。  
+- 读路径已做：traversal / 出树 symlink 拒绝；单文件默认 ≤512KB；跨 org URI 拒绝。
 
-### 行业对照（2025–2026）
+### 行业对照（简）
 
-主流结论：**知识库（RAG）与 Agent Memory 不是竞品，是两套生命周期；生产系统几乎都「两个都要」。**  
-分水岭是有没有 **agent 写回路径**，不是用不用向量库。
+通用 SaaS 常假设「人对 KB 只读、Memory 可写」。  
+**ACN Org 不同：** 协作主体是 agent → **KB 也应以 agent 写为主**，再用治理区分「可进组织资产」与「仅记忆」。  
+Karpathy **LLM Wiki + Obsidian**：适合作为**编译/浏览层配方**（agent 维护互链 markdown；Obsidian 可选前端），与「权威 charter 少而稳」可叠用，**不**单独替代治理。
 
-| | **知识库 / RAG** | **Agent Memory** |
-|---|---|---|
-| 回答 | 「文档/制度说什么？」 | 「关于这个人/这段协作，我记得什么？」 |
-| 读写 | 对人/运营可写；对 agent **基本只读** | agent **持续写**：抽取、更新、遗忘 |
-| 作用域 | 人人（或按 org）一样 | 按 user / session / agent（需租户隔离） |
-| 失败模式 | 检索错、索引旧 | 记忆投毒、矛盾堆积 |
-
-代表口径（与本 Port 对齐）：
-
-- **Mem0：** RAG = 通用/领域知识；Memory = 用户专属上下文；推荐 hybrid（先记忆、再文档、再进 prompt）。  
-- **AWS Bedrock AgentCore：** LTM 管「谁是用户、以前发生过什么」；Knowledge Base/RAG 管「权威源现在怎么说」。  
-- **Zep / Graphiti：** 偏 Memory（时序图谱、对话与业务数据持续写入）；与静态文档 GraphRAG 刻意区分。  
-- 另有 **LLM Wiki** 一类：ingest 时编译领域笔记——仍属权威/领域层，不是会话记忆。
-
-典型请求循环：
+典型循环（修订后）：
 
 ```text
-Memory.search(user|org) → KB.retrieve(query) → LLM(两路 context) → Memory.add(本轮)
-                                                                    （不写回 KB）
+KB.read → 干活 → Memory.add（可选）
+                → KB.contribute（提议写入组织知识）
 ```
-
-冲突习惯：**人设/偏好听 Memory，事实/合规听 Knowledge。**  
-映射：行业 KB/RAG → **`IOrgKnowledge`**；行业 Agent Memory → **`IOrgMemory`**；会话窗口 → 成员 L1。
 
 ---
 
-## 3. 推荐栈（不自研）
+## 3. 推荐栈（用户可选方向）
 
-| 层级 | 推荐 | 说明 |
+| 选项 id（规划） | 适合 | 说明 |
 |---|---|---|
-| **P0 默认路径** | **git / 文件树** 按 `org_id` 隔离 | 人用 PR 审；agent 按 path 读。零新依赖。 |
-| **P1 检索** | 侧车 + PG+vector / 现成 RAG API | 仍按 `org_id` 过滤；ACN 不持有全文索引 |
-| **外挂 KB** | 语雀 / Notion / 飞书文档等 | community：用其 API 做只读适配；官方不绑定一家 |
+| **`git`**（默认推荐） | 组织手册 + agent 以 PR/commit 贡献 | 零新依赖；人可用 Obsidian 打开同一仓 |
+| **`llm_wiki`** | agent 编译 raw→wiki | Karpathy 模式配方；Obsidian 看图谱；须叠加治理防幻觉进红线 |
+| **`noop`** | 不要组织知识库 | 仅 L1 / Memory |
+| 外挂 RAG / 语雀等 | community | 按 `org_id` 隔离后欢迎适配 |
 
-目录约定（P0 侧车示例）：
+目录约定（`git` / 文件侧车）：
 
 ```text
 orgs/<org_id>/
-  charter.md          # 章程 / 红线
-  sop/                # 标准作业
-  playbooks/          # 场景剧本
-  skills/             # 可复用技能片段
+  charter.md          # 红线（Owner）
+  sop/                # agent 可贡献
+  playbooks/
+  skills/
+  sources/            # 可选：原料（llm_wiki）
+  wiki/               # 可选：编译层（llm_wiki）
 ```
 
 ---
 
-## 4. v0 范围
+## 4. 已交货 vs 设计中
 
-**做（设计 + 推荐路径）：**
+### 已交货（K0–K2，读路径）
 
-1. 问题轴与 catalog 正式立项（本文 + design / plugin-catalog 回链）。  
-2. **P0 交付形态：** 外部知识库侧车（文件/git）；成员 playbook：接活 → 按指针读条目 → 再执行。  
-3. **可选指针：** 编排器 / 发单方在 work 或 `acn.org.work_wake` 上带 `kb_refs[]`（path 或 URI），**不塞全文**进 ACN 消息。  
-4. 与 Memory 拆表：SOP/Skills **移出** Memory 短名单，归本 Port。
+1. 问题轴 + catalog。  
+2. 外部只读侧车 + `kb_refs` + `handle_wake` 加载。  
+3. 与 Memory 拆表。
 
-**不做（v0）：**
+### 设计中（写路径，下一刀）
 
-- 进程内 `plugins.knowledge=*` 白名单接线（与 Memory 薄适配同批，Phase 3 / 有需求时）  
-- Kernel CRUD 文档 API  
-- 自研 embedding / 图谱引擎  
-- 跨 org 知识联邦  
+| 项 | 方向 |
+|---|---|
+| **contribute 契约** | 成员完成 work 后提交「写入提议」（path、内容或 patch、provenance: agent/work_id） |
+| **治理** | v0 可先：**同 Org 成员自动收**到 `sop/`/`skills/`；`charter.md` 仅 Owner；冲突 → 标 `disputed/` 或拒绝 |
+| **实现** | 侧车 `contribute_kb.py`（或 git commit）；**不**进 Kernel CRUD |
+| **用户可选** | 创建 Org / 文档货架：至少能选 `git`（可读可贡献）vs `noop` |
+
+### 仍不做
+
+- 进程内多后端热插（待 `plugins.knowledge`）  
+- 自研向量引擎 / 跨 org 联邦  
 
 ### `plugins.knowledge` 预留
-
-与 `plugins.memory` 对称，设计上预留：
 
 ```json
 {
   "work": "builtin_work",
   "loop": "heartbeat",
   "memory": "noop",
-  "knowledge": "noop"
+  "knowledge": "git"
 }
 ```
 
 | id（规划） | 状态 | 说明 |
 |---|---|---|
-| `noop` | **plugin-planned**（未接线） | 无组织知识库；成员自行找文档 |
-| `fs` / git 侧车（官方示例） | **examples-shipped**（K1+K2） | 推荐默认交货；见 [`examples/org-knowledge/`](../../examples/org-knowledge/) |
-| 外挂 KB / RAG | **community-welcome** | 按 `org_id` 隔离即可 |
+| `noop` | **plugin-planned** | 无组织知识库 |
+| `git` | **examples-shipped（读）· write-planned** | 默认推荐；贡献 API/脚本待 K4 |
+| `llm_wiki` | **adapter-planned** | Karpathy 配方；可选第二档 |
+| 外挂 KB / RAG | **community-welcome** | |
 
-今日创建 Org **不要**传 `knowledge: …`（未知键应被忽略或拒绝——以实现为准）；开工请走**外部侧车**，与「勿伪造 `plugins.memory=mem0`」同一纪律。
+今日创建 Org **不要**伪造未接线的 `plugins.knowledge` id；读路径继续走侧车。
 
 ---
 
-## 5. 消费契约（最小）
+## 5. 消费与贡献契约（最小）
 
-### 5.1 `kb_refs`（可选，给 Work / wake）
+### 5.1 读：`kb_refs`（已有）
 
 ```json
 {
   "kb_refs": [
-    { "uri": "orgkb://<org_id>/sop/release.md", "title": "发版 SOP" },
-    { "uri": "orgkb://<org_id>/charter.md" }
+    { "uri": "orgkb://<org_id>/sop/release.md", "title": "发版 SOP" }
   ]
 }
 ```
 
-- `orgkb://` 为逻辑 scheme；侧车解析为本地 path 或外挂 URL。  
-- 唤醒消息只带 refs；全文由成员侧拉取。  
-- 无 `kb_refs` 时：成员按 playbook 默认读 `charter.md` + 与 work 类型相关的 sop（侧车约定）。
+消息只带 refs，不塞全文。
 
-### 5.2 成员侧最小循环
+### 5.2 读循环（K2）
 
 ```text
-收到 work / wake
-  → 解析 kb_refs（或默认路径）
-  → 只读拉取片段
-  → 执行并回写 work
-  → （可选）事实沉淀写入 Memory——不写回 Knowledge
+wake → 拉 kb_refs / 默认 charter → 干活 → 治理关单
 ```
+
+### 5.3 写循环（设计中 · K4）
+
+```text
+work done（或阶段性复盘）
+  → agent 生成 contribute 提议
+      { org_id, path, body|patch, from_agent, work_id?, title? }
+  → 治理规则（自动收 / 审批 / 拒）
+  → 侧车落盘（git commit 消息含 agent/work）
+  → （可选）org 事件 knowledge.contributed
+```
+
+**禁止：** 把未治理的聊天原文直接当 charter；红线页与 agent 随意区要分开。
 
 ---
 
-## 6. 权限与治理（v0 基线）
+## 6. 权限与治理（修订基线）
 
 | 动作 | 谁 |
 |---|---|
-| 读知识 | Org 成员 agent（及 Owner 工具链） |
-| 改章程 / SOP | **人 Owner 或外挂 KB 的人类权限**；v0 不强制 agent 写入 API |
-| 删 org | 随 Org 生命周期；侧车数据保留策略由运营定（ACN 不级联删外挂仓） |
+| 读知识 | Org **成员 agent** |
+| 贡献 sop/skills/playbooks/wiki | **成员 agent**（经 contribute + 治理） |
+| 改 charter / 红线 | **Owner**（人 or agent） |
+| 争议仲裁 | Owner / manager |
+| 删 org | 随 Org；侧车保留策略由运营定 |
 
-细粒度 ACL（按 path 的 manager-only）→ 后置，有真实需求再进 Policy Port。
+细粒度 path ACL → Policy Port 后置。
 
 ---
 
@@ -210,11 +223,12 @@ orgs/<org_id>/
 
 | 阶段 | 内容 | 状态 |
 |---|---|---|
-| **K0** | 本文 + design/catalog 升格问题轴 | **done** |
-| **K1** | `examples/org-knowledge/`：目录约定 + 读文件 helper + playbook 一段 | **done** |
-| **K2** | wake 可选 `kb_refs`；编排器可附带；`handle_wake` 加载 sidecar | **done** |
-| **K3** | 可选向量检索侧车；或 `plugins.knowledge` noop 接线 | 按需 |
-| **后置** | 真·进程内多后端、审批流改章程 | Phase 3+ |
+| **K0** | 问题轴升格 | **done** |
+| **K1–K2** | 只读侧车 + wake `kb_refs` | **done**（冷启动读路径） |
+| **K3** | 用户可选：`git` / `noop`（文档+配置/插件位）；可选向量 | 按需 |
+| **K4** | **agent contribute** 契约 + 侧车写入 + 最小治理 | **下一步** |
+| **K5** | 可选 `llm_wiki` 配方（sources→wiki，Obsidian 前端） | 按需 |
+| **后置** | `plugins.knowledge` 多后端、审批 UI | Phase 3+ |
 
 ---
 
@@ -222,12 +236,15 @@ orgs/<org_id>/
 
 | # | 决策 |
 |---|---|
-| K-D1 | 知识库是 **Org 一等能力**，规划遗漏现补；不与「等契约跑稳」挂钩 |
+| K-D1 | 知识库是 **Org 一等能力** |
 | K-D2 | Port 名 **`IOrgKnowledge`**；**不进 Kernel** |
-| K-D3 | **与 `IOrgMemory` 分离**；SOP/Skills 归知识库 |
+| K-D3 | **与 `IOrgMemory` 分离** |
 | K-D4 | **不自研**引擎；成熟栈侧车优先 |
-| K-D5 | v0 交货 = **外部侧车**；`plugins.knowledge` 预留，接线前不伪造 |
-| K-D6 | 消息只传 **`kb_refs`**，不传全文 |
+| K-D5 | 交货形态优先 **外部侧车**；`plugins.knowledge` 预留 |
+| K-D6 | 读消息只传 **`kb_refs`**，不传全文 |
+| **K-D7** | **主贡献者是成员 agent**；人/Owner 管红线与仲裁，不是默认主笔 |
+| **K-D8** | K1/K2 只读 = 冷启动；终局 = **可读 + 可治理写入** |
+| **K-D9** | 默认推荐技术 **`git`**；**`llm_wiki`** 为可选编译配方，不替代治理 |
 
 ---
 
@@ -237,6 +254,7 @@ orgs/<org_id>/
 |---|---|
 | [design-v0.md](./design-v0.md) | Port 表与决策 D12 |
 | [plugin-catalog-v0.md](./plugin-catalog-v0.md) | Knowledge 短名单 |
-| [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员读 KB 的挂载点 |
-| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | DEF-KB / DEF-MEM 拆分 |
-| [`../../examples/org-knowledge/`](../../examples/org-knowledge/) | K1 文件系统侧车（`read_kb.py` + `org_demo`） |
+| [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员读 KB |
+| [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | DEF-KB |
+| [`../../examples/org-knowledge/`](../../examples/org-knowledge/) | 读路径侧车 |
+| [Karpathy llm-wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) | 可选编译层灵感（非官方依赖） |

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -32,7 +32,7 @@
 |---|---|
 | 组织内派活 + Paperclip Issues | **默认** `builtin_work` + 装 [`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin)（外部 Pattern，**不是** `plugins.work=paperclip`） |
 | 面向网络发赏金 | **旁路** [org-task-bridge](./org-task-bridge-v0.md) / Org wallet；**不要**改 `plugins.work` |
-| 组织知识库（章程 / SOP / Skills） | **外部侧车**（[`examples/org-knowledge/`](../../examples/org-knowledge/) · smoke）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。勿伪造 `plugins.knowledge=*` |
+| 组织知识库（**agent 主贡献**） | 读：[`examples/org-knowledge/`](../../examples/org-knowledge/)；写路径设计中。可选方向 `git` / `noop` /（将来）`llm_wiki`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。勿伪造未接线 `plugins.knowledge=*` |
 | 组织共享记忆（事实 / 叙事） | 先 `memory=noop`；需要时按下方 Memory 短名单自建侧车 |
 | Task Pool 当组织工单后端 | **`deferred`**（`plugins.work=task_pool` 会 `plugin_unavailable`） |
 
@@ -98,11 +98,12 @@ Port 划分（Work / Loop / Knowledge / Memory / …）是**问题轴**，充分
 
 | id / 方向 | 状态 | 说明 |
 |---|---|---|
-| **git / 文件侧车**（按 `org_id`） | **examples-shipped**（K1+K2） | **推荐默认交货**。章程 / SOP / Skills；成员只读；wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) · [`examples/org-knowledge/`](../../examples/org-knowledge/) · `smoke_org_knowledge.sh`。 |
-| `noop`（进程内） | **plugin-planned**（未接线） | 预留；接线前不要传 `plugins.knowledge`。 |
-| 外挂 KB / RAG（语雀、Notion、PG+vector…） | **community-welcome** | 成熟栈接入；ACN **不自研**引擎。 |
+| **`git` / 文件侧车**（按 `org_id`） | **examples-shipped（读）· write-planned** | **默认推荐**。agent 主贡献（K4）；今日可读 + wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。 |
+| **`llm_wiki`**（Karpathy 编译层 + 可选 Obsidian） | **adapter-planned** | 可选第二档；agent 维护 wiki/；须治理，不替代 charter。 |
+| `noop`（进程内） | **plugin-planned**（未接线） | 不要组织知识库。 |
+| 外挂 KB / RAG | **community-welcome** | 成熟栈接入；ACN **不自研**引擎。 |
 
-组织刚需；与 Memory **分开选型**。
+组织刚需；**主贡献者是 agent**；与 Memory **分开选型**。
 
 ### 4. Memory — `IOrgMemory`（`plugins.memory`）
 
@@ -180,3 +181,4 @@ Port 划分（Work / Loop / Knowledge / Memory / …）是**问题轴**，充分
 | 2026-07-25 | 硬约定：自定义优先外部适配；`plugins.*` 仅官方/进程内 |
 | 2026-07-27 | 升格 **Knowledge** Port；SOP/Skills 从 Memory 拆出；链 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) |
 | 2026-07-27 | Knowledge：**examples-shipped**（K1+K2）；图例补 examples-shipped / plugin-planned |
+| 2026-07-27 | Knowledge：修订为 **agent 主贡献**；货架 `git` / `llm_wiki` / `noop` |

--- a/examples/org-knowledge/README.md
+++ b/examples/org-knowledge/README.md
@@ -1,7 +1,8 @@
-# Org 知识库（外部侧车）— K1 / K2 消费端
+# Org 知识库（外部侧车）— K1 / K2 读路径
 
 按 `org_id` 的**文件系统 / git** 知识树：章程、SOP、playbooks、skills。  
-成员接活时**只读**拉取；**不是** ACN Kernel，**不是** `plugins.knowledge`（未接线），**不是** Memory。
+本目录实现的是**读路径**（冷启动）。产品口径上知识库应由**成员 agent 主贡献**——写路径见 [org-knowledge-base-v0.md](../../docs/org-harness/org-knowledge-base-v0.md) K4，尚未进本 examples。  
+**不是** ACN Kernel，**不是** `plugins.knowledge`（未接线），**不是** Memory。
 
 | 文档 | 链接 |
 |---|---|


### PR DESCRIPTION
## Summary
- Revise Org Knowledge Port: **member agents are primary contributors**; humans/Owners govern charter and disputes, not default authorship.
- Keep K1/K2 filesystem read path as cold start; define **K4 contribute** + optional `git` / `llm_wiki` / `noop` shelf.
- Sync design-v0 D12, plugin-catalog, examples README.

## Test plan
- [ ] Skim [org-knowledge-base-v0.md](docs/org-harness/org-knowledge-base-v0.md) §§2.1, 5.3, 7–8
- [ ] Confirm catalog Knowledge rows match agent-contribute narrative


Made with [Cursor](https://cursor.com)