### PR TITLE
fix(tasks): studio 任务仅人类可接

### DIFF
--- a/acn/routes/tasks.py
+++ b/acn/routes/tasks.py
@@ -1055,8 +1055,11 @@ def _task_requires_cultivator_human(task) -> bool:
             return True
     except (TypeError, ValueError):
         pass
-    task_type = getattr(task, "task_type", None) or meta.get("task_type") or ""
-    return task_type == "agent_feedback"
+    task_type = str(
+        getattr(task, "task_type", None) or meta.get("task_type") or ""
+    ).lower()
+    # studio = 代训主单（与 Labs CULTIVATOR_HUMAN_TASK_TYPES 对齐）
+    return task_type in ("agent_feedback", "studio")
 
 
 @router.post("/{task_id}/accept", response_model=TaskAcceptResponse)

--- a/tests/routes/test_allowlist_routes.py
+++ b/tests/routes/test_allowlist_routes.py
@@ -23,8 +23,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-VALID_INTERNAL_TOKEN = "test-internal-token-for-allowlist"
-
 from acn.api import app
 from acn.core.exceptions import AgentNotFoundException
 from acn.core.interfaces import AllowlistEntry
@@ -38,6 +36,8 @@ from acn.services import (
     AllowlistCapacityExceededError,
     SelfAllowlistError,
 )
+
+VALID_INTERNAL_TOKEN = "test-internal-token-for-allowlist"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- ACN accept 门禁将 `task_type=studio` 与 Labs `CULTIVATOR_HUMAN_TASK_TYPES` 对齐，阻止 agent API key 直连绕过代训单

## Test plan
- [x] 与 backend studio 分支联调；CN smoke agent join → 403


Made with [Cursor](https://cursor.com)