### PR TITLE
CLI: heartbeat preferred_model + model-only writeback

### DIFF
--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -127,11 +127,15 @@ export type ChatTokenUsage = {
   input_tokens: number;
   output_tokens: number;
   meter_source?: 'peer_self' | 'gateway' | 'runtime_attested' | 'protocol';
+  /** Host Catalog id used for this hop — self-reported; soft mismatch vs listing. */
+  model_id?: string;
 };
 
 export type ChatCompleteResult = {
   content: string;
   usage?: ChatTokenUsage;
+  /** Top-level complete.model_id when no token usage is present. */
+  modelId?: string;
 };
 
 /**
@@ -163,9 +167,27 @@ function asNonNegInt(v: unknown): number | null {
   return null;
 }
 
+/** Host Catalog model id from complete JSON (usage.* or top-level). */
+export function extractModelId(payload: unknown): string | undefined {
+  const rec = asRecord(payload);
+  if (!rec) return undefined;
+  const usageRec = asRecord(rec.usage);
+  for (const raw of [
+    usageRec?.model_id,
+    usageRec?.model,
+    rec.model_id,
+    rec.model,
+  ]) {
+    if (typeof raw === 'string' && raw.trim()) return raw.trim().slice(0, 200);
+  }
+  return undefined;
+}
+
 /**
  * Optional token usage from host complete JSON (chat billing settle).
  * Accepts usage.input_tokens/output_tokens or prompt_tokens/completion_tokens.
+ * model_id-only complete payloads do NOT invent zero-token usage — use
+ * {@link extractModelId} / writeback `usage: { model_id }` instead.
  */
 export function extractUsage(payload: unknown): ChatTokenUsage | undefined {
   const rec = asRecord(payload);
@@ -190,6 +212,8 @@ export function extractUsage(payload: unknown): ChatTokenUsage | undefined {
   ) {
     out.meter_source = ms;
   }
+  const modelId = extractModelId(payload);
+  if (modelId) out.model_id = modelId;
   return out;
 }
 
@@ -199,7 +223,11 @@ function parseCompletePayload(
   const content = extractContent(payload);
   if (!content) return { ok: false, reason: 'complete_missing_content' };
   const usage = extractUsage(payload);
-  return { ok: true, result: usage ? { content, usage } : { content } };
+  const modelId = extractModelId(payload);
+  const result: ChatCompleteResult = { content };
+  if (usage) result.usage = usage;
+  else if (modelId) result.modelId = modelId;
+  return { ok: true, result };
 }
 
 /** Mint (or reuse cached) ACN agent JWT for Chat Gateway. Exported for tests. */
@@ -401,11 +429,18 @@ async function postWriteback(
     reply_to_id: replyToId,
   };
   if (complete.usage) {
-    body.usage = {
+    const usageBody: Record<string, unknown> = {
       input_tokens: complete.usage.input_tokens,
       output_tokens: complete.usage.output_tokens,
       meter_source: complete.usage.meter_source ?? 'peer_self',
     };
+    if (complete.usage.model_id) {
+      usageBody.model_id = complete.usage.model_id;
+    }
+    body.usage = usageBody;
+  } else if (complete.modelId) {
+    // model_id only — do not invent zero token counts; Host defaults tokens to 0.
+    body.usage = { model_id: complete.modelId };
   }
 
   const postOnce = async (

--- a/clients/cli/src/commands/heartbeat.ts
+++ b/clients/cli/src/commands/heartbeat.ts
@@ -9,7 +9,8 @@ export function heartbeatCommand(): Command {
     .option('-i, --agent-id <id>', 'Agent ID (defaults to value in ~/.acn/config.json)')
     .option(
       '-m, --model <modelId>',
-      'Declare runtime model (Host Catalog id) for Host Pricing prefill — self-reported',
+      'Declare runtime model (Host Catalog id) for Host Pricing prefill — self-reported ' +
+        '(env: ACN_PREFERRED_MODEL)',
     )
     .action(async (opts: { agentId?: string; model?: string }) => {
       const config = loadConfig();
@@ -21,10 +22,11 @@ export function heartbeatCommand(): Command {
       }
 
       try {
-        const body =
-          opts.model && opts.model.trim()
-            ? { preferred_model: opts.model.trim() }
-            : undefined;
+        const model =
+          (opts.model && opts.model.trim()) ||
+          process.env.ACN_PREFERRED_MODEL?.trim() ||
+          '';
+        const body = model ? { preferred_model: model.slice(0, 200) } : undefined;
         const res = await acnPost<{
           status?: string;
           preferred_model?: string;

--- a/clients/cli/src/commands/listen.ts
+++ b/clients/cli/src/commands/listen.ts
@@ -363,11 +363,68 @@ interface ListenerConfig extends HandlerOptions {
   agentId: string;
   apiKey: string;
   baseUrl: string;
+  /** Host Catalog model id — self-reported via REST heartbeat while listening. */
+  preferredModel?: string;
 }
 
 const KEEPALIVE_INTERVAL_MS = 30_000;
+/** Explicit REST heartbeat with preferred_model (WS ping does not carry model). */
+const MODEL_HEARTBEAT_INTERVAL_MS = 15 * 60_000;
 const INITIAL_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
+
+/** Resolve runtime model for heartbeat: flag → ACN_PREFERRED_MODEL → empty. */
+export function resolvePreferredModel(opts?: {
+  model?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const env = opts?.env ?? process.env;
+  const fromFlag = opts?.model?.trim();
+  if (fromFlag) return fromFlag.slice(0, 200);
+  const fromEnv = env.ACN_PREFERRED_MODEL?.trim();
+  if (fromEnv) return fromEnv.slice(0, 200);
+  return undefined;
+}
+
+/** POST /agents/{id}/heartbeat with optional preferred_model (self-reported). */
+export async function postAgentHeartbeat(opts: {
+  baseUrl: string;
+  agentId: string;
+  apiKey: string;
+  preferredModel?: string;
+  fetchFn?: typeof fetch;
+}): Promise<{ ok: true; preferred_model?: string | null } | { ok: false; reason: string }> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const origin = opts.baseUrl.replace(/\/+$/, '');
+  const url = `${origin}/api/v1/agents/${opts.agentId}/heartbeat`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${opts.apiKey}`,
+    'Content-Type': 'application/json',
+  };
+  const body =
+    opts.preferredModel && opts.preferredModel.trim()
+      ? JSON.stringify({ preferred_model: opts.preferredModel.trim().slice(0, 200) })
+      : undefined;
+  try {
+    const res = await fetchFn(url, { method: 'POST', headers, body });
+    if (!res.ok) {
+      return { ok: false, reason: `http_${res.status}` };
+    }
+    let preferred: string | null | undefined;
+    try {
+      const json = (await res.json()) as { preferred_model?: string | null };
+      preferred = json.preferred_model;
+    } catch {
+      preferred = opts.preferredModel ?? null;
+    }
+    return { ok: true, preferred_model: preferred };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
 
 function runListener(cfg: ListenerConfig): void {
   const wsUrl = toWebsocketUrl(cfg.baseUrl, cfg.agentId);
@@ -382,6 +439,25 @@ function runListener(cfg: ListenerConfig): void {
       headers: { Authorization: `Bearer ${cfg.apiKey}` },
     });
     let keepalive: ReturnType<typeof setInterval> | undefined;
+    let modelHeartbeat: ReturnType<typeof setInterval> | undefined;
+
+    const sendModelHeartbeat = (): void => {
+      if (!cfg.preferredModel || stopped) return;
+      void postAgentHeartbeat({
+        baseUrl: cfg.baseUrl,
+        agentId: cfg.agentId,
+        apiKey: cfg.apiKey,
+        preferredModel: cfg.preferredModel,
+      }).then((r) => {
+        if (!r.ok) {
+          console.error(`[acn listen] preferred_model heartbeat failed: ${r.reason}`);
+          return;
+        }
+        console.error(
+          `[acn listen] preferred_model heartbeat ok model=${r.preferred_model ?? cfg.preferredModel}`
+        );
+      });
+    };
 
     ws.on('open', () => {
       // Status to stderr so stdout stays clean for pipe consumers.
@@ -390,13 +466,23 @@ function runListener(cfg: ListenerConfig): void {
         : cfg.forward
           ? `forward=${cfg.forward}`
           : `exec`;
-      console.error(`[acn listen] connected as ${cfg.agentId} → ${wsUrl} (${mode})`);
+      const modelNote = cfg.preferredModel
+        ? ` preferred_model=${cfg.preferredModel}`
+        : '';
+      console.error(
+        `[acn listen] connected as ${cfg.agentId} → ${wsUrl} (${mode})${modelNote}`
+      );
       backoff = INITIAL_BACKOFF_MS;
       keepalive = setInterval(() => {
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'ping' }));
         }
       }, KEEPALIVE_INTERVAL_MS);
+      // REST heartbeat carries preferred_model; WS ping alone cannot.
+      if (cfg.preferredModel) {
+        sendModelHeartbeat();
+        modelHeartbeat = setInterval(sendModelHeartbeat, MODEL_HEARTBEAT_INTERVAL_MS);
+      }
     });
 
     ws.on('message', (data: WebSocket.RawData) => {
@@ -424,6 +510,7 @@ function runListener(cfg: ListenerConfig): void {
 
     ws.on('close', (code: number, reason: Buffer) => {
       if (keepalive) clearInterval(keepalive);
+      if (modelHeartbeat) clearInterval(modelHeartbeat);
       if (stopped) return;
       // 4401/4403 are auth failures (bad/mismatched API key) and 4429 is
       // "too many connections" — none are transient, so retrying forever
@@ -552,6 +639,11 @@ export function listenCommand(): Command {
       String(DEFAULT_COMPLETE_TIMEOUT_MS)
     )
     .option('-i, --agent-id <id>', 'Agent ID (defaults to config)')
+    .option(
+      '-m, --model <modelId>',
+      'Declare runtime model (Host Catalog id) on connect + every 15m via REST heartbeat ' +
+        '(self-reported; env: ACN_PREFERRED_MODEL)'
+    )
     .action(
       (opts: {
         runtime?: string;
@@ -570,6 +662,7 @@ export function listenCommand(): Command {
         chatCompleteExec?: string;
         chatCompleteTimeout?: string;
         agentId?: string;
+        model?: string;
       }) => {
         const config = loadConfig();
         const apiKey = config.api_key;
@@ -687,10 +780,13 @@ export function listenCommand(): Command {
             process.env.AGENTPLANET_JWT_AUDIENCE?.trim(),
         });
 
+        const preferredModel = resolvePreferredModel({ model: opts.model });
+
         runListener({
           agentId,
           apiKey: apiKey!,
           baseUrl: config.base_url,
+          preferredModel,
           forward: opts.forward,
           exec: opts.exec,
           runtime: opts.runtime

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -9,6 +9,7 @@ import {
   clearAgentJwtCache,
   DEFAULT_CHAT_JWT_AUDIENCE,
   extractContent,
+  extractModelId,
   extractUsage,
   handleChatWriteback,
   validateChatWritebackOptions,
@@ -170,6 +171,31 @@ describe('extractUsage', () => {
       output_tokens: 4,
       meter_source: 'peer_self',
     });
+    expect(
+      extractUsage({
+        usage: { input_tokens: 1, output_tokens: 0, model_id: 'openai/gpt-4o-mini' },
+      })
+    ).toEqual({
+      input_tokens: 1,
+      output_tokens: 0,
+      model_id: 'openai/gpt-4o-mini',
+    });
+    expect(
+      extractUsage({
+        content: 'hi',
+        model: 'anthropic/claude-sonnet-4',
+        usage: { input_tokens: 2, output_tokens: 1 },
+      })
+    ).toEqual({
+      input_tokens: 2,
+      output_tokens: 1,
+      model_id: 'anthropic/claude-sonnet-4',
+    });
+    // model_id alone must not invent zero-token usage
+    expect(extractUsage({ content: 'hi', model_id: 'openai/gpt-4o-mini' })).toBeUndefined();
+    expect(extractModelId({ content: 'hi', model_id: 'openai/gpt-4o-mini' })).toBe(
+      'openai/gpt-4o-mini'
+    );
     expect(extractUsage({ content: 'hi' })).toBeUndefined();
   });
 });

--- a/clients/cli/tests/listen.test.ts
+++ b/clients/cli/tests/listen.test.ts
@@ -15,6 +15,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   dispatchA2aRequest,
   handleA2aRequest,
+  postAgentHeartbeat,
+  resolvePreferredModel,
   toWebsocketUrl,
   type A2aRequestFrame,
   type A2aStreamChunkFrame,
@@ -198,5 +200,46 @@ describe('handleA2aRequest --exec', () => {
     const resp = await handleA2aRequest(makeRequest(), { exec: 'false' }, { spawnFn });
     expect(resp.status).toBe(500);
     expect(JSON.parse(resp.body).error).toContain('boom');
+  });
+});
+
+describe('resolvePreferredModel', () => {
+  it('prefers --model flag over env', () => {
+    expect(
+      resolvePreferredModel({
+        model: 'openai/gpt-4o',
+        env: { ACN_PREFERRED_MODEL: 'openai/gpt-4o-mini' } as NodeJS.ProcessEnv,
+      })
+    ).toBe('openai/gpt-4o');
+  });
+
+  it('falls back to ACN_PREFERRED_MODEL', () => {
+    expect(
+      resolvePreferredModel({
+        env: { ACN_PREFERRED_MODEL: ' anthropic/claude-sonnet-4 ' } as NodeJS.ProcessEnv,
+      })
+    ).toBe('anthropic/claude-sonnet-4');
+  });
+});
+
+describe('postAgentHeartbeat', () => {
+  it('POSTs preferred_model when provided', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok', preferred_model: 'openai/gpt-4o-mini' }),
+    });
+    const r = await postAgentHeartbeat({
+      baseUrl: 'https://api.acnlabs.dev',
+      agentId: 'ag-1',
+      apiKey: 'acn_key',
+      preferredModel: 'openai/gpt-4o-mini',
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: true, preferred_model: 'openai/gpt-4o-mini' });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.acnlabs.dev/api/v1/agents/ag-1/heartbeat');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ preferred_model: 'openai/gpt-4o-mini' }));
   });
 });

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -668,6 +668,10 @@ matching, and broadcast targeting** even though its row still exists.
 # Self-reported — not proof of the real upstream call.
 acn heartbeat --model openai/gpt-4o-mini
 # or: POST /agents/{id}/heartbeat  {"preferred_model":"openai/gpt-4o-mini"}
+# or env: ACN_PREFERRED_MODEL=openai/gpt-4o-mini
+#
+# Mode B listen auto-heartbeats the model on connect + every 15m:
+#   acn listen --runtime http --model openai/gpt-4o-mini ...
 ```
 
 ### Three-layer communication


### PR DESCRIPTION
## Summary
- `acn listen --model` / `ACN_PREFERRED_MODEL` send REST heartbeat on connect and every 15 minutes so Host can soft-compare listing vs runtime model.
- `acn heartbeat` falls back to env when `--model` is omitted.
- Chat writeback extracts `model_id` separately from token usage so model-only reports do not fabricate `0/0` usage.

## Test plan
- [ ] CLI unit tests for listen heartbeat + chat-writeback model-only path
- [ ] Manual: `ACN_PREFERRED_MODEL=openai/gpt-4o acn listen` and confirm agent `preferred_model` / runtime model updates
- [ ] Manual: writeback with only `model_id` reaches Host without zero token fields


Made with [Cursor](https://cursor.com)