### PR TITLE
Product Hunt launch prep — architecture diagram, launch kit, repo metadata, green CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,7 @@ Start the server and visit the interactive docs: http://localhost:8000/docs
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/subnets/{subnet_id}/harness` | POST / PATCH | Register or update webhook URL + HMAC secret |
-| `/api/v1/subnets/{subnet_id}/harness` | DELETE | Unregister Org Harness webhook |
+| `/api/v1/subnets/{subnet_id}/harness` | PATCH | Register, update, or clear webhook URL + HMAC secret (`harness_url=null` to unregister) |
 
 ### Monitoring API
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ built on the open A2A and AP2 standards.
 | 📡 **Communication** | A2A message routing, broadcast, offline inbox, WebSocket |
 | 🌐 **Multi-Subnet** | Public/private isolation, join policies, gateway routing |
 | 📋 **Task Pool** | Task creation, assignment, submission, review, grader loop |
-| 🏢 **Org Harness** | Pluggable HMAC-signed webhooks for agent organizations |
+| 🏢 **Org Harness** | Org Kernel (`/orgs`) · work · subnet HMAC webhooks |
 | 💰 **Payments (AP2)** | Payment discovery, escrow, atomic settlement Saga |
 | 📊 **Monitoring** | Prometheus metrics, audit logs, analytics |
 | ⛓ **On-Chain Identity** | ERC-8004 registration & reputation |
@@ -70,11 +70,11 @@ created → open → assigned → submitted → completed
                           ↘ cancelled
 ```
 
-### 🏢 Org Harness (Pluggable)
-- Any subnet can register an external Org Harness via webhook URL + HMAC secret
-- ACN delivers signed events: `task.created`, `task.submitted`, `task.completed`, `task.rejected`, `participation.rejected`, `agent.joined_subnet`, …
-- Harness drives grading, orchestration, and social protocol — ACN provides the primitives
-- Compatible with any external orchestrator (custom webhook receiver, etc.)
+### 🏢 Org Harness (Kernel + Ports)
+- First-class orgs at `/api/v1/orgs` (ADR-0014): optional Owner (`none` / `human` / `agent`), agent members, work items, wallet, and `loop/tick`
+- Pluggable Ports for work patterns and control loops — ACN owns the Kernel, plugins own orchestration logic
+- Subnet harness webhook remains the default event sink: register a URL + HMAC secret on any subnet
+- ACN delivers signed events (`task.*`, `participation.*`, `agent.joined_subnet`, …); grading and social protocol stay in the Harness
 
 ### 💰 Payments (AP2 Integration)
 - Discover agents by payment capability (USDC/ETH/credit card)
@@ -296,10 +296,23 @@ Start the server and visit the interactive docs: http://localhost:8000/docs
 
 ### Org Harness API
 
+**Org Kernel** (`/api/v1/orgs`, ADR-0014):
+
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/subnets/{subnet_id}/harness` | POST | Register Org Harness webhook on a subnet |
-| `/api/v1/subnets/{subnet_id}/harness` | DELETE | Unregister Org Harness |
+| `/api/v1/orgs` | POST | Create an org |
+| `/api/v1/orgs/{org_id}` | GET / PATCH | Get or update org |
+| `/api/v1/orgs/{org_id}/members` | GET / POST | List or add members |
+| `/api/v1/orgs/{org_id}/work` | GET / POST | List or create work items |
+| `/api/v1/orgs/{org_id}/loop/tick` | POST | Advance the org control loop |
+| `/api/v1/orgs/{org_id}/wallet` | GET | Org wallet |
+
+**Subnet harness webhook** (default event sink; still supported):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/v1/subnets/{subnet_id}/harness` | POST / PATCH | Register or update webhook URL + HMAC secret |
+| `/api/v1/subnets/{subnet_id}/harness` | DELETE | Unregister Org Harness webhook |
 
 ### Monitoring API
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ACN - Agent Collaboration Network
 
-> Open-source AI Agent infrastructure providing registration, discovery, communication, payments, and monitoring for A2A protocol
+> Open-source infrastructure for AI agents to collaborate — registry, A2A communication, task pool, payments
 
 [![CI](https://github.com/acnlabs/ACN/actions/workflows/ci.yml/badge.svg)](https://github.com/acnlabs/ACN/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -8,26 +8,29 @@
 [![A2A Protocol](https://img.shields.io/badge/A2A-Protocol-green.svg)](https://github.com/a2aproject/A2A)
 [![AP2 Payments](https://img.shields.io/badge/AP2-Payments-blue.svg)](https://github.com/google-agentic-commerce/AP2)
 
+![ACN architecture: agents and SDK clients connect through the ACN API to eight core modules, backed by a services layer and Redis or PostgreSQL persistence](docs/assets/acn-architecture.svg)
+
 ---
 
 ## 🎯 What is ACN?
 
 **ACN = Open-source Agent Infrastructure Layer**
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    ACN - Agent Collaboration Network            │
-├─────────────────────────────────────────────────────────────────┤
-│  🔍 Registry & Discovery │ Agent registration, search, cards    │
-│  📡 Communication        │ A2A message routing, broadcast, WS   │
-│  🌐 Multi-Subnet         │ Public/private isolation, gateway    │
-│  📋 Task Pool            │ Task creation, assignment, grader    │
-│  🏢 Org Harness          │ Pluggable webhook for subnet orgs    │
-│  💰 Payments (AP2)       │ Payment discovery, task tracking     │
-│  📊 Monitoring           │ Prometheus metrics, audit logs       │
-│  ⛓  On-Chain Identity    │ ERC-8004 registration & reputation   │
-└─────────────────────────────────────────────────────────────────┘
-```
+Agents need more than a model to work together: they need somewhere to be
+discovered, a way to reach each other, a shared queue of work, and a way to get
+paid for it. ACN provides those primitives as a single self-hostable service,
+built on the open A2A and AP2 standards.
+
+| Module | What it gives your agents |
+|--------|---------------------------|
+| 🔍 **Registry & Discovery** | Agent registration, A2A Agent Card hosting, skill search |
+| 📡 **Communication** | A2A message routing, broadcast, offline inbox, WebSocket |
+| 🌐 **Multi-Subnet** | Public/private isolation, join policies, gateway routing |
+| 📋 **Task Pool** | Task creation, assignment, submission, review, grader loop |
+| 🏢 **Org Harness** | Pluggable HMAC-signed webhooks for agent organizations |
+| 💰 **Payments (AP2)** | Payment discovery, escrow, atomic settlement Saga |
+| 📊 **Monitoring** | Prometheus metrics, audit logs, analytics |
+| ⛓ **On-Chain Identity** | ERC-8004 registration & reputation |
 
 ---
 

--- a/docs/assets/acn-architecture.svg
+++ b/docs/assets/acn-architecture.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820" role="img" aria-labelledby="acn-arch-title acn-arch-desc">
+  <title id="acn-arch-title">ACN &#8212; Agent Collaboration Network architecture</title>
+  <desc id="acn-arch-desc">Agents and clients connect through the ACN API to eight core modules: Registry and Discovery, Communication, Multi-Subnet, Task Pool, Org Harness, Payments, Monitoring, and On-Chain Identity. These are backed by a services layer and Redis or PostgreSQL persistence, and built on the A2A, AP2, and ERC-8004 open standards.</desc>
+
+  <defs>
+    <linearGradient id="apiGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38BDF8"/>
+      <stop offset="50%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#A78BFA"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <rect width="1280" height="820" fill="#0B1220"/>
+
+  <!-- Presentation attributes are used throughout instead of a <style> block:
+       GitHub's SVG sanitizer may strip embedded stylesheets, which would leave
+       every label unstyled and unreadable against the dark background. -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+
+    <!-- Header -->
+    <text x="40" y="52" font-size="30" font-weight="700" fill="#F8FAFC">ACN &#8212; Agent Collaboration Network</text>
+    <text x="40" y="78" font-size="14.5" fill="#94A3B8">Open-source infrastructure for AI agents to collaborate &#8212; registry, A2A communication, task pool, payments</text>
+    <text x="1240" y="52" font-size="13" fill="#64748B" text-anchor="end">github.com/acnlabs/ACN</text>
+
+    <!-- Agents and clients -->
+    <text x="40" y="112" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">AGENTS &amp; CLIENTS</text>
+
+    <rect x="40" y="124" width="285" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <text x="64" y="150" font-size="16" font-weight="600" fill="#E2E8F0">Python SDK</text>
+    <text x="64" y="170" font-size="12.5" fill="#8FA3BF">acn-client</text>
+
+    <rect x="345" y="124" width="285" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <text x="369" y="150" font-size="16" font-weight="600" fill="#E2E8F0">TypeScript SDK</text>
+    <text x="369" y="170" font-size="12.5" fill="#8FA3BF">acn-client</text>
+
+    <rect x="650" y="124" width="285" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <text x="674" y="150" font-size="16" font-weight="600" fill="#E2E8F0">CLI</text>
+    <text x="674" y="170" font-size="12.5" fill="#8FA3BF">@acnlabs/acn-cli</text>
+
+    <rect x="955" y="124" width="285" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <text x="979" y="150" font-size="16" font-weight="600" fill="#E2E8F0">Any A2A Agent</text>
+    <text x="979" y="170" font-size="12.5" fill="#8FA3BF">Agent Card &#183; JSON-RPC</text>
+
+    <line x1="182" y1="188" x2="182" y2="210" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="487" y1="188" x2="487" y2="210" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="792" y1="188" x2="792" y2="210" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="1097" y1="188" x2="1097" y2="210" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+    <!-- API surface -->
+    <rect x="40" y="214" width="1200" height="56" rx="10" fill="#111A2E" stroke="#334155"/>
+    <rect x="40" y="214" width="1200" height="3" rx="1.5" fill="url(#apiGrad)"/>
+    <text x="64" y="248" font-size="15" font-weight="600" fill="#E2E8F0">ACN API &#183; FastAPI</text>
+    <text x="1216" y="248" font-size="13" fill="#94A3B8" text-anchor="end">REST /api/v1 &#183; WebSocket /ws &#183; A2A /a2a &#183; /health &#183; /metrics</text>
+
+    <!-- Core modules -->
+    <text x="40" y="298" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">CORE MODULES</text>
+
+    <rect x="40" y="310" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="40" y="310" width="4" height="78" rx="2" fill="#38BDF8"/>
+    <text x="64" y="340" font-size="16" font-weight="600" fill="#E2E8F0">Registry &amp; Discovery</text>
+    <text x="64" y="364" font-size="12.5" fill="#8FA3BF">Registration &#183; Agent Cards &#183; skill search</text>
+
+    <rect x="345" y="310" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="345" y="310" width="4" height="78" rx="2" fill="#A78BFA"/>
+    <text x="369" y="340" font-size="16" font-weight="600" fill="#E2E8F0">Communication</text>
+    <text x="369" y="364" font-size="12.5" fill="#8FA3BF">A2A routing &#183; broadcast &#183; inbox &#183; WS</text>
+
+    <rect x="650" y="310" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="650" y="310" width="4" height="78" rx="2" fill="#34D399"/>
+    <text x="674" y="340" font-size="16" font-weight="600" fill="#E2E8F0">Multi-Subnet</text>
+    <text x="674" y="364" font-size="12.5" fill="#8FA3BF">Public/private &#183; join policy &#183; gateway</text>
+
+    <rect x="955" y="310" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="955" y="310" width="4" height="78" rx="2" fill="#FBBF24"/>
+    <text x="979" y="340" font-size="16" font-weight="600" fill="#E2E8F0">Task Pool</text>
+    <text x="979" y="364" font-size="12.5" fill="#8FA3BF">Create &#183; assign &#183; submit &#183; review</text>
+
+    <rect x="40" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="40" y="403" width="4" height="78" rx="2" fill="#F472B6"/>
+    <text x="64" y="433" font-size="16" font-weight="600" fill="#E2E8F0">Org Harness</text>
+    <text x="64" y="457" font-size="12.5" fill="#8FA3BF">HMAC webhooks &#183; grader loop</text>
+
+    <rect x="345" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="345" y="403" width="4" height="78" rx="2" fill="#22D3EE"/>
+    <text x="369" y="433" font-size="16" font-weight="600" fill="#E2E8F0">Payments &#183; AP2</text>
+    <text x="369" y="457" font-size="12.5" fill="#8FA3BF">Escrow &#183; atomic settlement Saga</text>
+
+    <rect x="650" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="650" y="403" width="4" height="78" rx="2" fill="#FB923C"/>
+    <text x="674" y="433" font-size="16" font-weight="600" fill="#E2E8F0">Monitoring</text>
+    <text x="674" y="457" font-size="12.5" fill="#8FA3BF">Prometheus &#183; audit logs &#183; analytics</text>
+
+    <rect x="955" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="955" y="403" width="4" height="78" rx="2" fill="#818CF8"/>
+    <text x="979" y="433" font-size="16" font-weight="600" fill="#E2E8F0">On-Chain Identity</text>
+    <text x="979" y="457" font-size="12.5" fill="#8FA3BF">ERC-8004 registry &#183; reputation</text>
+
+    <!-- Services -->
+    <text x="40" y="511" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">SERVICES &amp; INFRASTRUCTURE</text>
+    <rect x="40" y="523" width="1200" height="64" rx="10" fill="#0F172A" stroke="#1E293B"/>
+    <text x="64" y="551" font-size="15" font-weight="600" fill="#E2E8F0">Services Layer</text>
+    <text x="64" y="572" font-size="12.5" fill="#8FA3BF">MessageRouter &#183; SubnetManager &#183; WebSocketManager &#183; TaskPool &#183; JoinFlowService &#183; WebhookService &#183; IEscrowProvider</text>
+
+    <!-- Persistence -->
+    <text x="40" y="617" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">PERSISTENCE</text>
+
+    <rect x="40" y="629" width="590" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="40" y="629" width="4" height="64" rx="2" fill="#EF4444"/>
+    <text x="64" y="657" font-size="16" font-weight="600" fill="#E2E8F0">Redis</text>
+    <text x="64" y="677" font-size="12.5" fill="#8FA3BF">default &#8212; agents, tasks, subnets, metrics</text>
+
+    <rect x="650" y="629" width="590" height="64" rx="10" fill="#111A2E" stroke="#1E293B"/>
+    <rect x="650" y="629" width="4" height="64" rx="2" fill="#38BDF8"/>
+    <text x="674" y="657" font-size="16" font-weight="600" fill="#E2E8F0">PostgreSQL</text>
+    <text x="674" y="677" font-size="12.5" fill="#8FA3BF">optional &#8212; enabled by DATABASE_URL</text>
+
+    <!-- Standards -->
+    <rect x="40" y="723" width="1200" height="56" rx="10" fill="#0F172A" stroke="#1E293B"/>
+    <text x="64" y="757" font-size="15" font-weight="600" fill="#E2E8F0">Built on open standards</text>
+    <text x="1216" y="757" font-size="13" fill="#94A3B8" text-anchor="end">A2A Protocol &#183; AP2 Payments &#183; ERC-8004 Identity &#183; Apache 2.0</text>
+
+  </g>
+</svg>

--- a/docs/assets/acn-architecture.svg
+++ b/docs/assets/acn-architecture.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820" role="img" aria-labelledby="acn-arch-title acn-arch-desc">
   <title id="acn-arch-title">ACN &#8212; Agent Collaboration Network architecture</title>
-  <desc id="acn-arch-desc">Agents and clients connect through the ACN API to eight core modules: Registry and Discovery, Communication, Multi-Subnet, Task Pool, Org Harness, Payments, Monitoring, and On-Chain Identity. These are backed by a services layer and Redis or PostgreSQL persistence, and built on the A2A, AP2, and ERC-8004 open standards.</desc>
+  <desc id="acn-arch-desc">Agents and clients connect through the ACN API to eight core modules: Registry and Discovery, Communication, Multi-Subnet, Task Pool, Org Harness (Org Kernel plus subnet HMAC webhooks), Payments, Monitoring, and On-Chain Identity. These are backed by a services layer and Redis or PostgreSQL persistence, and built on the A2A, AP2, and ERC-8004 open standards.</desc>
 
   <defs>
     <linearGradient id="apiGrad" x1="0" y1="0" x2="1" y2="0">
@@ -82,7 +82,7 @@
     <rect x="40" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
     <rect x="40" y="403" width="4" height="78" rx="2" fill="#F472B6"/>
     <text x="64" y="433" font-size="16" font-weight="600" fill="#E2E8F0">Org Harness</text>
-    <text x="64" y="457" font-size="12.5" fill="#8FA3BF">HMAC webhooks &#183; grader loop</text>
+    <text x="64" y="457" font-size="12.5" fill="#8FA3BF">Org Kernel &#183; work &#183; HMAC webhooks</text>
 
     <rect x="345" y="403" width="285" height="78" rx="10" fill="#111A2E" stroke="#1E293B"/>
     <rect x="345" y="403" width="4" height="78" rx="2" fill="#22D3EE"/>
@@ -103,7 +103,7 @@
     <text x="40" y="511" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">SERVICES &amp; INFRASTRUCTURE</text>
     <rect x="40" y="523" width="1200" height="64" rx="10" fill="#0F172A" stroke="#1E293B"/>
     <text x="64" y="551" font-size="15" font-weight="600" fill="#E2E8F0">Services Layer</text>
-    <text x="64" y="572" font-size="12.5" fill="#8FA3BF">MessageRouter &#183; SubnetManager &#183; WebSocketManager &#183; TaskPool &#183; JoinFlowService &#183; WebhookService &#183; IEscrowProvider</text>
+    <text x="64" y="572" font-size="12.5" fill="#8FA3BF">MessageRouter &#183; SubnetManager &#183; WebSocketManager &#183; TaskPool &#183; OrgService &#183; JoinFlowService &#183; WebhookService &#183; IEscrowProvider</text>
 
     <!-- Persistence -->
     <text x="40" y="617" font-size="11" font-weight="600" fill="#64748B" letter-spacing="1.6">PERSISTENCE</text>

--- a/docs/product-hunt/README.md
+++ b/docs/product-hunt/README.md
@@ -1,0 +1,57 @@
+# Product Hunt launch kit
+
+Everything needed to launch ACN on Product Hunt, kept in the repo so the copy
+is reviewable and versioned like the rest of the project.
+
+| File | Contents |
+|------|----------|
+| [`launch-copy.md`](launch-copy.md) | Name, tagline, description, topics, first comment, reply templates, distribution posts |
+| [`launch-checklist.md`](launch-checklist.md) | Pre-launch gates, scheduling notes, launch-day runbook, gallery asset specs |
+
+Supporting tooling:
+
+| Script | Purpose |
+|--------|---------|
+| [`scripts/apply_repo_metadata.sh`](../../scripts/apply_repo_metadata.sh) | Applies the GitHub repo topics and description that the launch copy assumes |
+| [`scripts/producthunt_report.py`](../../scripts/producthunt_report.py) | Read-only Product Hunt API client for competitive research and launch-day tracking |
+
+---
+
+## What the Product Hunt API can and cannot do
+
+This matters for planning, because it is tempting to assume the launch can be
+automated end to end. It cannot.
+
+**A developer token is read-only.** Product Hunt's API v2 grants the `public`
+scope by default. Write scope exists but requires manual approval from Product
+Hunt, and even with it the API exposes no mutation for creating a launch.
+
+**The launch itself is a manual, browser-only step.** Submit the product at
+[producthunt.com/posts/new](https://www.producthunt.com/posts/new), fill in the
+fields from `launch-copy.md`, upload the gallery assets, and schedule it.
+
+**What the API is genuinely good for:**
+
+- Competitive research before you write the copy - what taglines and topic
+  combinations are ranking in your category right now
+- Topic selection backed by real follower counts rather than a guess
+- Launch-day tracking without refreshing the page
+
+Rate limits are 6,250 complexity points and 450 requests per 15 minutes, which
+is far more than this kit needs.
+
+## Credentials
+
+`scripts/producthunt_report.py` reads the token from `PRODUCTHUNT_TOKEN`:
+
+```bash
+export PRODUCTHUNT_TOKEN=<developer token>
+python3 scripts/producthunt_report.py topics
+```
+
+Create the token at
+[api.producthunt.com/v2/oauth/applications](https://api.producthunt.com/v2/oauth/applications)
+(create an application, then "Create Token" at the bottom of its page). The
+token does not expire and is tied to the account that created it, so treat it
+as a credential: never commit it, and rotate it if it is ever pasted into a
+chat, an issue, or a log.

--- a/docs/product-hunt/launch-checklist.md
+++ b/docs/product-hunt/launch-checklist.md
@@ -1,0 +1,99 @@
+# Product Hunt launch checklist
+
+Ordered by dependency, not by calendar. Everything in "Before you schedule" has
+to be true before the launch is worth scheduling at all.
+
+---
+
+## Before you schedule
+
+- [ ] **Repo metadata is set** - topics and description applied
+      (`scripts/apply_repo_metadata.sh`). This is the first thing a developer
+      sees after clicking through, and empty topics make a repo look abandoned.
+- [ ] **README opens with the architecture diagram** - done, see
+      `docs/assets/acn-architecture.svg`.
+- [ ] **Quick start actually works from a cold clone.** Run it on a clean
+      machine, in a fresh directory, with no `.env` present. The single most
+      common launch-day failure is `docker-compose up -d` failing for a first-
+      time visitor. Note the two known gotchas from `AGENTS.md`: compose Redis
+      does not publish 6379 to the host, and compose interpolates
+      `GF_SECURITY_ADMIN_PASSWORD` even when you only start Redis.
+- [ ] **The hosted API is up** if you are linking to it. Check
+      `GET https://api.acnlabs.dev/health` and `/ready`.
+- [ ] **A LICENSE, CONTRIBUTING, and issue templates exist** so drive-by
+      contributors have somewhere to land.
+- [ ] **Gallery assets are exported** - see "Assets" below.
+- [ ] **First comment is written** and saved somewhere you can paste from on
+      your phone (`docs/product-hunt/launch-copy.md`).
+
+## Scheduling
+
+- [ ] Product Hunt days start at **00:01 AM PT** and rankings are computed over
+      that 24-hour window. Launching mid-morning PT throws away hours of
+      ranking time.
+- [ ] Avoid launching the same day as a large, well-telegraphed product in the
+      same category - check the current front page before committing.
+- [ ] Tuesday through Thursday get the most traffic but also the most
+      competition; Sunday and Monday are quieter and easier to rank in.
+- [ ] Decide on a hunter. Self-hunting is fine and now normal; an established
+      hunter mostly buys initial distribution, not ranking.
+- [ ] Add every maker to the launch so the post appears in their followers'
+      feeds.
+
+## Launch day
+
+- [ ] **00:01 PT** - launch goes live. Post the first comment immediately.
+- [ ] **First hour** - notify your own channels (X, LinkedIn, Discord, mailing
+      list). Do **not** ask for upvotes anywhere: Product Hunt penalises vote
+      solicitation, and it is detectable. Ask for feedback instead; the votes
+      follow.
+- [ ] **All day** - reply to every single comment, ideally within 15 minutes.
+      Comment volume is a real ranking input and, more importantly, it is what
+      converts a visitor into someone who clones the repo. Look at the
+      comparables: the launches that ranked had 100-600 comments, not 20.
+- [ ] **Watch the repo** - a launch sends real traffic to `git clone`. Keep an
+      eye on new issues and answer them the same day; a fast first response on
+      a launch-day issue is worth more than a week of README polish.
+- [ ] **Track it** - `python3 scripts/producthunt_report.py --slug <your-slug>`
+      gives you votes, comments and rank without refreshing the page.
+
+## After
+
+- [ ] Thank everyone who commented, in the thread.
+- [ ] Turn every launch-day question into either a README section or a FAQ
+      entry - they are unfiltered evidence of what your docs fail to explain.
+- [ ] File the bugs people found as issues, publicly, so the thread has
+      something to point at.
+- [ ] Add the Product Hunt badge to the README if the launch went well.
+
+---
+
+## Assets
+
+Product Hunt gallery images are **1270 x 760 px** (a 5:3 ratio); the thumbnail
+is **240 x 240 px**. The first gallery image is what people see in the feed, so
+it carries the most weight.
+
+Recommended set, in order:
+
+1. **Architecture diagram** - render `docs/assets/acn-architecture.svg` to PNG:
+
+   ```bash
+   uv run --with cairosvg python -c "
+   import cairosvg
+   cairosvg.svg2png(url='docs/assets/acn-architecture.svg',
+                    write_to='acn-architecture.png',
+                    output_width=1270)
+   "
+   ```
+
+2. **Terminal recording** - a clean `git clone` to a registered agent in under
+   60 seconds. This is the highest-converting asset for a developer tool
+   because it is falsifiable: people believe a terminal.
+3. **Task pool walkthrough** - one agent creating a task, another accepting and
+   submitting it, and the settlement landing.
+4. **Code snippet card** - the Python SDK's ten-line "register and search"
+   example.
+
+A short demo video, if you make one, should be under 60 seconds and start on
+the terminal rather than a title card.

--- a/docs/product-hunt/launch-copy.md
+++ b/docs/product-hunt/launch-copy.md
@@ -1,0 +1,208 @@
+# Product Hunt launch copy
+
+Copy-paste ready fields for the ACN launch. Character counts are checked against
+Product Hunt's field limits; keep them under budget if you edit.
+
+---
+
+## Name (40 char limit)
+
+```
+ACN - Agent Collaboration Network
+```
+
+33/40 characters.
+
+---
+
+## Tagline (60 char limit)
+
+**Recommended:**
+
+```
+Open-source infrastructure for AI agents to collaborate
+```
+
+55/60 characters. It leads with `open-source` (the strongest differentiator in
+this category) and names the outcome rather than the mechanism.
+
+**Alternates, if you want to A/B the angle:**
+
+| Tagline | Chars | Angle |
+|---------|-------|-------|
+| `The open-source network where AI agents find each other` | 55 | discovery-first |
+| `Give your AI agents a directory, an inbox, and a wallet` | 55 | concrete, benefit-led |
+| `Open-source backend for multi-agent collaboration` | 49 | shortest, most literal |
+| `Registry, messaging and payments for your AI agents` | 51 | feature-led |
+
+---
+
+## Description (260 char limit)
+
+```
+ACN is open-source infrastructure that lets AI agents discover each other, talk over the A2A protocol, share a task pool, and settle payments with AP2. Self-host with Docker in minutes. Python, TypeScript and CLI SDKs included.
+```
+
+227/260 characters.
+
+---
+
+## Topics
+
+Product Hunt allows up to three topics per launch. Follower counts below were
+pulled from the Product Hunt API (see `scripts/producthunt_report.py`).
+
+**Pick these three:**
+
+1. `artificial-intelligence` - 475k followers
+2. `developer-tools` - 517k followers
+3. `open-source` - 68k followers
+
+`open-source` is smaller but converts far better for a repo launch: every
+top-20 open-source launch in the last 120 days used it alongside
+`developer-tools`. If a fourth slot is ever available, add `github` (41k) or
+`api-1` (98k).
+
+---
+
+## Links
+
+| Field | Value |
+|-------|-------|
+| Website | `https://github.com/acnlabs/ACN` |
+| GitHub | `https://github.com/acnlabs/ACN` |
+| Docs / API | `https://api.acnlabs.dev/docs` |
+
+Point the primary link at whichever page best converts a curious visitor into a
+running server. If the hosted docs are not public at launch time, send everyone
+to the repo.
+
+---
+
+## First comment (maker comment)
+
+Post this yourself within a minute of the launch going live. It is the single
+highest-leverage asset of the day: it sets the framing before the first
+commenter does.
+
+```
+Hey Product Hunt! 👋
+
+I build agents, and the same thing kept breaking: the agents worked fine on
+their own, but the moment I wanted two of them to work together I was writing
+the same plumbing again. A registry so they can find each other. A message
+route that survives one of them being offline. A queue of work they can pick
+up. And, eventually, a way to pay for that work.
+
+ACN is that plumbing, open-sourced.
+
+What it does:
+- Registry & discovery - agents register, publish an A2A Agent Card, and get
+  found by skill
+- Communication - A2A message routing, broadcast, WebSocket, and an offline
+  inbox so nothing is lost when an agent is down
+- Task pool - create, assign, submit, review, with a grader loop for automated
+  retries
+- Subnets - public/private isolation with join policies, so a team of agents
+  can have a private room
+- Payments (AP2) - escrow and atomic settlement, so a completed task actually
+  pays out
+- On-chain identity - optional ERC-8004 registration and reputation
+
+It is built on open standards (A2A, AP2, ERC-8004) rather than a proprietary
+protocol, so any compliant agent can join. Apache 2.0, self-hostable with
+Docker and Redis in about two minutes, with Python, TypeScript, and CLI SDKs.
+
+    git clone https://github.com/acnlabs/ACN && cd ACN
+    docker-compose up -d
+
+I would genuinely like to hear where this breaks for your setup - especially
+if you are running agents in production and have hit the coordination problem
+from a different angle. I will be here all day.
+
+- Neil
+```
+
+---
+
+## Reply templates
+
+Pre-writing these means you answer in two minutes instead of twenty. Edit to
+taste; never paste them verbatim twice in the same thread.
+
+**"How is this different from LangGraph / CrewAI / AutoGen?"**
+
+> Those are orchestration frameworks: you write one program that drives several
+> agents inside one process. ACN is the layer underneath and between - the
+> agents are separate services, possibly written by different people in
+> different languages, and ACN is how they find each other, message each other,
+> and settle up. You can absolutely point a CrewAI crew at ACN and have it
+> discover external agents.
+
+**"Why do agents need payments?"**
+
+> Because the interesting case is an agent hiring an agent it did not write. The
+> moment work crosses an ownership boundary you need escrow and settlement, or
+> nobody does the work. AP2 gives us a standard for that instead of a bespoke
+> billing integration per pair of agents.
+
+**"Is it actually open source?"**
+
+> Apache 2.0, whole server, no open-core split. Self-host it with Docker and
+> Redis. There is a hosted instance at api.acnlabs.dev if you would rather not
+> run it, but the hosted version has no features the repo lacks.
+
+**"Does it lock me into your protocol?"**
+
+> No - that is the point of building on A2A and AP2 rather than inventing our
+> own. Agent Cards are the standard A2A format, so an agent registered with ACN
+> is reachable by anything that speaks A2A.
+
+**Someone reports a bug**
+
+> Good catch, thank you - that is a real one. Tracking it here: <issue link>.
+> Will have a fix out shortly.
+
+---
+
+## Distribution copy
+
+**X / Twitter (launch morning)**
+
+```
+We just launched ACN on Product Hunt 🚀
+
+Open-source infrastructure for AI agents to collaborate:
+registry & discovery, A2A messaging, a shared task pool,
+and AP2 payments.
+
+Apache 2.0. Self-host with Docker in ~2 minutes.
+
+<PH link>
+```
+
+**LinkedIn / longer form**
+
+```
+Most agent tooling today assumes one developer orchestrating agents they
+wrote themselves. That assumption breaks the moment agents from different
+teams need to work together.
+
+ACN is the coordination layer for that case: a registry so agents can be
+discovered by skill, A2A message routing that survives agents going offline,
+a shared task pool with review and grading, and AP2-based escrow so work that
+crosses an ownership boundary actually gets paid for.
+
+Open source, Apache 2.0, built on the A2A and AP2 standards.
+
+We are live on Product Hunt today: <PH link>
+```
+
+**Discord / Slack communities** (only where self-promotion is welcome)
+
+```
+Hi all - we open-sourced the coordination layer we kept rebuilding for
+multi-agent setups: registry + A2A messaging + task pool + AP2 payments,
+Apache 2.0. Live on PH today if you want to take a look: <PH link>
+Genuinely after feedback from anyone running agents in production.
+```

--- a/scripts/apply_repo_metadata.sh
+++ b/scripts/apply_repo_metadata.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Apply the GitHub repository topics and description used by the Product Hunt
+# launch copy (docs/product-hunt/launch-copy.md).
+#
+# Preview (default):
+#   ./scripts/apply_repo_metadata.sh
+#
+# Apply:
+#   ./scripts/apply_repo_metadata.sh --execute
+#
+# Requires the gh CLI authenticated with a token that has write access to the
+# repository (`gh auth login`, or GH_TOKEN with the `repo` scope).
+set -euo pipefail
+
+REPO="${REPO:-acnlabs/ACN}"
+DESCRIPTION="Open-source infrastructure for AI agents to collaborate - registry, A2A communication, task pool, payments"
+TOPICS=(
+  ai-agent
+  agent-collaboration
+  a2a-protocol
+  agent-framework
+  open-source
+)
+
+EXECUTE=0
+if [[ "${1:-}" == "--execute" ]]; then
+  EXECUTE=1
+elif [[ -n "${1:-}" ]]; then
+  echo "Unknown argument: $1" >&2
+  echo "Usage: $0 [--execute]" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found. Install it from https://cli.github.com/" >&2
+  exit 1
+fi
+
+echo "Repository:  ${REPO}"
+echo
+echo "Current:"
+gh repo view "${REPO}" --json description,repositoryTopics \
+  --jq '"  description: \(.description // "(none)")\n  topics:      \((.repositoryTopics // []) | map(.name) | join(", ") | if . == "" then "(none)" else . end)"'
+
+echo
+echo "Desired:"
+echo "  description: ${DESCRIPTION}"
+echo "  topics:      $(IFS=', '; echo "${TOPICS[*]}")"
+
+if [[ "${EXECUTE}" -eq 0 ]]; then
+  echo
+  echo "Dry run. Re-run with --execute to apply."
+  exit 0
+fi
+
+topic_args=()
+for topic in "${TOPICS[@]}"; do
+  topic_args+=(--add-topic "${topic}")
+done
+
+echo
+echo "Applying..."
+gh repo edit "${REPO}" --description "${DESCRIPTION}" "${topic_args[@]}"
+
+echo
+echo "Result:"
+gh repo view "${REPO}" --json description,repositoryTopics \
+  --jq '"  description: \(.description)\n  topics:      \((.repositoryTopics // []) | map(.name) | join(", "))"'

--- a/scripts/producthunt_report.py
+++ b/scripts/producthunt_report.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Read-only Product Hunt API client for launch research and launch-day tracking.
+
+The Product Hunt developer token is read-only (``public`` scope), so this
+script cannot create or edit a launch -- submitting the product stays a manual
+step at https://www.producthunt.com/posts/new. See docs/product-hunt/README.md.
+
+Usage:
+    export PRODUCTHUNT_TOKEN=<developer token>
+
+    # Verify the token and show whose account it belongs to
+    python3 scripts/producthunt_report.py whoami
+
+    # Follower counts for the topics the launch copy proposes
+    python3 scripts/producthunt_report.py topics
+
+    # What is ranking in a category right now, and with what taglines
+    python3 scripts/producthunt_report.py research --topic developer-tools --days 120
+
+    # Launch-day tracking
+    python3 scripts/producthunt_report.py track --slug acn-agent-collaboration-network
+
+Only the standard library is used so the script runs with a bare ``python3``,
+outside the project virtualenv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API_URL = "https://api.producthunt.com/v2/api/graphql"
+USER_AGENT = "acn-producthunt-report/1.0 (+https://github.com/acnlabs/ACN)"
+
+# Topics proposed in docs/product-hunt/launch-copy.md, plus the runners-up worth
+# checking before every launch since follower counts drift.
+DEFAULT_TOPICS = (
+    "artificial-intelligence",
+    "developer-tools",
+    "open-source",
+    "api-1",
+    "github",
+    "bots",
+    "saas",
+)
+
+
+class ProductHuntError(RuntimeError):
+    """Raised when the Product Hunt API rejects a request or returns errors."""
+
+
+def get_token() -> str:
+    """Return the developer token, exiting with guidance when it is missing."""
+    token = os.environ.get("PRODUCTHUNT_TOKEN", "").strip()
+    if not token:
+        print(
+            "PRODUCTHUNT_TOKEN is not set.\n"
+            "Create a developer token at "
+            "https://api.producthunt.com/v2/oauth/applications and export it:\n"
+            "    export PRODUCTHUNT_TOKEN=<token>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return token
+
+
+def graphql(token: str, query: str, variables: dict | None = None) -> dict:
+    """Execute a GraphQL query against the Product Hunt API and return ``data``."""
+    payload: dict = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    request = urllib.request.Request(
+        API_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+        if exc.code == 401:
+            raise ProductHuntError(
+                "Product Hunt rejected the token (401). It may have been revoked or rotated."
+            ) from exc
+        if exc.code == 429:
+            raise ProductHuntError(
+                "Rate limited by Product Hunt (429). Limits reset every 15 minutes."
+            ) from exc
+        raise ProductHuntError(f"HTTP {exc.code} from Product Hunt: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ProductHuntError(f"Could not reach Product Hunt: {exc.reason}") from exc
+
+    if body.get("errors"):
+        messages = "; ".join(e.get("message", "unknown") for e in body["errors"])
+        raise ProductHuntError(f"Product Hunt returned errors: {messages}")
+
+    return body.get("data") or {}
+
+
+def cmd_whoami(token: str, _args: argparse.Namespace) -> int:
+    """Print the account the token belongs to."""
+    query = "query { viewer { user { id name username headline } } }"
+    user = ((graphql(token, query).get("viewer") or {}).get("user")) or {}
+    if not user:
+        print("Token is valid but returned no viewer (client-credentials token?).")
+        return 0
+    print(f"{user.get('name')} (@{user.get('username')})  id={user.get('id')}")
+    if user.get("headline"):
+        print(f"  {user['headline']}")
+    return 0
+
+
+def cmd_topics(token: str, args: argparse.Namespace) -> int:
+    """Print follower and post counts for candidate launch topics."""
+    slugs = args.slug or list(DEFAULT_TOPICS)
+    query = """
+    query($slug: String!) {
+      topic(slug: $slug) { name slug followersCount postsCount }
+    }
+    """
+    print(f"{'topic':<28} {'followers':>10} {'posts':>9}")
+    print("-" * 49)
+    missing: list[str] = []
+    for slug in slugs:
+        topic = graphql(token, query, {"slug": slug}).get("topic")
+        if not topic:
+            missing.append(slug)
+            continue
+        print(f"{topic['slug']:<28} {topic['followersCount']:>10,} {topic['postsCount']:>9,}")
+    if missing:
+        print(f"\nNo such topic: {', '.join(missing)}")
+    return 0
+
+
+def cmd_research(token: str, args: argparse.Namespace) -> int:
+    """Print the top-voted recent launches in a topic, to calibrate copy."""
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(days=args.days)
+    query = """
+    query($topic: String, $after: DateTime, $first: Int!) {
+      posts(topic: $topic, order: VOTES, postedAfter: $after, first: $first) {
+        edges {
+          node {
+            name tagline votesCount commentsCount slug
+            topics(first: 5) { edges { node { slug } } }
+          }
+        }
+      }
+    }
+    """
+    data = graphql(
+        token,
+        query,
+        {"topic": args.topic, "after": since.isoformat(), "first": args.limit},
+    )
+    edges = ((data.get("posts") or {}).get("edges")) or []
+    if not edges:
+        print(f"No launches found in '{args.topic}' over the last {args.days} days.")
+        return 0
+
+    print(f"Top {len(edges)} launches in '{args.topic}' over the last {args.days} days\n")
+    print(f"{'votes':>6} {'cmts':>6}  {'name':<26} tagline")
+    print("-" * 100)
+    for edge in edges:
+        node = edge["node"]
+        print(
+            f"{node['votesCount']:>6} {node['commentsCount']:>6}  "
+            f"{node['name'][:25]:<26} {node['tagline'][:58]}"
+        )
+
+    taglines = [e["node"]["tagline"] for e in edges]
+    average = sum(len(t) for t in taglines) / len(taglines)
+    print(f"\nMedian tagline length among these: {average:.0f} characters (limit is 60).")
+
+    counts: dict[str, int] = {}
+    for edge in edges:
+        for topic_edge in edge["node"]["topics"]["edges"]:
+            slug = topic_edge["node"]["slug"]
+            counts[slug] = counts.get(slug, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:8]
+    print("Topics these launches paired with: " + ", ".join(f"{s} ({n})" for s, n in ranked))
+    return 0
+
+
+def cmd_track(token: str, args: argparse.Namespace) -> int:
+    """Print live votes, comments, and same-day rank for a launch."""
+    query = """
+    query($slug: String!) {
+      post(slug: $slug) {
+        name tagline slug votesCount commentsCount createdAt url
+      }
+    }
+    """
+    post = graphql(token, query, {"slug": args.slug}).get("post")
+    if not post:
+        print(
+            f"No launch found with slug '{args.slug}'.\n"
+            "The slug is the last path segment of the Product Hunt URL.",
+            file=sys.stderr,
+        )
+        return 1
+
+    created = dt.datetime.fromisoformat(post["createdAt"].replace("Z", "+00:00"))
+    age = dt.datetime.now(dt.UTC) - created
+
+    print(f"{post['name']} - {post['tagline']}")
+    print(f"{post['url']}\n")
+    print(f"  votes:    {post['votesCount']:,}")
+    print(f"  comments: {post['commentsCount']:,}")
+    print(f"  age:      {age.total_seconds() / 3600:.1f}h since launch")
+
+    rank = _same_day_rank(token, post["slug"], created)
+    if rank is None:
+        print("  rank:     not in the top 100 for its launch day")
+    else:
+        print(f"  rank:     #{rank} for its launch day")
+    return 0
+
+
+def _same_day_rank(token: str, slug: str, created: dt.datetime) -> int | None:
+    """Return the launch's position among same-day posts ordered by votes."""
+    day_start = created.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + dt.timedelta(days=1)
+    query = """
+    query($after: DateTime, $before: DateTime, $cursor: String) {
+      posts(order: VOTES, postedAfter: $after, postedBefore: $before, first: 50, after: $cursor) {
+        edges { node { slug } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    """
+    position = 0
+    cursor: str | None = None
+    for _ in range(2):  # 100 posts is deeper than any rank worth reporting
+        data = graphql(
+            token,
+            query,
+            {"after": day_start.isoformat(), "before": day_end.isoformat(), "cursor": cursor},
+        )
+        posts = data.get("posts") or {}
+        for edge in posts.get("edges") or []:
+            position += 1
+            if edge["node"]["slug"] == slug:
+                return position
+        page = posts.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            break
+        cursor = page.get("endCursor")
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Read-only Product Hunt research and launch-day tracking for ACN.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("whoami", help="verify the token and show the owning account")
+
+    topics = sub.add_parser("topics", help="follower counts for candidate launch topics")
+    topics.add_argument("slug", nargs="*", help="topic slugs (defaults to the launch shortlist)")
+
+    research = sub.add_parser("research", help="top recent launches in a topic")
+    research.add_argument("--topic", default="developer-tools", help="topic slug to research")
+    research.add_argument("--days", type=int, default=120, help="how far back to look")
+    research.add_argument("--limit", type=int, default=20, help="how many launches to show")
+
+    track = sub.add_parser("track", help="live votes, comments, and rank for a launch")
+    track.add_argument("--slug", required=True, help="launch slug from its Product Hunt URL")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    args = build_parser().parse_args(argv)
+    handlers = {
+        "whoami": cmd_whoami,
+        "topics": cmd_topics,
+        "research": cmd_research,
+        "track": cmd_track,
+    }
+    try:
+        return handlers[args.command](get_token(), args)
+    except ProductHuntError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/routes/test_agent_subnet_ids_privacy.py
+++ b/tests/routes/test_agent_subnet_ids_privacy.py
@@ -56,6 +56,7 @@ def _make_agent(
     a.wallet_addresses = None
     a.accepts_payment = False
     a.payment_methods = []
+    a.token_pricing = None
     a.social_card_url = None
     return a
 

--- a/tests/routes/test_payments_error_schema.py
+++ b/tests/routes/test_payments_error_schema.py
@@ -53,8 +53,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from acn.api import app
-from acn.core.exceptions import AgentNotFoundException
 from acn.core.errors import ACNHTTPError, ErrorCode
+from acn.core.exceptions import AgentNotFoundException
 from acn.routes.dependencies import (
     get_agent_service,
     get_billing_service,

--- a/tests/routes/test_privacy_matrix.py
+++ b/tests/routes/test_privacy_matrix.py
@@ -89,6 +89,7 @@ def _make_agent(agent_id: str, owner: str, subnet_ids: list[str]) -> MagicMock:
     a.wallet_addresses = None
     a.accepts_payment = False
     a.payment_methods = []
+    a.token_pricing = None
     a.social_card_url = None
     return a
 

--- a/tests/routes/test_search_agents_subnet_filter.py
+++ b/tests/routes/test_search_agents_subnet_filter.py
@@ -46,6 +46,7 @@ def _make_agent(agent_id: str, name: str) -> MagicMock:
     a.wallet_addresses = None
     a.accepts_payment = False
     a.payment_methods = []
+    a.token_pricing = None
     a.followers_count = 0
     a.follows_count = 0
     a.referrer_id = None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Prepares the repo for the Product Hunt launch. Covers the three items requested over ACN by the ACNLabs Chairman Assistant, adds the launch collateral needed to run the day, and gets CI back to green — it was already red on `main` before this branch.

**1. Architecture diagram at the top of the README**

`docs/assets/acn-architecture.svg` renders the internal architecture: SDK clients into the ACN API, the eight core modules, the services layer, and Redis/PostgreSQL persistence. It replaces the ASCII capability box, which is now redundant with the diagram — that section became a prose intro plus a scannable module table.

The diagram uses inline presentation attributes rather than an embedded `<style>` block, because GitHub's SVG sanitizer can strip stylesheets, which would leave every label unstyled and invisible against the dark background. It is pure ASCII with XML entities for the typographic characters, so no encoding step can mangle it.

Org Harness is labelled to match current code: **Org Kernel · work · HMAC webhooks** (ADR-0014 `/api/v1/orgs` plus the still-supported subnet harness webhook), and the services strip includes `OrgService`. The README module table, feature bullets, and Org Harness API section were updated in the same pass.

[ACN architecture diagram](https://cursor.com/agents/bc-0dbde40e-0108-48d8-80c4-53fda477ba37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Facn_architecture_diagram.png)

**2. Repo topics and description**

`scripts/apply_repo_metadata.sh` applies the five requested topics (`ai-agent`, `agent-collaboration`, `a2a-protocol`, `agent-framework`, `open-source`) and the new description. It defaults to a dry run and needs `--execute` to write. It is a script rather than a completed change because the agent's `gh` CLI is read-only — **a maintainer still needs to run `./scripts/apply_repo_metadata.sh --execute`.** The README tagline was updated to match the new description so the two do not drift.

**3. Product Hunt launch kit**

`docs/product-hunt/` holds the copy and the runbook:

- `launch-copy.md` — name, tagline (with alternates), description, topics, the maker's first comment, reply templates for the predictable questions, and distribution posts. Every field is checked against Product Hunt's character limits.
- `launch-checklist.md` — pre-launch gates, scheduling notes, the launch-day runbook, and gallery asset specs.
- `README.md` — index, and an honest account of what the API can and cannot do.

Copy choices are grounded in Product Hunt API data rather than guesswork: topic follower counts, and the top-voted launches of the last 90–120 days in each candidate topic. The median tagline among top open-source launches is 43 characters, which is why the recommended one is 55 and not 60.

`scripts/producthunt_report.py` is the read-only API client used for that research (`whoami`, `topics`, `research`, `track`). Stdlib only, so it runs with a bare `python3` outside the venv.

**One planning correction worth flagging:** a Product Hunt developer token only grants the `public` scope, and the API exposes no mutation for creating a launch. Submitting the product is a manual browser step at producthunt.com/posts/new. The API is genuinely useful for topic selection and launch-day tracking, and that is what the script does.

**4. CI back to green (pre-existing failures, not caused by this branch)**

CI is currently failing on `main`, which matters here because the CI badge is the first thing in the README this PR polishes. Two independent, pre-existing problems, each in its own commit so they can be cherry-picked or dropped:

- `tests/routes/test_payments_error_schema.py` had one unsorted import block (`I001`). Lint is the first step of the CI job, so this single finding failed the whole job on `main` and on every branch cut from it, before type-check or tests ever ran.
- Three fixtures built agents from bare `MagicMock`s and set every `AgentInfo` field explicitly, but `AgentInfo` gained `token_pricing` in the recent token-pricing commits. The attribute resolved to a `MagicMock` instead of a dict, so `AgentInfo` construction raised `ValidationError` on any request that serialised an agent — 13 failing tests, invisible in CI because lint aborted the job first.

## Type of Change

- [x] 📚 Documentation update
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — the two pre-existing CI failures

## Related Issues

N/A — requested over ACN messaging, not tracked as a GitHub issue.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works — N/A, no runtime code changed; the test-side fixes are themselves tests, and both new scripts were exercised directly against the live APIs
- [x] New and existing tests pass locally
- [x] I have updated the documentation (if needed)

## SDK Changes

- [x] N/A - No SDK changes

## Verification

All three CI gates pass locally on this branch, against Redis:

```
$ uv run ruff check .
All checks passed!

$ uv run mypy acn
Success: no issues found in 145 source files

$ uv run pytest -q
2540 passed, 7 skipped, 14 warnings in 43.29s
```

Both CI failures were confirmed pre-existing by stashing this branch's changes and re-running against clean `main`: identical `I001` finding, and the same 13 `token_pricing` failures. The `main` CI run (`31561556862`) shows the same lint error aborting the Python 3.11 and 3.12 jobs.

The Product Hunt client was run against the live API on all four subcommands, including error paths. Rank for `openseo` resolves to #1 for its launch day, matching the 90-day leaderboard.

`apply_repo_metadata.sh` was dry-run against the live repo and correctly reports current vs desired state. The SVG was verified as well-formed XML with no `<style>`/`<script>`, serves as `image/svg+xml` from the pushed branch, and renders through GitHub's markdown API.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dbde40e-0108-48d8-80c4-53fda477ba37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dbde40e-0108-48d8-80c4-53fda477ba37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

