### PR TITLE
feat(org): K3 — plugins.knowledge noop|git

### DIFF
--- a/acn/core/entities/org.py
+++ b/acn/core/entities/org.py
@@ -88,6 +88,7 @@ class Org:
             "work": "builtin_work",
             "loop": "heartbeat",
             "memory": "noop",
+            "knowledge": "noop",
         }
     )
     roles: list[str] = field(default_factory=lambda: list(_DEFAULT_ROLES))
@@ -148,6 +149,7 @@ class Org:
                 "work": "builtin_work",
                 "loop": "heartbeat",
                 "memory": "noop",
+                "knowledge": "noop",
             },
             roles=list(data.get("roles") or _DEFAULT_ROLES),
             status=data.get("status") or "active",

--- a/acn/core/interfaces/__init__.py
+++ b/acn/core/interfaces/__init__.py
@@ -19,6 +19,7 @@ from .join_flow_event_publisher import (
     JoinFlowEventType,
     JoinFlowEventVia,
 )
+from .org_knowledge import IOrgKnowledge
 from .org_repository import IOrgRepository
 from .settlement_outbox_repository import (
     ISettlementOutboxRepository,
@@ -42,6 +43,7 @@ __all__ = [
     "JoinFlowEventTrigger",
     "JoinFlowEventType",
     "JoinFlowEventVia",
+    "IOrgKnowledge",
     "IOrgRepository",
     "ISettlementOutboxRepository",
     "SettlementEvent",

--- a/acn/core/interfaces/org_knowledge.py
+++ b/acn/core/interfaces/org_knowledge.py
@@ -1,0 +1,27 @@
+"""IOrgKnowledge — Org shared knowledge Port (not Kernel).
+
+K3 wires ``plugins.knowledge`` to ``noop`` | ``git``. Content remains in an
+external sidecar (see ``examples/org-knowledge/``); this ABC documents the
+Port surface for future in-process adapters.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class IOrgKnowledge(ABC):
+    """Organization knowledge Port — agent-authored shared assets."""
+
+    @abstractmethod
+    def plugin_id(self) -> str:
+        """Canonical plugin id (``noop`` or ``git``)."""
+
+    @abstractmethod
+    def enabled(self) -> bool:
+        """False for ``noop`` — wake/contribute should skip the sidecar."""
+
+    def default_refs(self, org_id: str) -> list[dict[str, Any]]:
+        """Optional default ``kb_refs`` when work has none. Empty if disabled."""
+        return []

--- a/acn/infrastructure/persistence/postgres/org_repository.py
+++ b/acn/infrastructure/persistence/postgres/org_repository.py
@@ -35,7 +35,12 @@ class PostgresOrgRepository(IOrgRepository):
             subnet_id=row.subnet_id,
             steward_agent_id=row.steward_agent_id,
             plugins=row.plugins
-            or {"work": "builtin_work", "loop": "heartbeat", "memory": "noop"},
+            or {
+                "work": "builtin_work",
+                "loop": "heartbeat",
+                "memory": "noop",
+                "knowledge": "noop",
+            },
             roles=list(row.roles or ["manager", "worker", "reviewer"]),
             status=row.status,  # type: ignore[arg-type]
             created_at=row.created_at,

--- a/acn/routes/orgs.py
+++ b/acn/routes/orgs.py
@@ -262,7 +262,8 @@ class OrgCreateRequest(BaseModel):
     plugins: dict[str, str] | None = Field(
         default=None,
         description=(
-            "Org plugin map; work defaults to builtin_work. "
+            "Org plugin map; work defaults to builtin_work; "
+            "knowledge: noop|git (K3). "
             "Legacy aliases minimal→builtin_work, thin→heartbeat."
         ),
     )

--- a/acn/services/knowledge_patterns/__init__.py
+++ b/acn/services/knowledge_patterns/__init__.py
@@ -1,0 +1,15 @@
+"""Org knowledge plugins (K3) — ``plugins.knowledge`` = noop | git."""
+
+from __future__ import annotations
+
+from ...core.interfaces.org_knowledge import IOrgKnowledge
+from .git_sidecar import GitSidecarKnowledge
+from .noop import NoopKnowledge
+from .resolve import resolve_knowledge_plugin
+
+__all__ = [
+    "GitSidecarKnowledge",
+    "IOrgKnowledge",
+    "NoopKnowledge",
+    "resolve_knowledge_plugin",
+]

--- a/acn/services/knowledge_patterns/git_sidecar.py
+++ b/acn/services/knowledge_patterns/git_sidecar.py
@@ -1,0 +1,25 @@
+"""``plugins.knowledge=git`` — enable filesystem/git sidecar (examples/org-knowledge).
+
+In-process ACN does not host the vault; runners call ``read_kb`` / ``contribute_kb``.
+This adapter only signals that the Org opted into the sidecar contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.interfaces.org_knowledge import IOrgKnowledge
+
+
+class GitSidecarKnowledge(IOrgKnowledge):
+    def plugin_id(self) -> str:
+        return "git"
+
+    def enabled(self) -> bool:
+        return True
+
+    def default_refs(self, org_id: str) -> list[dict[str, Any]]:
+        oid = (org_id or "").strip()
+        if not oid:
+            return []
+        return [{"uri": f"orgkb://{oid}/charter.md", "title": "charter.md"}]

--- a/acn/services/knowledge_patterns/noop.py
+++ b/acn/services/knowledge_patterns/noop.py
@@ -1,0 +1,18 @@
+"""``plugins.knowledge=noop`` — Org declares no shared knowledge base."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.interfaces.org_knowledge import IOrgKnowledge
+
+
+class NoopKnowledge(IOrgKnowledge):
+    def plugin_id(self) -> str:
+        return "noop"
+
+    def enabled(self) -> bool:
+        return False
+
+    def default_refs(self, org_id: str) -> list[dict[str, Any]]:
+        return []

--- a/acn/services/knowledge_patterns/resolve.py
+++ b/acn/services/knowledge_patterns/resolve.py
@@ -1,0 +1,32 @@
+"""Resolve ``plugins.knowledge`` ids to ``IOrgKnowledge`` adapters."""
+
+from __future__ import annotations
+
+from ...core.exceptions import OrgConflictError
+from ...core.interfaces.org_knowledge import IOrgKnowledge
+from .git_sidecar import GitSidecarKnowledge
+from .noop import NoopKnowledge
+
+_KNOWN = frozenset({"noop", "git"})
+
+
+def resolve_knowledge_plugin(plugin_id: str) -> IOrgKnowledge:
+    pid = (plugin_id or "noop").strip() or "noop"
+    if pid == "noop":
+        return NoopKnowledge()
+    if pid == "git":
+        return GitSidecarKnowledge()
+    raise OrgConflictError(
+        "unknown_plugin",
+        f"unknown knowledge plugin: {plugin_id!r}",
+    )
+
+
+def knowledge_enabled(plugins: dict[str, str] | None) -> bool:
+    """True when Org ``plugins.knowledge`` is an enabled adapter (today: ``git``)."""
+    if not plugins:
+        return False
+    pid = (plugins.get("knowledge") or "noop").strip() or "noop"
+    if pid not in _KNOWN:
+        return False
+    return resolve_knowledge_plugin(pid).enabled()

--- a/acn/services/work_patterns/__init__.py
+++ b/acn/services/work_patterns/__init__.py
@@ -6,6 +6,7 @@ from ...core.interfaces.work_pattern import IWorkPattern
 from .builtin import BuiltinWorkPattern
 from .registry import (
     DEFAULT_ORG_PLUGINS,
+    canonicalize_knowledge_plugin,
     canonicalize_work_plugin,
     normalize_org_plugins,
     resolve_work_pattern,
@@ -16,6 +17,7 @@ __all__ = [
     "BuiltinWorkPattern",
     "DEFAULT_ORG_PLUGINS",
     "IWorkPattern",
+    "canonicalize_knowledge_plugin",
     "canonicalize_work_plugin",
     "normalize_org_plugins",
     "resolve_work_pattern",

--- a/acn/services/work_patterns/registry.py
+++ b/acn/services/work_patterns/registry.py
@@ -7,11 +7,12 @@ from ...core.interfaces.org_repository import IOrgRepository
 from ...core.interfaces.work_pattern import IWorkPattern
 from .builtin import BuiltinWorkPattern
 
-# Canonical defaults (phase2-work-port-v0).
+# Canonical defaults (phase2-work-port-v0 + K3 knowledge).
 DEFAULT_ORG_PLUGINS: dict[str, str] = {
     "work": "builtin_work",
     "loop": "heartbeat",
     "memory": "noop",
+    "knowledge": "noop",
 }
 
 # Legacy Phase 1 ids still accepted when reading stored Orgs.
@@ -33,6 +34,9 @@ _WORK_KNOWN_UNAVAILABLE: frozenset[str] = frozenset({"task_pool", "paperclip"})
 
 _LOOP_KNOWN: frozenset[str] = frozenset({"heartbeat"})
 _MEMORY_KNOWN: frozenset[str] = frozenset({"noop"})
+# K3: git = filesystem/git sidecar (examples/org-knowledge); llm_wiki = K5 later.
+_KNOWLEDGE_KNOWN: frozenset[str] = frozenset({"noop", "git"})
+_KNOWLEDGE_KNOWN_UNAVAILABLE: frozenset[str] = frozenset({"llm_wiki"})
 
 
 def canonicalize_work_plugin(plugin_id: str) -> str:
@@ -41,6 +45,11 @@ def canonicalize_work_plugin(plugin_id: str) -> str:
 
 def canonicalize_loop_plugin(plugin_id: str) -> str:
     return _LOOP_ALIASES.get(plugin_id, plugin_id)
+
+
+def canonicalize_knowledge_plugin(plugin_id: str) -> str:
+    pid = (plugin_id or "noop").strip() or "noop"
+    return pid
 
 
 def normalize_org_plugins(plugins: dict[str, str] | None) -> dict[str, str]:
@@ -52,6 +61,9 @@ def normalize_org_plugins(plugins: dict[str, str] | None) -> dict[str, str]:
     merged["loop"] = canonicalize_loop_plugin(merged.get("loop", "heartbeat"))
     if "memory" not in merged or not merged["memory"]:
         merged["memory"] = "noop"
+    merged["knowledge"] = canonicalize_knowledge_plugin(
+        merged.get("knowledge", "noop")
+    )
     return merged
 
 
@@ -83,6 +95,20 @@ def validate_org_plugins(plugins: dict[str, str]) -> None:
         raise OrgConflictError(
             "unknown_plugin",
             f"unknown memory plugin: {memory!r}",
+        )
+
+    knowledge = canonicalize_knowledge_plugin(plugins.get("knowledge", "noop"))
+    if knowledge in _KNOWLEDGE_KNOWN:
+        pass
+    elif knowledge in _KNOWLEDGE_KNOWN_UNAVAILABLE:
+        raise OrgConflictError(
+            "plugin_unavailable",
+            f"knowledge plugin '{knowledge}' is not available yet (K5+)",
+        )
+    else:
+        raise OrgConflictError(
+            "unknown_plugin",
+            f"unknown knowledge plugin: {plugins.get('knowledge')!r}",
         )
 
 

--- a/docs/org-harness/org-knowledge-base-v0.md
+++ b/docs/org-harness/org-knowledge-base-v0.md
@@ -1,7 +1,8 @@
 # Org 知识库 — 产品与 Port 定义 v0
 
-**Status:** Design Accepted · **K1–K4 examples 已落地**（读 + agent contribute）  
+**Status:** Design Accepted · **K1–K4 examples 已落地** · **K3 `plugins.knowledge` 已接线**  
 **Code：** [`examples/org-knowledge/`](../../examples/org-knowledge/)（`read_kb.py` · `contribute_kb.py` · wake 加载）  
+**Plugins：** `acn.services.knowledge_patterns`（`noop` | `git`）  
 **Smoke：** [`scripts/smoke_org_knowledge.sh`](../../scripts/smoke_org_knowledge.sh)  
 
 **Date:** 2026-07-27  
@@ -70,7 +71,7 @@ agent 干活 → 读 KB → 产出
 ```
 
 **K1/K2：** 读路径。**K4：** 侧车 `contribute`（成员区自动收；charter 需 Owner；冲突 → `disputed/`）。  
-进程内 `plugins.knowledge` 仍未接线。
+进程内 `plugins.knowledge`：**K3 已接线**（默认 `noop`；`git` 启用侧车契约）。
 
 ### 与 Memory 的硬边界
 
@@ -148,7 +149,7 @@ orgs/<org_id>/
 - Kernel CRUD 文档 API  
 - 自研向量引擎 / 跨 org 联邦  
 
-### `plugins.knowledge` 预留
+### `plugins.knowledge`（K3）
 
 ```json
 {
@@ -159,14 +160,14 @@ orgs/<org_id>/
 }
 ```
 
-| id（规划） | 状态 | 说明 |
+| id | 状态 | 说明 |
 |---|---|---|
-| `noop` | **plugin-planned** | 无组织知识库 |
-| `git` | **examples-shipped**（读+写 K4） | 默认推荐 |
-| `llm_wiki` | **adapter-planned** | Karpathy 配方；可选第二档 |
+| `noop` | **wired**（默认） | 无组织知识库；runner 可设 `ORG_PLUGINS_KNOWLEDGE=noop` 跳过读/写 |
+| `git` | **wired** + 侧车 examples | 启用 filesystem/git 侧车契约（`read_kb` / `contribute_kb`） |
+| `llm_wiki` | **plugin-unavailable**（K5） | Karpathy 配方；可选第二档 |
 | 外挂 KB / RAG | **community-welcome** | |
 
-今日创建 Org **不要**伪造未接线的 `plugins.knowledge` id；读写继续走侧车。
+创建 Org 时可显式传 `knowledge=git`；内容仍在侧车，不进 Kernel CRUD。
 
 ---
 
@@ -234,7 +235,7 @@ python3 contribute_kb.py --org org_x --from-agent agt_1 \
 | **K0** | 问题轴升格 | **done** |
 | **K1–K2** | 读侧车 + wake `kb_refs` | **done** |
 | **K4** | **agent contribute** + 最小治理（`contribute_kb.py`） | **done** |
-| **K3** | 用户可选：`git` / `noop`（`plugins.knowledge`）；可选向量 | 按需 |
+| **K3** | 用户可选：`git` / `noop`（`plugins.knowledge`）；可选向量 | **done**（向量后置） |
 | **K5** | 可选 `llm_wiki` 配方（sources→wiki，Obsidian 前端） | 按需 |
 | **后置** | `plugins.knowledge` 多后端、审批 UI | Phase 3+ |
 

--- a/docs/org-harness/plugin-catalog-v0.md
+++ b/docs/org-harness/plugin-catalog-v0.md
@@ -32,7 +32,7 @@
 |---|---|
 | 组织内派活 + Paperclip Issues | **默认** `builtin_work` + 装 [`paperclip-acn-plugin`](https://github.com/acnlabs/paperclip-acn-plugin)（外部 Pattern，**不是** `plugins.work=paperclip`） |
 | 面向网络发赏金 | **旁路** [org-task-bridge](./org-task-bridge-v0.md) / Org wallet；**不要**改 `plugins.work` |
-| 组织知识库（**agent 主贡献**） | 读：[`examples/org-knowledge/`](../../examples/org-knowledge/)；写路径设计中。可选方向 `git` / `noop` /（将来）`llm_wiki`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。勿伪造未接线 `plugins.knowledge=*` |
+| 组织知识库（**agent 主贡献**） | `plugins.knowledge=noop|git`（K3）；侧车 [`examples/org-knowledge/`](../../examples/org-knowledge/)。`llm_wiki` → K5。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md) |
 | 组织共享记忆（事实 / 叙事） | 先 `memory=noop`；需要时按下方 Memory 短名单自建侧车 |
 | Task Pool 当组织工单后端 | **`deferred`**（`plugins.work=task_pool` 会 `plugin_unavailable`） |
 
@@ -46,7 +46,7 @@
 
 | 路径 | 谁用 | v0 事实 |
 |---|---|---|
-| **`org.plugins.*`（进程内 registry）** | ACN 内置 Builtin | 白名单 id only（今日：`builtin_work` / `heartbeat` / `noop`）。任意第三方字符串 → 拒绝。完整第三方进程内插件 → **Phase 3**（宿主 + 信任模型）之后才谈。 |
+| **`org.plugins.*`（进程内 registry）** | ACN 内置 Builtin | 白名单 id only（今日：`builtin_work` / `heartbeat` / `memory=noop` / `knowledge=noop|git`）。任意第三方字符串 → 拒绝。完整第三方进程内插件 → **Phase 3**（宿主 + 信任模型）之后才谈。 |
 | **外部 Pattern / 侧车** | 用户与社区的主自定义路径 | 消费 Org / work / harness 事件（见 [adapter spec](./org-pattern-adapter-spec-v0.md)），或按 `org_id` 挂 Memory/MCP 侧车。**不**要求改 `plugins.work=…`。Paperclip 即此路。 |
 
 因此：
@@ -94,13 +94,13 @@ Port 划分（Work / Loop / Knowledge / Memory / …）是**问题轴**，充分
 | **ACN Org 编排器**（叫醒成员 agent） | **adapter-planned**（P2 examples） | Loop 轴外部 Pattern；[产品定义](./org-orchestrator-v0.md) · [唤醒契约](./org-orchestrator-wake-contract-v0.md) · [`examples/org-orchestrator/`](../../examples/org-orchestrator/)。无 `plugins.loop=orchestrator`。 |
 | **ClawTeam ↔ Org Loop 适配器** | **adapter-planned**（选型 only） | 编排器的**可选**执行后端：Org work ↔ CT task；见 [clawteam-org-loop-adapter-v0.md](./clawteam-org-loop-adapter-v0.md)。 |
 
-### 3. Knowledge — `IOrgKnowledge`（`plugins.knowledge` 预留）
+### 3. Knowledge — `IOrgKnowledge`（`plugins.knowledge` · K3）
 
 | id / 方向 | 状态 | 说明 |
 |---|---|---|
-| **`git` / 文件侧车**（按 `org_id`） | **examples-shipped**（读 K1/K2 · 写 K4） | **默认推荐**。`read_kb` + `contribute_kb`；wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。 |
-| **`llm_wiki`**（Karpathy 编译层 + 可选 Obsidian） | **adapter-planned** | 可选第二档；agent 维护 wiki/；须治理，不替代 charter。 |
-| `noop`（进程内） | **plugin-planned**（未接线） | 不要组织知识库。 |
+| **`noop`** | **wired**（默认） | 不要组织知识库。 |
+| **`git` / 文件侧车**（按 `org_id`） | **wired** + examples（读 K1/K2 · 写 K4） | 启用侧车契约。`read_kb` + `contribute_kb`；wake `kb_refs`。见 [org-knowledge-base-v0.md](./org-knowledge-base-v0.md)。 |
+| **`llm_wiki`**（Karpathy 编译层 + 可选 Obsidian） | **plugin-unavailable**（K5） | 可选第二档；agent 维护 wiki/；须治理，不替代 charter。 |
 | 外挂 KB / RAG | **community-welcome** | 成熟栈接入；ACN **不自研**引擎。 |
 
 组织刚需；**主贡献者是 agent**；与 Memory **分开选型**。

--- a/examples/org-knowledge/README.md
+++ b/examples/org-knowledge/README.md
@@ -2,7 +2,8 @@
 
 按 `org_id` 的**文件系统 / git** 知识树。  
 **成员 agent 主贡献**：`contribute_kb.py` 写入 `sop|skills|playbooks|wiki|sources`；`charter` 需 `--as-owner`；冲突进 `disputed/`。  
-**不是** ACN Kernel，**不是** `plugins.knowledge`（未接线），**不是** Memory。
+**不是** ACN Kernel，**不是** Memory。  
+ACN Org 可配 `plugins.knowledge=git|noop`（K3）；侧车内容仍在本目录。Runner 可设 `ORG_PLUGINS_KNOWLEDGE=noop` 拒绝 contribute / 跳过 wake 加载。
 
 | 文档 | 链接 |
 |---|---|
@@ -36,6 +37,7 @@ $ORG_KB_ROOT/orgs/<org_id>/
 | `ORG_KB_ROOT` | 知识树根；默认 `./data` |
 | `ORG_KB_ORG_ID` | 默认 org；与 `--org` 一起会**钉死** URI 的 org_id |
 | `ORG_KB_MAX_FILE_BYTES` | 单文件上限，默认 `524288` |
+| `ORG_PLUGINS_KNOWLEDGE` | 显式 `noop` 时 `contribute` 拒绝（`knowledge_plugin_noop`） |
 
 ## 试用
 

--- a/examples/org-knowledge/contribute.py
+++ b/examples/org-knowledge/contribute.py
@@ -122,6 +122,18 @@ def contribute(
     *,
     root: Path | None = None,
 ) -> ContributeResult:
+    import os
+
+    # K3: runner may mirror Org plugins.knowledge=noop to block writes.
+    knowledge = (os.environ.get("ORG_PLUGINS_KNOWLEDGE") or "").strip().lower()
+    if knowledge == "noop":
+        return ContributeResult(
+            decision=ContributeDecision.REJECTED,
+            path=(prop.path or "").strip(),
+            abs_path="",
+            reason="knowledge_plugin_noop",
+        )
+
     if not prop.from_agent.strip():
         raise ValueError("from_agent required")
     rel = normalize_rel_path(prop.path)

--- a/examples/org-orchestrator/handle_wake.py
+++ b/examples/org-orchestrator/handle_wake.py
@@ -143,7 +143,14 @@ def assignee_matches_me(
 
 
 def load_knowledge_bundle(wake: dict[str, Any]) -> str | None:
-    """Read Org KB sidecar using wake.kb_refs or default charter. None if skipped/missing."""
+    """Read Org KB sidecar using wake.kb_refs or default charter. None if skipped/missing.
+
+    Honors explicit ``ORG_PLUGINS_KNOWLEDGE=noop`` (K3) like ``HANDLE_WAKE_SKIP_KB``.
+    Unset env keeps prior sidecar load behavior.
+    """
+    if (os.environ.get("ORG_PLUGINS_KNOWLEDGE") or "").strip().lower() == "noop":
+        return None
+
     if str(_KB_DIR) not in sys.path:
         sys.path.insert(0, str(_KB_DIR))
     try:

--- a/examples/org-orchestrator/run_orchestrator.py
+++ b/examples/org-orchestrator/run_orchestrator.py
@@ -32,8 +32,20 @@ def wake_key(org_id: str, wid: str, assignee: str) -> str:
     return f"{org_id}:{wid}:wake:{WAKE_GENERATION}:{assignee}"
 
 
+def _knowledge_plugin_disabled() -> bool:
+    """True only when runner explicitly mirrors ``plugins.knowledge=noop``."""
+    return (os.environ.get("ORG_PLUGINS_KNOWLEDGE") or "").strip().lower() == "noop"
+
+
 def _kb_refs_for_item(org_id: str, item: dict) -> list[dict]:
-    """Optional kb_refs: work field → ORG_KB_REFS_JSON → ORG_KB_ATTACH_DEFAULTS."""
+    """Optional kb_refs: work field → ORG_KB_REFS_JSON → ORG_KB_ATTACH_DEFAULTS.
+
+    When ``ORG_PLUGINS_KNOWLEDGE=noop``, never attach kb_refs. Unset env keeps
+    prior sidecar behavior (opt-in via ORG_KB_*).
+    """
+    if _knowledge_plugin_disabled():
+        return []
+
     raw = item.get("kb_refs")
     if isinstance(raw, list) and raw:
         return [x for x in raw if isinstance(x, dict) and x.get("uri")]

--- a/tests/examples/test_org_knowledge_contribute.py
+++ b/tests/examples/test_org_knowledge_contribute.py
@@ -43,6 +43,21 @@ def test_member_accepts_sop(root: Path) -> None:
     assert "agt_1" in text
 
 
+def test_knowledge_plugin_noop_rejects_write(root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORG_PLUGINS_KNOWLEDGE", "noop")
+    r = contribute(
+        ContributeProposal(
+            org_id="org_x",
+            path="sop/tip.md",
+            body="# tip\n",
+            from_agent="agt_1",
+        ),
+        root=root,
+    )
+    assert r.decision == ContributeDecision.REJECTED
+    assert r.reason == "knowledge_plugin_noop"
+
+
 def test_member_rejected_on_charter(root: Path) -> None:
     r = contribute(
         ContributeProposal(

--- a/tests/services/test_knowledge_patterns.py
+++ b/tests/services/test_knowledge_patterns.py
@@ -1,0 +1,40 @@
+"""Unit tests for Org knowledge plugins (K3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from acn.core.exceptions import OrgConflictError
+from acn.services.knowledge_patterns import (
+    GitSidecarKnowledge,
+    NoopKnowledge,
+    resolve_knowledge_plugin,
+)
+from acn.services.knowledge_patterns.resolve import knowledge_enabled
+
+
+def test_resolve_noop_and_git():
+    noop = resolve_knowledge_plugin("noop")
+    assert isinstance(noop, NoopKnowledge)
+    assert noop.enabled() is False
+    assert noop.default_refs("org_x") == []
+
+    git = resolve_knowledge_plugin("git")
+    assert isinstance(git, GitSidecarKnowledge)
+    assert git.enabled() is True
+    assert git.default_refs("org_x") == [
+        {"uri": "orgkb://org_x/charter.md", "title": "charter.md"}
+    ]
+
+
+def test_resolve_unknown_knowledge_plugin():
+    with pytest.raises(OrgConflictError) as ei:
+        resolve_knowledge_plugin("mem0")
+    assert ei.value.reason == "unknown_plugin"
+
+
+def test_knowledge_enabled_helper():
+    assert knowledge_enabled(None) is False
+    assert knowledge_enabled({"knowledge": "noop"}) is False
+    assert knowledge_enabled({"knowledge": "git"}) is True
+    assert knowledge_enabled({"knowledge": "weird"}) is False

--- a/tests/services/test_org_service.py
+++ b/tests/services/test_org_service.py
@@ -786,6 +786,42 @@ class TestOrgPluginResolve:
         )
         assert org.plugins["work"] == "builtin_work"
         assert org.plugins["loop"] == "heartbeat"
+        assert org.plugins["knowledge"] == "noop"
+
+    async def test_create_accepts_knowledge_git(
+        self, org_service, mock_org_repo, mock_subnet_service
+    ):
+        subnet = Subnet(
+            slug="org-kb-git",
+            name="KB Git",
+            owner="agt_steward",
+            member_agent_ids={"agt_steward"},
+        )
+        mock_subnet_service.get_subnet = AsyncMock(
+            side_effect=[SubnetNotFoundException("x"), subnet]
+        )
+        mock_subnet_service.create_subnet = AsyncMock(return_value=subnet)
+        org = await org_service.create_org(
+            display_name="KB Git",
+            caller_type="agent",
+            caller_sub="agt_steward",
+            subnet_id="org-kb-git",
+            plugins={"knowledge": "git"},
+        )
+        assert org.plugins["knowledge"] == "git"
+
+    async def test_create_rejects_unknown_knowledge_plugin(
+        self, org_service, mock_org_repo
+    ):
+        with pytest.raises(OrgConflictError) as ei:
+            await org_service.create_org(
+                display_name="Bad KB",
+                caller_type="agent",
+                caller_sub="agt_steward",
+                plugins={"knowledge": "mem0"},
+            )
+        assert ei.value.reason == "unknown_plugin"
+        mock_org_repo.save_org.assert_not_called()
 
     async def test_update_rejects_unavailable_plugin(
         self, org_service, mock_org_repo

--- a/tests/services/test_work_patterns.py
+++ b/tests/services/test_work_patterns.py
@@ -21,6 +21,7 @@ def test_default_plugins_are_canonical():
         "work": "builtin_work",
         "loop": "heartbeat",
         "memory": "noop",
+        "knowledge": "noop",
     }
 
 
@@ -29,7 +30,14 @@ def test_normalize_legacy_aliases():
         "work": "builtin_work",
         "loop": "heartbeat",
         "memory": "noop",
+        "knowledge": "noop",
     }
+
+
+def test_normalize_knowledge_default_and_git():
+    assert normalize_org_plugins(None)["knowledge"] == "noop"
+    assert normalize_org_plugins({"knowledge": "git"})["knowledge"] == "git"
+    assert normalize_org_plugins({"knowledge": ""})["knowledge"] == "noop"
 
 
 def test_validate_unknown_plugin():
@@ -45,6 +53,17 @@ def test_validate_unavailable_plugins():
     with pytest.raises(OrgConflictError) as ei:
         validate_org_plugins({"work": "paperclip"})
     assert ei.value.reason == "plugin_unavailable"
+
+
+def test_validate_knowledge_plugins():
+    validate_org_plugins(normalize_org_plugins({"knowledge": "noop"}))
+    validate_org_plugins(normalize_org_plugins({"knowledge": "git"}))
+    with pytest.raises(OrgConflictError) as ei:
+        validate_org_plugins(normalize_org_plugins({"knowledge": "llm_wiki"}))
+    assert ei.value.reason == "plugin_unavailable"
+    with pytest.raises(OrgConflictError) as ei:
+        validate_org_plugins(normalize_org_plugins({"knowledge": "mem0"}))
+    assert ei.value.reason == "unknown_plugin"
 
 
 def test_resolve_builtin_and_aliases():


### PR DESCRIPTION
## Summary
- Wire `plugins.knowledge` to `noop` (default) | `git` with `IOrgKnowledge` adapters.
- Reject unknown ids; `llm_wiki` returns `plugin_unavailable` (K5).
- Runner env `ORG_PLUGINS_KNOWLEDGE=noop` skips wake KB load and rejects contribute.
- Docs: K3 done in org-knowledge-base + plugin-catalog.

## Test plan
- [x] `pytest` knowledge/work_patterns/org plugin resolve + contribute noop gate (26 passed)
- [ ] CI green
- [ ] Create Org with `knowledge=git` / reject `knowledge=mem0`


Made with [Cursor](https://cursor.com)