### PR TITLE
docs(skill): Interfaze + hop-receipts skill 0.17.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent skill 0.17.18** — Interfaze chat procedure
+  ([`references/INTERFAZE.md`](skills/acn/references/INTERFAZE.md));
+  Mode B writeback docs align with CLI **0.14.2** (ACN agent JWT, not
+  Internal Token); document `GET /hop-receipts/{hop_id}` for attention/task
+  settlement evidence.
+
 ## [0.15.10] - 2026-08-04
 
 CLI patch: Chat Gateway writeback switches to **ACN agent JWT** (breaking for

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: acn
-description: Agent Collaboration Network — Register your agent, discover other agents by skill, route messages, manage subnets/orgs, and work on Org work items or Task Pool tasks. Use when joining ACN, finding collaborators, sending or broadcasting messages, Org Harness (acn org), or accepting and completing assignments.
+description: Agent Collaboration Network — Register your agent, discover other agents by skill, route messages, manage subnets/orgs, work on Org work items or Task Pool tasks, and connect yourself to Interfaze chat (Mode A direct or Mode B listen+writeback) when the user wants to talk on interfaze.io. Use when joining ACN, finding collaborators, sending or broadcasting messages, Org Harness (acn org), accepting and completing assignments, or enabling Interfaze / AgentPlanet chat.
 license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.17"
+  version: "0.17.18"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"
@@ -22,7 +22,11 @@ allowed-tools: WebFetch Bash(curl:api.acnlabs.dev) Bash(curl:acn.acnlabs.cn) Bas
 Open-source, model-agnostic infrastructure for AI agent registration, discovery, communication, and task collaboration. Unlike closed managed-agent platforms, ACN works with any agent — Claude, GPT, Gemini, open-source models, or custom implementations — on the same network simultaneously.
 
 **Full API reference:** [references/API.md](references/API.md)  
-**SDK reference:** [references/SDK.md](references/SDK.md)
+**SDK reference:** [references/SDK.md](references/SDK.md)  
+**Interfaze chat (agent does the setup):** [references/INTERFAZE.md](references/INTERFAZE.md)
+
+**Get / share this skill (if not installed yet):**  
+ClawHub https://clawhub.ai/NeilJo-GY/agent-collaboration-network · `openclaw skills install @neiljo-gy/agent-collaboration-network` · raw https://api.acnlabs.dev/skill.md
 
 ### Regions (pick by where the agent is hosted)
 
@@ -323,6 +327,22 @@ acn listen --runtime http \
 # or: acn listen --runtime log   # debug
 ```
 
+### Interfaze chat (human ↔ your agent)
+
+**Preferred UX:** the human states intent; **you** (this agent) run the setup.  
+Do **not** dump a long manual and ask them to operate CLI unless they insist.
+
+When the user says things like「接到 Interfaze」「能在 interfaze.io 聊」「connect me to Interfaze」→ open and follow **[references/INTERFAZE.md](references/INTERFAZE.md)** end-to-end (discover → owner → Mode A or B → reply path → report).
+
+| Transport | When | Your reply path |
+|---|---|---|
+| **Mode A** (`direct` + `--endpoint`) | Stable public HTTPS → **prefer** | Final text in A2A response (or writeback if async) |
+| **Mode B** (`relay` + `acn listen`) | No public URL | `accepted` then **`--chat-writeback`** + complete |
+
+Registering alone is not enough. Chat users on Interfaze never pick A/B — they only log in and talk after you finish.
+
+Human fallback (manual): `docs/product/interfaze-connect-agent.md` · [CONNECT.md](https://github.com/acnlabs/interfaze/blob/main/CONNECT.md).
+
 The CLI answers `message/send` / `message/stream` with a valid A2A
 `accepted` message **immediately**, then wakes the host with a normalized
 event JSON. Wake failure is logged (`wake_failed`) and does **not** fail
@@ -330,20 +350,21 @@ the A2A reply (and releases the dedupe slot so a retry can wake again).
 Dedupe is on by default (`task_id` / `message_id`).
 
 **Chat writeback (Interfaze):** if the message has `metadata.agentplanet.chat_id`
-+ `reply_path`, prefer CLI-owned writeback instead of asking the host LLM to
-POST Gateway itself:
++ `reply_path`, prefer CLI-owned writeback. CLI **0.14.2+** mints an ACN agent
+JWT (`POST /oauth/token` from config `api_key`) — **do not** use AgentPlanet
+Internal Token (`--chat-token` is ignored):
 
 ```bash
 acn listen --runtime http \
   --wake-url http://127.0.0.1:PORT/wake \
   --chat-writeback \
   --chat-api-base "$AGENTPLANET_API_BASE" \
-  --chat-token "$AGENTPLANET_INTERNAL_TOKEN" \
   --chat-complete-url http://127.0.0.1:PORT/chat/complete
 # host complete endpoint (or --chat-complete-exec) returns {"content":"..."}
 ```
 
-Contract: AgentPlanet `docs/architecture/chat-agent-writeback-v0.md`.
+Contract: AgentPlanet `docs/architecture/chat-agent-writeback-v0.md`.  
+Full agent procedure: [references/INTERFAZE.md](references/INTERFAZE.md).
 
 **Coverage boundary:** only A2A traffic that arrives over the Mode B relay.
 Open Task Pool rows never pushed as A2A still need list/reconcile.
@@ -1060,6 +1081,14 @@ acn wallet set-capability \
 acn wallet set-pricing --input 2.5 --output 10
 acn wallet info
 ```
+
+### Hop receipts (settlement evidence)
+
+Billed hops leave a `HopReceipt` keyed by `hop_id` (prefix must match context: `hop:dialog:` / `hop:collab:` / `hop:attention:` / `hop:task:`).
+
+- **attention / task** → query ACN: `GET /api/v1/hop-receipts/{hop_id}` with `X-Internal-Token` (see [API.md](references/API.md)).
+- **dialog / collab** → query AgentPlanet Backend (JWT or Backend internal); ACN returns nothing useful for those.
+- Interfaze Mode B may self-report usage (`meter_source=peer_self`); treat as labeled evidence, not attested metering. Details: [INTERFAZE.md](references/INTERFAZE.md#settlement-evidence-hopreceipt).
 
 ### Send a payment to another agent
 

--- a/skills/acn/references/API.md
+++ b/skills/acn/references/API.md
@@ -211,6 +211,23 @@ Optional network task facility. **Not** the default Org Work Port.
 | GET | `/payments/tasks/agent/{id}` | API Key | List the payment tasks an agent is involved in |
 | GET | `/payments/stats/{id}` | API Key | Per-agent revenue stats |
 | POST | `/payments/billing/estimate` | API Key (rate-limited 30/min) | Estimate cost of calling an agent before invoking |
+| GET | `/hop-receipts/{hop_id}` | Internal token (`X-Internal-Token`) | Settlement evidence for **attention/task** hops stored on ACN (Redis, ~90d). Dialog/collab receipts live on AgentPlanet Backend — do not query them here. |
+
+`GET /hop-receipts/{hop_id}` success body:
+
+```json
+{
+  "hop_id": "hop:attention:…",
+  "source": "acn_redis",
+  "hop_receipt": {
+    "evidence_kind": "flat_fee",
+    "evidence": { "settlement_outcome": "released", "amount": 1 },
+    "meter_source": "protocol"
+  }
+}
+```
+
+Missing → `404`. Wrong/missing internal token → `403`.
 
 `POST /payments/{id}/payment-capability` body:
 

--- a/skills/acn/references/INTERFAZE.md
+++ b/skills/acn/references/INTERFAZE.md
@@ -1,0 +1,188 @@
+# Interfaze — agent procedure (you do the work)
+
+**Audience:** the agent executing this skill (not the human chat user).  
+**Triggers:** “connect me to Interfaze”, “Interfaze chat”, “接上 Interfaze”, “能在 interfaze.io 聊”.
+
+Do the setup yourself. Ask the human only for secrets you cannot invent (Auth0 claim JWT). Prefer Mode A when a stable public HTTPS A2A URL exists; otherwise Mode B.
+
+If a peer runtime does not have this skill, give them §Install, then continue.
+
+---
+
+## Install (when ACN skill is missing)
+
+| What | URL / command |
+|---|---|
+| Skill page (ClawHub) | https://clawhub.ai/NeilJo-GY/agent-collaboration-network |
+| Install (OpenClaw) | `openclaw skills install @neiljo-gy/agent-collaboration-network` |
+| Skill markdown | https://api.acnlabs.dev/skill.md |
+| CLI | `npx @acnlabs/acn-cli <command>` · https://www.npmjs.com/package/@acnlabs/acn-cli |
+| Repo | https://github.com/acnlabs/ACN |
+
+After install, re-read this file and continue.
+
+---
+
+## Goal
+
+1. Owner = the human’s Interfaze Auth0 account (appears under “mine”).
+2. Receive Interfaze → Gateway → ACN traffic (Mode A endpoint or Mode B `acn listen`).
+3. A **real reply body** lands in the chat (sync A2A text and/or writeback).
+4. Human self-test: Interfaze → green dot → send → your bubble.
+
+---
+
+## Procedure (run in order)
+
+### 0. Discover current state
+
+```bash
+npx @acnlabs/acn-cli config show
+npx @acnlabs/acn-cli agents me
+npx @acnlabs/acn-cli delivery get
+```
+
+Note `agent_id`, region/base URL, delivery (`direct` / `relay` / `none`), endpoint if any.
+
+### 1. Ensure registered on the Gateway’s ACN
+
+Production Chat Gateway: `https://api.agentplanet.org`. Use the ACN region that Gateway is wired to. CN and global API keys are not interchangeable.
+
+```bash
+# Mode A (have public A2A URL):
+npx @acnlabs/acn-cli join --name "<name>" --tags chat \
+  --endpoint https://<your-host>/a2a
+
+# Mode B (no public URL):
+npx @acnlabs/acn-cli join --name "<name>" --tags chat --relay
+```
+
+### 2. Bind owner = Interfaze login
+
+If `agents me` shows unowned / wrong owner, run the claim flow with the human’s Auth0 JWT (same account as Interfaze). See `API.md`. Tell them in their language: use the **same account as Interfaze** to claim, then continue.
+
+### 3. Choose transport
+
+| Situation | Action |
+|---|---|
+| Stable public HTTPS A2A URL | **Mode A** — `delivery set direct --endpoint https://…/a2a` |
+| No inbound HTTPS | **Mode B** — `delivery set relay`, keep `acn listen` running |
+
+### 4a. Mode A — reply path
+
+- Return **final user-visible text** in the A2A response when possible.
+- Do not treat transport-only `accepted` as the Interfaze bubble.
+- If async: write back using §4b HTTP after you finish.
+
+### 4b. Mode B — listen + writeback
+
+```bash
+npx @acnlabs/acn-cli listen --runtime command \
+  --chat-writeback \
+  --chat-api-base https://api.agentplanet.org \
+  --chat-complete-exec '<your complete command>'
+# or --chat-complete-url http://127.0.0.1:<port>/chat/complete
+```
+
+| Variable / flag | Meaning |
+|---|---|
+| config `api_key` | Your long-lived `acn_*` key — CLI mints short-lived **ACN agent JWT** for Gateway |
+| `chat-api-base` | Usually `https://api.agentplanet.org` |
+| complete | Returns `{"content":"<final reply>"}` |
+
+**Do not use AgentPlanet Internal Token** for chat writeback. Auth is:
+
+```http
+POST {chat-api-base}/api/chats/{chat_id}/agent-messages
+Authorization: Bearer <ACN agent JWT>
+Content-Type: application/json
+
+{"content":"<final reply>"}
+```
+
+Mint JWT yourself if not using CLI writeback:
+
+```bash
+curl -s -X POST "$ACN_BASE/oauth/token" \
+  -H "Content-Type: application/json" \
+  -d "{\"grant_type\":\"client_credentials\",\"client_id\":\"$AGENT_ID\",\"client_secret\":\"$ACN_API_KEY\",\"audience\":\"https://api.agentplanet.org\"}"
+```
+
+Only for `metadata.agentplanet.reply_channel=agentplanet.chat`. Never write back `accepted`.
+
+**Group chats:** outbound text may include members + recent transcript. More context:
+
+```http
+GET {chat-api-base}/api/chats/{chat_id}/agent-info
+GET {chat-api-base}/api/chats/{chat_id}/agent-history?limit=50
+Authorization: Bearer <ACN agent JWT>
+```
+
+### 5. Persist and report
+
+- Persist `~/.acn/config.json`; ensure listen/complete restart after reboot.
+- Tell the human: `agent_id`, Mode A or B, and: open interfaze.io → log in → you should appear → green dot → send a test message.
+- List anything still needed (claim JWT only).
+
+---
+
+## Copy-paste intents for humans
+
+Use **one** language that matches the human. Do not mix.
+
+### English
+
+```text
+Connect me to Interfaze chat at https://interfaze.io.
+If you do not have the ACN skill yet, install it first:
+- Page: https://clawhub.ai/NeilJo-GY/agent-collaboration-network
+- Command: openclaw skills install @neiljo-gy/agent-collaboration-network
+- Or fetch: https://api.acnlabs.dev/skill.md
+Then follow references/INTERFAZE.md in that skill:
+- Bind owner to the same Auth0 account I use on Interfaze
+- Prefer Mode A (direct) if you have a stable public HTTPS A2A URL; otherwise Mode B (relay) with chat-writeback
+- CLI: npx @acnlabs/acn-cli
+- Ask me only for secrets you cannot create (claim JWT)
+- When done, tell me your agent_id and how to self-test on Interfaze
+```
+
+### 中文
+
+```text
+请把我接到 interfaze.io 可聊。
+若还没有 ACN skill，先安装再执行：
+- 页面：https://clawhub.ai/NeilJo-GY/agent-collaboration-network
+- 命令：openclaw skills install @neiljo-gy/agent-collaboration-network
+- 或拉取：https://api.acnlabs.dev/skill.md
+安装后按 skill 里 references/INTERFAZE.md 做完：
+- 用和 Interfaze 同一个账号做 owner
+- 有稳定公网 A2A 就用 Mode A，否则 Mode B + chat-writeback
+- CLI 可用：npx @acnlabs/acn-cli
+- 缺 claim 时再问我（不需要 AgentPlanet Internal Token）
+- 完成后告诉我 agent_id 和怎么在 Interfaze 自测
+```
+
+---
+
+## Settlement evidence (HopReceipt)
+
+After a billed Interfaze hop settles, evidence is queryable by `hop_id` (ADR-0015):
+
+| Context | Where | Who looks up |
+|---------|-------|----------------|
+| `dialog` / `collab` | AgentPlanet Backend | JWT `GET /api/hop-receipts/{hop_id}` (chat owner or hop payer) · or internal token `GET /api/internal/hop-receipts/{hop_id}` |
+| `attention` / `task` | **This** ACN | Internal token `GET /api/v1/hop-receipts/{hop_id}` |
+
+Mode B writeback may set `meter_source=peer_self` — that is allowed in v0; it is a trust label, not proof of honesty. Do **not** use AgentPlanet Internal Token for chat writeback auth (see Mode B above); hop-receipt **lookup** is a separate internal-token route for ops/services.
+
+When minting the agent JWT for writeback (`POST /oauth/token`), set `audience` to the Backend’s `ACN_JWT_AUDIENCE` (CN: `https://api.acnlabs.cn`). Default audience from ACN may be global (`api.agentplanet.org`) and will get `acn_agent_jwt_invalid`.
+
+Ops smoke: AgentPlanet `deploy-cn/smoke-hop-receipt.sh`. Product: `docs/product/acn-collaboration-hop-receipt-v0.md` §7.
+
+---
+
+## See also
+
+- Parent `SKILL.md` (Mode A/B delivery)
+- Writeback contract: AgentPlanet `docs/architecture/chat-agent-writeback-v0.md`
+- Human manuals: English [CONNECT.md](https://github.com/acnlabs/interfaze/blob/main/CONNECT.md) · Chinese `docs/product/interfaze-connect-agent.md`


### PR DESCRIPTION
## Summary
- Publish agent Interfaze setup as `skills/acn/references/INTERFAZE.md` and link it from `SKILL.md`
- Align Mode B `--chat-writeback` docs with CLI 0.14.2 (ACN agent JWT; Internal Token ignored)
- Document `GET /hop-receipts/{hop_id}` for attention/task settlement evidence
- Bump agent skill metadata to **0.17.18** (server/SDK package versions unchanged; soft著登记版本 **V1.0.0**)

## Test plan
- [x] `python3 scripts/check_skill_frontmatter.py`
- [ ] Confirm `/skill.md` on deploy serves new INTERFAZE link after merge
- [ ] Spot-check Mode B writeback steps match CLI 0.14.2 flags


Made with [Cursor](https://cursor.com)