### PR TITLE
chore(release): cut v1.0.1 — preferred_model heartbeat + token_pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-12
+
+Coordinated patch: server, SDKs, CLI, and agent skill all **1.0.1**.
+
+### Added
+
+- **Heartbeat `preferred_model`** — optional JSON body on
+  `POST /agents/{id}/heartbeat` stores Host Catalog id on
+  `metadata.preferred_model` for Host Pricing prefill (self-reported).
+  Python/TS SDKs expose the same optional argument; CLI
+  `acn heartbeat --model` / `ACN_PREFERRED_MODEL`, and Mode B
+  `acn listen --model` refreshes on connect + every 15m.
+- **`AgentInfo.token_pricing`** — L2 listing (USD per 1M in/out, optional
+  `model_id`) on agent responses for Host chat billing
+  (`pricing_ref.source=agent_declared`).
+
+### Changed
+
+- **`PUT`/`POST` token pricing** — auth is `OwnerOrInternalDep` (agent API
+  key or Host Gateway `X-Internal-Token`); optional `model_id` /
+  `markup_percent`; price-only updates keep a previously stored `model_id`.
+- **CLI chat writeback** — may send `model_id` without fabricating zero
+  token usage when the host reports a model-only complete.
+
+### Docs
+
+- **Agent skill 1.0.1** — document `preferred_model` heartbeat, env, and
+  listen auto-refresh (`skills/acn/SKILL.md` + `references/API.md`).
+
 ## [1.0.0] - 2026-08-10
 
 First stable major release. Server tag **v1.0.0** and the coordinated client

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 
 | Server | Python `acn-client` | TypeScript `acn-client` | `@acnlabs/acn-cli` | Agent skill |
 |--------|---------------------|-------------------------|--------------------|-------------|
-| **1.0.0** (current) | **1.0.0** | **1.0.0** | **1.0.0** | **1.0.0** |
+| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.1** | **1.0.1** |
+| 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 |
 | 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
 
 Pin clients to the row matching your deployed server.

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-12
+
+Coordinated patch with ACN server **1.0.1**.
+
+### Added
+- **`acn heartbeat --model` / `ACN_PREFERRED_MODEL`** — declare Host Catalog
+  model id on heartbeat (`metadata.preferred_model`).
+- **`acn listen --model`** — Mode B refreshes preferred model on connect and
+  every 15m alongside the alive heartbeat.
+
+### Changed
+- **Chat writeback** — host complete may return `model_id` without usage;
+  CLI forwards `model_id` without fabricating zero token counts.
+
 ## [1.0.0] - 2026-08-10
 
 Coordinated major with ACN server **1.0.0**.

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.0",
-  "description": "Official CLI for ACN (Agent Collaboration Network) — zero-integration agent access",
+  "version": "1.0.1",
+  "description": "Official CLI for ACN (Agent Collaboration Network) \u2014 zero-integration agent access",
   "main": "dist/index.js",
   "bin": {
     "acn": "dist/index.js"

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `acn-client` are documented here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-12
+
+Coordinated patch with ACN server **1.0.1**.
+
+### Added
+
+- `ACNClient.heartbeat(..., preferred_model=...)` — optional Host Catalog id
+  stored on `metadata.preferred_model` (self-reported; Host Pricing prefill).
+
 ## [1.0.0] - 2026-08-10
 
 Coordinated major with ACN server **1.0.0**. No intentional

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acn-client"
-version = "1.0.0"
+version = "1.0.1"
 description = "Official Python client for ACN (Agent Collaboration Network)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `acn-client` (TypeScript) are documented here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-12
+
+Coordinated patch with ACN server **1.0.1**.
+
+### Added
+
+- `ACNClient.heartbeat(agentId, { preferredModel })` — optional Host Catalog
+  id stored on `metadata.preferred_model` (self-reported; Host Pricing prefill).
+
 ## [1.0.0] - 2026-08-10
 
 Coordinated major with ACN server **1.0.0**. No intentional

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acn-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acn-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "^2.0.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acn-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official TypeScript/JavaScript client for ACN (Agent Collaboration Network)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acn"
-version = "1.0.0"
+version = "1.0.1"
 description = "Agent Collaboration Network - Open-source infrastructure for AI Agent registration and discovery"
 authors = [
     {name = "acnlabs", email = "team@acnlabs.dev"}

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "1.0.0"
+  version: "1.0.1"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ http-server = [
 
 [[package]]
 name = "acn"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },


### PR DESCRIPTION
## Summary
- Coordinated **1.0.1** bump for server, Python/TS SDKs, CLI, and agent skill (post-1.0.0 unreleased work).
- Documents heartbeat `preferred_model`, `AgentInfo.token_pricing`, listen `--model` refresh, and model-only chat writeback in CHANGELOGs + README compat matrix.

## After merge
```bash
git checkout main && git pull
git tag v1.0.1
git push origin v1.0.1
```
Tag `v1.0.1` triggers `.github/workflows/release.yml` (PyPI / npm / CLI / GHCR). PyPI is still on `0.12.1` while the repo declared `1.0.0` — this tag should publish **1.0.1** (and still skip any already-published artifacts).

## Test plan
- [ ] CI version-sync + Python/CLI/TS jobs green
- [ ] After tag: confirm npm `@acnlabs/acn-cli@1.0.1`, `acn-client@1.0.1`, and PyPI `acn-client==1.0.1`
- [ ] Deployed `/skill.md` shows `metadata.version: "1.0.1"` after server roll


Made with [Cursor](https://cursor.com)