### PR TITLE
release: v1.0.0 — server, SDKs, CLI, skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ this server tag and the coordinated client packages below.
 - **Server `acn` 1.0.0** — declare Production/Stable; tag `v1.0.0`.
 - **Python `acn-client` 1.0.0** / **TypeScript `acn-client` 1.0.0** /
   **`@acnlabs/acn-cli` 1.0.0** — coordinated major for registry alignment
-  (no intentional API break beyond prior 0.15.x surface).
+  (no intentional API break beyond prior 0.15.x surface). CLI writeback
+  forwards optional host `usage` + `reply_to_id` for chat billing settle.
 - **Agent skill 1.0.0** — same product line as server 1.0.0; includes
   Interfaze procedure ([`references/INTERFAZE.md`](skills/acn/references/INTERFAZE.md)),
   CLI JWT writeback notes, and `GET /hop-receipts/{hop_id}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-10
+
+First stable major release. Registration / product version **V1.0.0** matches
+this server tag and the coordinated client packages below.
+
 ### Changed
 
-- **Agent skill 0.17.18** — Interfaze chat procedure
-  ([`references/INTERFAZE.md`](skills/acn/references/INTERFAZE.md));
-  Mode B writeback docs align with CLI **0.14.2** (ACN agent JWT, not
-  Internal Token); document `GET /hop-receipts/{hop_id}` for attention/task
-  settlement evidence.
+- **Server `acn` 1.0.0** — declare Production/Stable; tag `v1.0.0`.
+- **Python `acn-client` 1.0.0** / **TypeScript `acn-client` 1.0.0** /
+  **`@acnlabs/acn-cli` 1.0.0** — coordinated major for registry alignment
+  (no intentional API break beyond prior 0.15.x surface).
+- **Agent skill 1.0.0** — same product line as server 1.0.0; includes
+  Interfaze procedure ([`references/INTERFAZE.md`](skills/acn/references/INTERFAZE.md)),
+  CLI JWT writeback notes, and `GET /hop-receipts/{hop_id}`.
+- **Studio cultivator tasks** — `task_type=studio` accept path is humans-only
+  (agents get 403), same gate as other cultivator-human TaskBoard kinds.
 
 ## [0.15.10] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ curl "http://localhost:8000/api/v1/payments/discover?payment_method=usdc&network
 
 ACN provides official client SDKs for TypeScript/JavaScript and Python.
 
+### Server ↔ SDK Compatibility
+
+| Server | Python `acn-client` | TypeScript `acn-client` | `@acnlabs/acn-cli` | Agent skill |
+|--------|---------------------|-------------------------|--------------------|-------------|
+| **1.0.0** (current) | **1.0.0** | **1.0.0** | **1.0.0** | **1.0.0** |
+| 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
+
+Pin clients to the row matching your deployed server. Product version
+**V1.0.0** corresponds to server tag `v1.0.0`.
+
 ### TypeScript/JavaScript
 
 ```bash

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-10
+
+Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). Behavior matches
+**0.14.2** (JWT chat writeback); package version aligned for registry/release.
+
 ## [0.14.2] - 2026-08-04
 
 ### Changed — Chat writeback auth (breaking)

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -6,8 +6,12 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [1.0.0] - 2026-08-10
 
-Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). Behavior matches
-**0.14.2** (JWT chat writeback); package version aligned for registry/release.
+Coordinated major with ACN server **1.0.0**.
+
+### Added
+- **Chat writeback usage** — host complete may return
+  `{"content","usage":{"input_tokens","output_tokens","meter_source"?}}`;
+  CLI forwards `usage` and `reply_to_id` on `agent-messages` (JWT auth unchanged).
 
 ## [0.14.2] - 2026-08-04
 

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "0.14.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "0.14.2",
+  "version": "1.0.0",
   "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -88,7 +88,7 @@ export function validateChatWritebackOptions(opts: {
   if (hasUrl === hasExec) {
     return (
       '--chat-writeback requires exactly one of --chat-complete-url or --chat-complete-exec ' +
-      '(host returns JSON {"content":"..."}).'
+      '(host returns JSON {"content":"..."} and optional usage).'
     );
   }
   return null;

--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -5,9 +5,12 @@
  * the CLI:
  *   1) asks the host for reply text (--chat-complete-url | --chat-complete-exec)
  *   2) mints a short-lived ACN agent JWT via POST /oauth/token (acn_* API key)
- *   3) POSTs { content } to Chat Gateway agent-messages with Bearer JWT
+ *   3) POSTs { content, reply_to_id?, usage? } to Chat Gateway agent-messages
+ *      with Bearer JWT
  *
- * Hosts only need to return {"content":"..."} — they do not call Gateway themselves.
+ * Hosts return {"content":"..."} and optionally
+ * {"usage":{"input_tokens":N,"output_tokens":M}} for chat billing settle.
+ * They do not call Gateway themselves.
  */
 
 import { spawn } from 'child_process';
@@ -120,6 +123,17 @@ export function buildChatWritebackOptions(opts: {
   };
 }
 
+export type ChatTokenUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  meter_source?: 'peer_self' | 'gateway' | 'runtime_attested' | 'protocol';
+};
+
+export type ChatCompleteResult = {
+  content: string;
+  usage?: ChatTokenUsage;
+};
+
 /**
  * Host complete response → reply text.
  * Prefer content/reply/text; never treat a nested "message" object or ACK as content.
@@ -136,6 +150,56 @@ export function extractContent(payload: unknown): string | null {
     }
   }
   return null;
+}
+
+function asNonNegInt(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
+    return Math.floor(v);
+  }
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n) && n >= 0) return Math.floor(n);
+  }
+  return null;
+}
+
+/**
+ * Optional token usage from host complete JSON (chat billing settle).
+ * Accepts usage.input_tokens/output_tokens or prompt_tokens/completion_tokens.
+ */
+export function extractUsage(payload: unknown): ChatTokenUsage | undefined {
+  const rec = asRecord(payload);
+  if (!rec) return undefined;
+  const usageRec = asRecord(rec.usage) ?? rec;
+  const input =
+    asNonNegInt(usageRec.input_tokens) ?? asNonNegInt(usageRec.prompt_tokens);
+  const output =
+    asNonNegInt(usageRec.output_tokens) ??
+    asNonNegInt(usageRec.completion_tokens);
+  if (input === null && output === null) return undefined;
+  const out: ChatTokenUsage = {
+    input_tokens: input ?? 0,
+    output_tokens: output ?? 0,
+  };
+  const ms = usageRec.meter_source;
+  if (
+    ms === 'peer_self' ||
+    ms === 'gateway' ||
+    ms === 'runtime_attested' ||
+    ms === 'protocol'
+  ) {
+    out.meter_source = ms;
+  }
+  return out;
+}
+
+function parseCompletePayload(
+  payload: unknown
+): { ok: true; result: ChatCompleteResult } | { ok: false; reason: string } {
+  const content = extractContent(payload);
+  if (!content) return { ok: false, reason: 'complete_missing_content' };
+  const usage = extractUsage(payload);
+  return { ok: true, result: usage ? { content, usage } : { content } };
 }
 
 /** Mint (or reuse cached) ACN agent JWT for Chat Gateway. Exported for tests. */
@@ -203,7 +267,9 @@ async function completeViaHttp(
   event: NormalizedEvent,
   opts: ChatWritebackOptions,
   deps: ChatWritebackDeps
-): Promise<{ ok: true; content: string } | { ok: false; reason: string }> {
+): Promise<
+  { ok: true; result: ChatCompleteResult } | { ok: false; reason: string }
+> {
   const fetchFn = deps.fetchFn ?? fetch;
   const timeoutMs = opts.completeTimeoutMs ?? DEFAULT_COMPLETE_TIMEOUT_MS;
   const controller = new AbortController();
@@ -225,9 +291,7 @@ async function completeViaHttp(
     } catch {
       return { ok: false, reason: 'complete_invalid_json' };
     }
-    const content = extractContent(parsed);
-    if (!content) return { ok: false, reason: 'complete_missing_content' };
-    return { ok: true, content };
+    return parseCompletePayload(parsed);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
@@ -243,7 +307,9 @@ function completeViaExec(
   event: NormalizedEvent,
   opts: ChatWritebackOptions,
   deps: ChatWritebackDeps
-): Promise<{ ok: true; content: string } | { ok: false; reason: string }> {
+): Promise<
+  { ok: true; result: ChatCompleteResult } | { ok: false; reason: string }
+> {
   const spawnFn = deps.spawnFn ?? spawn;
   const timeoutMs = opts.completeTimeoutMs ?? DEFAULT_COMPLETE_TIMEOUT_MS;
   const body = Buffer.from(JSON.stringify(event), 'utf-8');
@@ -254,7 +320,11 @@ function completeViaExec(
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
 
-    const finish = (result: { ok: true; content: string } | { ok: false; reason: string }) => {
+    const finish = (
+      result:
+        | { ok: true; result: ChatCompleteResult }
+        | { ok: false; reason: string }
+    ) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -283,12 +353,7 @@ function completeViaExec(
       const text = Buffer.concat(stdout).toString('utf-8').trim();
       try {
         const parsed = JSON.parse(text) as unknown;
-        const content = extractContent(parsed);
-        if (!content) {
-          finish({ ok: false, reason: 'complete_missing_content' });
-          return;
-        }
-        finish({ ok: true, content });
+        finish(parseCompletePayload(parsed));
       } catch {
         finish({ ok: false, reason: 'complete_invalid_json' });
       }
@@ -300,7 +365,7 @@ function completeViaExec(
 
 async function postWriteback(
   event: NormalizedEvent,
-  content: string,
+  complete: ChatCompleteResult,
   opts: ChatWritebackOptions,
   deps: ChatWritebackDeps
 ): Promise<ChatWritebackResult> {
@@ -330,6 +395,18 @@ async function postWriteback(
   }
 
   const timeoutMs = opts.writebackTimeoutMs ?? DEFAULT_WRITEBACK_TIMEOUT_MS;
+  const replyToId = chat.gateway_message_id ?? event.message_id;
+  const body: Record<string, unknown> = {
+    content: complete.content,
+    reply_to_id: replyToId,
+  };
+  if (complete.usage) {
+    body.usage = {
+      input_tokens: complete.usage.input_tokens,
+      output_tokens: complete.usage.output_tokens,
+      meter_source: complete.usage.meter_source ?? 'peer_self',
+    };
+  }
 
   const postOnce = async (
     token: string
@@ -343,7 +420,7 @@ async function postWriteback(
           'content-type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ content }),
+        body: JSON.stringify(body),
         signal: controller.signal,
       });
       if (res.status === 200 || res.status === 201) {
@@ -420,7 +497,7 @@ export async function handleChatWriteback(
     return { ok: false, reason: completed.reason };
   }
 
-  const written = await postWriteback(event, completed.content, opts, deps);
+  const written = await postWriteback(event, completed.result, opts, deps);
   if (!written.ok) {
     logFn(
       `[acn listen] chat_writeback_failed chat_id=${event.chat.chat_id} ` +
@@ -429,9 +506,13 @@ export async function handleChatWriteback(
     return written;
   }
 
+  const usageNote = completed.result.usage
+    ? ` usage_in=${completed.result.usage.input_tokens}` +
+      ` usage_out=${completed.result.usage.output_tokens}`
+    : '';
   logFn(
     `[acn listen] chat_writeback_ok chat_id=${event.chat.chat_id} ` +
-      `message_id=${event.message_id} http=${written.httpStatus}`
+      `message_id=${event.message_id} http=${written.httpStatus}${usageNote}`
   );
   return written;
 }

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -9,6 +9,7 @@ import {
   clearAgentJwtCache,
   DEFAULT_CHAT_JWT_AUDIENCE,
   extractContent,
+  extractUsage,
   handleChatWriteback,
   validateChatWritebackOptions,
 } from '../src/commands/chat-writeback.js';
@@ -155,6 +156,24 @@ describe('extractContent', () => {
   });
 });
 
+describe('extractUsage', () => {
+  it('reads nested usage and OpenAI-style aliases', () => {
+    expect(
+      extractUsage({ usage: { input_tokens: 1, output_tokens: 2 } })
+    ).toEqual({ input_tokens: 1, output_tokens: 2 });
+    expect(
+      extractUsage({
+        usage: { prompt_tokens: 3, completion_tokens: 4, meter_source: 'peer_self' },
+      })
+    ).toEqual({
+      input_tokens: 3,
+      output_tokens: 4,
+      meter_source: 'peer_self',
+    });
+    expect(extractUsage({ content: 'hi' })).toBeUndefined();
+  });
+});
+
 describe('validateChatWritebackOptions', () => {
   it('allows disabled', () => {
     expect(validateChatWritebackOptions({})).toBeNull();
@@ -255,10 +274,65 @@ describe('handleChatWriteback', () => {
     expect(calls[2].url).toBe(
       'http://gw:8000/api/chats/chat-uuid/agent-messages'
     );
-    expect(JSON.parse(calls[2].body)).toEqual({ content: 'agent says hi' });
+    expect(JSON.parse(calls[2].body)).toEqual({
+      content: 'agent says hi',
+      reply_to_id: expect.any(String),
+    });
     const hdrs = calls[2].headers as Record<string, string>;
     expect(hdrs['Authorization']).toBe('Bearer jwt-from-acn');
     expect(hdrs['X-Internal-Token']).toBeUndefined();
+  });
+
+  it('forwards host usage + reply_to_id for billing settle', async () => {
+    clearAgentJwtCache();
+    const calls: Array<{ url: string; body: string }> = [];
+    const fetchFn = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      calls.push({ url: u, body: String(init?.body ?? '') });
+      if (u.includes('/complete')) {
+        return mockOkResponse(
+          JSON.stringify({
+            content: 'billed reply',
+            usage: { input_tokens: 12, output_tokens: 34 },
+          })
+        );
+      }
+      if (u.includes('/oauth/token')) {
+        return mockOkResponse(
+          JSON.stringify({ access_token: 'jwt-usage', expires_in: 1800 })
+        );
+      }
+      return mockOkResponse(JSON.stringify({ id: 'm1' }), 201);
+    });
+
+    const event = normalizeEvent(
+      (parseJsonRpcBody(chatMessageBody()) as { ok: true; body: Record<string, unknown> })
+        .body
+    );
+    const opts = buildChatWritebackOptions({
+      chatWriteback: true,
+      chatApiBase: 'http://gw:8000',
+      acnBaseUrl: 'https://api.acnlabs.dev',
+      apiKey: 'acn_secret',
+      chatCompleteUrl: 'http://127.0.0.1:9/complete',
+      agentId: 'agent-1',
+    })!;
+
+    const result = await handleChatWriteback(event, opts, {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      logFn: () => {},
+    });
+    expect(result).toEqual({ ok: true, httpStatus: 201 });
+    const writeback = JSON.parse(calls[2].body);
+    expect(writeback).toMatchObject({
+      content: 'billed reply',
+      reply_to_id: event.chat?.gateway_message_id ?? event.message_id,
+      usage: {
+        input_tokens: 12,
+        output_tokens: 34,
+        meter_source: 'peer_self',
+      },
+    });
   });
 
   it('defaults JWT audience to AgentPlanet canonical, not chat-api-base origin', () => {

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -276,7 +276,7 @@ describe('handleChatWriteback', () => {
     );
     expect(JSON.parse(calls[2].body)).toEqual({
       content: 'agent says hi',
-      reply_to_id: expect.any(String),
+      reply_to_id: 'user-msg-1',
     });
     const hdrs = calls[2].headers as Record<string, string>;
     expect(hdrs['Authorization']).toBe('Bearer jwt-from-acn');
@@ -324,15 +324,16 @@ describe('handleChatWriteback', () => {
     });
     expect(result).toEqual({ ok: true, httpStatus: 201 });
     const writeback = JSON.parse(calls[2].body);
-    expect(writeback).toMatchObject({
+    expect(writeback).toEqual({
       content: 'billed reply',
-      reply_to_id: event.chat?.gateway_message_id ?? event.message_id,
+      reply_to_id: 'user-msg-1',
       usage: {
         input_tokens: 12,
         output_tokens: 34,
         meter_source: 'peer_self',
       },
     });
+    expect(event.chat?.gateway_message_id).toBe('user-msg-1');
   });
 
   it('defaults JWT audience to AgentPlanet canonical, not chat-api-base origin', () => {

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `acn-client` are documented here.
 
 ## [1.0.0] - 2026-08-10
 
-Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). No intentional
+Coordinated major with ACN server **1.0.0**. No intentional
 API break beyond the 0.13.x surface.
 
 ### Added

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-10
+
+Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). No intentional
+API break beyond the 0.13.x surface.
+
 ### Added
 
 - `OrgWorkItem.metadata` / create+update request fields — opaque JSON object

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "0.13.0"
+version = "1.0.0"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-10
+
+Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). No intentional
+API break beyond the 0.15.x surface.
+
 ### Added
 
 - `OrgWorkItem.metadata` / create+update request fields — opaque JSON object

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [1.0.0] - 2026-08-10
 
-Coordinated major with ACN server **1.0.0** (soft著 V1.0.0). No intentional
+Coordinated major with ACN server **1.0.0**. No intentional
 API break beyond the 0.15.x surface.
 
 ### Added

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "0.14.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "0.14.2",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "0.15.0",
+  "version": "1.0.0",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "0.15.10"
+version = "1.0.0"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}
@@ -10,7 +10,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 keywords = ["ai", "agents", "registry", "discovery", "a2a", "multi-agent"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "0.17.18"
+  version: "1.0.0"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"

--- a/skills/acn/references/INTERFAZE.md
+++ b/skills/acn/references/INTERFAZE.md
@@ -97,8 +97,18 @@ POST {chat-api-base}/api/chats/{chat_id}/agent-messages
 Authorization: Bearer <ACN agent JWT>
 Content-Type: application/json
 
-{"content":"<final reply>"}
+{
+  "content": "<final reply>",
+  "reply_to_id": "<user message id from envelope>",
+  "usage": {
+    "input_tokens": 1200,
+    "output_tokens": 340,
+    "meter_source": "peer_self"
+  }
+}
 ```
+
+`acn listen --chat-writeback`：complete 返回 `{"content"}` 即可；若附带 `usage`，CLI 会一并 POST（并自动填 `reply_to_id`）。Host 开了 `CHAT_BILLING_ENABLED` 且要求 usage 时，缺 usage 则本跳不扣费。
 
 Mint JWT yourself if not using CLI writeback:
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "0.15.10"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Bump **server / Python SDK / TypeScript SDK / CLI / agent skill** to **1.0.0**
- Tag target: `v1.0.0` (product / software-copyright registration version V1.0.0)
- Add Server ↔ SDK compatibility matrix in README
- Mark PyPI classifier Production/Stable

## Test plan
- [ ] CI green (version-sync, unit, SDK, CLI, Docker)
- [ ] After merge: `git tag v1.0.0 && git push origin v1.0.0`
- [ ] Confirm Release workflow publishes PyPI/npm/CLI/Docker (or skips already-published)
- [ ] Confirm GitHub Release `v1.0.0` created


Made with [Cursor](https://cursor.com)