### PR TITLE
chore(release): cut CLI 1.0.3 — writeback usage extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-16
+
+CLI-only patch (`@acnlabs/acn-cli@1.0.3`). Server / SDKs / skill stay **1.0.1**.
+
+### Added
+
+- **Chat writeback usage extras** — Mode B forwards self-reported
+  reasoning / cache / duration / provider on Host `agent-messages`.
+  Billing still uses cumulative in/out only (`#240`).
+
 ## [1.0.2] - 2026-08-15
 
 CLI-only patch (`@acnlabs/acn-cli@1.0.2`). Server / SDKs / skill stay **1.0.1**.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 
 | Server | Python `acn-client` | TypeScript `acn-client` | `@acnlabs/acn-cli` | Agent skill |
 |--------|---------------------|-------------------------|--------------------|-------------|
-| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.2** | **1.0.1** |
+| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.3** | **1.0.1** |
 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 |
 | 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
 

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `@acnlabs/acn-cli` are documented here.
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-16
+
+CLI-only patch. Server / SDK / skill stay **1.0.1**.
+
+### Added
+- **Writeback usage extras** — `acn listen --chat-writeback` forwards
+  OpenClaw-style `reasoning_tokens`, `cache_read_tokens` /
+  `cache_write_tokens`, `total_tokens`, `duration_ms`, and `provider`
+  from complete JSON (also accepts `input`/`output`, `reasoningTokens`,
+  `cacheRead`/`cacheWrite`, `durationMs`). Settlement still uses
+  cumulative `input_tokens` / `output_tokens` only.
+
 ## [1.0.2] - 2026-08-15
 
 CLI-only patch. Server / SDK / skill stay **1.0.1**.

--- a/clients/cli/package-lock.json
+++ b/clients/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acnlabs/acn-cli",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acnlabs/acn-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Official CLI for ACN (Agent Collaboration Network) \u2014 zero-integration agent access",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Publish `@acnlabs/acn-cli@1.0.3` with hop usage extras already landed in #240.
- Server / SDKs / skill stay **1.0.1**.
- Tag `v1.0.3` after merge so the Release workflow publishes the CLI.

## Test plan
- [x] Version / CHANGELOG sync: CLI `1.0.3` has dated entries
- [ ] CI green
- [ ] After merge: `git tag v1.0.3 && git push origin v1.0.3`
- [ ] `npm view @acnlabs/acn-cli version` → `1.0.3`
- [ ] Comiclaw: `npm i -g @acnlabs/acn-cli@1.0.3` then restart `acn-listen`


Made with [Cursor](https://cursor.com)