### PR TITLE
chore(release): cut skill 1.0.2 — Interfaze usage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-08-17
+
+Skill-only patch (agent skill **1.0.2**). Server / SDKs stay **1.0.1**. CLI stays **1.0.3**.
+
+### Added
+
+- **Interfaze complete `usage` contract** — billed cumulative in/out;
+  optional extras stored not billed; helper `skills/acn/scripts/chat_usage.py`
+  normalizes aliases without walking a vendor tree (`#242`–`#245`).
+
 ## [1.0.3] - 2026-08-16
 
 CLI-only patch (`@acnlabs/acn-cli@1.0.3`). Server / SDKs / skill stay **1.0.1**.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ACN provides official client SDKs for TypeScript/JavaScript and Python.
 
 | Server | Python `acn-client` | TypeScript `acn-client` | `@acnlabs/acn-cli` | Agent skill |
 |--------|---------------------|-------------------------|--------------------|-------------|
-| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.3** | **1.0.1** |
+| **1.0.1** (current) | **1.0.1** | **1.0.1** | **1.0.3** | **1.0.2** |
 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 | 1.0.0 |
 | 0.15.10 | 0.13.0 | 0.15.0 | 0.14.2 | 0.17.18 |
 

--- a/skills/acn/SKILL.md
+++ b/skills/acn/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires ACN_API_KEY env var (from POST /agents/join). Optional: ACN_BASE_URL or --region cn|global; AUTH0_JWT for owner-scoped endpoints (claim/transfer/release/delete); WALLET_PRIVATE_KEY for on-chain ERC-8004 registration (requires pip install web3 httpx, writes .env mode 0600). HTTPS access to the chosen regional ACN required."
 metadata:
   author: acnlabs
-  version: "1.0.1"
+  version: "1.0.2"
   homepage: "https://acnlabs.dev"
   repository: "https://github.com/acnlabs/ACN"
   api_base: "https://api.acnlabs.dev/api/v1"


### PR DESCRIPTION
## Summary
- Agent skill metadata **1.0.2** (was 1.0.1 while usage contract content already shipped).
- Changelog cut **1.0.4** (skill-only). Server/SDKs stay 1.0.1; CLI stays 1.0.3.
- README compatibility table skill column → 1.0.2.

## Test plan
- [x] Skill frontmatter `version: "1.0.2"`
- [ ] After merge + deploy: `curl -s https://api.acnlabs.dev/skill.md | rg 'version:'`
- [ ] ClawHub republish separately if you want installed agents to pick this up


Made with [Cursor](https://cursor.com)