### PR TITLE
feat(cli): forward hop usage extras on chat writeback

### DIFF
--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -129,6 +129,12 @@ export type ChatTokenUsage = {
   meter_source?: 'peer_self' | 'gateway' | 'runtime_attested' | 'protocol';
   /** Host Catalog id used for this hop — self-reported; soft mismatch vs listing. */
   model_id?: string;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  total_tokens?: number;
+  duration_ms?: number;
+  provider?: string;
 };
 
 export type ChatCompleteResult = {
@@ -194,10 +200,13 @@ export function extractUsage(payload: unknown): ChatTokenUsage | undefined {
   if (!rec) return undefined;
   const usageRec = asRecord(rec.usage) ?? rec;
   const input =
-    asNonNegInt(usageRec.input_tokens) ?? asNonNegInt(usageRec.prompt_tokens);
+    asNonNegInt(usageRec.input_tokens) ??
+    asNonNegInt(usageRec.prompt_tokens) ??
+    asNonNegInt(usageRec.input);
   const output =
     asNonNegInt(usageRec.output_tokens) ??
-    asNonNegInt(usageRec.completion_tokens);
+    asNonNegInt(usageRec.completion_tokens) ??
+    asNonNegInt(usageRec.output);
   if (input === null && output === null) return undefined;
   const out: ChatTokenUsage = {
     input_tokens: input ?? 0,
@@ -214,6 +223,28 @@ export function extractUsage(payload: unknown): ChatTokenUsage | undefined {
   }
   const modelId = extractModelId(payload);
   if (modelId) out.model_id = modelId;
+  const reasoning =
+    asNonNegInt(usageRec.reasoning_tokens) ?? asNonNegInt(usageRec.reasoningTokens);
+  const cacheRead =
+    asNonNegInt(usageRec.cache_read_tokens) ?? asNonNegInt(usageRec.cacheRead);
+  const cacheWrite =
+    asNonNegInt(usageRec.cache_write_tokens) ?? asNonNegInt(usageRec.cacheWrite);
+  const total = asNonNegInt(usageRec.total_tokens) ?? asNonNegInt(usageRec.total);
+  const duration =
+    asNonNegInt(usageRec.duration_ms) ??
+    asNonNegInt(usageRec.durationMs) ??
+    asNonNegInt(rec.duration_ms) ??
+    asNonNegInt(rec.durationMs);
+  const provider =
+    (typeof usageRec.provider === 'string' && usageRec.provider.trim()) ||
+    (typeof rec.provider === 'string' && rec.provider.trim()) ||
+    '';
+  if (reasoning !== null) out.reasoning_tokens = reasoning;
+  if (cacheRead !== null) out.cache_read_tokens = cacheRead;
+  if (cacheWrite !== null) out.cache_write_tokens = cacheWrite;
+  if (total !== null) out.total_tokens = total;
+  if (duration !== null) out.duration_ms = duration;
+  if (provider) out.provider = provider.slice(0, 80);
   return out;
 }
 
@@ -436,6 +467,24 @@ async function postWriteback(
     };
     if (complete.usage.model_id) {
       usageBody.model_id = complete.usage.model_id;
+    }
+    if (complete.usage.reasoning_tokens != null) {
+      usageBody.reasoning_tokens = complete.usage.reasoning_tokens;
+    }
+    if (complete.usage.cache_read_tokens != null) {
+      usageBody.cache_read_tokens = complete.usage.cache_read_tokens;
+    }
+    if (complete.usage.cache_write_tokens != null) {
+      usageBody.cache_write_tokens = complete.usage.cache_write_tokens;
+    }
+    if (complete.usage.total_tokens != null) {
+      usageBody.total_tokens = complete.usage.total_tokens;
+    }
+    if (complete.usage.duration_ms != null) {
+      usageBody.duration_ms = complete.usage.duration_ms;
+    }
+    if (complete.usage.provider) {
+      usageBody.provider = complete.usage.provider;
     }
     body.usage = usageBody;
   } else if (complete.modelId) {

--- a/clients/cli/tests/chat-writeback.test.ts
+++ b/clients/cli/tests/chat-writeback.test.ts
@@ -213,6 +213,31 @@ describe('extractUsage', () => {
       'openai/gpt-4o-mini'
     );
     expect(extractUsage({ content: 'hi' })).toBeUndefined();
+    expect(
+      extractUsage({
+        usage: {
+          input: 10,
+          output: 2,
+          reasoningTokens: 3,
+          cacheRead: 4,
+          cacheWrite: 1,
+          total: 16,
+          duration_ms: 800,
+          provider: 'tencenttokenplan',
+          model_id: 'tencenttokenplan/kimi-k2.5',
+        },
+      })
+    ).toEqual({
+      input_tokens: 10,
+      output_tokens: 2,
+      model_id: 'tencenttokenplan/kimi-k2.5',
+      reasoning_tokens: 3,
+      cache_read_tokens: 4,
+      cache_write_tokens: 1,
+      total_tokens: 16,
+      duration_ms: 800,
+      provider: 'tencenttokenplan',
+    });
   });
 });
 
@@ -335,7 +360,17 @@ describe('handleChatWriteback', () => {
         return mockOkResponse(
           JSON.stringify({
             content: 'billed reply',
-            usage: { input_tokens: 12, output_tokens: 34 },
+            usage: {
+              input_tokens: 12,
+              output_tokens: 34,
+              reasoningTokens: 3,
+              cacheRead: 4,
+              cacheWrite: 1,
+              total: 50,
+              durationMs: 800,
+              provider: 'tencenttokenplan',
+              model_id: 'tencenttokenplan/kimi-k2.5',
+            },
           })
         );
       }
@@ -373,6 +408,13 @@ describe('handleChatWriteback', () => {
         input_tokens: 12,
         output_tokens: 34,
         meter_source: 'peer_self',
+        model_id: 'tencenttokenplan/kimi-k2.5',
+        reasoning_tokens: 3,
+        cache_read_tokens: 4,
+        cache_write_tokens: 1,
+        total_tokens: 50,
+        duration_ms: 800,
+        provider: 'tencenttokenplan',
       },
     });
     expect(event.chat?.gateway_message_id).toBe('user-msg-1');


### PR DESCRIPTION
## Summary
- Extract OpenClaw-style extras (`reasoningTokens`, `cacheRead`/`cacheWrite`, `total`, `durationMs`, `provider`) from complete JSON.
- Forward them on Host writeback. Settlement still uses cumulative `input_tokens` / `output_tokens` only.
- Host `main` already persists these on `metadata.usage`.

## Test plan
- [x] `npm test -- tests/chat-writeback.test.ts` — 20 passed
- [ ] After merge + CLI 1.0.3 cut, upgrade Comiclaw listen and hop once
- [ ] Host message `usage` includes extras; bubble footer still shows in/out only


Made with [Cursor](https://cursor.com)