### PR TITLE
docs: scrub registration jargon from v1.0.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-08-10
 
-First stable major release. Registration / product version **V1.0.0** matches
-this server tag and the coordinated client packages below.
+First stable major release. Server tag **v1.0.0** and the coordinated client
+packages below all ship as **1.0.0**.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 | **1.0.0** (current) | **1.0.0** | **1.0.0** | **1.0.0** | **1.0.0** |
 | 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
 
-Pin clients to the row matching your deployed server. Product version
-**V1.0.0** corresponds to server tag `v1.0.0`.
+Pin clients to the row matching your deployed server.
 
 ### TypeScript/JavaScript
 

--- a/docs/auto-collab-pull-mvp-v0.md
+++ b/docs/auto-collab-pull-mvp-v0.md
@@ -232,7 +232,7 @@ MVP-1 风险相对可控（名单已知），仍须遵守 P1/P3。
 | A3d | 完成率灌数 · Kernel `agent_performance` + settle 钩子 + refresh API；侧车 `run_perf_enrich` 调 Kernel；历史窗口 last 50 | **done** 2026-07-31 |
 | A4 | 上层 UI/BFF：一键「需要协作」→ Backend `POST …/collab-match`（tags 召回 → ACN invite / `task_request` 叫醒；**不**跑 MVP-1 `collab_pull` 侧车）+ CN BFF 透传（含 `/invite`，invite 须校验任务主人）+ ParticipantsCard | **done** 2026-07-31 |
 | A5 | （可选）短名单 LLM 重排 | 待办（建议先观察；见 [acn-match-router-v0](../../docs/product/acn-match-router-v0.md)） |
-| A6 | 上层 Match/Router 产品化（Router 参与稀疏协作、用量计费、单次上限） | 方案 **Accepted** · [acn-match-router-v0](../../docs/product/acn-match-router-v0.md)；工程 **P1/P2 done**（计量默认关） |
+| A6 | 上层 Match/Router 产品化（Router 参与稀疏协作、用量计费、单次上限） | 方案 **Accepted** · [acn-match-router-v0](../../docs/product/acn-match-router-v0.md)；工程 **P1–P3 done**（计量默认关；邀/接/过/拒特征日志） |
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove “Registration / product version” phrasing from root CHANGELOG
- Simplify README compat-matrix caption to version pinning only

## Test plan
- [x] Confirm no 软著 / registration-version jargon remains in those release notes


Made with [Cursor](https://cursor.com)