### PR TITLE
feat(org): knowledge contribute path for agent authors (K4)

### DIFF
--- a/docs/org-harness/README.md
+++ b/docs/org-harness/README.md
@@ -67,7 +67,7 @@ L1 harness（含会话级 fan-out）: 成员自带，不进 Org Harness Kernel
 - **对外发布 / 导入（v0）：** [org-task-bridge-v0.md](./org-task-bridge-v0.md)（`publish-task` / `import-task`；**不是** P2b）。  
 - **经济主体：** [org-wallet-v0.md](./org-wallet-v0.md) — **v0 收线**（S6b 插件内 topup **deferred**；外置 Backend 充值即可）。  
 - **插件冷启动：** [plugin-catalog-v0.md](./plugin-catalog-v0.md)（官方短名单；Knowledge / Memory 等 adapter-planned）。  
-- **Org 知识库：** [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)（**agent 主贡献**；读路径 K1/K2 已落地；**K4 contribute** 下一步）· [侧车](../../examples/org-knowledge/) · [`smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)。  
+- **Org 知识库：** [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)（**agent 主贡献**；读 K1/K2 + **写 K4**）· [侧车](../../examples/org-knowledge/) · [`smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)。  
 - **按需（有真实卡住再开）：** P2b；自动 receive；按 `org_id` 列表 Tasks；Memory/Capability 薄适配；知识库 K3。  
 - **实验（C1–C2）：** [Org 待办执行器（外部）](./org-loop-spawn-sidecar-poc-v0.md) + [`examples/org-loop-spawn-sidecar/`](../../examples/org-loop-spawn-sidecar/)（C3 webhook 按需）。  
 - **Org 编排器：** [产品定义](./org-orchestrator-v0.md) P0 + [唤醒契约](./org-orchestrator-wake-contract-v0.md) P1 + [P2 侧车](../../examples/org-orchestrator/)；P3 webhook/催办按需。  

--- a/docs/org-harness/design-v0.md
+++ b/docs/org-harness/design-v0.md
@@ -222,7 +222,7 @@ Membership **不是**「加人产品」：进围栏走既有 subnet admission；
 | **`IWorkPattern`** | 活怎么建模、认领、状态 | **`builtin_work`**（Phase 1 `OrgWorkItem`） | TaskPool（可选/deferred）；自研 DAG；**Paperclip = 外部 Pattern**（非 `plugins.work`） |
 | **`IOrgLoop`** | 看队列→分派/唤醒→回收 | Heartbeat / 简单 dispatcher | （将来）ClawTeam **Loop 适配器**、自定义巡检；今日自定义走**外部 Pattern** |
 | **`ICapabilityPool`** | 组织能力目录 | 聚合成员 ACN skills（可先内置非插件） | 外挂 MCP catalog |
-| **`IOrgKnowledge`** | 组织知识（**agent 主贡献**；章程红线 + SOP/Skills/wiki） | 外部侧车读路径已落地；写路径见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | git（默认可选）、llm_wiki 配方、外挂 KB |
+| **`IOrgKnowledge`** | 组织知识（**agent 主贡献**；章程红线 + SOP/Skills/wiki） | 外部侧车读+写（K4 contribute）；见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | git（默认）、llm_wiki 配方、外挂 KB |
 | **`IOrgMemory`** | 集体记忆（事实 / 偏好 / 叙事） | `noop` | Mem0、Zep/Graphiti、PG+vector |
 | **`IPolicyBudget`** | 角色权限、花费 | Kernel 角色枚举 | 审批流、月度硬停 |
 | **`IEventSink`** | 生命周期外推 | subnet harness webhook | 多 webhook、OTel |
@@ -436,7 +436,7 @@ Org Memory 深度、知识库进程内多后端、跨 org 信誉、Dispute、Fed
 | D9 | v0 不做「加人」叙事；复用 subnet 围栏 |
 | D10 | v0 只做满 Kernel + Work + 薄 Loop + Events，避免过度对称 |
 | D11 | 自定义优先 **外部 Pattern**；`plugins.*` 仅官方 Builtin 白名单（见 plugin-catalog） |
-| D12 | **`IOrgKnowledge`** 与 Memory 并列；**成员 agent 主贡献**，Owner 管红线/仲裁；不进 Kernel；读侧车已交货、写路径设计中（[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)） |
+| D12 | **`IOrgKnowledge`** 与 Memory 并列；**成员 agent 主贡献**，Owner 管红线；不进 Kernel；侧车读+写（K4）（[org-knowledge-base-v0.md](./org-knowledge-base-v0.md)） |
 
 ---
 

--- a/docs/org-harness/org-knowledge-base-v0.md
+++ b/docs/org-harness/org-knowledge-base-v0.md
@@ -1,7 +1,7 @@
 # Org 知识库 — 产品与 Port 定义 v0
 
-**Status:** Design Accepted（**2026-07-27 修订：agent 主贡献**）· K1+K2 只读侧车已落地；写路径设计中  
-**Code（读路径）：** [`examples/org-knowledge/`](../../examples/org-knowledge/) · wake `kb_refs` + `handle_wake` 加载  
+**Status:** Design Accepted · **K1–K4 examples 已落地**（读 + agent contribute）  
+**Code：** [`examples/org-knowledge/`](../../examples/org-knowledge/)（`read_kb.py` · `contribute_kb.py` · wake 加载）  
 **Smoke：** [`scripts/smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)  
 
 **Date:** 2026-07-27  
@@ -69,8 +69,8 @@ agent 干活 → 读 KB → 产出
            → 写入侧车（git commit / vault 更新）
 ```
 
-**K1/K2 现状：** 只读侧车——视为冷启动，**不是**终局。  
-**终局：** 读 + **可治理的写** 都是一等能力。
+**K1/K2：** 读路径。**K4：** 侧车 `contribute`（成员区自动收；charter 需 Owner；冲突 → `disputed/`）。  
+进程内 `plugins.knowledge` 仍未接线。
 
 ### 与 Memory 的硬边界
 
@@ -126,26 +126,26 @@ orgs/<org_id>/
 
 ---
 
-## 4. 已交货 vs 设计中
+## 4. 已交货 vs 其后
 
-### 已交货（K0–K2，读路径）
+### 已交货（K0–K4）
 
-1. 问题轴 + catalog。  
-2. 外部只读侧车 + `kb_refs` + `handle_wake` 加载。  
-3. 与 Memory 拆表。
+1. 问题轴 + catalog（agent 主贡献）。  
+2. 读：侧车 + `kb_refs` + `handle_wake`。  
+3. **写：** [`contribute_kb.py`](../../examples/org-knowledge/contribute_kb.py) — 提议落盘 + 最小治理（见 §5.3）。  
+4. 与 Memory 拆表。
 
-### 设计中（写路径，下一刀）
+### 其后
 
 | 项 | 方向 |
 |---|---|
-| **contribute 契约** | 成员完成 work 后提交「写入提议」（path、内容或 patch、provenance: agent/work_id） |
-| **治理** | v0 可先：**同 Org 成员自动收**到 `sop/`/`skills/`；`charter.md` 仅 Owner；冲突 → 标 `disputed/` 或拒绝 |
-| **实现** | 侧车 `contribute_kb.py`（或 git commit）；**不**进 Kernel CRUD |
-| **用户可选** | 创建 Org / 文档货架：至少能选 `git`（可读可贡献）vs `noop` |
+| **用户可选** | 创建 Org 货架：`git` / `noop`（`plugins.knowledge` 接线） |
+| **llm_wiki** | sources→wiki 编译配方 |
+| **真·成员校验** | contribute 前打 ACN Membership（今日信任 runner 断言 `from_agent` / `--as-owner`） |
 
 ### 仍不做
 
-- 进程内多后端热插（待 `plugins.knowledge`）  
+- Kernel CRUD 文档 API  
 - 自研向量引擎 / 跨 org 联邦  
 
 ### `plugins.knowledge` 预留
@@ -162,11 +162,11 @@ orgs/<org_id>/
 | id（规划） | 状态 | 说明 |
 |---|---|---|
 | `noop` | **plugin-planned** | 无组织知识库 |
-| `git` | **examples-shipped（读）· write-planned** | 默认推荐；贡献 API/脚本待 K4 |
+| `git` | **examples-shipped**（读+写 K4） | 默认推荐 |
 | `llm_wiki` | **adapter-planned** | Karpathy 配方；可选第二档 |
 | 外挂 KB / RAG | **community-welcome** | |
 
-今日创建 Org **不要**伪造未接线的 `plugins.knowledge` id；读路径继续走侧车。
+今日创建 Org **不要**伪造未接线的 `plugins.knowledge` id；读写继续走侧车。
 
 ---
 
@@ -190,18 +190,26 @@ orgs/<org_id>/
 wake → 拉 kb_refs / 默认 charter → 干活 → 治理关单
 ```
 
-### 5.3 写循环（设计中 · K4）
+### 5.3 写循环（K4 · 已实现侧车）
 
 ```text
 work done（或阶段性复盘）
-  → agent 生成 contribute 提议
-      { org_id, path, body|patch, from_agent, work_id?, title? }
-  → 治理规则（自动收 / 审批 / 拒）
-  → 侧车落盘（git commit 消息含 agent/work）
-  → （可选）org 事件 knowledge.contributed
+  → agent 调用 contribute_kb.py / contribute()
+      { org_id, path, body, from_agent, work_id?, title?, as_owner? }
+  → 治理：
+      - sop|skills|playbooks|wiki|sources → 成员自动 accepted
+      - charter.md|charter/ → 需 as_owner，否则 rejected
+      - 其它路径 → 非 Owner rejected
+      - 目标已存在且内容不同（无 force）→ disputed/<path>
+  → 落盘并附 provenance 注释（agent / work / 时间）
 ```
 
-**禁止：** 把未治理的聊天原文直接当 charter；红线页与 agent 随意区要分开。
+```bash
+python3 contribute_kb.py --org org_x --from-agent agt_1 \
+  --path sop/learned.md --body-file ./note.md --work-id work_…
+```
+
+**禁止：** 未授权改 charter；信任边界见 §2（runner 须保证 `from_agent` / `--as-owner` 真实）。
 
 ---
 
@@ -224,9 +232,9 @@ work done（或阶段性复盘）
 | 阶段 | 内容 | 状态 |
 |---|---|---|
 | **K0** | 问题轴升格 | **done** |
-| **K1–K2** | 只读侧车 + wake `kb_refs` | **done**（冷启动读路径） |
-| **K3** | 用户可选：`git` / `noop`（文档+配置/插件位）；可选向量 | 按需 |
-| **K4** | **agent contribute** 契约 + 侧车写入 + 最小治理 | **下一步** |
+| **K1–K2** | 读侧车 + wake `kb_refs` | **done** |
+| **K4** | **agent contribute** + 最小治理（`contribute_kb.py`） | **done** |
+| **K3** | 用户可选：`git` / `noop`（`plugins.knowledge`）；可选向量 | 按需 |
 | **K5** | 可选 `llm_wiki` 配方（sources→wiki，Obsidian 前端） | 按需 |
 | **后置** | `plugins.knowledge` 多后端、审批 UI | Phase 3+ |
 
@@ -256,5 +264,5 @@ work done（或阶段性复盘）
 | [plugin-catalog-v0.md](./plugin-catalog-v0.md) | Knowledge 短名单 |
 | [org-orchestrator-member-playbook-v0.md](./org-orchestrator-member-playbook-v0.md) | 成员读 KB |
 | [org-pattern-adapter-spec-v0.md](./org-pattern-adapter-spec-v0.md) | DEF-KB |
-| [`../../examples/org-knowledge/`](../../examples/org-knowledge/) | 读路径侧车 |
+| [`../../examples/org-knowledge/`](../../examples/org-knowledge/) | 读/写侧车（`read_kb` · `contribute_kb`） |
 | [Karpathy llm-wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) | 可选编译层灵感（非官方依赖） |

--- a/docs/org-harness/org-orchestrator-member-playbook-v0.md
+++ b/docs/org-harness/org-orchestrator-member-playbook-v0.md
@@ -29,8 +29,9 @@
   → 解析 type == acn.org.work_wake（见契约）
   → list work 找到 work_id，确认仍 open 且 **API assignee = 自己**（空 assignee 不干）
   → 同一 `idempotency_key` 只处理一次（`handle_wake.py` 写本地 idem 文件）
-  → 只读拉组织知识：`examples/org-knowledge/read_kb.py`（默认 charter；或信封 `kb_refs` → `--from-json -`）
+  → 拉组织知识：`examples/org-knowledge/read_kb.py`（默认 charter；或信封 `kb_refs`）
   → L1 执行 title/描述要求的活
+  → （可选）贡献可复用结论：`contribute_kb.py --path sop/…`（勿写 charter，除非 Owner）
   → 完成：通知治理方 PATCH done（或 Owner/编排器代关）
   → 放弃：治理 PATCH cancelled
 ```
@@ -97,4 +98,5 @@ v0 不要求编排器自动 `done`（避免未干完误关）。
 | [`run_orchestrator.py`](../../examples/org-orchestrator/run_orchestrator.py) | 编排器侧车 |
 | [`smoke_org_orchestrator.sh`](../../scripts/smoke_org_orchestrator.sh) | 狗粮 A（无成员 listen） |
 | [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) | 组织知识库 / `kb_refs`（可选） |
-| [`examples/org-knowledge/read_kb.py`](../../examples/org-knowledge/read_kb.py) | K1：接活前读 charter/SOP |
+| [`examples/org-knowledge/read_kb.py`](../../examples/org-knowledge/read_kb.py) | 接活前读 charter/SOP |
+| [`examples/org-knowledge/contribute_kb.py`](../../examples/org-knowledge/contribute_kb.py) | K4：干完后贡献 sop/skills/… |

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -98,7 +98,7 @@ Port 划分（Work / Loop / Knowledge / Memory / …）是**问题轴**，充分
 
 | id / 方向 | 状态 | 说明 |
 |---|---|---|
-| **`git` / 文件侧车**（按 `org_id`） | **examples-shipped（读）· write-planned** | **默认推荐**。agent 主贡献（K4）；今日可读 + wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。 |
+| **`git` / 文件侧车**（按 `org_id`） | **examples-shipped**（读 K1/K2 · 写 K4） | **默认推荐**。`read_kb` + `contribute_kb`；wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。 |
 | **`llm_wiki`**（Karpathy 编译层 + 可选 Obsidian） | **adapter-planned** | 可选第二档；agent 维护 wiki/；须治理，不替代 charter。 |
 | `noop`（进程内） | **plugin-planned**（未接线） | 不要组织知识库。 |
 | 外挂 KB / RAG | **community-welcome** | 成熟栈接入；ACN **不自研**引擎。 |

--- a/examples/org-knowledge/README.md
+++ b/examples/org-knowledge/README.md
@@ -1,7 +1,7 @@
-# Org 知识库（外部侧车）— K1 / K2 读路径
+# Org 知识库（外部侧车）— 读（K1/K2）+ 贡献（K4）
 
-按 `org_id` 的**文件系统 / git** 知识树：章程、SOP、playbooks、skills。  
-本目录实现的是**读路径**（冷启动）。产品口径上知识库应由**成员 agent 主贡献**——写路径见 [org-knowledge-base-v0.md](../../docs/org-harness/org-knowledge-base-v0.md) K4，尚未进本 examples。  
+按 `org_id` 的**文件系统 / git** 知识树。  
+**成员 agent 主贡献**：`contribute_kb.py` 写入 `sop|skills|playbooks|wiki|sources`；`charter` 需 `--as-owner`；冲突进 `disputed/`。  
 **不是** ACN Kernel，**不是** `plugins.knowledge`（未接线），**不是** Memory。
 
 | 文档 | 链接 |
@@ -52,13 +52,29 @@ echo '{"kb_refs":[{"uri":"orgkb://org_demo/charter.md"},{"uri":"orgkb://org_demo
   | python3 read_kb.py --org org_demo --from-json -
 ```
 
+## 贡献（K4）
+
+```bash
+# 成员：自动落到 sop/
+python3 contribute_kb.py --org org_demo --from-agent agt_1 \
+  --path sop/learned.md --body '# What we learned\n\n…' --work-id work_…
+
+# charter 仅 Owner
+python3 contribute_kb.py --org org_demo --from-agent agt_owner --as-owner \
+  --path charter.md --body-file ./charter.md
+
+# 冲突（目标已有不同内容）→ disputed/… ；--force 可覆盖
+```
+
+信任：侧车**不**校验 ACN 成员身份；生产上由 runner/编排器保证 `--from-agent` / `--as-owner` 真实。
+
 本地 smoke（无 ACN）：
 
 ```bash
 ./scripts/smoke_org_knowledge.sh
 ```
 
-## 与编排器（K2）
+## 与编排器（K2 读 / K4 写）
 
 - 编排器信封可带可选 `kb_refs[]`（work 字段 / `ORG_KB_REFS_JSON` / `ORG_KB_ATTACH_DEFAULTS=1`）。  
 - `handle_wake.py` 在校验通过后加载 sidecar（`HANDLE_WAKE_SKIP_KB=1` 可关）。

--- a/examples/org-knowledge/contribute.py
+++ b/examples/org-knowledge/contribute.py
@@ -1,0 +1,204 @@
+"""Org knowledge contribute (write path) — agent proposals with minimal governance.
+
+K4: members may auto-land under sop|skills|playbooks|wiki|sources.
+charter.md (and charter/) require --as-owner.
+Conflicts (existing different content, no --force) → disputed/<path>.
+
+Trust: this sidecar does not call ACN Membership. The caller asserts
+from_agent / as_owner; gate that in the orchestrator or runner in production.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from kb import _safe_file, max_file_bytes, org_dir
+
+_AGENT_ZONE_PREFIXES = (
+    "sop/",
+    "skills/",
+    "playbooks/",
+    "wiki/",
+    "sources/",
+)
+_CHARTER_NAMES = frozenset({"charter.md"})
+_CHARTER_PREFIXES = ("charter/",)
+_MD_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.+/-]*\.md$")
+
+
+class ContributeDecision(StrEnum):
+    ACCEPTED = "accepted"
+    DISPUTED = "disputed"
+    REJECTED = "rejected"
+    NOOP = "noop"  # identical content already present
+
+
+@dataclass(frozen=True)
+class ContributeProposal:
+    org_id: str
+    path: str  # relative within org tree, e.g. sop/foo.md
+    body: str
+    from_agent: str
+    work_id: str = ""
+    title: str = ""
+    as_owner: bool = False
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class ContributeResult:
+    decision: ContributeDecision
+    path: str
+    abs_path: str
+    reason: str = ""
+
+
+def normalize_rel_path(path: str) -> str:
+    rel = (path or "").strip().replace("\\", "/").lstrip("/")
+    if not rel or ".." in rel.split("/"):
+        raise ValueError(f"invalid path: {path!r}")
+    if not _MD_NAME.match(rel):
+        raise ValueError(
+            f"path must be a safe .md relative path: {path!r}"
+        )
+    return rel
+
+
+def is_charter_path(rel: str) -> bool:
+    if rel in _CHARTER_NAMES:
+        return True
+    return any(rel.startswith(p) for p in _CHARTER_PREFIXES)
+
+
+def is_agent_zone(rel: str) -> bool:
+    return any(rel.startswith(p) for p in _AGENT_ZONE_PREFIXES)
+
+
+def classify_write(rel: str, *, as_owner: bool) -> tuple[bool, str]:
+    """Return (allowed, reason)."""
+    if is_charter_path(rel):
+        if as_owner:
+            return True, "owner charter write"
+        return False, "charter requires --as-owner / Owner role"
+    if is_agent_zone(rel):
+        return True, "member zone auto-accept"
+    if as_owner:
+        return True, "owner unrestricted (within org tree)"
+    return (
+        False,
+        "path not in agent zones (sop|skills|playbooks|wiki|sources); "
+        "use Owner or move under an allowed prefix",
+    )
+
+
+def _provenance_footer(prop: ContributeProposal) -> str:
+    ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    parts = [
+        "",
+        "---",
+        f"<!-- orgkb:contribute agent={prop.from_agent}"
+        + (f" work={prop.work_id}" if prop.work_id else "")
+        + f" at={ts} -->",
+    ]
+    if prop.title:
+        parts.insert(2, f"<!-- title: {prop.title} -->")
+    return "\n".join(parts) + "\n"
+
+
+def prepare_body(prop: ContributeProposal) -> str:
+    body = prop.body if prop.body.endswith("\n") else prop.body + "\n"
+    # Avoid duplicating footer if caller already added one.
+    if "<!-- orgkb:contribute" in body:
+        return body
+    return body + _provenance_footer(prop)
+
+
+def contribute(
+    prop: ContributeProposal,
+    *,
+    root: Path | None = None,
+) -> ContributeResult:
+    if not prop.from_agent.strip():
+        raise ValueError("from_agent required")
+    rel = normalize_rel_path(prop.path)
+    allowed, why = classify_write(rel, as_owner=prop.as_owner)
+    if not allowed:
+        return ContributeResult(
+            decision=ContributeDecision.REJECTED,
+            path=rel,
+            abs_path="",
+            reason=why,
+        )
+
+    text = prepare_body(prop)
+    limit = max_file_bytes()
+    if len(text.encode("utf-8")) > limit:
+        return ContributeResult(
+            decision=ContributeDecision.REJECTED,
+            path=rel,
+            abs_path="",
+            reason=f"body too large (>{limit} bytes)",
+        )
+
+    target = _safe_file(prop.org_id, rel, root=root)
+    odir = org_dir(prop.org_id, root=root)
+
+    if target.is_file() and not prop.force:
+        existing = target.read_text(encoding="utf-8")
+        # Compare without provenance footers for noop detection.
+        if _strip_footer(existing) == _strip_footer(text):
+            return ContributeResult(
+                decision=ContributeDecision.NOOP,
+                path=rel,
+                abs_path=str(target),
+                reason="identical content",
+            )
+        # Conflict → disputed/
+        disputed_rel = f"disputed/{rel}"
+        disputed = _safe_file(prop.org_id, disputed_rel, root=root)
+        disputed.parent.mkdir(parents=True, exist_ok=True)
+        # Unique name if disputed file already exists.
+        if disputed.is_file():
+            stem = Path(rel).stem
+            suffix = Path(rel).suffix
+            parent = str(Path(rel).parent).replace("\\", "/")
+            if parent == ".":
+                parent = ""
+            ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+            disputed_rel = (
+                f"disputed/{parent}/{stem}.{ts}{suffix}"
+                if parent
+                else f"disputed/{stem}.{ts}{suffix}"
+            )
+            disputed = _safe_file(prop.org_id, disputed_rel, root=root)
+            disputed.parent.mkdir(parents=True, exist_ok=True)
+        disputed.write_text(text, encoding="utf-8")
+        return ContributeResult(
+            decision=ContributeDecision.DISPUTED,
+            path=disputed_rel,
+            abs_path=str(disputed),
+            reason=f"conflict with existing {rel}; wrote disputed copy",
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Ensure org root exists.
+    odir.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    return ContributeResult(
+        decision=ContributeDecision.ACCEPTED,
+        path=rel,
+        abs_path=str(target),
+        reason=why,
+    )
+
+
+def _strip_footer(text: str) -> str:
+    marker = "\n---\n<!-- orgkb:contribute"
+    idx = text.find(marker)
+    if idx >= 0:
+        return text[:idx].rstrip() + "\n"
+    return text

--- a/examples/org-knowledge/contribute_kb.py
+++ b/examples/org-knowledge/contribute_kb.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""CLI: agent contribute to Org knowledge (filesystem sidecar).
+
+Examples:
+  python3 contribute_kb.py --org org_demo --from-agent agt_1 \\
+    --path sop/learned.md --body-file ./note.md
+
+  echo '# tip' | python3 contribute_kb.py --org org_demo --from-agent agt_1 \\
+    --path skills/tip.md --body -
+
+  # charter (Owner only)
+  python3 contribute_kb.py --org org_demo --from-agent agt_owner --as-owner \\
+    --path charter.md --body-file ./charter.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from contribute import ContributeProposal, contribute  # noqa: E402
+from kb import default_kb_root  # noqa: E402
+
+
+def _read_body(args: argparse.Namespace) -> str:
+    if args.body is not None:
+        if args.body == "-":
+            return sys.stdin.read()
+        return args.body
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    if args.from_json:
+        raw = (
+            sys.stdin.read()
+            if args.from_json == "-"
+            else Path(args.from_json).read_text(encoding="utf-8")
+        )
+        data = json.loads(raw)
+        return str(data.get("body") or "")
+    raise ValueError("need --body, --body-file, or --from-json")
+
+
+def _proposal_from_json(raw: str, *, defaults: argparse.Namespace) -> ContributeProposal:
+    data = json.loads(raw)
+    org_id = str(data.get("org_id") or defaults.org or "").strip()
+    path = str(data.get("path") or defaults.path or "").strip()
+    body = str(data.get("body") or "")
+    from_agent = str(data.get("from_agent") or defaults.from_agent or "").strip()
+    if not org_id or not path or not from_agent:
+        raise ValueError("JSON needs org_id, path, from_agent (and body)")
+    if not body and defaults.body_file:
+        body = Path(defaults.body_file).read_text(encoding="utf-8")
+    return ContributeProposal(
+        org_id=org_id,
+        path=path,
+        body=body,
+        from_agent=from_agent,
+        work_id=str(data.get("work_id") or defaults.work_id or ""),
+        title=str(data.get("title") or defaults.title or ""),
+        as_owner=bool(data.get("as_owner") or defaults.as_owner),
+        force=bool(data.get("force") or defaults.force),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Contribute to Org knowledge base")
+    p.add_argument("--org", default="", help="org_id")
+    p.add_argument("--root", default="", help="ORG_KB_ROOT")
+    p.add_argument("--from-agent", default="", help="contributing agent_id")
+    p.add_argument("--path", default="", help="relative .md path under org")
+    p.add_argument("--body", default=None, help="markdown body, or '-' for stdin")
+    p.add_argument("--body-file", default="", help="read body from file")
+    p.add_argument("--work-id", default="", help="optional work_id provenance")
+    p.add_argument("--title", default="", help="optional title note")
+    p.add_argument(
+        "--as-owner",
+        action="store_true",
+        help="allow charter / unrestricted paths",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite on conflict instead of disputed/",
+    )
+    p.add_argument(
+        "--from-json",
+        default="",
+        help="proposal JSON path, or '-' for stdin",
+    )
+    p.add_argument("--json-out", action="store_true", help="machine-readable result")
+    args = p.parse_args(argv)
+
+    if args.root:
+        os.environ["ORG_KB_ROOT"] = args.root
+    root = default_kb_root()
+
+    try:
+        if args.from_json:
+            raw = (
+                sys.stdin.read()
+                if args.from_json == "-"
+                else Path(args.from_json).read_text(encoding="utf-8")
+            )
+            prop = _proposal_from_json(raw, defaults=args)
+            if not prop.body:
+                # Allow body alongside JSON via --body-file
+                if args.body is not None or args.body_file:
+                    prop = ContributeProposal(
+                        org_id=prop.org_id,
+                        path=prop.path,
+                        body=_read_body(args),
+                        from_agent=prop.from_agent,
+                        work_id=prop.work_id,
+                        title=prop.title,
+                        as_owner=prop.as_owner,
+                        force=prop.force,
+                    )
+        else:
+            org_id = (args.org or os.environ.get("ORG_KB_ORG_ID", "")).strip()
+            from_agent = (
+                args.from_agent or os.environ.get("ORG_KB_FROM_AGENT", "")
+            ).strip()
+            if not org_id or not args.path or not from_agent:
+                print(
+                    "Need --org, --path, --from-agent (or --from-json)",
+                    file=sys.stderr,
+                )
+                return 2
+            prop = ContributeProposal(
+                org_id=org_id,
+                path=args.path,
+                body=_read_body(args),
+                from_agent=from_agent,
+                work_id=args.work_id,
+                title=args.title,
+                as_owner=args.as_owner,
+                force=args.force,
+            )
+
+        result = contribute(prop, root=root)
+    except (ValueError, OSError, json.JSONDecodeError) as e:
+        print(f"[contribute_kb] error: {e}", file=sys.stderr)
+        return 1
+
+    payload = {
+        "decision": result.decision.value,
+        "path": result.path,
+        "abs_path": result.abs_path,
+        "reason": result.reason,
+        "org_id": prop.org_id,
+        "from_agent": prop.from_agent,
+    }
+    if args.json_out:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"[contribute_kb] {result.decision.value}: {result.path}"
+            + (f" ({result.reason})" if result.reason else ""),
+            flush=True,
+        )
+        if result.abs_path:
+            print(result.abs_path, flush=True)
+
+    if result.decision.value == "rejected":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_org_knowledge.sh
+++ b/scripts/smoke_org_knowledge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Smoke: Org knowledge sidecar (no ACN required)
+# Smoke: Org knowledge sidecar (no ACN required) — read (K1/K2) + contribute (K4)
 #
 # Usage:
 #   ./scripts/smoke_org_knowledge.sh
@@ -13,10 +13,16 @@ if [[ ! -x "$PY" ]]; then
   PY="python3"
 fi
 
-echo "==> Unit tests (org-knowledge)"
-"$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q --no-cov 2>/dev/null \
-  || "$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q -p no:cov 2>/dev/null \
-  || "$PY" -m pytest "${ROOT}/tests/examples/test_org_knowledge_kb.py" -q
+run_pytest() {
+  "$PY" -m pytest "$@" -q --no-cov 2>/dev/null \
+    || "$PY" -m pytest "$@" -q -p no:cov 2>/dev/null \
+    || "$PY" -m pytest "$@" -q
+}
+
+echo "==> Unit tests (org-knowledge read + contribute)"
+run_pytest \
+  "${ROOT}/tests/examples/test_org_knowledge_kb.py" \
+  "${ROOT}/tests/examples/test_org_knowledge_contribute.py"
 
 echo "==> read_kb.py --org org_demo"
 out="$("$PY" "${KB}/read_kb.py" --org org_demo)"
@@ -39,5 +45,18 @@ EOF
 out="$(echo "$wake" | "$PY" "${ORCH}/handle_wake.py")"
 echo "$out" | grep -q "knowledge bundle"
 echo "$out" | grep -qiE "Release|SOP"
+
+echo "==> contribute (K4) member sop + reject charter"
+TMP_ROOT="$(mktemp -d -t orgkb-smoke.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+"$PY" "${KB}/contribute_kb.py" --root "$TMP_ROOT" --org org_smoke \
+  --from-agent agt_smoke --path sop/smoke.md --body '# smoke tip' --json-out \
+  | grep -q '"accepted"'
+set +e
+"$PY" "${KB}/contribute_kb.py" --root "$TMP_ROOT" --org org_smoke \
+  --from-agent agt_smoke --path charter.md --body '# no' --json-out >/dev/null
+rc=$?
+set -e
+[[ "$rc" -eq 1 ]]
 
 echo "==> OK smoke_org_knowledge"

--- a/tests/examples/test_org_knowledge_contribute.py
+++ b/tests/examples/test_org_knowledge_contribute.py
@@ -1,0 +1,175 @@
+"""Tests for examples/org-knowledge contribute (K4)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EX_DIR = Path(__file__).resolve().parents[2] / "examples" / "org-knowledge"
+sys.path.insert(0, str(EX_DIR))
+
+from contribute import (  # noqa: E402
+    ContributeDecision,
+    ContributeProposal,
+    contribute,
+    normalize_rel_path,
+)
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def test_member_accepts_sop(root: Path) -> None:
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="sop/tip.md",
+            body="# tip\n\nDo X.\n",
+            from_agent="agt_1",
+            work_id="work_1",
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.ACCEPTED
+    text = Path(r.abs_path).read_text(encoding="utf-8")
+    assert "Do X." in text
+    assert "orgkb:contribute" in text
+    assert "agt_1" in text
+
+
+def test_member_rejected_on_charter(root: Path) -> None:
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="charter.md",
+            body="# bad\n",
+            from_agent="agt_1",
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.REJECTED
+
+
+def test_owner_can_write_charter(root: Path) -> None:
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="charter.md",
+            body="# Charter\n",
+            from_agent="agt_owner",
+            as_owner=True,
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.ACCEPTED
+
+
+def test_conflict_goes_to_disputed(root: Path) -> None:
+    p = ContributeProposal(
+        org_id="org_x",
+        path="sop/a.md",
+        body="# v1\n",
+        from_agent="agt_1",
+    )
+    assert contribute(p, root=root).decision == ContributeDecision.ACCEPTED
+    r2 = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="sop/a.md",
+            body="# v2\n",
+            from_agent="agt_2",
+        ),
+        root=root,
+    )
+    assert r2.decision == ContributeDecision.DISPUTED
+    assert r2.path.startswith("disputed/")
+    assert Path(r2.abs_path).is_file()
+    # original preserved
+    assert (root / "orgs" / "org_x" / "sop" / "a.md").read_text(
+        encoding="utf-8"
+    ).startswith("# v1")
+
+
+def test_force_overwrites(root: Path) -> None:
+    contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="skills/s.md",
+            body="# old\n",
+            from_agent="agt_1",
+        ),
+        root=root,
+    )
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="skills/s.md",
+            body="# new\n",
+            from_agent="agt_1",
+            force=True,
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.ACCEPTED
+    assert "# new" in Path(r.abs_path).read_text(encoding="utf-8")
+
+
+def test_noop_identical(root: Path) -> None:
+    body = "# same\n"
+    contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="playbooks/p.md",
+            body=body,
+            from_agent="agt_1",
+        ),
+        root=root,
+    )
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="playbooks/p.md",
+            body=body,
+            from_agent="agt_1",
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.NOOP
+
+
+def test_reject_bad_path() -> None:
+    with pytest.raises(ValueError):
+        normalize_rel_path("../etc/passwd.md")
+
+
+def test_cli_json(root: Path) -> None:
+    payload = {
+        "org_id": "org_cli",
+        "path": "wiki/note.md",
+        "body": "# from json\n",
+        "from_agent": "agt_cli",
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(EX_DIR / "contribute_kb.py"),
+            "--root",
+            str(root),
+            "--from-json",
+            "-",
+            "--json-out",
+        ],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["decision"] == "accepted"


### PR DESCRIPTION
## Summary
- Implement **K4 agent contribute** on the filesystem knowledge sidecar: `contribute.py` / `contribute_kb.py`.
- Governance: member auto-accept under `sop|skills|playbooks|wiki|sources`; `charter` requires `--as-owner`; conflicts → `disputed/`.
- Docs/playbook/smoke updated; still no Kernel CRUD / `plugins.knowledge` wiring.

## Test plan
- [x] `pytest tests/examples/test_org_knowledge_contribute.py tests/examples/test_org_knowledge_kb.py`
- [x] `./scripts/smoke_org_knowledge.sh`
- [ ] Skim contribute section in [org-knowledge-base-v0.md](docs/org-harness/org-knowledge-base-v0.md)


Made with [Cursor](https://cursor.com)