### PR TITLE
docs(skill): Interfaze usage contract + OpenClaw helper

### DIFF
--- a/clients/cli/src/commands/chat-writeback.ts
+++ b/clients/cli/src/commands/chat-writeback.ts
@@ -8,8 +8,8 @@
  *   3) POSTs { content, reply_to_id?, usage? } to Chat Gateway agent-messages
  *      with Bearer JWT
  *
- * Hosts return {"content":"..."} and optionally
- * {"usage":{"input_tokens":N,"output_tokens":M}} for chat billing settle.
+ * Hosts return {"content":"..."} and optionally usage (in/out billed;
+ * extras stored). See skills/acn/references/INTERFAZE.md.
  * They do not call Gateway themselves.
  */
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   primary_env: "ACN_API_KEY"
   optional_env: "ACN_BASE_URL, AUTH0_JWT, WALLET_PRIVATE_KEY"
   writes_to_disk: ".env — WALLET_PRIVATE_KEY + WALLET_ADDRESS, mode 0600, on-chain registration only; ~/.acn/config.json — credentials + region"
-allowed-tools: WebFetch Bash(curl:api.acnlabs.dev) Bash(curl:acn.acnlabs.cn) Bash(python:scripts/register_onchain.py)
+allowed-tools: WebFetch Bash(curl:api.acnlabs.dev) Bash(curl:acn.acnlabs.cn) Bash(python:scripts/register_onchain.py) Bash(python:scripts/openclaw_chat_usage.py)
 ---
 
 # ACN — Agent Collaboration Network
@@ -360,11 +360,13 @@ acn listen --runtime http \
   --chat-writeback \
   --chat-api-base "$AGENTPLANET_API_BASE" \
   --chat-complete-url http://127.0.0.1:PORT/chat/complete
-# host complete endpoint (or --chat-complete-exec) returns {"content":"..."}
+# host complete returns {"content":"..."} and optional usage
+# (input/output billed; extras stored). CLI 1.0.3+ forwards extras.
+# Contract: references/INTERFAZE.md  ·  OpenClaw helper: scripts/openclaw_chat_usage.py
 ```
 
 Contract: AgentPlanet `docs/architecture/chat-agent-writeback-v0.md`.  
-Full agent procedure: [references/INTERFAZE.md](references/INTERFAZE.md).
+Full agent procedure + usage fields: [references/INTERFAZE.md](references/INTERFAZE.md).
 
 **Coverage boundary:** only A2A traffic that arrives over the Mode B relay.
 Open Task Pool rows never pushed as A2A still need list/reconcile.

--- a/skills/acn/references/INTERFAZE.md
+++ b/skills/acn/references/INTERFAZE.md
@@ -88,7 +88,7 @@ npx @acnlabs/acn-cli listen --runtime command \
 |---|---|
 | config `api_key` | Your long-lived `acn_*` key — CLI mints short-lived **ACN agent JWT** for Gateway |
 | `chat-api-base` | Usually `https://api.agentplanet.org` |
-| complete | Returns `{"content":"<final reply>"}` |
+| complete | Returns `{"content":"<final reply>"}` plus optional `usage` (see contract below). CLI **1.0.3+** forwards extras. |
 
 **Do not use AgentPlanet Internal Token** for chat writeback. Auth is:
 
@@ -103,12 +103,38 @@ Content-Type: application/json
   "usage": {
     "input_tokens": 1200,
     "output_tokens": 340,
-    "meter_source": "peer_self"
+    "meter_source": "peer_self",
+    "model_id": "tencenttokenplan/kimi-k2.5",
+    "reasoning_tokens": 40,
+    "total_tokens": 1240,
+    "duration_ms": 3711,
+    "provider": "tencenttokenplan"
   }
 }
 ```
 
-`acn listen --chat-writeback`：complete 返回 `{"content"}` 即可；若附带 `usage`，CLI 会一并 POST（并自动填 `reply_to_id`）。Host 开了 `CHAT_BILLING_ENABLED` 且要求 usage 时，缺 usage 则本跳不扣费。
+`acn listen --chat-writeback`：complete 返回 `{"content"}` 即可；若附带 `usage`，CLI **1.0.3+** 会一并 POST（并自动填 `reply_to_id`）。Host 开了 `CHAT_BILLING_ENABLED` 且要求 usage 时，缺 usage 则本跳不扣费。
+
+#### Complete `usage` contract
+
+This is the ACN/Interfaze contract. Any runtime (OpenClaw, Hermes, custom) must emit this JSON — the CLI does not parse vendor payloads.
+
+| Field | Required | Role |
+|---|---|---|
+| `input_tokens` / `output_tokens` | for a billed hop | **Settlement and bubble in/out.** Cumulative for the whole hop (tool loops included). Do **not** use last-call-only counts. |
+| `model_id` | recommended | What actually ran (Host Catalog id, `provider/name` or bare name). |
+| `meter_source` | recommended | Mode B self-report → `peer_self`. Label, not anti-fraud. |
+| `reasoning_tokens` | optional | Stored. OpenClaw already folds this into `output`; **do not add it again to the bill**. |
+| `cache_read_tokens` / `cache_write_tokens` | optional | Stored. v0 L2 does not price cache separately. |
+| `total_tokens` | optional | Checksum / observe. |
+| `duration_ms` | optional | Hop wall time. |
+| `provider` | optional | e.g. `tencenttokenplan`. |
+
+Omit a field if the runtime did not report it. Do **not** invent zeros to look complete. Do **not** send `sessionId`, `sessionFile`, `contextTokens`, or `lastCallUsage` as settlement.
+
+`model_id` without tokens is allowed (CLI will not invent `0/0`). Tokens without `model_id` still settle; Host may fall back to listing / heartbeat for the model.
+
+OpenClaw reference extractor (not a required runtime): [scripts/openclaw_chat_usage.py](../scripts/openclaw_chat_usage.py). Pipe `openclaw agent --json` output in; put the printed object on complete `usage`.
 
 Mint JWT yourself if not using CLI writeback:
 

--- a/skills/acn/scripts/openclaw_chat_usage.py
+++ b/skills/acn/scripts/openclaw_chat_usage.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Extract Interfaze/Host `usage` from OpenClaw `agent --json` output.
+
+This is a reference adapter, not ACN core. The writeback contract is the
+JSON this prints — CLI 1.0.3+ forwards it. Settlement uses cumulative
+input/output only; extras are stored, not billed.
+
+Usage:
+  openclaw agent --json ... > /tmp/oc.json
+  python3 scripts/openclaw_chat_usage.py /tmp/oc.json
+  python3 scripts/openclaw_chat_usage.py < /tmp/oc.json
+
+Exit 0 even when no tokens were found (prints {}). Do not invent 0/0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def load_json_object(raw: str) -> dict[str, Any]:
+    raw = raw.lstrip("\ufeff")
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+    start, end = raw.find("{"), raw.rfind("}")
+    if start < 0 or end <= start:
+        return {}
+    try:
+        data = json.loads(raw[start : end + 1])
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def as_int(v: Any) -> int | None:
+    if isinstance(v, bool) or v is None:
+        return None
+    if isinstance(v, (int, float)) and v >= 0:
+        return int(v)
+    return None
+
+
+def first_int(*vals: Any) -> int | None:
+    for v in vals:
+        n = as_int(v)
+        if n is not None:
+            return n
+    return None
+
+
+def dig(obj: Any, *paths: str) -> Any:
+    for path in paths:
+        cur = obj
+        ok = True
+        for part in path.split("."):
+            if not isinstance(cur, dict) or part not in cur:
+                ok = False
+                break
+            cur = cur[part]
+        if ok:
+            return cur
+    return None
+
+
+def as_str(v: Any, n: int = 200) -> str:
+    if not isinstance(v, str):
+        return ""
+    s = v.strip()
+    return s[:n] if len(s) > n else s
+
+
+def extract_usage(data: dict[str, Any]) -> dict[str, Any]:
+    # Cumulative hop usage — never lastCallUsage.
+    u = dig(
+        data,
+        "result.meta.agentMeta.usage",
+        "meta.agentMeta.usage",
+        "agentMeta.usage",
+    )
+    if not isinstance(u, dict):
+        u = {}
+
+    out: dict[str, Any] = {}
+    inp = first_int(u.get("input"), u.get("input_tokens"), u.get("prompt_tokens"))
+    tok = first_int(u.get("output"), u.get("output_tokens"), u.get("completion_tokens"))
+    if inp is not None or tok is not None:
+        out["input_tokens"] = inp or 0
+        out["output_tokens"] = tok or 0
+        out["meter_source"] = "peer_self"
+
+    provider = as_str(
+        dig(
+            data,
+            "result.meta.agentMeta.provider",
+            "meta.agentMeta.provider",
+            "result.meta.provider",
+            "provider",
+        ),
+        80,
+    )
+    raw_model = as_str(
+        dig(
+            data,
+            "result.meta.agentMeta.model",
+            "meta.agentMeta.model",
+            "result.meta.model",
+            "model",
+        )
+    )
+    if provider and raw_model and "/" not in raw_model:
+        out["model_id"] = f"{provider}/{raw_model}"[:200]
+    elif raw_model:
+        out["model_id"] = raw_model[:200]
+    if provider:
+        out["provider"] = provider
+
+    reason = first_int(u.get("reasoningTokens"), u.get("reasoning_tokens"))
+    cache_r = first_int(u.get("cacheRead"), u.get("cache_read"), u.get("cache_read_tokens"))
+    cache_w = first_int(u.get("cacheWrite"), u.get("cache_write"), u.get("cache_write_tokens"))
+    total = first_int(u.get("total"), u.get("total_tokens"))
+    duration = first_int(
+        dig(data, "result.meta.durationMs", "meta.durationMs", "durationMs"),
+        dig(data, "result.meta.duration_ms", "meta.duration_ms"),
+    )
+    if reason is not None:
+        out["reasoning_tokens"] = reason
+    if cache_r is not None:
+        out["cache_read_tokens"] = cache_r
+    if cache_w is not None:
+        out["cache_write_tokens"] = cache_w
+    if total is not None:
+        out["total_tokens"] = total
+    if duration is not None:
+        out["duration_ms"] = duration
+    return out
+
+
+def _self_test() -> None:
+    sample = {
+        "result": {
+            "meta": {
+                "durationMs": 15876,
+                "agentMeta": {
+                    "provider": "tencenttokenplan",
+                    "model": "kimi-k2.5",
+                    "usage": {
+                        "input": 42214,
+                        "output": 220,
+                        "reasoningTokens": 216,
+                        "total": 42434,
+                    },
+                    "lastCallUsage": {"input": 1, "output": 1},
+                },
+            }
+        }
+    }
+    got = extract_usage(sample)
+    expect = {
+        "input_tokens": 42214,
+        "output_tokens": 220,
+        "meter_source": "peer_self",
+        "model_id": "tencenttokenplan/kimi-k2.5",
+        "provider": "tencenttokenplan",
+        "reasoning_tokens": 216,
+        "total_tokens": 42434,
+        "duration_ms": 15876,
+    }
+    if got != expect:
+        raise SystemExit(f"self-test failed: {got}")
+    if extract_usage({}) != {}:
+        raise SystemExit("empty payload must not invent zeros")
+    print("self-test OK", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        _self_test()
+        return 0
+    if len(argv) > 1 and argv[1] not in ("-", "--"):
+        raw = open(argv[1], encoding="utf-8").read()
+    else:
+        raw = sys.stdin.read()
+    print(json.dumps(extract_usage(load_json_object(raw)), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Document the Mode B complete `usage` contract in the ACN skill (in/out billed; extras stored; no lastCallUsage / session paths).
- Add `scripts/openclaw_chat_usage.py` as a reference adapter for OpenClaw agents. CLI 1.0.3+ already forwards these fields.
- Point SKILL.md writeback notes at the contract.

## Test plan
- [x] `python3 skills/acn/scripts/openclaw_chat_usage.py --self-test`
- [ ] Skill readers emit `model_id` + extras on complete JSON
- [ ] Non-OpenClaw agents follow the table, not the helper


Made with [Cursor](https://cursor.com)