### PR TITLE
chore(release): cut v0.15.9 — CLI chat writeback 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Agent skill 0.17.14 / 0.17.15** — Org 编排器入口、wake 契约、成员 playbook。
 
+## [0.15.9] - 2026-08-02
+
+CLI patch: Interfaze / Chat Gateway writeback. Server and SDK package versions
+unchanged (publish jobs skip already-published artifacts); CLI publishes
+**0.14.1**.
+
+### Added
+
+- **`@acnlabs/acn-cli@0.14.1`** — `acn listen --chat-writeback` completes host
+  reply (`{"content"}`) then POSTs Chat Gateway `agent-messages`. See
+  `clients/cli/CHANGELOG.md`.
+
+### Docs
+
+- **Agent skill 0.17.17** — document `--chat-writeback` + complete URL/exec.
+
 ## [0.15.8] - 2026-07-25
 
 Server patch: Org wallet **S6** soft-val proxy + Org Harness docs/skill closeout.

--- a/acn/services/org_service.py
+++ b/acn/services/org_service.py
@@ -27,11 +27,11 @@ from ..core.exceptions import (
 )
 from ..core.interfaces.org_repository import IOrgRepository
 from ..core.interfaces.task_repository import ITaskRepository
+from ..core.interfaces.work_pattern import METADATA_UNSET
 from ..protocols.ap2 import WebhookEventType
 from ..protocols.ap2.webhook import WebhookService
 from .agent_service import AgentService
 from .subnet_service import SubnetService
-from ..core.interfaces.work_pattern import METADATA_UNSET
 from .work_patterns import (
     normalize_org_plugins,
     resolve_work_pattern,

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-08-02
+
+### Added — Chat Gateway writeback (Interfaze)
+
+- **`acn listen --chat-writeback`** — when a Mode B relayed message carries
+  `metadata.agentplanet` (`chat_id`, `reply_path`, `reply_channel=agentplanet.chat`),
+  the CLI asks the host for reply text then `POST`s Chat Gateway
+  `agent-messages` (`X-Internal-Token`).
+- **`--chat-api-base` / `--chat-token`** (env: `AGENTPLANET_API_BASE`,
+  `AGENTPLANET_INTERNAL_TOKEN`) — Gateway origin + internal token.
+- **`--chat-complete-url` | `--chat-complete-exec`** — host returns
+  `{"content":"..."}` (HTTP or stdin/stdout). Mutually exclusive.
+- **`--chat-complete-timeout`** — host complete timeout (default 120s).
+- Path allowlist: `reply_path` must be exactly
+  `/api/chats/{chat_id}/agent-messages`. Dedupe key
+  `chat:{chat_id}:{gateway_message_id}`.
+
 ## [0.14.0] - 2026-07-23
 
 ### Added — Local receiver + runtime wake (Mode B production path)

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -89,6 +89,24 @@ Semantics: CLI answers `message/send` / `message/stream` with a valid A2A
 wake the host. Wake failure is logged (`wake_failed`) and does **not** fail
 the A2A reply. Dedupe is on by default (`--no-dedupe` to disable).
 
+**Chat writeback (Interfaze / Chat Gateway):** when the relayed message carries
+`metadata.agentplanet.chat_id` + `reply_path`, enable the CLI to complete a
+host reply and POST `agent-messages` (hosts only return `{"content":"..."}`):
+
+```bash
+export AGENTPLANET_API_BASE=https://api.example.com
+export AGENTPLANET_INTERNAL_TOKEN=…   # or AGENTPLANET_INTERNAL_API_TOKEN
+
+acn listen --runtime http \
+  --wake-url http://127.0.0.1:10122/hooks/agent \
+  --chat-writeback \
+  --chat-complete-url http://127.0.0.1:10122/chat/complete
+# or: --chat-complete-exec 'python3 /path/to/complete.py'
+```
+
+Task / Org wakes still use `--wake-url` / `--wake-exec`. Chat envelopes skip
+wake and use the complete → writeback path instead.
+
 **Coverage:** only traffic that arrives over the Mode B relay. Open Task Pool
 rows that were never pushed as A2A still need `acn tasks list` / reconcile.
 

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -1,0 +1,331 @@
+/**
+ * Unified Interfaze / Chat Gateway writeback for Mode B listen.
+ *
+ * When a relayed A2A message carries metadata.agentplanet (chat_id + reply_path),
+ * the CLI:
+ *   1) asks the host for reply text (--chat-complete-url | --chat-complete-exec)
+ *   2) POSTs { content } to Chat Gateway agent-messages
+ *
+ * Hosts only need to return {"content":"..."} — they do not call Gateway themselves.
+ */
+
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import type { NormalizedEvent } from './normalize-event.js';
+import { isAllowedChatReplyPath } from './normalize-event.js';
+
+export interface ChatWritebackOptions {
+  enabled: boolean;
+  /** Chat Gateway origin, e.g. https://api.example.com */
+  apiBase: string;
+  /** X-Internal-Token for AgentPlanet INTERNAL_API_TOKEN */
+  token: string;
+  /** This listener's ACN agent_id (query param on writeback). */
+  agentId: string;
+  /** POST NormalizedEvent → JSON {"content":"..."} */
+  completeUrl?: string;
+  /** Shell: event JSON on stdin → stdout JSON {"content":"..."} */
+  completeExec?: string;
+  completeTimeoutMs?: number;
+  /** Timeout for the Gateway agent-messages POST (default 30s). */
+  writebackTimeoutMs?: number;
+}
+
+export type ChatWritebackResult =
+  | { ok: true; httpStatus: number }
+  | { ok: false; reason: string };
+
+export interface ChatWritebackDeps {
+  fetchFn?: typeof fetch;
+  spawnFn?: typeof spawn;
+  logFn?: (line: string) => void;
+}
+
+const DEFAULT_COMPLETE_TIMEOUT_MS = 120_000;
+const DEFAULT_WRITEBACK_TIMEOUT_MS = 30_000;
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+/** Validate chat-writeback flags when --chat-writeback is set. */
+export function validateChatWritebackOptions(opts: {
+  chatWriteback?: boolean;
+  chatApiBase?: string;
+  chatToken?: string;
+  chatCompleteUrl?: string;
+  chatCompleteExec?: string;
+  agentId?: string;
+}): string | null {
+  if (!opts.chatWriteback) return null;
+  if (!opts.agentId) {
+    return '--chat-writeback requires a known agent id (join / --agent-id).';
+  }
+  if (!opts.chatApiBase?.trim()) {
+    return '--chat-writeback requires --chat-api-base (or ACN_CHAT_API_BASE / AGENTPLANET_API_BASE).';
+  }
+  if (!opts.chatToken?.trim()) {
+    return (
+      '--chat-writeback requires --chat-token ' +
+      '(or ACN_CHAT_WRITEBACK_TOKEN / AGENTPLANET_INTERNAL_TOKEN / AGENTPLANET_INTERNAL_API_TOKEN).'
+    );
+  }
+  const hasUrl = Boolean(opts.chatCompleteUrl?.trim());
+  const hasExec = Boolean(opts.chatCompleteExec?.trim());
+  if (hasUrl === hasExec) {
+    return (
+      '--chat-writeback requires exactly one of --chat-complete-url or --chat-complete-exec ' +
+      '(host returns JSON {"content":"..."}).'
+    );
+  }
+  return null;
+}
+
+export function buildChatWritebackOptions(opts: {
+  chatWriteback?: boolean;
+  chatApiBase?: string;
+  chatToken?: string;
+  chatCompleteUrl?: string;
+  chatCompleteExec?: string;
+  chatCompleteTimeoutMs?: number;
+  chatWritebackTimeoutMs?: number;
+  agentId: string;
+}): ChatWritebackOptions | undefined {
+  if (!opts.chatWriteback) return undefined;
+  return {
+    enabled: true,
+    apiBase: opts.chatApiBase!.replace(/\/+$/, ''),
+    token: opts.chatToken!,
+    agentId: opts.agentId,
+    completeUrl: opts.chatCompleteUrl?.trim() || undefined,
+    completeExec: opts.chatCompleteExec?.trim() || undefined,
+    completeTimeoutMs: opts.chatCompleteTimeoutMs,
+    writebackTimeoutMs: opts.chatWritebackTimeoutMs,
+  };
+}
+
+/**
+ * Host complete response → reply text.
+ * Prefer content/reply/text; never treat a nested "message" object or ACK as content.
+ */
+export function extractContent(payload: unknown): string | null {
+  const rec = asRecord(payload);
+  if (!rec) return null;
+  for (const key of ['content', 'reply', 'text']) {
+    const v = rec[key];
+    if (typeof v === 'string' && v.trim()) {
+      const t = v.trim();
+      if (t.toLowerCase() === 'accepted') continue;
+      return t;
+    }
+  }
+  return null;
+}
+
+async function completeViaHttp(
+  event: NormalizedEvent,
+  opts: ChatWritebackOptions,
+  deps: ChatWritebackDeps
+): Promise<{ ok: true; content: string } | { ok: false; reason: string }> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const timeoutMs = opts.completeTimeoutMs ?? DEFAULT_COMPLETE_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(opts.completeUrl!, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(event),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    if (res.status < 200 || res.status >= 300) {
+      return { ok: false, reason: `complete_http_${res.status}` };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return { ok: false, reason: 'complete_invalid_json' };
+    }
+    const content = extractContent(parsed);
+    if (!content) return { ok: false, reason: 'complete_missing_content' };
+    return { ok: true, content };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
+      return { ok: false, reason: 'complete_timeout' };
+    }
+    return { ok: false, reason: msg.slice(0, 200) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function completeViaExec(
+  event: NormalizedEvent,
+  opts: ChatWritebackOptions,
+  deps: ChatWritebackDeps
+): Promise<{ ok: true; content: string } | { ok: false; reason: string }> {
+  const spawnFn = deps.spawnFn ?? spawn;
+  const timeoutMs = opts.completeTimeoutMs ?? DEFAULT_COMPLETE_TIMEOUT_MS;
+  const body = Buffer.from(JSON.stringify(event), 'utf-8');
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const child: ChildProcess = spawnFn(opts.completeExec!, { shell: true });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    const finish = (result: { ok: true; content: string } | { ok: false; reason: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish({ ok: false, reason: 'complete_timeout' });
+    }, timeoutMs);
+
+    child.stdout?.on('data', (d: Buffer) => stdout.push(Buffer.from(d)));
+    child.stderr?.on('data', (d: Buffer) => stderr.push(Buffer.from(d)));
+    child.on('error', (e: Error) =>
+      finish({ ok: false, reason: e.message.slice(0, 200) })
+    );
+    child.on('close', (code: number | null) => {
+      if (code !== 0) {
+        const detail = Buffer.concat(stderr).toString('utf-8').slice(0, 80);
+        finish({
+          ok: false,
+          reason: detail ? `complete_exit_${code}:${detail}` : `complete_exit_${code}`,
+        });
+        return;
+      }
+      const text = Buffer.concat(stdout).toString('utf-8').trim();
+      try {
+        const parsed = JSON.parse(text) as unknown;
+        const content = extractContent(parsed);
+        if (!content) {
+          finish({ ok: false, reason: 'complete_missing_content' });
+          return;
+        }
+        finish({ ok: true, content });
+      } catch {
+        finish({ ok: false, reason: 'complete_invalid_json' });
+      }
+    });
+
+    child.stdin?.end(body);
+  });
+}
+
+async function postWriteback(
+  event: NormalizedEvent,
+  content: string,
+  opts: ChatWritebackOptions,
+  deps: ChatWritebackDeps
+): Promise<ChatWritebackResult> {
+  const chat = event.chat;
+  if (!chat) return { ok: false, reason: 'no_chat_envelope' };
+
+  // Defense in depth: never trust reply_path without allowlist (INTERNAL token).
+  if (!isAllowedChatReplyPath(chat.chat_id, chat.reply_path)) {
+    return { ok: false, reason: 'reply_path_rejected' };
+  }
+  if (chat.reply_channel !== 'agentplanet.chat') {
+    return { ok: false, reason: 'reply_channel_rejected' };
+  }
+
+  const fetchFn = deps.fetchFn ?? fetch;
+  const path = chat.reply_path; // already allowlisted absolute path
+  let url: URL;
+  let baseOrigin: string;
+  try {
+    baseOrigin = new URL(opts.apiBase).origin;
+    url = new URL(`${opts.apiBase}${path}`);
+  } catch {
+    return { ok: false, reason: 'invalid_api_base' };
+  }
+  if (url.origin !== baseOrigin) {
+    return { ok: false, reason: 'reply_url_origin_mismatch' };
+  }
+  url.searchParams.set('agent_id', opts.agentId);
+
+  const timeoutMs = opts.writebackTimeoutMs ?? DEFAULT_WRITEBACK_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(url.toString(), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-Internal-Token': opts.token,
+      },
+      body: JSON.stringify({ content }),
+      signal: controller.signal,
+    });
+    if (res.status === 200 || res.status === 201) {
+      return { ok: true, httpStatus: res.status };
+    }
+    try {
+      await res.arrayBuffer();
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, reason: `writeback_http_${res.status}` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
+      return { ok: false, reason: 'writeback_timeout' };
+    }
+    return { ok: false, reason: msg.slice(0, 200) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Complete host reply + Gateway writeback. Never throws.
+ * Only call when event.chat is present and opts.enabled.
+ */
+export async function handleChatWriteback(
+  event: NormalizedEvent,
+  opts: ChatWritebackOptions,
+  deps: ChatWritebackDeps = {}
+): Promise<ChatWritebackResult> {
+  const logFn = deps.logFn ?? ((line: string) => console.error(line));
+  if (!event.chat) return { ok: false, reason: 'no_chat_envelope' };
+
+  const completed = opts.completeUrl
+    ? await completeViaHttp(event, opts, deps)
+    : await completeViaExec(event, opts, deps);
+
+  if (!completed.ok) {
+    logFn(
+      `[acn listen] chat_complete_failed chat_id=${event.chat.chat_id} ` +
+        `message_id=${event.message_id} reason=${completed.reason}`
+    );
+    return { ok: false, reason: completed.reason };
+  }
+
+  const written = await postWriteback(event, completed.content, opts, deps);
+  if (!written.ok) {
+    logFn(
+      `[acn listen] chat_writeback_failed chat_id=${event.chat.chat_id} ` +
+        `message_id=${event.message_id} reason=${written.reason}`
+    );
+    return written;
+  }
+
+  logFn(
+    `[acn listen] chat_writeback_ok chat_id=${event.chat.chat_id} ` +
+      `message_id=${event.message_id} http=${written.httpStatus}`
+  );
+  return written;
+}
+
+export { DEFAULT_COMPLETE_TIMEOUT_MS, DEFAULT_WRITEBACK_TIMEOUT_MS };

--- a/clients/cli/src/commands/listen.ts
+++ b/clients/cli/src/commands/listen.ts
@@ -3,6 +3,12 @@ import { spawn } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import WebSocket from 'ws';
 import { loadConfig } from '../config.js';
+import {
+  buildChatWritebackOptions,
+  DEFAULT_COMPLETE_TIMEOUT_MS,
+  validateChatWritebackOptions,
+  type ChatWritebackOptions,
+} from './chat-writeback.js';
 import { DedupeStore } from './normalize-event.js';
 import { dispatchLocalReceiver } from './local-receiver.js';
 import {
@@ -36,6 +42,11 @@ import {
  *   --runtime http|command|log  built-in A2A receiver + wake host (production default)
  *   --forward <url>             tunnel to a local A2A server (compat; SSE streamed)
  *   --exec <command>            stdout = full A2A JSON-RPC response (compat; buffered)
+ *
+ * Chat writeback (optional, with --runtime):
+ *   When a relayed message carries metadata.agentplanet.chat_id + reply_path,
+ *   ask the host for {"content"} then POST Chat Gateway agent-messages.
+ *   Task / Org wakes keep using --wake-url / --wake-exec.
  */
 
 export interface A2aRequestFrame {
@@ -87,6 +98,7 @@ export interface RuntimeHandlerOptions {
   wakeTimeoutMs?: number;
   dedupe: boolean;
   dedupeTtlSec: number;
+  chatWriteback?: ChatWritebackOptions;
 }
 
 export interface HandlerOptions {
@@ -512,6 +524,34 @@ export function listenCommand(): Command {
       '--exec <command>',
       'Compat: shell per request; stdout must be a full A2A JSON-RPC response'
     )
+    .option(
+      '--chat-writeback',
+      'On Chat Gateway envelopes: complete host reply then POST agent-messages ' +
+        '(requires --runtime)'
+    )
+    .option(
+      '--chat-api-base <url>',
+      'Chat Gateway origin for writeback ' +
+        '(env: ACN_CHAT_API_BASE or AGENTPLANET_API_BASE)'
+    )
+    .option(
+      '--chat-token <token>',
+      'X-Internal-Token for agent-messages (env: ACN_CHAT_WRITEBACK_TOKEN, ' +
+        'AGENTPLANET_INTERNAL_TOKEN, or AGENTPLANET_INTERNAL_API_TOKEN)'
+    )
+    .option(
+      '--chat-complete-url <url>',
+      'POST NormalizedEvent → JSON {"content":"..."} (mutually exclusive with --chat-complete-exec)'
+    )
+    .option(
+      '--chat-complete-exec <cmd>',
+      'Shell: event JSON on stdin → stdout JSON {"content":"..."}'
+    )
+    .option(
+      '--chat-complete-timeout <ms>',
+      `Host complete timeout in ms (default ${DEFAULT_COMPLETE_TIMEOUT_MS})`,
+      String(DEFAULT_COMPLETE_TIMEOUT_MS)
+    )
     .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
     .action(
       (opts: {
@@ -524,6 +564,12 @@ export function listenCommand(): Command {
         dedupeTtl?: string;
         forward?: string;
         exec?: string;
+        chatWriteback?: boolean;
+        chatApiBase?: string;
+        chatToken?: string;
+        chatCompleteUrl?: string;
+        chatCompleteExec?: string;
+        chatCompleteTimeout?: string;
         agentId?: string;
       }) => {
         const config = loadConfig();
@@ -555,6 +601,38 @@ export function listenCommand(): Command {
           process.exit(1);
         }
 
+        const chatApiBase =
+          opts.chatApiBase?.trim() ||
+          process.env.ACN_CHAT_API_BASE?.trim() ||
+          process.env.AGENTPLANET_API_BASE?.trim();
+        const chatToken =
+          opts.chatToken?.trim() ||
+          process.env.ACN_CHAT_WRITEBACK_TOKEN?.trim() ||
+          process.env.AGENTPLANET_INTERNAL_TOKEN?.trim() ||
+          process.env.AGENTPLANET_INTERNAL_API_TOKEN?.trim();
+        const chatCompleteUrl =
+          opts.chatCompleteUrl?.trim() ||
+          process.env.ACN_CHAT_COMPLETE_URL?.trim();
+        const chatCompleteExec = opts.chatCompleteExec?.trim();
+
+        if (opts.chatWriteback && !opts.runtime) {
+          console.error('--chat-writeback requires --runtime http|command|log.');
+          process.exit(1);
+        }
+
+        const chatErr = validateChatWritebackOptions({
+          chatWriteback: opts.chatWriteback,
+          chatApiBase,
+          chatToken,
+          chatCompleteUrl,
+          chatCompleteExec,
+          agentId,
+        });
+        if (chatErr) {
+          console.error(chatErr);
+          process.exit(1);
+        }
+
         let wakeHeaders: Record<string, string> | undefined;
         if (opts.runtime === 'http') {
           try {
@@ -567,6 +645,10 @@ export function listenCommand(): Command {
 
         const wakeTimeoutMs = Number.parseInt(opts.wakeTimeout ?? '', 10);
         const dedupeTtlSec = Number.parseInt(opts.dedupeTtl ?? '', 10);
+        const chatCompleteTimeoutMs = Number.parseInt(
+          opts.chatCompleteTimeout ?? '',
+          10
+        );
         if (opts.runtime && (!Number.isFinite(wakeTimeoutMs) || wakeTimeoutMs <= 0)) {
           console.error('--wake-timeout must be a positive integer (ms).');
           process.exit(1);
@@ -575,6 +657,25 @@ export function listenCommand(): Command {
           console.error('--dedupe-ttl must be a positive integer (seconds).');
           process.exit(1);
         }
+        if (
+          opts.chatWriteback &&
+          (!Number.isFinite(chatCompleteTimeoutMs) || chatCompleteTimeoutMs <= 0)
+        ) {
+          console.error('--chat-complete-timeout must be a positive integer (ms).');
+          process.exit(1);
+        }
+
+        const chatWriteback = buildChatWritebackOptions({
+          chatWriteback: opts.chatWriteback,
+          chatApiBase,
+          chatToken,
+          chatCompleteUrl,
+          chatCompleteExec,
+          chatCompleteTimeoutMs: opts.chatWriteback
+            ? chatCompleteTimeoutMs
+            : undefined,
+          agentId,
+        });
 
         runListener({
           agentId,
@@ -592,6 +693,7 @@ export function listenCommand(): Command {
                 // commander: --no-dedupe sets dedupe=false; default true
                 dedupe: opts.dedupe !== false,
                 dedupeTtlSec,
+                chatWriteback,
               }
             : undefined,
         });

--- a/clients/cli/src/commands/local-receiver.ts
+++ b/clients/cli/src/commands/local-receiver.ts
@@ -12,6 +12,11 @@ import {
   type NormalizedEvent,
 } from './normalize-event.js';
 import {
+  handleChatWriteback,
+  type ChatWritebackDeps,
+  type ChatWritebackOptions,
+} from './chat-writeback.js';
+import {
   wakeRuntime,
   type RuntimeWakeOptions,
   type WakeDeps,
@@ -31,9 +36,11 @@ export interface ReceiverResponseFrame {
 export interface LocalReceiverOptions extends RuntimeWakeOptions {
   dedupe: boolean;
   dedupeTtlSec: number;
+  /** When set, chat envelopes skip wakeRuntime and use Gateway writeback. */
+  chatWriteback?: ChatWritebackOptions;
 }
 
-export interface LocalReceiverDeps extends WakeDeps {
+export interface LocalReceiverDeps extends WakeDeps, ChatWritebackDeps {
   generateId?: () => string;
   now?: () => Date;
   logFn?: (line: string) => void;
@@ -191,6 +198,24 @@ export function dispatchLocalReceiver(
 
   const event = result.event;
   const key = opts.dedupe ? dedupeKey(event) : null;
+
+  // Chat Gateway envelopes: complete host reply + writeback (not task wake).
+  if (event.chat && opts.chatWriteback?.enabled) {
+    void handleChatWriteback(event, opts.chatWriteback, deps)
+      .then((written) => {
+        if (!written.ok && key) dedupeStore.forget(key);
+      })
+      .catch((err: unknown) => {
+        if (key) dedupeStore.forget(key);
+        const msg = err instanceof Error ? err.message : String(err);
+        logFn(
+          `[acn listen] chat_writeback_failed message_id=${event.message_id} ` +
+            `reason=${msg.slice(0, 200)}`
+        );
+      });
+    return;
+  }
+
   void wakeRuntime(event, opts, deps)
     .then((wake) => {
       if (!wake.ok) {
@@ -234,6 +259,27 @@ export async function dispatchLocalReceiverAndWaitWake(
   }
 
   const key = opts.dedupe ? dedupeKey(result.event) : null;
+
+  if (result.event.chat && opts.chatWriteback?.enabled) {
+    try {
+      const written = await handleChatWriteback(
+        result.event,
+        opts.chatWriteback,
+        deps
+      );
+      if (!written.ok && key) dedupeStore.forget(key);
+      return { dedupeHit: false, woke: written.ok };
+    } catch (err) {
+      if (key) dedupeStore.forget(key);
+      const msg = err instanceof Error ? err.message : String(err);
+      logFn(
+        `[acn listen] chat_writeback_failed message_id=${result.event.message_id} ` +
+          `reason=${msg.slice(0, 200)}`
+      );
+      return { dedupeHit: false, woke: false };
+    }
+  }
+
   try {
     const wake = await wakeRuntime(result.event, opts, deps);
     if (!wake.ok) {

--- a/clients/cli/src/commands/normalize-event.ts
+++ b/clients/cli/src/commands/normalize-event.ts
@@ -3,12 +3,27 @@
  * provide an in-process TTL dedupe window (restart clears the window).
  */
 
+/** Required reply_channel on Chat Gateway writeback envelopes. */
+export const CHAT_REPLY_CHANNEL = 'agentplanet.chat';
+
+/** Chat Gateway / Interfaze writeback envelope (metadata.agentplanet). */
+export interface ChatEnvelope {
+  chat_id: string;
+  reply_path: string;
+  reply_channel: typeof CHAT_REPLY_CHANNEL;
+  /** Stable user-message id from Gateway (preferred for dedupe). */
+  gateway_message_id: string | null;
+  user_text: string | null;
+}
+
 export interface NormalizedEvent {
   event_type: 'a2a_message';
   task_id: string | null;
   message_id: string;
   context_id: string | null;
   from_agent: string | null;
+  /** Present when Chat Gateway attached a writeback contract. */
+  chat: ChatEnvelope | null;
   received_at: string;
   raw: Record<string, unknown>;
 }
@@ -92,6 +107,69 @@ function extractFromAgent(message: Record<string, unknown>): string | null {
   );
 }
 
+function extractUserText(message: Record<string, unknown>): string | null {
+  const parts = message.parts;
+  if (!Array.isArray(parts)) return null;
+  const chunks: string[] = [];
+  for (const part of parts) {
+    const p = asRecord(part);
+    if (!p || p.kind !== 'text') continue;
+    const t = asNonEmptyString(p.text);
+    if (t) chunks.push(t);
+  }
+  return chunks.length > 0 ? chunks.join('\n') : null;
+}
+
+/**
+ * Allowlist Chat Gateway writeback path.
+ * Exact match only — blocks `..`, `//`, query, fragment, and other hosts/paths
+ * that could exfiltrate X-Internal-Token on the same apiBase origin.
+ */
+export function isAllowedChatReplyPath(
+  chatId: string,
+  replyPath: string
+): boolean {
+  if (!chatId || !replyPath) return false;
+  if (
+    replyPath.includes('..') ||
+    replyPath.includes('?') ||
+    replyPath.includes('#') ||
+    replyPath.includes('//') ||
+    replyPath.includes('\\') ||
+    !replyPath.startsWith('/')
+  ) {
+    return false;
+  }
+  return replyPath === `/api/chats/${chatId}/agent-messages`;
+}
+
+/**
+ * Extract Chat Gateway writeback envelope from message.metadata.agentplanet.
+ * Requires chat_id, reply_channel=agentplanet.chat, and allowlisted reply_path.
+ */
+export function extractChatEnvelope(
+  message: Record<string, unknown>
+): ChatEnvelope | null {
+  const metadata = asRecord(message.metadata);
+  if (!metadata) return null;
+  const ap = asRecord(metadata.agentplanet);
+  if (!ap) return null;
+  const chatId = asNonEmptyString(ap.chat_id);
+  const replyPath = asNonEmptyString(ap.reply_path);
+  const replyChannel = asNonEmptyString(ap.reply_channel);
+  if (!chatId || !replyPath) return null;
+  if (replyChannel !== CHAT_REPLY_CHANNEL) return null;
+  if (!isAllowedChatReplyPath(chatId, replyPath)) return null;
+  return {
+    chat_id: chatId,
+    reply_path: replyPath,
+    reply_channel: CHAT_REPLY_CHANNEL,
+    gateway_message_id:
+      asNonEmptyString(ap.message_id) ?? asNonEmptyString(ap.messageId),
+    user_text: extractUserText(message),
+  };
+}
+
 /**
  * Build a normalized wake event from a valid JSON-RPC body.
  * Call only after parseJsonRpcBody succeeds for message/send|stream.
@@ -111,12 +189,17 @@ export function normalizeEvent(
     message_id: extractMessageId(message, generateId),
     context_id: extractContextId(message),
     from_agent: extractFromAgent(message),
+    chat: extractChatEnvelope(message),
     received_at: now().toISOString(),
     raw: body,
   };
 }
 
 export function dedupeKey(event: NormalizedEvent): string {
+  if (event.chat) {
+    const mid = event.chat.gateway_message_id ?? event.message_id;
+    return `chat:${event.chat.chat_id}:${mid}`;
+  }
   return event.task_id ?? event.message_id;
 }
 

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Tests for Chat Gateway writeback path on Mode B listen.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildChatWritebackOptions,
+  extractContent,
+  handleChatWriteback,
+  validateChatWritebackOptions,
+} from '../src/commands/chat-writeback.js';
+import {
+  dispatchLocalReceiverAndWaitWake,
+} from '../src/commands/local-receiver.js';
+import {
+  DedupeStore,
+  dedupeKey,
+  extractChatEnvelope,
+  isAllowedChatReplyPath,
+  normalizeEvent,
+  parseJsonRpcBody,
+} from '../src/commands/normalize-event.js';
+
+function chatMessageBody(
+  agentplanet?: Record<string, unknown> | null,
+  messageExtra: Record<string, unknown> = {}
+): string {
+  const baseMeta = {
+    chat_id: 'chat-uuid',
+    message_id: 'user-msg-1',
+    from_user: 'auth0|x',
+    reply_channel: 'agentplanet.chat',
+    reply_path: '/api/chats/chat-uuid/agent-messages',
+  };
+  const ap =
+    agentplanet === null
+      ? undefined
+      : { ...baseMeta, ...(agentplanet ?? {}) };
+  const message = {
+    role: 'user',
+    messageId: 'msg-chat-1',
+    kind: 'message',
+    parts: [{ kind: 'text', text: 'hello from interfaze' }],
+    metadata: ap ? { agentplanet: ap } : {},
+    ...messageExtra,
+  };
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 'rpc-chat',
+    method: 'message/send',
+    params: { message },
+  });
+}
+
+function mockOkResponse(body: string, status = 200) {
+  return {
+    status,
+    headers: { get: () => null },
+    text: async () => body,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  };
+}
+
+describe('isAllowedChatReplyPath', () => {
+  it('allows exact Gateway path only', () => {
+    expect(
+      isAllowedChatReplyPath('chat-uuid', '/api/chats/chat-uuid/agent-messages')
+    ).toBe(true);
+    expect(
+      isAllowedChatReplyPath('chat-uuid', '/api/chats/other/agent-messages')
+    ).toBe(false);
+    expect(
+      isAllowedChatReplyPath('chat-uuid', '/api/chats/chat-uuid/../admin')
+    ).toBe(false);
+    expect(
+      isAllowedChatReplyPath('chat-uuid', '//evil.com/steal')
+    ).toBe(false);
+    expect(
+      isAllowedChatReplyPath(
+        'chat-uuid',
+        '/api/chats/chat-uuid/agent-messages?x=1'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('extractChatEnvelope / normalizeEvent.chat', () => {
+  it('extracts chat envelope from metadata.agentplanet', () => {
+    const parsed = parseJsonRpcBody(chatMessageBody());
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const event = normalizeEvent(parsed.body);
+    expect(event.chat).toEqual({
+      chat_id: 'chat-uuid',
+      reply_path: '/api/chats/chat-uuid/agent-messages',
+      reply_channel: 'agentplanet.chat',
+      gateway_message_id: 'user-msg-1',
+      user_text: 'hello from interfaze',
+    });
+    const params = parsed.body.params as { message: Record<string, unknown> };
+    expect(extractChatEnvelope(params.message)?.chat_id).toBe('chat-uuid');
+  });
+
+  it('returns null when chat_id or reply_path missing', () => {
+    const parsed = parseJsonRpcBody(
+      chatMessageBody({ chat_id: 'only-id', reply_path: undefined as unknown as string })
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const body = parsed.body;
+    const params = body.params as {
+      message: { metadata: { agentplanet: Record<string, unknown> } };
+    };
+    delete params.message.metadata.agentplanet.reply_path;
+    expect(normalizeEvent(body).chat).toBeNull();
+  });
+
+  it('returns null when reply_channel is wrong', () => {
+    const parsed = parseJsonRpcBody(
+      chatMessageBody({ reply_channel: 'other.channel' })
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(normalizeEvent(parsed.body).chat).toBeNull();
+  });
+
+  it('returns null when reply_path is not allowlisted', () => {
+    const parsed = parseJsonRpcBody(
+      chatMessageBody({ reply_path: '/api/internal/admin' })
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(normalizeEvent(parsed.body).chat).toBeNull();
+  });
+
+  it('dedupeKey prefers gateway message id for chat', () => {
+    const parsed = parseJsonRpcBody(chatMessageBody());
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const event = normalizeEvent(parsed.body);
+    expect(dedupeKey(event)).toBe('chat:chat-uuid:user-msg-1');
+  });
+});
+
+describe('extractContent', () => {
+  it('reads content/reply/text only', () => {
+    expect(extractContent({ content: 'hi' })).toBe('hi');
+    expect(extractContent({ reply: 'r' })).toBe('r');
+    expect(extractContent({ text: 't' })).toBe('t');
+    expect(extractContent({ message: 'should-ignore' })).toBeNull();
+    expect(extractContent({ content: 'accepted' })).toBeNull();
+  });
+});
+
+describe('validateChatWritebackOptions', () => {
+  it('allows disabled', () => {
+    expect(validateChatWritebackOptions({})).toBeNull();
+  });
+
+  it('requires base, token, and exactly one complete source', () => {
+    expect(
+      validateChatWritebackOptions({
+        chatWriteback: true,
+        agentId: 'a1',
+        chatApiBase: 'http://gw',
+        chatToken: 't',
+      })
+    ).toMatch(/exactly one/);
+
+    expect(
+      validateChatWritebackOptions({
+        chatWriteback: true,
+        agentId: 'a1',
+        chatApiBase: 'http://gw',
+        chatToken: 't',
+        chatCompleteUrl: 'http://host/complete',
+        chatCompleteExec: 'echo',
+      })
+    ).toMatch(/exactly one/);
+
+    expect(
+      validateChatWritebackOptions({
+        chatWriteback: true,
+        agentId: 'a1',
+        chatApiBase: 'http://gw',
+        chatToken: 't',
+        chatCompleteUrl: 'http://host/complete',
+      })
+    ).toBeNull();
+  });
+});
+
+describe('handleChatWriteback', () => {
+  it('completes via HTTP then POSTs agent-messages', async () => {
+    const calls: Array<{ url: string; body: string; headers: HeadersInit }> = [];
+    const fetchFn = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      calls.push({
+        url: u,
+        body: String(init?.body ?? ''),
+        headers: init?.headers ?? {},
+      });
+      if (u.includes('/complete')) {
+        return mockOkResponse(JSON.stringify({ content: 'agent says hi' }));
+      }
+      return mockOkResponse(JSON.stringify({ id: 'm1' }), 201);
+    });
+
+    const event = normalizeEvent(
+      (parseJsonRpcBody(chatMessageBody()) as { ok: true; body: Record<string, unknown> })
+        .body
+    );
+    const opts = buildChatWritebackOptions({
+      chatWriteback: true,
+      chatApiBase: 'http://gw:8000',
+      chatToken: 'secret',
+      chatCompleteUrl: 'http://127.0.0.1:9/complete',
+      agentId: 'agent-1',
+    })!;
+
+    const result = await handleChatWriteback(event, opts, {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      logFn: () => {},
+    });
+    expect(result).toEqual({ ok: true, httpStatus: 201 });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toContain('/complete');
+    expect(JSON.parse(calls[0].body).chat.chat_id).toBe('chat-uuid');
+    expect(calls[1].url).toBe(
+      'http://gw:8000/api/chats/chat-uuid/agent-messages?agent_id=agent-1'
+    );
+    expect(JSON.parse(calls[1].body)).toEqual({ content: 'agent says hi' });
+    const hdrs = calls[1].headers as Record<string, string>;
+    expect(hdrs['X-Internal-Token']).toBe('secret');
+  });
+
+  it('fails when complete JSON lacks content', async () => {
+    const fetchFn = vi.fn(async () => mockOkResponse('{}'));
+    const event = normalizeEvent(
+      (parseJsonRpcBody(chatMessageBody()) as { ok: true; body: Record<string, unknown> })
+        .body
+    );
+    const result = await handleChatWriteback(
+      event,
+      buildChatWritebackOptions({
+        chatWriteback: true,
+        chatApiBase: 'http://gw',
+        chatToken: 't',
+        chatCompleteUrl: 'http://host/c',
+        agentId: 'a',
+      })!,
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: () => {} }
+    );
+    expect(result).toEqual({ ok: false, reason: 'complete_missing_content' });
+  });
+
+  it('rejects writeback when envelope reply_path was tampered after normalize', async () => {
+    const fetchFn = vi.fn(async (url: string | URL) => {
+      if (String(url).includes('/complete')) {
+        return mockOkResponse(JSON.stringify({ content: 'x' }));
+      }
+      return mockOkResponse('{}', 201);
+    });
+    const event = normalizeEvent(
+      (parseJsonRpcBody(chatMessageBody()) as { ok: true; body: Record<string, unknown> })
+        .body
+    );
+    event.chat!.reply_path = '/api/internal/admin';
+    const result = await handleChatWriteback(
+      event,
+      buildChatWritebackOptions({
+        chatWriteback: true,
+        chatApiBase: 'http://gw',
+        chatToken: 't',
+        chatCompleteUrl: 'http://host/complete',
+        agentId: 'a',
+      })!,
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: () => {} }
+    );
+    expect(result).toEqual({ ok: false, reason: 'reply_path_rejected' });
+    expect(fetchFn.mock.calls.every((c) => !String(c[0]).includes('/admin'))).toBe(
+      true
+    );
+  });
+});
+
+describe('dispatchLocalReceiver chat vs task wake', () => {
+  it('routes chat envelope to writeback, not wake-url', async () => {
+    const wakeFetch = vi.fn(async () => mockOkResponse('ok'));
+    const completeFetch = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes('wake')) {
+        return mockOkResponse('should-not', 500);
+      }
+      if (u.includes('complete')) {
+        return mockOkResponse(JSON.stringify({ content: 'done' }));
+      }
+      return mockOkResponse('{}', 201);
+    });
+
+    const frames: unknown[] = [];
+    const store = new DedupeStore(3600);
+    const out = await dispatchLocalReceiverAndWaitWake(
+      'corr-c',
+      chatMessageBody(),
+      {
+        runtime: 'http',
+        wakeUrl: 'http://host/wake',
+        dedupe: true,
+        dedupeTtlSec: 3600,
+        chatWriteback: buildChatWritebackOptions({
+          chatWriteback: true,
+          chatApiBase: 'http://gw',
+          chatToken: 't',
+          chatCompleteUrl: 'http://host/complete',
+          agentId: 'agent-1',
+        }),
+      },
+      store,
+      (f) => frames.push(f),
+      {
+        fetchFn: completeFetch as unknown as typeof fetch,
+        logFn: () => {},
+      }
+    );
+
+    expect(out.woke).toBe(true);
+    expect(wakeFetch).not.toHaveBeenCalled();
+    expect(completeFetch.mock.calls.some((c) => String(c[0]).includes('wake'))).toBe(
+      false
+    );
+    expect(
+      completeFetch.mock.calls.some((c) => String(c[0]).includes('complete'))
+    ).toBe(true);
+    expect(frames[0]).toMatchObject({ type: 'a2a_response', status: 200 });
+  });
+
+  it('falls through to task wake when forged chat channel is rejected', async () => {
+    const body = chatMessageBody(
+      { reply_channel: 'forged' },
+      { metadata: { task_id: 'task-9', agentplanet: {
+        chat_id: 'chat-uuid',
+        message_id: 'user-msg-1',
+        reply_channel: 'forged',
+        reply_path: '/api/chats/chat-uuid/agent-messages',
+      } } }
+    );
+    const fetchFn = vi.fn().mockResolvedValue(mockOkResponse('', 204));
+    const store = new DedupeStore(3600);
+    const out = await dispatchLocalReceiverAndWaitWake(
+      'corr-forge',
+      body,
+      {
+        runtime: 'http',
+        wakeUrl: 'http://host/wake',
+        dedupe: true,
+        dedupeTtlSec: 3600,
+        chatWriteback: buildChatWritebackOptions({
+          chatWriteback: true,
+          chatApiBase: 'http://gw',
+          chatToken: 't',
+          chatCompleteUrl: 'http://host/complete',
+          agentId: 'agent-1',
+        }),
+      },
+      store,
+      () => {},
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: () => {} }
+    );
+    expect(out.woke).toBe(true);
+    expect(String(fetchFn.mock.calls[0][0])).toContain('/wake');
+  });
+
+  it('keeps task wake when no chat envelope', async () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          role: 'user',
+          messageId: 'm-task',
+          parts: [{ kind: 'text', text: 'do task' }],
+          metadata: { task_id: 'task-9' },
+        },
+      },
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockOkResponse('', 204));
+    const store = new DedupeStore(3600);
+    const out = await dispatchLocalReceiverAndWaitWake(
+      'corr-t',
+      body,
+      {
+        runtime: 'http',
+        wakeUrl: 'http://host/wake',
+        dedupe: true,
+        dedupeTtlSec: 3600,
+        chatWriteback: buildChatWritebackOptions({
+          chatWriteback: true,
+          chatApiBase: 'http://gw',
+          chatToken: 't',
+          chatCompleteUrl: 'http://host/complete',
+          agentId: 'agent-1',
+        }),
+      },
+      store,
+      () => {},
+      { fetchFn: fetchFn as unknown as typeof fetch, logFn: () => {} }
+    );
+    expect(out.woke).toBe(true);
+    expect(String(fetchFn.mock.calls[0][0])).toContain('/wake');
+  });
+});

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -193,13 +193,13 @@ describe('validateChatWritebackOptions', () => {
 
 describe('handleChatWriteback', () => {
   it('completes via HTTP then POSTs agent-messages', async () => {
-    const calls: Array<{ url: string; body: string; headers: HeadersInit }> = [];
+    const calls: Array<{ url: string; body: string; headers: unknown }> = [];
     const fetchFn = vi.fn(async (url: string | URL, init?: RequestInit) => {
       const u = String(url);
       calls.push({
         url: u,
         body: String(init?.body ?? ''),
-        headers: init?.headers ?? {},
+        headers: init?.headers,
       });
       if (u.includes('/complete')) {
         return mockOkResponse(JSON.stringify({ content: 'agent says hi' }));

--- a/clients/cli/tests/local-receiver.test.ts
+++ b/clients/cli/tests/local-receiver.test.ts
@@ -352,6 +352,7 @@ describe('wakeRuntime + dispatch order', () => {
         message_id: 'msg-cmd',
         context_id: null,
         from_agent: null,
+        chat: null,
         received_at: new Date().toISOString(),
         raw: {},
       },

--- a/examples/auto-collab-pull/completion.py
+++ b/examples/auto-collab-pull/completion.py
@@ -8,9 +8,8 @@ fixtures and optional local ``PERF_CACHE`` overlay in the matcher.
 from __future__ import annotations
 
 import json
-import math
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +32,7 @@ def _parse_ts(raw: Any) -> datetime | None:
     except ValueError:
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
     return dt
 
 

--- a/examples/auto-collab-pull/match.py
+++ b/examples/auto-collab-pull/match.py
@@ -5,9 +5,8 @@ See docs/auto-collab-pull-mvp-v0.md §3 · sparse-collab-contract §7 P2.
 
 from __future__ import annotations
 
-from typing import Any, Literal
-
 import os
+from typing import Any, Literal
 
 from effective_cap import effective_cap_from_task, parse_sparse_collab
 from performance import performance_scores

--- a/examples/auto-collab-pull/offline_checks.py
+++ b/examples/auto-collab-pull/offline_checks.py
@@ -19,8 +19,8 @@ from effective_cap import (  # noqa: E402
     effective_cap_from_task,
     seats_taken,
 )
-from idempotency import IdempotencyStore  # noqa: E402
 from handle_collab_pull import parse_collab_pull, resolve_idempotency_key  # noqa: E402
+from idempotency import IdempotencyStore  # noqa: E402
 from match import (  # noqa: E402
     MatchEmptyError,
     MatchForbiddenError,
@@ -137,7 +137,7 @@ def main() -> int:
     except MatchEmptyError:
         pass
 
-    from semantic import lexical_similarity, agent_profile_text, task_query_text
+    from semantic import agent_profile_text, lexical_similarity, task_query_text
 
     t = {
         "title": "fix login authentication",

--- a/examples/auto-collab-pull/performance.py
+++ b/examples/auto-collab-pull/performance.py
@@ -11,7 +11,7 @@ Optional metadata hooks (product/BFF may fill later):
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 
@@ -20,7 +20,7 @@ def _parse_ts(raw: Any) -> datetime | None:
         return None
     if isinstance(raw, (int, float)):
         try:
-            return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+            return datetime.fromtimestamp(float(raw), tz=UTC)
         except (OverflowError, OSError, ValueError):
             return None
     s = str(raw).strip()
@@ -33,7 +33,7 @@ def _parse_ts(raw: Any) -> datetime | None:
     except ValueError:
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
     return dt
 
 
@@ -41,8 +41,8 @@ def _freshness(ts: datetime | None, *, half_life_hours: float = 24.0) -> float |
     """1.0 = just now, decays toward 0; None if unknown."""
     if ts is None:
         return None
-    now = datetime.now(timezone.utc)
-    age_h = max(0.0, (now - ts.astimezone(timezone.utc)).total_seconds() / 3600.0)
+    now = datetime.now(UTC)
+    age_h = max(0.0, (now - ts.astimezone(UTC)).total_seconds() / 3600.0)
     # exponential-ish: half_life → 0.5
     score = 0.5 ** (age_h / max(half_life_hours, 1e-6))
     return float(max(0.0, min(1.0, score)))
@@ -142,7 +142,7 @@ def _self_test() -> None:
         "status": "online",
         "inbound_reachable": True,
         "consec_push_failures": 0,
-        "last_heartbeat": datetime.now(timezone.utc).isoformat(),
+        "last_heartbeat": datetime.now(UTC).isoformat(),
         "metadata": {
             "performance": {
                 "completion_rate": 0.9,

--- a/examples/auto-collab-pull/run_matcher.py
+++ b/examples/auto-collab-pull/run_matcher.py
@@ -27,8 +27,8 @@ from acn_client import (  # noqa: E402
     normalize_base,
     search_agents,
 )
-from effective_cap import effective_cap_from_task  # noqa: E402
 from completion import PerfCache  # noqa: E402
+from effective_cap import effective_cap_from_task  # noqa: E402
 from match import (  # noqa: E402
     MatchEmptyError,
     MatchForbiddenError,

--- a/examples/auto-collab-pull/semantic.py
+++ b/examples/auto-collab-pull/semantic.py
@@ -167,7 +167,7 @@ def _l2_normalize(vec: list[float]) -> list[float]:
 def cosine(a: list[float], b: list[float]) -> float:
     if not a or not b or len(a) != len(b):
         return 0.0
-    return float(sum(x * y for x, y in zip(a, b)))
+    return float(sum(x * y for x, y in zip(a, b, strict=True)))
 
 
 def semantic_scores(

--- a/examples/org-knowledge/contribute.py
+++ b/examples/org-knowledge/contribute.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 
@@ -20,7 +20,7 @@ from kb import _safe_file, max_file_bytes, org_dir
 
 # Sidecars often run on host Python (CN deploy hosts may be 3.10).
 # Keep this module importable below ACN server's requires-python (>=3.11).
-UTC = timezone.utc
+UTC = UTC
 
 _AGENT_ZONE_PREFIXES = (
     "sop/",
@@ -34,7 +34,7 @@ _CHARTER_PREFIXES = ("charter/",)
 _MD_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.+/-]*\.md$")
 
 
-class ContributeDecision(str, Enum):
+class ContributeDecision(str, Enum):  # noqa: UP042  # host Python may be <3.11 (no StrEnum)
     ACCEPTED = "accepted"
     DISPUTED = "disputed"
     REJECTED = "rejected"

--- a/examples/org-orchestrator/send_handoff.py
+++ b/examples/org-orchestrator/send_handoff.py
@@ -15,7 +15,6 @@ import sys
 
 from acn_client_min import agents_me, normalize_base, send_message
 
-
 HANDOFF_TYPE = "acn.org.work_handoff"
 
 

--- a/examples/org-orchestrator/work_observe.py
+++ b/examples/org-orchestrator/work_observe.py
@@ -20,7 +20,7 @@ import fcntl
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -28,14 +28,14 @@ from swarm_metrics import evaluate, score_wave
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
 def _parse_ts(raw: Any) -> datetime | None:
     if raw is None or raw == "":
         return None
     if isinstance(raw, (int, float)):
-        return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+        return datetime.fromtimestamp(float(raw), tz=UTC)
     s = str(raw).strip()
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
@@ -44,7 +44,7 @@ def _parse_ts(raw: Any) -> datetime | None:
     except ValueError:
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
     return dt
 
 
@@ -191,7 +191,7 @@ def timeline_from_events(
     for wid, rows in by_id.items():
         def _sort_key(r: dict[str, Any]) -> datetime:
             return _parse_ts(r.get("observed_at") or r.get("ts")) or datetime(
-                1970, 1, 1, tzinfo=timezone.utc
+                1970, 1, 1, tzinfo=UTC
             )
 
         rows.sort(key=_sort_key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.15.8"
+version = "0.15.9"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.16"
+  version: "0.17.17"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -98,6 +98,7 @@ acn config show
 | `acn join --base-url <origin>` | Join a custom/self-hosted ACN origin |
 | `acn join --relay` | Register for Mode B (no public endpoint; then run `acn listen`) |
 | `acn listen --runtime http\|command\|log` | Mode B production path: built-in A2A receiver + wake host (no local port) |
+| `acn listen … --chat-writeback` | Chat Gateway: complete host `{"content"}` then POST agent-messages |
 | `acn listen --forward <url>` / `--exec <cmd>` | Mode B compat tunnels (you supply A2A replies) |
 | `acn delivery get` | Show derived delivery transport (`direct` / `relay` / `none`) |
 | `acn delivery set relay` | Switch to Mode B without re-registering (then `acn listen`) |
@@ -327,6 +328,22 @@ The CLI answers `message/send` / `message/stream` with a valid A2A
 event JSON. Wake failure is logged (`wake_failed`) and does **not** fail
 the A2A reply (and releases the dedupe slot so a retry can wake again).
 Dedupe is on by default (`task_id` / `message_id`).
+
+**Chat writeback (Interfaze):** if the message has `metadata.agentplanet.chat_id`
++ `reply_path`, prefer CLI-owned writeback instead of asking the host LLM to
+POST Gateway itself:
+
+```bash
+acn listen --runtime http \
+  --wake-url http://127.0.0.1:PORT/wake \
+  --chat-writeback \
+  --chat-api-base "$AGENTPLANET_API_BASE" \
+  --chat-token "$AGENTPLANET_INTERNAL_TOKEN" \
+  --chat-complete-url http://127.0.0.1:PORT/chat/complete
+# host complete endpoint (or --chat-complete-exec) returns {"content":"..."}
+```
+
+Contract: AgentPlanet `docs/architecture/chat-agent-writeback-v0.md`.
 
 **Coverage boundary:** only A2A traffic that arrives over the Mode B relay.
 Open Task Pool rows never pushed as A2A still need list/reconcile.

--- a/tests/test_error_code_details_consistency.py
+++ b/tests/test_error_code_details_consistency.py
@@ -122,6 +122,10 @@ UNION_SCHEMA_CODES: dict[str, str] = {
         "registry dev-mode-disabled uses {reason}; tasks JWT scope check "
         "uses {required_permission}"
     ),
+    "INTERNAL_SERVER_ERROR": (
+        "org wallet proxy uses {org_id, reason} when BACKEND_URL missing; "
+        "registry uses {agent_id, reason} for agent-scoped misconfig paths"
+    ),
     # ``COMMUNICATION_REJECTED`` was a union-schema candidate during
     # sprint #2a's planning (registry catch-all proxy was originally
     # going to carry an ``upstream_status_code`` extra field). The

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.15.8"
+version = "0.15.9"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Publish `@acnlabs/acn-cli@0.14.1` with `acn listen --chat-writeback` (host complete → Chat Gateway `agent-messages`)
- Cut server release `v0.15.9` (SDK package versions unchanged; publish jobs skip already-published artifacts)
- Skill `0.17.17` documents the new flags

## Test plan
- [ ] CI green (CLI vitest includes `chat-writeback.test.ts`)
- [ ] After merge: `git tag v0.15.9 && git push origin v0.15.9`
- [ ] Release workflow publishes CLI; confirm `npm view @acnlabs/acn-cli version` → `0.14.1`
- [ ] Production: `npm i -g @acnlabs/acn-cli@0.14.1` and `acn listen --help | grep chat-writeback`


Made with [Cursor](https://cursor.com)