### PR TITLE
chore(release): cut CLI 1.0.2 — wake requested_model + supported_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-15
+
+CLI-only patch (`@acnlabs/acn-cli@1.0.2`). Server / SDKs / skill stay **1.0.1**.
+
 ### Added
 
 - **Heartbeat `supported_models`** — optional JSON body on

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 
 | Server | Python `acn-client` | TypeScript `acn-client` | `@acnlabs/acn-cli` | Agent skill |
 |--------|---------------------|-------------------------|--------------------|-------------|
-| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.1** | **1.0.1** |
+| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.2** | **1.0.1** |
 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 |
 | 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
 

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-15
+
+CLI-only patch. Server / SDK / skill stay **1.0.1**.
+
 ### Added
 - **`acn heartbeat --supported-models` / `ACN_SUPPORTED_MODELS`** — declare
   Host Catalog model ids on heartbeat (`metadata.supported_models`) for

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official CLI for ACN (Agent Collaboration Network) \u2014 zero-integration agent access",
   "main": "dist/index.js",
   "bin": {

--- a/tests/routes/test_route_service_contracts.py
+++ b/tests/routes/test_route_service_contracts.py
@@ -469,6 +469,7 @@ class TestRegistryContract:
         stub_agent_service.update_heartbeat.assert_awaited_once_with(
             "agent-hb",
             preferred_model=None,
+            supported_models=None,
         )
 
 


### PR DESCRIPTION
## Summary
- Bump `@acnlabs/acn-cli` to **1.0.2** so npm can publish the already-landed Mode B wake envelope (`chat.requested_model` / `max_output_tokens`) and `supported_models` heartbeat.
- Server / Python SDK / TypeScript SDK / agent skill stay **1.0.1**. Compat table updated accordingly.
- Feature code is already on `main` (`bdd2dfb`). This PR is version + changelog only.

## After merge
Tag `v1.0.2` to trigger `.github/workflows/release.yml`:
- CLI publishes `@acnlabs/acn-cli@1.0.2`
- Python / TS SDK 1.0.1 already on registries → skip
- **Side effect:** Docker also pushes `ghcr.io/.../acn:1.0.2` and `:latest` from the same server tree (still 1.0.1). Functional no-op if prod deploys from git, not `latest`.

## Test plan
- [x] CLI `chat-writeback` tests include `requested_model` extract (20 passed locally)
- [ ] CI green on this PR
- [ ] After tag: `npm view @acnlabs/acn-cli version` is `1.0.2`
- [ ] Comiclaw: `npm i -g @acnlabs/acn-cli@1.0.2` and restart listen (wrapper can stay)


Made with [Cursor](https://cursor.com)